### PR TITLE
[Clean] Remove diagnostic for use of "topic://" links (SR-15319)

### DIFF
--- a/Sources/SwiftDocC/Semantics/MarkupReferenceResolver.swift
+++ b/Sources/SwiftDocC/Semantics/MarkupReferenceResolver.swift
@@ -101,15 +101,6 @@ struct MarkupReferenceResolver: MarkupRewriter {
             return link
         }
         guard url.components.scheme == ResolvedTopicReference.urlScheme else {
-            if url.components.scheme == "topic", let linkRange = link.range {
-                var components = url.components
-                components.scheme = ResolvedTopicReference.urlScheme
-                let diagnostic = Diagnostic(source: source, severity: .warning, range: link.range, identifier: "org.swift.docc.deprecatedSchemaReference", summary: "'topic' reference scheme is deprecated in favor of the 'doc' sheme")
-                let solution = Solution(summary: "Replace 'topic' reference scheme with 'doc' scheme.", replacements: [
-                    Replacement(range: linkRange, replacement: "<\(components.url!.absoluteString)>")
-                ])
-                problems.append(Problem(diagnostic: diagnostic, possibleSolutions: [solution]))
-            }
             return link // Create a non-topic link
         }
         let unresolved = TopicReference.unresolved(.init(topicURL: url))


### PR DESCRIPTION
# Issue
https://bugs.swift.org/browse/SR-15319

## Summary

Swift-DocC used to allow <doc:> style links to be written as <topic:> links. We no longer support this old syntax and all warnings related to it should be removed.

This PR's commits delete the related diagnostic code and test code.

## Testing

Steps:
1. Create a new Xcode project using Xcode 13, and add the documentation.
2. Use a <doc:> in the documentation file and it will a warning
3. Change the DocC version  Xcode use to this PR's product and it will not produce a warning.(the repo's README has instruction for it)

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Ran the `./bin/test` script and it succeeded