### PR TITLE
Navigator index multi-language render JSON support

### DIFF
--- a/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
@@ -14,7 +14,7 @@ import XCTest
 typealias Node = NavigatorTree.Node
 typealias PageType = NavigatorIndex.PageType
 
-let testBundleIndetifier = "org.swift.docc.example"
+let testBundleIdentifier = "org.swift.docc.example"
 
 class NavigatorIndexingTests: XCTestCase {
     
@@ -177,7 +177,7 @@ Root
         
         let original = NavigatorTree(root: root)
         try original.write(to: indexURL)
-        let readTree = try NavigatorTree.read(from: indexURL, bundleIdentifier: testBundleIndetifier, interfaceLanguages: [.swift], atomically: true)
+        let readTree = try NavigatorTree.read(from: indexURL, bundleIdentifier: testBundleIdentifier, interfaceLanguages: [.swift], atomically: true)
         
         XCTAssertEqual(original.root.countItems(), readTree.root.countItems())
         XCTAssertTrue(compare(lhs: original.root, rhs: readTree.root))
@@ -198,7 +198,7 @@ Root
         XCTAssertTrue(validateTree(node: readTree.root, validator: bundleIdentifierValidator), "The tree has bundle identifier missing.")
         XCTAssertTrue(validateTree(node: readTree.root, validator: emptyPresentationIdentifierValidator), "The tree has a presentation identifier set which should not be present.")
         
-        var treeWithPresentationIdentifier = try NavigatorTree.read(from: indexURL, bundleIdentifier: testBundleIndetifier, interfaceLanguages: [.swift], atomically: true, presentationIdentifier: "com.example.test")
+        var treeWithPresentationIdentifier = try NavigatorTree.read(from: indexURL, bundleIdentifier: testBundleIdentifier, interfaceLanguages: [.swift], atomically: true, presentationIdentifier: "com.example.test")
         
         let presentationIdentifierValidator: (NavigatorTree.Node) -> Bool = { node in
             return node.presentationIdentifier == "com.example.test"
@@ -209,7 +209,7 @@ Root
         XCTAssertTrue(validateTree(node: treeWithPresentationIdentifier.root, validator: presentationIdentifierValidator), "The tree lacks the presentation identifier.")
         
         // Test non-atomic read.
-        treeWithPresentationIdentifier = try NavigatorTree.read(from: indexURL, bundleIdentifier: testBundleIndetifier, interfaceLanguages: [.swift], atomically: false, presentationIdentifier: "com.example.test")
+        treeWithPresentationIdentifier = try NavigatorTree.read(from: indexURL, bundleIdentifier: testBundleIdentifier, interfaceLanguages: [.swift], atomically: false, presentationIdentifier: "com.example.test")
         
         XCTAssertTrue(validateTree(node: treeWithPresentationIdentifier.root, validator: idValidator), "The tree has IDs missing.")
         XCTAssertTrue(validateTree(node: treeWithPresentationIdentifier.root, validator: bundleIdentifierValidator), "The tree has bundle identifier missing.")
@@ -290,7 +290,7 @@ Root
             try? FileManager.default.removeItem(at: targetURL)
         }
         
-        let builder = NavigatorIndex.Builder(outputURL: targetURL, bundleIdentifier: testBundleIndetifier)
+        let builder = NavigatorIndex.Builder(outputURL: targetURL, bundleIdentifier: testBundleIdentifier)
         builder.setup()
         builder.finalize()
                
@@ -347,7 +347,7 @@ Root
             try? FileManager.default.removeItem(at: targetURL)
         }
 
-        let builder = NavigatorIndex.Builder(outputURL: targetURL, bundleIdentifier: testBundleIndetifier)
+        let builder = NavigatorIndex.Builder(outputURL: targetURL, bundleIdentifier: testBundleIdentifier)
         builder.setup()
         try builder.index(renderNode: renderNode)
         builder.finalize()
@@ -365,7 +365,7 @@ Root
         // Create an index 10 times to ensure we have not undeterministic behavior across builds
         for _ in 0..<10 {
             let targetURL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
-            let builder = NavigatorIndex.Builder(outputURL: targetURL, bundleIdentifier: testBundleIndetifier, sortRootChildrenByName: true)
+            let builder = NavigatorIndex.Builder(outputURL: targetURL, bundleIdentifier: testBundleIdentifier, sortRootChildrenByName: true)
             builder.setup()
             
             for identifier in context.knownPages {
@@ -389,7 +389,7 @@ Root
             XCTAssertEqual(Set(navigatorIndex.languages), Set(["Swift"]))
             XCTAssertEqual(navigatorIndex.navigatorTree.root.countItems(), navigatorIndex.navigatorTree.numericIdentifierToNode.count)
             XCTAssertTrue(validateTree(node: navigatorIndex.navigatorTree.root, validator: { (node) -> Bool in
-                return node.bundleIdentifier == testBundleIndetifier
+                return node.bundleIdentifier == testBundleIdentifier
             }))
             
             let allNodes = navigatorIndex.navigatorTree.numericIdentifierToNode.values
@@ -411,7 +411,7 @@ Root
         let jsonData = try Data(contentsOf: jsonFile)
         
         let targetURL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
-        let builder = NavigatorIndex.Builder(outputURL: targetURL, bundleIdentifier: testBundleIndetifier, sortRootChildrenByName: true, groupByLanguage: true)
+        let builder = NavigatorIndex.Builder(outputURL: targetURL, bundleIdentifier: testBundleIdentifier, sortRootChildrenByName: true, groupByLanguage: true)
         builder.setup()
         
         let renderNode = try XCTUnwrap(RenderJSONDecoder.makeDecoder().decode(RenderNode.self, from: jsonData))
@@ -447,7 +447,7 @@ Root
         // Create an index 10 times to ensure we have not undeterministic behavior across builds
         for _ in 0..<10 {
             let targetURL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
-            let builder = NavigatorIndex.Builder(outputURL: targetURL, bundleIdentifier: testBundleIndetifier, sortRootChildrenByName: true, usePageTitle: true)
+            let builder = NavigatorIndex.Builder(outputURL: targetURL, bundleIdentifier: testBundleIdentifier, sortRootChildrenByName: true, usePageTitle: true)
             builder.setup()
             
             for identifier in context.knownPages {
@@ -471,7 +471,7 @@ Root
             XCTAssertEqual(Set(navigatorIndex.languages), Set(["Swift"]))
             XCTAssertEqual(navigatorIndex.navigatorTree.root.countItems(), navigatorIndex.navigatorTree.numericIdentifierToNode.count)
             XCTAssertTrue(validateTree(node: navigatorIndex.navigatorTree.root, validator: { (node) -> Bool in
-                return node.bundleIdentifier == testBundleIndetifier
+                return node.bundleIdentifier == testBundleIdentifier
             }))
             
             let allNodes = navigatorIndex.navigatorTree.numericIdentifierToNode.values
@@ -496,7 +496,7 @@ Root
         // Create an index 10 times to ensure we have not undeterministic behavior across builds
         for _ in 0..<10 {
             let targetURL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
-            let builder = NavigatorIndex.Builder(outputURL: targetURL, bundleIdentifier: testBundleIndetifier, sortRootChildrenByName: true, writePathsOnDisk: false)
+            let builder = NavigatorIndex.Builder(outputURL: targetURL, bundleIdentifier: testBundleIdentifier, sortRootChildrenByName: true, writePathsOnDisk: false)
             builder.setup()
             
             for identifier in context.knownPages {
@@ -521,7 +521,7 @@ Root
             XCTAssertEqual(Set(navigatorIndex.languages), Set(["Swift"]))
             XCTAssertEqual(navigatorIndex.navigatorTree.root.countItems(), navigatorIndex.navigatorTree.numericIdentifierToNode.count)
             XCTAssertTrue(validateTree(node: navigatorIndex.navigatorTree.root, validator: { (node) -> Bool in
-                return node.bundleIdentifier == testBundleIndetifier
+                return node.bundleIdentifier == testBundleIdentifier
             }))
             
             let allNodes = navigatorIndex.navigatorTree.numericIdentifierToNode.values
@@ -551,7 +551,7 @@ Root
         let converter = DocumentationContextConverter(bundle: bundle, context: context, renderContext: renderContext)
         
         let targetURL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
-        let builder = NavigatorIndex.Builder(outputURL: targetURL, bundleIdentifier: testBundleIndetifier, sortRootChildrenByName: true, groupByLanguage: true)
+        let builder = NavigatorIndex.Builder(outputURL: targetURL, bundleIdentifier: testBundleIdentifier, sortRootChildrenByName: true, groupByLanguage: true)
         builder.setup()
         
         for identifier in context.knownPages {
@@ -602,7 +602,7 @@ Root
         // Create an index 10 times to ensure we have no undeterministic behavior across builds
         for _ in 0..<10 {
             let targetURL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
-            let builder = NavigatorIndex.Builder(outputURL: targetURL, bundleIdentifier: testBundleIndetifier, sortRootChildrenByName: true)
+            let builder = NavigatorIndex.Builder(outputURL: targetURL, bundleIdentifier: testBundleIdentifier, sortRootChildrenByName: true)
             builder.setup()
             
             for identifier in context.knownPages {
@@ -663,7 +663,7 @@ Root
         let converter = DocumentationContextConverter(bundle: bundle, context: context, renderContext: renderContext)
         
         let targetURL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
-        let builder = NavigatorIndex.Builder(outputURL: targetURL, bundleIdentifier: testBundleIndetifier, sortRootChildrenByName: true)
+        let builder = NavigatorIndex.Builder(outputURL: targetURL, bundleIdentifier: testBundleIdentifier, sortRootChildrenByName: true)
         builder.setup()
         
         for identifier in context.knownPages {
@@ -678,7 +678,7 @@ Root
         let navigatorIndex = try NavigatorIndex(url: targetURL)
         
         XCTAssertEqual(navigatorIndex.pathHasher, .md5)
-        XCTAssertEqual(navigatorIndex.bundleIdentifier, testBundleIndetifier)
+        XCTAssertEqual(navigatorIndex.bundleIdentifier, testBundleIdentifier)
         XCTAssertEqual(navigatorIndex.availabilityIndex.platforms, [.watchOS, .iOS, .macCatalyst, .tvOS, .macOS])
         XCTAssertEqual(navigatorIndex.availabilityIndex.versions(for: .macOS), Set([
             Platform.Version(string: "10.9")!,
@@ -762,7 +762,7 @@ Root
         let converter = DocumentationContextConverter(bundle: bundle, context: context, renderContext: renderContext)
         
         let targetURL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
-        let builder = NavigatorIndex.Builder(outputURL: targetURL, bundleIdentifier: testBundleIndetifier, sortRootChildrenByName: true)
+        let builder = NavigatorIndex.Builder(outputURL: targetURL, bundleIdentifier: testBundleIdentifier, sortRootChildrenByName: true)
         builder.setup()
         
         // Change the path hasher to the FNV-1 implementation and make sure paths and mappings are still working.

--- a/Tests/SwiftDocCTests/Test Resources/Variant-render-node.json
+++ b/Tests/SwiftDocCTests/Test Resources/Variant-render-node.json
@@ -1,0 +1,134 @@
+{
+  "abstract": [],
+  "documentVersion": 0,
+  "identifier": {
+    "interfaceLanguage": "swift",
+    "url": "doc://org.swift.docc/documentation/mykit/my-article"
+  },
+  "kind": "article",
+  "metadata": {
+    "modules": [
+      {
+        "name": "mykit"
+      }
+    ],
+    "role": "article",
+    "roleHeading": "Article",
+    "title": "My Article"
+  },
+  "primaryContentSections": [],
+  "references": {
+    "doc://org.swift.docc/documentation/mykit": {
+      "identifier": "doc://org.swift.docc/documentation/mykit",
+      "kind": "symbol",
+      "role": "collection",
+      "title": "mykit",
+      "type": "topic",
+      "url": "/documentation/mykit"
+    },
+    "doc://org.swift.docc/documentation/mykit/my-article": {
+      "abstract": [],
+      "identifier": "doc://org.swift.docc/documentation/mykit/my-article",
+      "kind": "article",
+      "role": "article",
+      "title": "My Article",
+      "type": "topic",
+      "url": "/documentation/mykit/my-article"
+    },
+    "doc://org.swift.docc/documentation/mykit/myclass": {
+      "abstract": [],
+      "fragments": [
+        {
+          "kind": "text",
+          "text": "class "
+        },
+        {
+          "kind": "identifier",
+          "text": "myclass"
+        }
+      ],
+      "identifier": "doc://org.swift.docc/documentation/mykit/myclass",
+      "kind": "symbol",
+      "role": "symbol",
+      "title": "myclass",
+      "type": "topic",
+      "url": "/documentation/mykit/myclass"
+    }
+  },
+  "schemaVersion": {
+    "major": 0,
+    "minor": 1,
+    "patch": 0
+  },
+  "sections": [],
+  "seeAlsoSections": [],
+  "topicSections": [
+    {
+      "anchor": "2959524",
+      "identifiers": [
+        "doc://org.swift.docc/documentation/mykit/myclass"
+      ],
+      "kind": "taskGroup",
+      "title": "Task Group 1"
+    },
+    {
+      "anchor": "2958803",
+      "identifiers": [
+        "doc://org.swift.docc/documentation/mykit/myclass"
+      ],
+      "kind": "taskGroup",
+      "title": "Task Group 2"
+    },
+    {
+      "anchor": "3016821",
+      "identifiers": [
+        "doc://org.swift.docc/documentation/mykit/myclass"
+      ],
+      "kind": "taskGroup",
+      "title": "Task Group 3"
+    }
+  ],
+  "variants": [
+    {
+      "paths": [
+        "documentation/mykit/my-article"
+      ],
+      "traits": [
+        {
+          "interfaceLanguage": "objc"
+        }
+      ]
+    },
+    {
+      "paths": [
+        "documentation/mykit/my-article"
+      ],
+      "traits": [
+        {
+          "interfaceLanguage": "swift"
+        }
+      ]
+    }
+  ],
+  "variantOverrides": [
+    {
+      "patch": [
+        {
+          "op": "replace",
+          "path": "/metadata/title",
+          "value": "My Article in Objective-C"
+        },
+        {
+          "op": "replace",
+          "path": "/identifier/interfaceLanguage",
+          "value": "objc"
+        }
+      ],
+      "traits": [
+        {
+          "interfaceLanguage": "objc"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://83398083

## Summary

Adds support for the navigator index to process render JSON that contains variant overrides by applying patches for the languages in which the page is available.

Note: the first commit adds the support and second commit fixes a typo

## Dependencies

None.

## Testing

Verify that when building a navigator index that contains multi-language render JSON, the content gets curated under each language tree.

## Checklist

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
