### PR TITLE
Refactor DocumentationBundle.Info

### DIFF
--- a/Sources/SwiftDocC/DocumentationService/Convert/ConvertService+DataProvider.swift
+++ b/Sources/SwiftDocC/DocumentationService/Convert/ConvertService+DataProvider.swift
@@ -21,26 +21,20 @@ extension ConvertService {
         var files: [URL: Data] = [:]
         
         mutating func registerBundle(
-            displayName: String,
-            identifier: String,
-            version: String,
+            info: DocumentationBundle.Info,
             symbolGraphs: [Data],
             markupFiles: [Data],
-            miscResourceURLs: [URL],
-            defaultCodeListingLanguage: String?
+            miscResourceURLs: [URL]
         ) {
             let symbolGraphURLs = symbolGraphs.map { registerFile(contents: $0, isMarkupFile: false) }
             let markupFileURLs = markupFiles.map { registerFile(contents: $0, isMarkupFile: true) }
             
             bundles.append(
                 DocumentationBundle(
-                    displayName: displayName,
-                    identifier: identifier,
-                    version: Version(versionString: version)!,
+                    info: info,
                     symbolGraphURLs: symbolGraphURLs,
                     markupURLs: markupFileURLs,
-                    miscResourceURLs: miscResourceURLs,
-                    defaultCodeListingLanguage: defaultCodeListingLanguage
+                    miscResourceURLs: miscResourceURLs
                 )
             )
         }

--- a/Sources/SwiftDocC/DocumentationService/Convert/ConvertService.swift
+++ b/Sources/SwiftDocC/DocumentationService/Convert/ConvertService.swift
@@ -153,7 +153,7 @@ public struct ConvertService: DocumentationService {
                 context.externalSymbolResolver = resolver
             }
 
-            var converter = self.converter ?? DocumentationConverter(
+            var converter = try self.converter ?? DocumentationConverter(
                 documentationBundleURL: request.bundleLocation ?? URL(fileURLWithPath: "/"),
                 emitDigest: false,
                 documentationCoverageOptions: .noCoverage,
@@ -164,12 +164,7 @@ public struct ConvertService: DocumentationService {
                 externalIDsToConvert: request.externalIDsToConvert,
                 documentPathsToConvert: request.documentPathsToConvert,
                 bundleDiscoveryOptions: BundleDiscoveryOptions(
-                    infoPlistFallbacks: [
-                        "CFBundleDisplayName": request.displayName,
-                        "CFBundleIdentifier": request.identifier,
-                        "CFBundleVersion": request.version,
-                        "CDDefaultCodeListingLanguage": request.defaultCodeListingLanguage as Any
-                    ],
+                    fallbackInfo: request.bundleInfo,
                     additionalSymbolGraphFiles: []
                 ),
                 // We're enabling the inclusion of symbol declaration file paths

--- a/Sources/SwiftDocC/DocumentationService/Convert/ConvertService.swift
+++ b/Sources/SwiftDocC/DocumentationService/Convert/ConvertService.swift
@@ -129,13 +129,10 @@ public struct ConvertService: DocumentationService {
                 var inMemoryProvider = InMemoryContentDataProvider()
                 
                 inMemoryProvider.registerBundle(
-                    displayName: request.displayName,
-                    identifier: request.identifier,
-                    version: request.version,
+                    info: request.bundleInfo,
                     symbolGraphs: request.symbolGraphs,
                     markupFiles: request.markupFiles,
-                    miscResourceURLs: request.miscResourceURLs,
-                    defaultCodeListingLanguage: request.defaultCodeListingLanguage
+                    miscResourceURLs: request.miscResourceURLs
                 )
                 
                 provider = inMemoryProvider
@@ -146,13 +143,13 @@ public struct ConvertService: DocumentationService {
             
             if let linkResolvingServer = linkResolvingServer {
                 let resolver = try OutOfProcessReferenceResolver(
-                    bundleIdentifier: request.identifier,
+                    bundleIdentifier: request.bundleInfo.identifier,
                     server: linkResolvingServer,
                     convertRequestIdentifier: messageIdentifier
                 )
                 
-                context.fallbackReferenceResolvers[request.identifier] = resolver
-                context.fallbackAssetResolvers[request.identifier] = resolver
+                context.fallbackReferenceResolvers[request.bundleInfo.identifier] = resolver
+                context.fallbackAssetResolvers[request.bundleInfo.identifier] = resolver
                 context.externalSymbolResolver = resolver
             }
 

--- a/Sources/SwiftDocC/DocumentationService/Models/Services/Convert/ConvertRequest.swift
+++ b/Sources/SwiftDocC/DocumentationService/Models/Services/Convert/ConvertRequest.swift
@@ -13,6 +13,12 @@ import Foundation
 
 /// A request to convert in-memory documentation.
 public struct ConvertRequest: Codable {
+    /// Information about the documentation bundle to convert.
+    ///
+    /// ## See Also
+    /// - ``DocumentationBundle/Info-swift.struct``
+    public var bundleInfo: DocumentationBundle.Info
+    
     /// The external IDs of the symbols to convert.
     ///
     /// Use this property to indicate what symbol documentation nodes should be converted. When ``externalIDsToConvert``
@@ -52,19 +58,43 @@ public struct ConvertRequest: Codable {
     ///
     /// ## See Also
     /// - ``DocumentationBundle/displayName``
-    public var displayName: String
+    @available(*, deprecated, message: "Use 'bundleInfo.displayName' instead.")
+    public var displayName: String {
+        get {
+            return bundleInfo.displayName
+        }
+        set {
+            bundleInfo.displayName = newValue
+        }
+    }
     
     /// The identifier of the documentation bundle to convert.
     ///
     /// ## See Also
     /// - ``DocumentationBundle/identifier``
-    public var identifier: String
+    @available(*, deprecated, message: "Use 'bundleInfo.identifier' instead.")
+    public var identifier: String {
+        get {
+            return bundleInfo.identifier
+        }
+        set {
+            bundleInfo.identifier = newValue
+        }
+    }
     
     /// The version of the documentation bundle to convert.
     ///
     /// ## See Also
     /// - ``DocumentationBundle/version``
-    public var version: String
+    @available(*, deprecated, message: "Use 'bundleInfo.version' instead.")
+    public var version: String {
+        get {
+            return bundleInfo.version.description
+        }
+        set {
+            bundleInfo.version = Version(versionString: newValue) ?? bundleInfo.version
+        }
+    }
     
     /// The symbols graph data included in the documentation bundle to convert.
     ///
@@ -88,24 +118,17 @@ public struct ConvertRequest: Codable {
     ///
     /// ## See Also
     /// - ``DocumentationBundle/defaultCodeListingLanguage``
-    public var defaultCodeListingLanguage: String?
+    @available(*, deprecated, message: "Use 'bundleInfo.defaultCodeListingLanguage' instead.")
+    public var defaultCodeListingLanguage: String? {
+        get {
+            return bundleInfo.defaultCodeListingLanguage
+        }
+        set {
+            bundleInfo.defaultCodeListingLanguage = newValue
+        }
+    }
     
-    /// Creates a request to convert in-memory documentation.
-    /// - Parameters:
-    ///   - externalIDsToConvert: The external IDs of the symbols to convert. In Swift, the external ID of a symbol is its USR.
-    ///   - documentPathsToConvert: The paths of the documentation nodes to convert.
-    ///   - includeRenderReferenceStore: Whether the conversion's render reference store should be included in the
-    ///   response.
-    ///   - bundleLocation: The file location of the documentation bundle to convert, if any.
-    ///   - displayName: The display name of the documentation bundle to convert.
-    ///   - identifier: The identifier of the documentation bundle to convert.
-    ///   - version: The version of the documentation bundle to convert.
-    ///   - symbolGraphs: The symbols graph data included in the documentation bundle to convert.
-    ///   - knownDisambiguatedSymbolPathComponents: The mapping of external symbol identifiers to
-    ///   known disambiguated symbol path components.
-    ///   - markupFiles: The markup file data included in the documentation bundle to convert.
-    ///   - miscResourceURLs: The on-disk resources in the documentation bundle to convert.
-    ///   - defaultCodeListingLanguage: The default code listing language for the documentation bundle to convert.
+    @available(*, deprecated, message: "Use 'init(bundleInfo:externalIDsToConvert:...)' instead.")
     public init(
         externalIDsToConvert: [String]?,
         documentPathsToConvert: [String]? = nil,
@@ -124,13 +147,50 @@ public struct ConvertRequest: Codable {
         self.documentPathsToConvert = documentPathsToConvert
         self.includeRenderReferenceStore = includeRenderReferenceStore
         self.bundleLocation = bundleLocation
-        self.displayName = displayName
-        self.identifier = identifier
-        self.version = version
         self.symbolGraphs = symbolGraphs
         self.knownDisambiguatedSymbolPathComponents = knownDisambiguatedSymbolPathComponents
         self.markupFiles = markupFiles
         self.miscResourceURLs = miscResourceURLs
-        self.defaultCodeListingLanguage = defaultCodeListingLanguage
+        
+        self.bundleInfo = DocumentationBundle.Info(
+            displayName: displayName,
+            identifier: identifier,
+            version: Version(versionString: version)!,
+            defaultCodeListingLanguage: defaultCodeListingLanguage
+        )
+    }
+    
+    /// Creates a request to convert in-memory documentation.
+    /// - Parameters:
+    ///   - bundleInfo: Information about the bundle to convert.
+    ///   - documentPathsToConvert: The paths of the documentation nodes to convert.
+    ///   - includeRenderReferenceStore: Whether the conversion's render reference store should be included in the
+    ///   response.
+    ///   - bundleLocation: The file location of the documentation bundle to convert, if any.
+    ///   - symbolGraphs: The symbols graph data included in the documentation bundle to convert.
+    ///   - knownDisambiguatedSymbolPathComponents: The mapping of external symbol identifiers to
+    ///   known disambiguated symbol path components.
+    ///   - markupFiles: The markup file data included in the documentation bundle to convert.
+    ///   - miscResourceURLs: The on-disk resources in the documentation bundle to convert.
+    public init(
+        bundleInfo: DocumentationBundle.Info,
+        externalIDsToConvert: [String]?,
+        documentPathsToConvert: [String]? = nil,
+        includeRenderReferenceStore: Bool? = nil,
+        bundleLocation: URL? = nil,
+        symbolGraphs: [Data],
+        knownDisambiguatedSymbolPathComponents: [String: [String]]? = nil,
+        markupFiles: [Data],
+        miscResourceURLs: [URL]
+    ) {
+        self.externalIDsToConvert = externalIDsToConvert
+        self.documentPathsToConvert = documentPathsToConvert
+        self.includeRenderReferenceStore = includeRenderReferenceStore
+        self.bundleLocation = bundleLocation
+        self.symbolGraphs = symbolGraphs
+        self.knownDisambiguatedSymbolPathComponents = knownDisambiguatedSymbolPathComponents
+        self.markupFiles = markupFiles
+        self.miscResourceURLs = miscResourceURLs
+        self.bundleInfo = bundleInfo
     }
 }

--- a/Sources/SwiftDocC/Infrastructure/DocumentationBundle.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationBundle.swift
@@ -41,17 +41,24 @@ public struct DocumentationBundle {
         }
     }
     
+    /// Information about this documentation bundle that's unrelated to its documentation content.
+    public let info: Info
+    
     /**
      The bundle's human-readable display name.
      */
-    public let displayName: String
-
+    public var displayName: String {
+        info.displayName
+    }
+    
     /**
      The documentation bundle identifier.
 
      An identifier string that specifies the app type of the bundle. The string should be in reverse DNS format using only the Roman alphabet in upper and lower case (A–Z, a–z), the dot (“.”), and the hyphen (“-”).
      */
-    public let identifier: String
+    public var identifier: String {
+        info.identifier
+    }
 
     /**
      The documentation bundle's version.
@@ -66,7 +73,9 @@ public struct DocumentationBundle {
 
      If the value of the third number is 0, you can omit it and the second period.
      */
-    public let version: Version
+    public var version: Version {
+        info.version
+    }
     
     /// Code listings extracted from the documented modules' source, indexed by their identifier.
     public var attributedCodeListings: [String: AttributedCodeListing]
@@ -87,13 +96,18 @@ public struct DocumentationBundle {
     public let customFooter: URL?
 
     /// Default syntax highlighting to use for code samples in this bundle.
-    public let defaultCodeListingLanguage: String?
-
-    /// Default availability information for modules in this bundle.
-    public let defaultAvailability: DefaultAvailability?
+    @available(*, deprecated, message: "Use 'info.defaultCodeListingLanguage' instead.")
+    public var defaultCodeListingLanguage: String? {
+        return info.defaultCodeListingLanguage
+    }
     
-    /*
-    A URL prefix to be appended to the relative presentation
+    @available(*, deprecated, message: "Use 'info.defaultAvailability' instead.")
+    public var defaultAvailability: DefaultAvailability? {
+        return info.defaultAvailability
+    }
+    
+    /**
+    A URL prefix to be appended to the relative presentation URL.
     
     This is used when a bundle's documentation is hosted in a known location.
     */
@@ -113,10 +127,46 @@ public struct DocumentationBundle {
        - defaultCodeListingLanguage: The default language for code blocks.
        - defaultAvailability: Default availability information for modules in this bundle.
      */
+    @available(*, deprecated, message: "Use 'init(info:baseURL:...)' instead.")
     public init(displayName: String, identifier: String, version: Version, baseURL: URL = URL(string: "/")!, attributedCodeListings: [String: AttributedCodeListing] = [:], symbolGraphURLs: [URL], markupURLs: [URL], miscResourceURLs: [URL], customHeader: URL? = nil, customFooter: URL? = nil, defaultCodeListingLanguage: String? = nil, defaultAvailability: DefaultAvailability? = nil) {
-        self.displayName = displayName
-        self.identifier = identifier
-        self.version = version
+        self.init(
+            info: Info(
+                displayName: displayName,
+                identifier: identifier,
+                version: version,
+                defaultCodeListingLanguage: defaultCodeListingLanguage,
+                defaultAvailability: defaultAvailability
+            ),
+            symbolGraphURLs: symbolGraphURLs,
+            markupURLs: markupURLs,
+            miscResourceURLs: miscResourceURLs,
+            customHeader: customHeader,
+            customFooter: customFooter
+        )
+    }
+    
+    /// Creates a documentation bundle.
+    ///
+    /// - Parameters:
+    ///   - info: Information about the bundle.
+    ///   - baseURL: A URL prefix to be appended to the relative presentation URL.
+    ///   - attributedCodeListings: Code listings extracted from the documented modules' source, indexed by their identifier.
+    ///   - symbolGraphURLs: Symbol Graph JSON files for the modules documented by the bundle.
+    ///   - markupURLs: DocC Markup files of the bundle.
+    ///   - miscResourceURLs: Miscellaneous resources of the bundle.
+    ///   - customHeader: Custom HTML file to use as the header for rendered output.
+    ///   - customFooter: Custom HTML file to use as the footer for rendered output.
+    public init(
+        info: Info,
+        baseURL: URL = URL(string: "/")!,
+        attributedCodeListings: [String: AttributedCodeListing] = [:],
+        symbolGraphURLs: [URL],
+        markupURLs: [URL],
+        miscResourceURLs: [URL],
+        customHeader: URL? = nil,
+        customFooter: URL? = nil
+    ) {
+        self.info = info
         self.baseURL = baseURL
         self.attributedCodeListings = attributedCodeListings
         self.symbolGraphURLs = symbolGraphURLs
@@ -124,14 +174,11 @@ public struct DocumentationBundle {
         self.miscResourceURLs = miscResourceURLs
         self.customHeader = customHeader
         self.customFooter = customFooter
-        self.defaultCodeListingLanguage = defaultCodeListingLanguage
-        self.defaultAvailability = defaultAvailability
-        
-        self.rootReference = ResolvedTopicReference(bundleIdentifier: identifier, path: "/", sourceLanguage: .swift)
-        self.documentationRootReference = ResolvedTopicReference(bundleIdentifier: identifier, path: NodeURLGenerator.Path.documentationFolder, sourceLanguage: .swift)
-        self.tutorialsRootReference = ResolvedTopicReference(bundleIdentifier: identifier, path: NodeURLGenerator.Path.tutorialsFolder, sourceLanguage: .swift)
-        self.technologyTutorialsRootReference = tutorialsRootReference.appendingPath(urlReadablePath(displayName))
-        self.articlesDocumentationRootReference = documentationRootReference.appendingPath(urlReadablePath(displayName))
+        self.rootReference = ResolvedTopicReference(bundleIdentifier: info.identifier, path: "/", sourceLanguage: .swift)
+        self.documentationRootReference = ResolvedTopicReference(bundleIdentifier: info.identifier, path: NodeURLGenerator.Path.documentationFolder, sourceLanguage: .swift)
+        self.tutorialsRootReference = ResolvedTopicReference(bundleIdentifier: info.identifier, path: NodeURLGenerator.Path.tutorialsFolder, sourceLanguage: .swift)
+        self.technologyTutorialsRootReference = tutorialsRootReference.appendingPath(urlReadablePath(info.displayName))
+        self.articlesDocumentationRootReference = documentationRootReference.appendingPath(urlReadablePath(info.displayName))
     }
     
     public private(set) var rootReference: ResolvedTopicReference

--- a/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphLoader.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphLoader.swift
@@ -145,7 +145,7 @@ struct SymbolGraphLoader {
     /// this method adds them to each of the symbols in the graph.
     private func addDefaultAvailability(to symbolGraph: inout SymbolGraph, moduleName: String) {
         // Check if there are defined default availabilities for the current module
-        if let defaultAvailabilities = bundle.defaultAvailability?.modules[moduleName],
+        if let defaultAvailabilities = bundle.info.defaultAvailability?.modules[moduleName],
             let platformName = symbolGraph.module.platform.name.map(PlatformName.init) {
             
             // Prepare a default availability lookup for this module.

--- a/Sources/SwiftDocC/Infrastructure/Workspace/DataProviderBundleDiscovery.swift
+++ b/Sources/SwiftDocC/Infrastructure/Workspace/DataProviderBundleDiscovery.swift
@@ -80,7 +80,7 @@ extension DocumentationWorkspaceDataProvider where Self: FileSystemProvider {
         let customHeader = findCustomHeader(bundleChildren)?.url
         let customFooter = findCustomFooter(bundleChildren)?.url
         
-        return DocumentationBundle(displayName: info.displayName, identifier: info.identifier, version: info.version, symbolGraphURLs: symbolGraphFiles, markupURLs: markupFiles, miscResourceURLs: miscResources, customHeader: customHeader, customFooter: customFooter, defaultCodeListingLanguage: info.defaultCodeListingLanguage, defaultAvailability: info.defaultAvailability)
+        return DocumentationBundle(info: info, symbolGraphURLs: symbolGraphFiles, markupURLs: markupFiles, miscResourceURLs: miscResources, customHeader: customHeader, customFooter: customFooter)
     }
     
     /// Performs a shallow search for the first Info.plist file in the given list of files and directories.

--- a/Sources/SwiftDocC/Infrastructure/Workspace/DocumentationBundle+Info.swift
+++ b/Sources/SwiftDocC/Infrastructure/Workspace/DocumentationBundle+Info.swift
@@ -14,71 +14,166 @@ extension DocumentationBundle {
     /// Information about a documentation bundle that's unrelated to its documentation content.
     ///
     /// This information is meant to be decoded from the bundle's Info.plist file.
-    struct Info {
-        
-        /// Represents a key in an Info.plist file.
-        struct Key {
-            let rawValue: String
-            let argumentName: String
-            
-            /// The display name of a bundle
-            static let bundleDisplayName = Key(rawValue: "CFBundleDisplayName", argumentName: "--fallback-display-name")
-            /// A reverse-DNS style bundle identifier
-            static let bundleIdentifier = Key(rawValue: "CFBundleIdentifier", argumentName: "--fallback-bundle-identifier")
-            /// A version number for a bundle
-            static let bundleVersion = Key(rawValue: "CFBundleVersion", argumentName: "--fallback-bundle-version")
-            /// The default code language for code listings in a bundle
-            static let defaultCodeListingLanaguage = Key(rawValue: "CDDefaultCodeListingLanguage", argumentName: "--default-code-listing-language")
-        }
-        
+    public struct Info: Codable, Equatable {
         /// The display name of the bundle.
-        let displayName: String
+        public var displayName: String
+        
         /// The unique identifier of the bundle.
-        let identifier: String
+        public var identifier: String
+        
         /// The version of the bundle.
-        let version: Version
+        public var version: Version
+        
         /// The default language identifier for code listings in the bundle.
-        let defaultCodeListingLanguage: String?
+        public var defaultCodeListingLanguage: String?
+        
         /// The default availability for the various modules in the bundle.
-        let defaultAvailability: DefaultAvailability?
+        public var defaultAvailability: DefaultAvailability?
         
         /// The keys that must be present in an Info.plist file in order for doc compilation to proceed.
-        static let requiredKeys: [Key] = [.bundleDisplayName, .bundleIdentifier, .bundleVersion]
+        static let requiredKeys: Set<CodingKeys> = [.displayName, .identifier, .version]
         
-        /// Parses a property list dictionary mapping into a new info value.
-        ///
-        /// - Parameter infoPlist: The property list dictionary to parse.
-        /// - Throws: If the property list dictionary is missing required values or contains invalid data.
-        init(plist infoPlist: [String: Any]) throws {
-            let missingKeys = Self.requiredKeys
-                .filter({ !infoPlist.keys.contains($0.rawValue) })
-                .sorted(by: { $0.rawValue < $1.rawValue })
+        enum CodingKeys: String, CodingKey {
+            case displayName = "CFBundleDisplayName"
+            case identifier = "CFBundleIdentifier"
+            case version = "CFBundleVersion"
+            case defaultCodeListingLanguage = "CDDefaultCodeListingLanguage"
+            case defaultAvailability = "CDAppleDefaultAvailability"
+            
+            var argumentName: String? {
+                switch self {
+                case .displayName:
+                    return "--fallback-display-name"
+                case .identifier:
+                    return "--fallback-bundle-identifier"
+                case .version:
+                    return "--fallback-bundle-version"
+                case .defaultCodeListingLanguage:
+                    return "--default-code-listing-language"
+                case .defaultAvailability:
+                    return nil
+                }
+            }
+        }
+        
+        /// Creates documentation bundle information from the given Info.plist data, falling back to the values
+        /// in the given bundle discovery options if necessary.
+        init(
+            from infoPlist: Data? = nil,
+            bundleDiscoveryOptions options: BundleDiscoveryOptions? = nil
+        ) throws {
+            if let infoPlist = infoPlist {
+                let propertyListDecoder = PropertyListDecoder()
+                
+                if let options = options {
+                    propertyListDecoder.userInfo[.bundleDiscoveryOptions] = options
+                }
+                
+                self = try propertyListDecoder.decode(
+                    DocumentationBundle.Info.self,
+                    from: infoPlist
+                )
+            } else {
+                try self.init(with: nil, bundleDiscoveryOptions: options)
+            }
+        }
+        
+        public init(from decoder: Decoder) throws {
+            let bundleDiscoveryOptions = decoder.userInfo[.bundleDiscoveryOptions] as? BundleDiscoveryOptions
+            
+            try self.init(
+                with: decoder.container(keyedBy: CodingKeys.self),
+                bundleDiscoveryOptions: bundleDiscoveryOptions
+            )
+        }
+        
+        private init(
+            with values: KeyedDecodingContainer<DocumentationBundle.Info.CodingKeys>?,
+            bundleDiscoveryOptions: BundleDiscoveryOptions?
+        ) throws {
+            // Here we define two helper functions that simplify
+            // the decoding logic where we'll need to first check if the value
+            // is in the Codable container, and then fall back to the
+            // Info.plist fallbacks in the bundle discovery options if necessary.
+            
+            /// Helper function that decodes a value of the given type for the given key,
+            /// if present in either the Codable container or Info.plist fallbacks.
+            func decodeOrFallbackIfPresent<T>(
+                _ expectedType: T.Type,
+                with key: CodingKeys
+            ) throws -> T? where T : Decodable {
+                try values?.decodeIfPresent(T.self, forKey: key)
+                    ?? bundleDiscoveryOptions?.infoPlistFallbacks.decodeIfPresent(T.self, forKey: key.rawValue)
+            }
+            
+            /// Helper function that decodes a value of the given type for the given key
+            /// in either the Codable container or Info.plist fallbacks.
+            func decodeOrFallback<T>(
+                _ expectedType: T.Type, with key: CodingKeys
+            ) throws -> T where T : Decodable {
+                if let bundleDiscoveryOptions = bundleDiscoveryOptions {
+                    return try values?.decodeIfPresent(T.self, forKey: key)
+                        ?? bundleDiscoveryOptions.infoPlistFallbacks.decode(T.self, forKey: key.rawValue)
+                } else if let values = values {
+                    return try values.decode(T.self, forKey: key)
+                } else {
+                    throw DocumentationBundle.PropertyListError.keyNotFound(key.rawValue)
+                }
+            }
+            
+            // Before decoding, confirm that all required keys are present
+            // in either the decoding container or Info.plist fallbacks.
+            //
+            // This allows us to throw a more comprehensive error that includes
+            // **all** missing required keys, instead of just the first one hit.
+            
+            let givenKeys = Set(values?.allKeys ?? []).union(
+                bundleDiscoveryOptions?.infoPlistFallbacks.keys.compactMap {
+                    CodingKeys(stringValue: $0)
+                } ?? []
+            )
+            
+            let missingKeys = Self.requiredKeys.subtracting(givenKeys)
             
             guard missingKeys.isEmpty else {
-                throw TypedValueError.missingRequiredKeys(missingKeys)
+                throw TypedValueError.missingRequiredKeys(
+                    missingKeys.sorted { first, second in
+                        first.rawValue < second.rawValue
+                    }
+                )
             }
             
-            displayName = try infoPlist.typedValue(forKey: .bundleDisplayName)
-            identifier = try infoPlist.typedValue(forKey: .bundleIdentifier)
-            defaultCodeListingLanguage = try? infoPlist.typedValue(forKey: .defaultCodeListingLanaguage)
+            // Now that we've confirmed that all keys are here, begin
+            // by decoding the required keys, throwing an error if we fail to
+            // decode them for some reason.
             
-            if let availabilityPropertyList: [String: [[String: String]]] = try? infoPlist.typedValue(forKey: "CDAppleDefaultAvailability") {
-                defaultAvailability = try DefaultAvailability(parsingPropertyList: availabilityPropertyList)
-            } else {
-                defaultAvailability = nil
-            }
+            self.displayName = try decodeOrFallback(String.self, with: .displayName)
+            self.identifier = try decodeOrFallback(String.self, with: .identifier)
+            self.version = try decodeOrFallback(Version.self, with: .version)
             
-            let versionString: String = try infoPlist.typedValue(forKey: .bundleVersion)
-            guard let version = Version(versionString: versionString) else {
-                throw DocumentationBundle.PropertyListError.invalidVersionString(versionString)
-            }
+            // Finally, decode the optional keys if they're present.
+            
+            self.defaultCodeListingLanguage = try decodeOrFallbackIfPresent(String.self, with: .defaultCodeListingLanguage)
+            self.defaultAvailability = try decodeOrFallbackIfPresent(DefaultAvailability.self, with: .defaultAvailability)
+        }
+        
+        init(
+            displayName: String,
+            identifier: String,
+            version: Version,
+            defaultCodeListingLanguage: String? = nil,
+            defaultAvailability: DefaultAvailability? = nil
+        ) {
+            self.displayName = displayName
+            self.identifier = identifier
             self.version = version
+            self.defaultCodeListingLanguage = defaultCodeListingLanguage
+            self.defaultAvailability = defaultAvailability
         }
     }
 }
 
-fileprivate extension Dictionary where Key == String, Value == Any {
-    func typedValue<T>(forKey key: DocumentationBundle.Info.Key) throws -> T {
-        return try typedValue(forKey: key.rawValue)
-    }
+private extension CodingUserInfoKey {
+    /// A user info key to store bundle discovery options in the decoder.
+    static let bundleDiscoveryOptions = CodingUserInfoKey(rawValue: "bundleDiscoveryOptions")!
 }

--- a/Sources/SwiftDocC/Infrastructure/Workspace/DocumentationWorkspaceDataProvider.swift
+++ b/Sources/SwiftDocC/Infrastructure/Workspace/DocumentationWorkspaceDataProvider.swift
@@ -70,4 +70,34 @@ public struct BundleDiscoveryOptions {
         self.infoPlistFallbacks = infoPlistFallbacks
         self.additionalSymbolGraphFiles = additionalSymbolGraphFiles
     }
+    
+    /// Creates new bundle discovery options with the provided documentation bundle info
+    /// as Info.plist fallback values.
+    ///
+    /// - Parameters:
+    ///   - fallbackInfo: Fallback documentation bundle information to use if any discovered bundles are missing an Info.plist.
+    ///   - additionalSymbolGraphFiles: Additional symbol graph files to augment any discovered bundles.
+    public init(
+        fallbackInfo: DocumentationBundle.Info,
+        additionalSymbolGraphFiles: [URL] = []
+    ) throws {
+        // Use JSONEncoder to dynamically create the Info.plist fallback
+        // dictionary the `BundleDiscoveryOption`s expect from given DocumentationBundle.Info
+        // model.
+        
+        let data = try JSONEncoder().encode(fallbackInfo)
+        let serializedFallbackInfo = try JSONSerialization.jsonObject(with: data)
+        
+        guard let fallbackInfoDictionary = serializedFallbackInfo as? [String: Any] else {
+            throw DocumentationBundle.Info.Error.wrongType(
+                expected: [String: Any].Type.self,
+                actual: type(of: serializedFallbackInfo)
+            )
+        }
+        
+        self.init(
+            infoPlistFallbacks: fallbackInfoDictionary,
+            additionalSymbolGraphFiles: additionalSymbolGraphFiles
+        )
+    }
 }

--- a/Sources/SwiftDocC/Infrastructure/Workspace/GeneratedDataProvider.swift
+++ b/Sources/SwiftDocC/Infrastructure/Workspace/GeneratedDataProvider.swift
@@ -47,15 +47,11 @@ public struct GeneratedDataProvider: DocumentationWorkspaceDataProvider {
         
         return [
             DocumentationBundle(
-                displayName: info.displayName,
-                identifier: info.identifier,
-                version: info.version,
+                info: info,
                 attributedCodeListings: [:],
                 symbolGraphURLs: options.additionalSymbolGraphFiles,
                 markupURLs: [topLevelPage],
-                miscResourceURLs: [],
-                defaultCodeListingLanguage: info.defaultCodeListingLanguage,
-                defaultAvailability: nil
+                miscResourceURLs: []
             )
         ]
     }

--- a/Sources/SwiftDocC/Infrastructure/Workspace/GeneratedDataProvider.swift
+++ b/Sources/SwiftDocC/Infrastructure/Workspace/GeneratedDataProvider.swift
@@ -31,8 +31,7 @@ public struct GeneratedDataProvider: DocumentationWorkspaceDataProvider {
         self.options = options
         self.symbolGraphDataLoader = symbolGraphDataLoader
         do {
-            let info = try DocumentationBundle.Info(plist: options.infoPlistFallbacks)
-            self.info = info
+            self.info = try DocumentationBundle.Info(bundleDiscoveryOptions: options)
         } catch {
             throw Error.notEnoughDataToGenerateBundle(options: options, underlyingError: error)
         }

--- a/Sources/SwiftDocC/Model/Rendering/RenderContentCompiler.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderContentCompiler.swift
@@ -40,7 +40,7 @@ struct RenderContentCompiler: MarkupVisitor {
     
     mutating func visitCodeBlock(_ codeBlock: CodeBlock) -> [RenderContent] {
         // Default to the bundle's code listing syntax if one is not explicitly declared in the code block.
-        return [RenderBlockContent.codeListing(syntax: codeBlock.language ?? bundle.defaultCodeListingLanguage, code: codeBlock.code.splitByNewlines, metadata: nil)]
+        return [RenderBlockContent.codeListing(syntax: codeBlock.language ?? bundle.info.defaultCodeListingLanguage, code: codeBlock.code.splitByNewlines, metadata: nil)]
     }
     
     mutating func visitHeading(_ heading: Heading) -> [RenderContent] {

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -1321,7 +1321,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
         }
         
         // Find default module availability if existing
-        guard let bundleDefaultAvailability = bundle.defaultAvailability,
+        guard let bundleDefaultAvailability = bundle.info.defaultAvailability,
             let moduleAvailability = bundleDefaultAvailability.modules[moduleName] else {
             return nil
         }

--- a/Sources/SwiftDocC/Utility/FoundationExtensions/Dictionary+TypedValues.swift
+++ b/Sources/SwiftDocC/Utility/FoundationExtensions/Dictionary+TypedValues.swift
@@ -11,19 +11,38 @@
 import Foundation
 
 extension Dictionary where Key == String, Value == Any {
-    /// Reads the value for the given key as the requested type.
-    ///
-    /// - Parameter key: The key to read from the dictionary.
-    /// - Throws: A ``TypedValueError/missingValue`` if the value is missing or ``TypedValueError/wrongType`` if the value has the wrong type.
-    /// - Returns: The value for the specified key as the requested type.
-    func typedValue<T>(forKey key: String) throws -> T {
+    /// Returns the value for the given key decoded as the requested type.
+    func decode<T>(_ expectedType: T.Type, forKey key: String) throws -> T where T : Decodable {
         guard let value = self[key] else {
             throw TypedValueError.missingValue(key: key)
         }
-        guard let castedValue = value as? T else {
+        
+        // First attempt to just cast the value as the requested type
+        if let castedValue = value as? T {
+            return castedValue
+        }
+        
+        // If that fails, attempt to decode it. Since we know T is Decodable,
+        // even if the given value cannot be _directly_ cast to T, it's possible
+        // that it can be decoded as T.
+        //
+        // For example, the String "1.0.0" cannot be cast directly to `Version`,
+        // but it can be _decoded_ to `Version`.
+        do {
+            let data = try JSONSerialization.data(withJSONObject: value, options: .fragmentsAllowed)
+            return try JSONDecoder().decode(T.self, from: data)
+        } catch {
+            // Decoding failed as well, throw an error indicating that we were given the wrong type.
             throw TypedValueError.wrongType(key: key, expected: T.self, actual: type(of: value))
         }
-        return castedValue
+    }
+    
+    /// Returns the value for the given key decoded as the requested type, if present.
+    func decodeIfPresent<T>(_ expectedType: T.Type, forKey key: String) throws -> T? where T : Decodable {
+        guard self.keys.contains(key) else {
+            return nil
+        }
+        return try decode(expectedType, forKey: key)
     }
 }
 
@@ -34,7 +53,7 @@ enum TypedValueError: DescribedError {
     /// The requested value is of the wrong type.
     case wrongType(key: String, expected: Any.Type, actual: Any.Type)
     /// One or more required ``DocumentationBundle.Info.Key``s are missing.
-    case missingRequiredKeys([DocumentationBundle.Info.Key])
+    case missingRequiredKeys([DocumentationBundle.Info.CodingKeys])
     
     var errorDescription: String {
         switch self {
@@ -49,8 +68,18 @@ enum TypedValueError: DescribedError {
                 errorMessage += """
                 \n
                 Missing value for \(key.rawValue.singleQuoted).
-                Use the \(key.argumentName.singleQuoted) argument or add \(key.rawValue.singleQuoted) to the bundle Info.plist.
+                
                 """
+                
+                if let argumentName = key.argumentName {
+                    errorMessage += """
+                    Use the \(argumentName.singleQuoted) argument or add \(key.rawValue.singleQuoted) to the bundle Info.plist.
+                    """
+                } else {
+                    errorMessage += """
+                    Add \(key.rawValue.singleQuoted) to the bundle Info.plist.
+                    """
+                }
             }
             
             return errorMessage

--- a/Sources/SwiftDocC/Utility/Version.swift
+++ b/Sources/SwiftDocC/Utility/Version.swift
@@ -9,7 +9,7 @@
 */
 
 /// An arbitrary-length version tuple.
-public struct Version: RandomAccessCollection, ExpressibleByArrayLiteral, CustomStringConvertible, Equatable {
+public struct Version: Codable, RandomAccessCollection, ExpressibleByArrayLiteral, CustomStringConvertible, Equatable {
     private var elements: [Int]
     
     /// The start index of the version-components tuple.
@@ -46,6 +46,24 @@ public struct Version: RandomAccessCollection, ExpressibleByArrayLiteral, Custom
             return nil
         }
         self.elements = intComponents
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let string = try container.decode(String.self)
+        if let versionFromString = Version(versionString: string) {
+            self = versionFromString
+        } else {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Failed to create Version from given string '\(string)'"
+            )
+        }
     }
 
     /// The string representation of the version.

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/ActionExtensions/ConvertAction+CommandInitialization.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/ActionExtensions/ConvertAction+CommandInitialization.swift
@@ -38,16 +38,22 @@ extension ConvertAction {
         // into a dictionary. This will throw with a descriptive error upon failure.
         let parsedPlatforms = try PlatformArgumentParser.parse(convert.platforms)
 
-        var infoPlistFallbacks = [String: Any]()
-        infoPlistFallbacks["CFBundleDisplayName"] = convert.fallbackBundleDisplayName
-        infoPlistFallbacks["CFBundleIdentifier"] = convert.fallbackBundleIdentifier
-        infoPlistFallbacks["CFBundleVersion"] = convert.fallbackBundleVersion
-        infoPlistFallbacks["CDDefaultCodeListingLanguage"] = convert.defaultCodeListingLanguage
-
+        let additionalSymbolGraphFiles = convert.additionalSymbolGraphFiles + symbolGraphFiles(
+            in: convert.additionalSymbolGraphDirectory
+        )
+        
+        let bundleDiscoveryOptions = BundleDiscoveryOptions(
+            fallbackDisplayName: convert.fallbackBundleDisplayName,
+            fallbackIdentifier: convert.fallbackBundleIdentifier,
+            fallbackVersion: convert.fallbackBundleVersion,
+            fallbackDefaultCodeListingLanguage: convert.defaultCodeListingLanguage,
+            additionalSymbolGraphFiles: additionalSymbolGraphFiles
+        )
+        
         // The `preview` and `convert` action defaulting to the current working directory is only supported
         // when running `docc preview` and `docc convert` without any of the fallback options.
         let documentationBundleURL: URL?
-        if infoPlistFallbacks.isEmpty {
+        if bundleDiscoveryOptions.infoPlistFallbacks.isEmpty {
             documentationBundleURL = convert.documentationBundle.urlOrFallback
         } else {
             documentationBundleURL = convert.documentationBundle.url
@@ -66,11 +72,7 @@ extension ConvertAction {
             documentationCoverageOptions: DocumentationCoverageOptions(
                 from: convert.experimentalDocumentationCoverageOptions
             ),
-
-            bundleDiscoveryOptions: BundleDiscoveryOptions(
-                infoPlistFallbacks: infoPlistFallbacks,
-                additionalSymbolGraphFiles: symbolGraphFiles(in: convert.additionalSymbolGraphDirectory) + convert.additionalSymbolGraphFiles
-            ),
+            bundleDiscoveryOptions: bundleDiscoveryOptions,
             diagnosticLevel: convert.diagnosticLevel,
             emitFixits: convert.emitFixits,
             inheritDocs: convert.enableInheritedDocs,

--- a/Tests/SwiftDocCTests/DocumentationService/ConvertService/ConvertServiceTests.swift
+++ b/Tests/SwiftDocCTests/DocumentationService/ConvertService/ConvertServiceTests.swift
@@ -14,6 +14,12 @@ import Foundation
 import SymbolKit
 
 class ConvertServiceTests: XCTestCase {
+    private let testBundleInfo = DocumentationBundle.Info(
+        displayName: "TestBundle",
+        identifier: "identifier",
+        version: Version(versionString: "1.0.0")!
+    )
+    
     func testConvertSinglePage() throws {
         let symbolGraphFile = Bundle.module.url(
             forResource: "mykit-one-symbol",
@@ -24,15 +30,12 @@ class ConvertServiceTests: XCTestCase {
         let symbolGraph = try Data(contentsOf: symbolGraphFile)
         
         let request = ConvertRequest(
+            bundleInfo: testBundleInfo,
             externalIDsToConvert: ["s:5MyKit0A5ClassC10myFunctionyyF"],
             documentPathsToConvert: [],
-            displayName: "TestBundle",
-            identifier: "identifier",
-            version: "1.0.0",
             symbolGraphs: [symbolGraph],
             markupFiles: [],
-            miscResourceURLs: [],
-            defaultCodeListingLanguage: nil
+            miscResourceURLs: []
         )
         
         try processAndAssert(request: request) { message in
@@ -110,15 +113,12 @@ class ConvertServiceTests: XCTestCase {
         let myFunctionExtensionData = try Data(contentsOf: myFunctionExtension)
         
         let request = ConvertRequest(
+            bundleInfo: testBundleInfo,
             externalIDsToConvert: ["s:5MyKit0A5ClassC10myFunctionyyF"],
             documentPathsToConvert: [],
-            displayName: "TestBundle",
-            identifier: "identifier",
-            version: "1.0.0",
             symbolGraphs: [symbolGraph],
             markupFiles: [myFunctionExtensionData],
-            miscResourceURLs: [],
-            defaultCodeListingLanguage: nil
+            miscResourceURLs: []
         )
         
         try processAndAssert(request: request) { message in
@@ -177,15 +177,12 @@ class ConvertServiceTests: XCTestCase {
         )
         
         let request = ConvertRequest(
+            bundleInfo: testBundleInfo,
             externalIDsToConvert: ["s:5MyKit0A5ClassC10myFunctionyyF"],
             documentPathsToConvert: [],
-            displayName: "TestBundle",
-            identifier: "identifier",
-            version: "1.0.0",
             symbolGraphs: [symbolGraph],
             markupFiles: [unrelatedFunctionExtensionData],
-            miscResourceURLs: [],
-            defaultCodeListingLanguage: nil
+            miscResourceURLs: []
         )
         
         try processAndAssert(request: request) { message in
@@ -256,18 +253,15 @@ class ConvertServiceTests: XCTestCase {
         )
         
         let request = ConvertRequest(
+            bundleInfo: testBundleInfo,
             externalIDsToConvert: ["s:5MyKit0A5ClassC10myFunctionyyF"],
             documentPathsToConvert: [],
-            displayName: "TestBundle",
-            identifier: "identifier",
-            version: "1.0.0",
             symbolGraphs: [symbolGraph],
             knownDisambiguatedSymbolPathComponents: [
                 "s:5MyKit0A5ClassC10myFunctionyyF": ["MyClass-swift.class", "myFunction()"]
             ],
             markupFiles: [myFunctionExtensionData],
-            miscResourceURLs: [],
-            defaultCodeListingLanguage: nil
+            miscResourceURLs: []
         )
         
         try processAndAssert(request: request) { message in
@@ -311,18 +305,15 @@ class ConvertServiceTests: XCTestCase {
         let symbolGraph = try Data(contentsOf: symbolGraphFile)
         
         var request = ConvertRequest(
+            bundleInfo: testBundleInfo,
             externalIDsToConvert: ["s:5MyKit0A5ClassC10myFunctionyyF"],
             documentPathsToConvert: [],
-            displayName: "TestBundle",
-            identifier: "identifier",
-            version: "1.0.0",
             symbolGraphs: [symbolGraph],
             knownDisambiguatedSymbolPathComponents: [
                 "s:5MyKit0A5ClassC10myFunctionyyF": ["MyClass-swift.class", "myFunction()"]
             ],
             markupFiles: [],
-            miscResourceURLs: [],
-            defaultCodeListingLanguage: nil
+            miscResourceURLs: []
         )
         
         try processAndAssert(request: request) { message in
@@ -420,18 +411,15 @@ class ConvertServiceTests: XCTestCase {
         let symbolGraph = try Data(contentsOf: symbolGraphFile)
         
         let request = ConvertRequest(
+            bundleInfo: testBundleInfo,
             externalIDsToConvert: ["s:5MyKit0A5ClassC10myFunctionyyF"],
             documentPathsToConvert: [],
-            displayName: "TestBundle",
-            identifier: "com.test.bundle",
-            version: "1.0.0",
             symbolGraphs: [symbolGraph],
             knownDisambiguatedSymbolPathComponents: [
                 "s:5MyKit0A5ClassC10myFunctionyyF": ["MyClass-swift.class", "myFunction()"]
             ],
             markupFiles: [],
-            miscResourceURLs: [],
-            defaultCodeListingLanguage: nil
+            miscResourceURLs: []
         )
         
         let server = DocumentationServer()
@@ -484,11 +472,9 @@ class ConvertServiceTests: XCTestCase {
         let symbolGraph = try Data(contentsOf: symbolGraphFile)
         
         let request = ConvertRequest(
+            bundleInfo: testBundleInfo,
             externalIDsToConvert: ["s:5MyKit0A5ClassC10myFunctionyyF"],
             documentPathsToConvert: [],
-            displayName: "TestBundle",
-            identifier: "identifier",
-            version: "1.0.0",
             symbolGraphs: [symbolGraph],
             knownDisambiguatedSymbolPathComponents: [
                 // Only provide a single path component when this USR should
@@ -496,8 +482,7 @@ class ConvertServiceTests: XCTestCase {
                 "s:5MyKit0A5ClassC10myFunctionyyF": ["MyClass-swift.class"]
             ],
             markupFiles: [],
-            miscResourceURLs: [],
-            defaultCodeListingLanguage: nil
+            miscResourceURLs: []
         )
         
         try processAndAssert(request: request) { message in
@@ -565,15 +550,12 @@ class ConvertServiceTests: XCTestCase {
         let symbolGraph = try Data(contentsOf: symbolGraphFile)
         
         let request = ConvertRequest(
+            bundleInfo: testBundleInfo,
             externalIDsToConvert: nil,
             documentPathsToConvert: nil,
-            displayName: "TestBundle",
-            identifier: "identifier",
-            version: "1.0.0",
             symbolGraphs: [symbolGraph],
             markupFiles: [],
-            miscResourceURLs: [],
-            defaultCodeListingLanguage: nil
+            miscResourceURLs: []
         )
         
         try processAndAssertResponseContents(
@@ -589,16 +571,13 @@ class ConvertServiceTests: XCTestCase {
             forResource: "TestBundle", withExtension: "docc", subdirectory: "Test Bundles")!
                 
         let request = ConvertRequest(
+            bundleInfo: testBundleInfo,
             externalIDsToConvert: nil,
             documentPathsToConvert: nil,
             bundleLocation: testBundleURL,
-            displayName: "TestBundle",
-            identifier: "identifier",
-            version: "1.0.0",
             symbolGraphs: [],
             markupFiles: [],
-            miscResourceURLs: [],
-            defaultCodeListingLanguage: nil
+            miscResourceURLs: []
         )
         
         try processAndAssertResponseContents(
@@ -653,16 +632,13 @@ class ConvertServiceTests: XCTestCase {
             forResource: "TestBundle", withExtension: "docc", subdirectory: "Test Bundles")!
                 
         let request = ConvertRequest(
+            bundleInfo: testBundleInfo,
             externalIDsToConvert: ["s:5MyKit0A5ClassC10myFunctionyyF"],
             documentPathsToConvert: ["/documentation/Test-Bundle/article"],
             bundleLocation: testBundleURL,
-            displayName: "TestBundle",
-            identifier: "identifier",
-            version: "1.0.0",
             symbolGraphs: [],
             markupFiles: [],
-            miscResourceURLs: [],
-            defaultCodeListingLanguage: nil
+            miscResourceURLs: []
         )
         
         try processAndAssertResponseContents(
@@ -680,16 +656,13 @@ class ConvertServiceTests: XCTestCase {
             forResource: "TestBundle", withExtension: "docc", subdirectory: "Test Bundles")!
                 
         let request = ConvertRequest(
+            bundleInfo: testBundleInfo,
             externalIDsToConvert: [],
             documentPathsToConvert: [],
             bundleLocation: testBundleURL,
-            displayName: "TestBundle",
-            identifier: "identifier",
-            version: "1.0.0",
             symbolGraphs: [],
             markupFiles: [],
-            miscResourceURLs: [],
-            defaultCodeListingLanguage: nil
+            miscResourceURLs: []
         )
         
         try processAndAssertResponseContents(
@@ -717,17 +690,14 @@ class ConvertServiceTests: XCTestCase {
         )
         
         let request = ConvertRequest(
+            bundleInfo: testBundleInfo,
             externalIDsToConvert: [],
             documentPathsToConvert: [],
             includeRenderReferenceStore: true,
             bundleLocation: testBundleURL,
-            displayName: "TestBundle",
-            identifier: "identifier",
-            version: "1.0.0",
             symbolGraphs: [],
             markupFiles: [],
-            miscResourceURLs: [],
-            defaultCodeListingLanguage: nil
+            miscResourceURLs: []
         )
         
         try processAndAssertResponseContents(
@@ -846,17 +816,14 @@ class ConvertServiceTests: XCTestCase {
         )
         
         let request = ConvertRequest(
+            bundleInfo: testBundleInfo,
             externalIDsToConvert: [],
             documentPathsToConvert: [],
             includeRenderReferenceStore: true,
             bundleLocation: testBundleURL,
-            displayName: "TestBundle",
-            identifier: "identifier",
-            version: "1.0.0",
             symbolGraphs: [],
             markupFiles: [],
-            miscResourceURLs: [],
-            defaultCodeListingLanguage: nil
+            miscResourceURLs: []
         )
         
         try processAndAssertResponseContents(
@@ -893,17 +860,14 @@ class ConvertServiceTests: XCTestCase {
         )
         
         let request = ConvertRequest(
+            bundleInfo: testBundleInfo,
             externalIDsToConvert: [],
             documentPathsToConvert: [],
             includeRenderReferenceStore: true,
             bundleLocation: testBundleURL,
-            displayName: "TestBundle",
-            identifier: "identifier",
-            version: "1.0.0",
             symbolGraphs: [],
             markupFiles: [],
-            miscResourceURLs: [],
-            defaultCodeListingLanguage: nil
+            miscResourceURLs: []
         )
         
         try processAndAssertResponseContents(
@@ -952,15 +916,16 @@ class ConvertServiceTests: XCTestCase {
         let symbolGraph = try Data(contentsOf: symbolGraphFile)
         
         let request = ConvertRequest(
+            bundleInfo: DocumentationBundle.Info(
+                displayName: "TestBundle",
+                identifier: "com.test.bundle",
+                version: Version(versionString: "1.0.0")!
+            ),
             externalIDsToConvert: ["s:5MyKit0A5ClassC10myFunctionyyF"],
             documentPathsToConvert: [],
-            displayName: "TestBundle",
-            identifier: "com.test.bundle",
-            version: "1.0.0",
             symbolGraphs: [symbolGraph],
             markupFiles: [],
-            miscResourceURLs: [],
-            defaultCodeListingLanguage: nil
+            miscResourceURLs: []
         )
         
         let server = DocumentationServer()
@@ -1237,15 +1202,16 @@ class ConvertServiceTests: XCTestCase {
         let symbolGraph = try Data(contentsOf: symbolGraphFile)
         
         let request = ConvertRequest(
+            bundleInfo: DocumentationBundle.Info(
+                displayName: "TestBundleDisplayName",
+                identifier: "com.test.bundle",
+                version: Version(versionString: "1.0.0")!
+            ),
             externalIDsToConvert: ["s:21SmallTestingFramework40EnumerationWithSingleUnresolvableDocLinkO"],
             documentPathsToConvert: [],
-            displayName: "TestBundleDisplayName",
-            identifier: "com.test.bundle",
-            version: "1.0.0",
             symbolGraphs: [symbolGraph],
             markupFiles: [],
-            miscResourceURLs: [],
-            defaultCodeListingLanguage: nil
+            miscResourceURLs: []
         )
         
         let receivedLinkResolutionRequests = try linkResolutionRequestsForConvertRequest(request)
@@ -1283,15 +1249,16 @@ class ConvertServiceTests: XCTestCase {
         let symbolGraph = try Data(contentsOf: symbolGraphFile)
         
         let request = ConvertRequest(
+            bundleInfo: DocumentationBundle.Info(
+                displayName: "TestBundleDisplayName",
+                identifier: "com.test.bundle",
+                version: Version(versionString: "1.0.0")!
+            ),
             externalIDsToConvert: ["s:21SmallTestingFramework15TestEnumerationO06NesteddE0O0D6StructV06deeplyfD31FunctionWithUnresolvableDocLinkyyF"],
             documentPathsToConvert: [],
-            displayName: "TestBundleDisplayName",
-            identifier: "com.test.bundle",
-            version: "1.0.0",
             symbolGraphs: [symbolGraph],
             markupFiles: [],
-            miscResourceURLs: [],
-            defaultCodeListingLanguage: nil
+            miscResourceURLs: []
         )
         
         let receivedLinkResolutionRequests = try linkResolutionRequestsForConvertRequest(request)
@@ -1322,15 +1289,16 @@ class ConvertServiceTests: XCTestCase {
         let symbolGraph = try Data(contentsOf: symbolGraphFile)
         
         let request = ConvertRequest(
+            bundleInfo: DocumentationBundle.Info(
+                displayName: "TestBundleDisplayName",
+                identifier: "com.test.bundle",
+                version: Version(versionString: "1.0.0")!
+            ),
             externalIDsToConvert: ["s:21SmallTestingFramework43EnumerationWithSingleUnresolvableSymbolLinkO"],
             documentPathsToConvert: [],
-            displayName: "TestBundleDisplayName",
-            identifier: "com.test.bundle",
-            version: "1.0.0",
             symbolGraphs: [symbolGraph],
             markupFiles: [],
-            miscResourceURLs: [],
-            defaultCodeListingLanguage: nil
+            miscResourceURLs: []
         )
         
         let receivedLinkResolutionRequests = try linkResolutionRequestsForConvertRequest(request)
@@ -1421,14 +1389,11 @@ class ConvertServiceTests: XCTestCase {
     
     func testReturnsErrorWhenConversionThrows() throws {
         let request = ConvertRequest(
+            bundleInfo: testBundleInfo,
             externalIDsToConvert: nil,
-            displayName: "TestBundle",
-            identifier: "identifier",
-            version: "1.0.0",
             symbolGraphs: [],
             markupFiles: [],
-            miscResourceURLs: [],
-            defaultCodeListingLanguage: nil
+            miscResourceURLs: []
         )
         
         try processAndAssert(
@@ -1446,14 +1411,11 @@ class ConvertServiceTests: XCTestCase {
     
     func testReturnsErrorWhenConversionHasProblems() throws {
         let request = ConvertRequest(
+            bundleInfo: testBundleInfo,
             externalIDsToConvert: nil,
-            displayName: "TestBundle",
-            identifier: "identifier",
-            version: "1.0.0",
             symbolGraphs: [],
             markupFiles: [],
-            miscResourceURLs: [],
-            defaultCodeListingLanguage: nil
+            miscResourceURLs: []
         )
         
         let testProblem = Problem(

--- a/Tests/SwiftDocCTests/DocumentationService/DocumentationServer+DefaultTests.swift
+++ b/Tests/SwiftDocCTests/DocumentationService/DocumentationServer+DefaultTests.swift
@@ -9,7 +9,7 @@
 */
 
 import XCTest
-import SwiftDocC
+@testable import SwiftDocC
 
 class DocumentationServer_DefaultTests: XCTestCase {
     func testCreatesDefaultServerWithSpecifiedQualityOfService() {
@@ -66,14 +66,15 @@ class DocumentationServer_DefaultTests: XCTestCase {
         let symbolGraph = try Data(contentsOf: symbolGraphFile)
         
         let request = ConvertRequest(
+            bundleInfo: DocumentationBundle.Info(
+                displayName: "TestBundle",
+                identifier: "identifier",
+                version: Version(versionString: "1.0.0")!
+            ),
             externalIDsToConvert: ["s:5MyKit0A5ClassC10myFunctionyyF"],
-            displayName: "TestBundle",
-            identifier: "com.test.bundle",
-            version: "1.0.0",
             symbolGraphs: [symbolGraph],
             markupFiles: [],
-            miscResourceURLs: [],
-            defaultCodeListingLanguage: nil
+            miscResourceURLs: []
         )
         
         let message = DocumentationServer.Message(

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationBundleInfoTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationBundleInfoTests.swift
@@ -189,4 +189,69 @@ class DocumentationBundleInfoTests: XCTestCase {
             infoPlist
         )
     }
+    
+    func testFallbackToBundleDiscoveryOptions() throws {
+        let bundleDiscoveryOptions = BundleDiscoveryOptions(
+            fallbackDisplayName: "Display Name",
+            fallbackIdentifier: "swift.org.Identifier",
+            fallbackVersion: "1.0.0",
+            fallbackDefaultCodeListingLanguage: "swift",
+            fallbackDefaultAvailability: DefaultAvailability(
+                with: [
+                    "MyModule": [
+                        DefaultAvailability.ModuleAvailability(
+                            platformName: .iOS,
+                            platformVersion: "7.0.0"
+                        )
+                    ]
+                ]
+            )
+        )
+        
+        let info = try DocumentationBundle.Info(bundleDiscoveryOptions: bundleDiscoveryOptions)
+        XCTAssertEqual(
+            info,
+            DocumentationBundle.Info(
+                displayName: "Display Name",
+                identifier: "swift.org.Identifier",
+                version: Version(arrayLiteral: 1,0,0),
+                defaultCodeListingLanguage: "swift",
+                defaultAvailability: DefaultAvailability(
+                    with: [
+                        "MyModule": [
+                            DefaultAvailability.ModuleAvailability(
+                                platformName: .iOS,
+                                platformVersion: "7.0.0"
+                            )
+                        ]
+                    ]
+                )
+            )
+        )
+    }
+    
+    func testFallbackToInfoInBundleDiscoveryOptions() throws {
+        let info = DocumentationBundle.Info(
+            displayName: "Display Name",
+            identifier: "swift.org.Identifier",
+            version: Version(arrayLiteral: 1,0,0),
+            defaultCodeListingLanguage: "swift",
+            defaultAvailability: DefaultAvailability(
+                with: [
+                    "MyModule": [
+                        DefaultAvailability.ModuleAvailability(
+                            platformName: .iOS,
+                            platformVersion: "7.0.0"
+                        )
+                    ]
+                ]
+            )
+        )
+        
+        let bundleDiscoveryOptions = try BundleDiscoveryOptions(fallbackInfo: info)
+        XCTAssertEqual(
+            info,
+            try DocumentationBundle.Info(bundleDiscoveryOptions: bundleDiscoveryOptions)
+        )
+    }
 }

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationWorkspaceTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationWorkspaceTests.swift
@@ -9,7 +9,7 @@
 */
 
 import XCTest
-import SwiftDocC
+@testable import SwiftDocC
 
 class DocumentationWorkspaceTests: XCTestCase {
     func testEmptyWorkspace() {
@@ -145,7 +145,16 @@ class DocumentationWorkspaceTests: XCTestCase {
         }
         
         static func bundle(_ suffix: String) -> DocumentationBundle {
-            return DocumentationBundle(displayName: "Test" + suffix, identifier: "com.example.test" + suffix, version: Version(versionString: "0.1.0")!, symbolGraphURLs: [testSymbolGraphFile], markupURLs: [testMarkupFile], miscResourceURLs: [testResourceFile], defaultCodeListingLanguage: nil)
+            return DocumentationBundle(
+                info: DocumentationBundle.Info(
+                    displayName: "Test" + suffix,
+                    identifier: "com.example.test" + suffix,
+                    version: Version(versionString: "0.1.0")!
+                ),
+                symbolGraphURLs: [testSymbolGraphFile],
+                markupURLs: [testMarkupFile],
+                miscResourceURLs: [testResourceFile]
+            )
         }
         
         static let bundle1 = bundle("1")

--- a/Tests/SwiftDocCTests/Infrastructure/PresentationURLGeneratorTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/PresentationURLGeneratorTests.swift
@@ -35,7 +35,17 @@ class PresentationURLGeneratorTests: XCTestCase {
     }
     
     func testExternalURLs() throws {
-        let bundle = DocumentationBundle(displayName: "Test", identifier: "com.example.test", version: Version(versionString: "1.0")!, baseURL: URL(string: "https://example.com/example")!, symbolGraphURLs: [], markupURLs: [], miscResourceURLs: [], defaultCodeListingLanguage: nil)
+        let bundle = DocumentationBundle(
+            info: DocumentationBundle.Info(
+                displayName: "Test",
+                identifier: "com.example.test",
+                version: Version(versionString: "1.0")!
+            ),
+            baseURL: URL(string: "https://example.com/example")!,
+            symbolGraphURLs: [],
+            markupURLs: [],
+            miscResourceURLs: []
+        )
         
         let provider = PrebuiltLocalFileSystemDataProvider(bundles: [bundle])
         
@@ -77,7 +87,17 @@ class PresentationURLGeneratorTests: XCTestCase {
             }
         }
         
-        let bundle = DocumentationBundle(displayName: "Test", identifier: "com.example.test", version: Version(versionString: "1.0")!, baseURL: URL(string: "https://example.com/example")!, symbolGraphURLs: [], markupURLs: [], miscResourceURLs: [], defaultCodeListingLanguage: nil)
+        let bundle = DocumentationBundle(
+            info: DocumentationBundle.Info(
+                displayName: "Test",
+                identifier: "com.example.test",
+                version: Version(versionString: "1.0")!
+            ),
+            baseURL: URL(string: "https://example.com/example")!,
+            symbolGraphURLs: [],
+            markupURLs: [],
+            miscResourceURLs: []
+        )
         let provider = PrebuiltLocalFileSystemDataProvider(bundles: [bundle])
         
         let workspace = DocumentationWorkspace()

--- a/Tests/SwiftDocCTests/Infrastructure/SymbolGraph/SymbolGraphLoaderTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/SymbolGraph/SymbolGraphLoaderTests.swift
@@ -352,9 +352,12 @@ class SymbolGraphLoaderTests: XCTestCase {
     private func makeSymbolGraphLoader(symbolGraphURLs: [URL]) throws -> SymbolGraphLoader {
         let workspace = DocumentationWorkspace()
         let bundle = DocumentationBundle(
-            displayName: "Test",
-            identifier: "com.example.test",
-            version: Version(arrayLiteral: 1,2,3),
+            info: DocumentationBundle.Info(
+                displayName: "Test",
+                identifier: "com.example.test",
+                version: Version(arrayLiteral: 1,2,3)
+            ),
+            baseURL: URL(string: "https://example.com/example")!,
             symbolGraphURLs: symbolGraphURLs,
             markupURLs: [],
             miscResourceURLs: []

--- a/Tests/SwiftDocCTests/Rendering/DefaultAvailabilityTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/DefaultAvailabilityTests.swift
@@ -18,7 +18,7 @@ class DefaultAvailabilityTests: XCTestCase {
     // Test whether missing default availability key correctly produces nil availability
     func testBundleWithoutDefaultAvailability() {
         let bundle = testBundle(named: "BundleWithoutAvailability")
-        XCTAssertNil(bundle.defaultAvailability)
+        XCTAssertNil(bundle.info.defaultAvailability)
     }
 
     // Test resource with default availability included
@@ -40,10 +40,10 @@ class DefaultAvailabilityTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: url) }
         
         // Verify the bundle has loaded the default availability
-        XCTAssertEqual(bundle.defaultAvailability?.modules["MyKit"]?.map({ "\($0.platformName.displayName) \($0.platformVersion)" }).sorted(), expectedDefaultAvailability)
+        XCTAssertEqual(bundle.info.defaultAvailability?.modules["MyKit"]?.map({ "\($0.platformName.displayName) \($0.platformVersion)" }).sorted(), expectedDefaultAvailability)
         
         // Bail the rendering part of the test if the availability hasn't been loaded
-        guard bundle.defaultAvailability != nil else {
+        guard bundle.info.defaultAvailability != nil else {
             return
         }
         

--- a/Tests/SwiftDocCTests/Rendering/DefaultAvailabilityTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/DefaultAvailabilityTests.swift
@@ -282,7 +282,13 @@ class DefaultAvailabilityTests: XCTestCase {
                 ]
             ]
         ]
-        let defaultAvailability = try DefaultAvailability(parsingPropertyList: plistEntries)
+        
+        let plistData = try PropertyListEncoder().encode(plistEntries)
+        let defaultAvailability = try PropertyListDecoder().decode(
+            DefaultAvailability.self,
+            from: plistData
+        )
+        
         let module = try XCTUnwrap(defaultAvailability.modules["SwiftUI"])
         XCTAssertEqual(module.count, 5)
         XCTAssertEqual(module.filter({ $0.platformName.displayName == "Mac Catalyst" }).count, 1)
@@ -313,7 +319,12 @@ class DefaultAvailabilityTests: XCTestCase {
                 ]
             ]
         ]
-        let defaultAvailability = try DefaultAvailability(parsingPropertyList: plistEntries)
+        let plistData = try PropertyListEncoder().encode(plistEntries)
+        let defaultAvailability = try PropertyListDecoder().decode(
+            DefaultAvailability.self,
+            from: plistData
+        )
+        
         let module = try XCTUnwrap(defaultAvailability.modules["SwiftUI"])
         XCTAssertEqual(module.count, 5)
         XCTAssertEqual(module.filter({ $0.platformName.displayName == "Mac Catalyst" }).count, 1)

--- a/Tests/SwiftDocCTests/Rendering/DefaultCodeListingSyntaxTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/DefaultCodeListingSyntaxTests.swift
@@ -45,15 +45,17 @@ class DefaultCodeBlockSyntaxTests: XCTestCase {
 
         // Copy the bundle but explicitly set `defaultCodeListingLanguage` to `nil` to mimic having no default language set.
         testBundleWithoutLanguageDefault = DocumentationBundle(
-            displayName: testBundleWithLanguageDefault.displayName,
-            identifier: testBundleWithLanguageDefault.identifier,
-            version: testBundleWithLanguageDefault.version,
+            info: DocumentationBundle.Info(
+                displayName: testBundleWithLanguageDefault.displayName,
+                identifier: testBundleWithLanguageDefault.identifier,
+                version: testBundleWithLanguageDefault.version,
+                defaultCodeListingLanguage: nil
+            ),
             baseURL: testBundleWithLanguageDefault.baseURL,
             attributedCodeListings: testBundleWithLanguageDefault.attributedCodeListings,
             symbolGraphURLs: testBundleWithLanguageDefault.symbolGraphURLs,
             markupURLs: testBundleWithLanguageDefault.markupURLs,
-            miscResourceURLs: testBundleWithLanguageDefault.miscResourceURLs,
-            defaultCodeListingLanguage: nil
+            miscResourceURLs: testBundleWithLanguageDefault.miscResourceURLs
         )
 
         renderSectionWithLanguageDefault = renderSection(for: testBundleWithLanguageDefault, in: context)

--- a/Tests/SwiftDocCUtilitiesTests/Utility/TestFileSystem.swift
+++ b/Tests/SwiftDocCUtilitiesTests/Utility/TestFileSystem.swift
@@ -89,7 +89,18 @@ class TestFileSystem: FileManagerProtocol, DocumentationWorkspaceDataProvider {
                 let customHeader = files.first(where: { DocumentationBundleFileTypes.isCustomHeader($0) })
                 let customFooter = files.first(where: { DocumentationBundleFileTypes.isCustomFooter($0) })
                 
-                let bundle = DocumentationBundle(displayName: info.content.displayName, identifier: info.content.identifier, version: Version(versionString: info.content.versionString)!, symbolGraphURLs: graphs, markupURLs: markupFiles, miscResourceURLs: miscFiles, customHeader: customHeader, customFooter: customFooter)
+                let bundle = DocumentationBundle(
+                    info: DocumentationBundle.Info(
+                        displayName: info.content.displayName,
+                        identifier: info.content.identifier,
+                        version: Version(versionString: info.content.versionString)!
+                    ),
+                    symbolGraphURLs: graphs,
+                    markupURLs: markupFiles,
+                    miscResourceURLs: miscFiles,
+                    customHeader: customHeader,
+                    customFooter: customFooter
+                )
                 _bundles.append(bundle)
             }
         }


### PR DESCRIPTION
## Summary

This work refactors the existing logic for handling DocumentationBundle Info to make it easier to add new configuration options moving forward.

## Details

1. Use DocumentationBundle.Info to pass around bundle info. 

    Currently we pass around DocumentationBundle Info as function parameters in a multitude of places. This means that when we add a new property to the `DocumentationBundle.Info` model, we have to add new function parameters in several places across the codebase. It's easy to miss some of these and I think likely to introduce bugs in the future.

   We already have a model for handling documentation bundle info, so this just updates a number of calling sites to rely on passing around the DocumentationBundle.Info directly instead of its properties.

   This change is isolated in this commit c357b35 with another commit here (1c850a6) that addresses deprecation warnings.

2. Use Codable to parse the Info.plist

    I believe when this code was originally written, `PropertyListEncoder` was macOS only so we relied on using `PropertyListSerialization` directly instead.

    `PropertyListEncoder` is now supported on Linux so I refactored the DocumentationBundle.Info models to be Codable which simplifies a lot of our logic here.

    That change is isolated here 2e5658d.

3. Use a strongly-typed API for creating bundle discovery options

    The bundle discovery options are intentionally stringly-typed so that we can easily add new info plist fields and have clients adopt them immediately. However, there's no reason for us to be using the stringly-typed API within DocC itself. This led to some unnecessary duplication of the Info.plist keys.

    This change is isolated to this commit 22c6c80 and just adds some convenience initializers to the bundle discovery options to reduce duplication of the Info.plist keys in DocC itself.

## Dependencies

None.

## Testing

Perform basic regression testing. No functionality change is expected.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
