### PR TITLE
Use SymbolKit's "unified symbol graph" representation when loading symbol graphs

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -33,7 +33,7 @@
         "repositoryURL": "https://github.com/apple/swift-docc-symbolkit",
         "state": {
           "branch": "main",
-          "revision": "b76b8d683d9e406287d3ffb3f340f5bb745ea2ee",
+          "revision": "cdaf2be26bca2a24d788cd58449348ef6e66ba87",
           "version": null
         }
       },

--- a/Sources/SwiftDocC/DocumentationService/Convert/ConvertService.swift
+++ b/Sources/SwiftDocC/DocumentationService/Convert/ConvertService.swift
@@ -115,6 +115,10 @@ public struct ConvertService: DocumentationService {
         messageIdentifier: String
     ) -> Result<([RenderNode], RenderReferenceStore?), ConvertServiceError> {
         Result {
+            // Update DocC's current feature flags based on the ones provided
+            // in the request.
+            FeatureFlags.current = request.featureFlags
+            
             // Set up the documentation context.
 
             let workspace = DocumentationWorkspace()

--- a/Sources/SwiftDocC/DocumentationService/Models/Services/Convert/ConvertRequest.swift
+++ b/Sources/SwiftDocC/DocumentationService/Models/Services/Convert/ConvertRequest.swift
@@ -19,6 +19,9 @@ public struct ConvertRequest: Codable {
     /// - ``DocumentationBundle/Info-swift.struct``
     public var bundleInfo: DocumentationBundle.Info
     
+    /// Feature flags to enable when performing this convert request.
+    public var featureFlags: FeatureFlags
+    
     /// The external IDs of the symbols to convert.
     ///
     /// Use this property to indicate what symbol documentation nodes should be converted. When ``externalIDsToConvert``
@@ -151,6 +154,7 @@ public struct ConvertRequest: Codable {
         self.knownDisambiguatedSymbolPathComponents = knownDisambiguatedSymbolPathComponents
         self.markupFiles = markupFiles
         self.miscResourceURLs = miscResourceURLs
+        self.featureFlags = FeatureFlags()
         
         self.bundleInfo = DocumentationBundle.Info(
             displayName: displayName,
@@ -174,6 +178,7 @@ public struct ConvertRequest: Codable {
     ///   - miscResourceURLs: The on-disk resources in the documentation bundle to convert.
     public init(
         bundleInfo: DocumentationBundle.Info,
+        featureFlags: FeatureFlags = FeatureFlags(),
         externalIDsToConvert: [String]?,
         documentPathsToConvert: [String]? = nil,
         includeRenderReferenceStore: Bool? = nil,
@@ -192,5 +197,6 @@ public struct ConvertRequest: Codable {
         self.markupFiles = markupFiles
         self.miscResourceURLs = miscResourceURLs
         self.bundleInfo = bundleInfo
+        self.featureFlags = featureFlags
     }
 }

--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -949,7 +949,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
     
     private func referenceFor(_ symbol: UnifiedSymbolGraph.Symbol, moduleName: String, bundle: DocumentationBundle, shouldAddHash: Bool = false, shouldAddKind: Bool = false) -> ResolvedTopicReference {
         let identifier = symbol.swiftIdentifier
-        let selector = symbol.swiftSelector!
+        let selector = symbol.defaultSelector!
         let language = SourceLanguage(id: identifier.interfaceLanguage)
         
         let symbolReference: SymbolReference
@@ -1012,7 +1012,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
     private func addSymbolsToTopicGraph(symbolGraph: UnifiedSymbolGraph, url: URL?, symbolReferences: [SymbolGraph.Symbol.Identifier : ResolvedTopicReference], bundle: DocumentationBundle) {
         let symbols = Array(symbolGraph.symbols.values)
         let results: [AddSymbolResultWithProblems] = symbols.concurrentPerform { symbol, results in
-            if let selector = symbol.swiftSelector, let module = symbol.modules[selector] {
+            if let selector = symbol.defaultSelector, let module = symbol.modules[selector] {
                 let reference = symbolReferences[symbol.swiftIdentifier]!
                 let result = preparedSymbolData(
                     symbol,
@@ -1382,7 +1382,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
         let mergeError = Synchronized<Error?>(nil)
         
         let results: [AddSymbolResultWithProblems] = Array(otherSymbolGraph.symbols.values).concurrentPerform { symbol, result in
-            guard let defaultSymbol = symbol.defaultSymbol, let swiftSelector = symbol.swiftSelector, let module = symbol.modules[swiftSelector] else {
+            guard let defaultSymbol = symbol.defaultSymbol, let swiftSelector = symbol.defaultSelector, let module = symbol.modules[swiftSelector] else {
                 fatalError("""
                     Only Swift symbols are currently supported. \
                     This initializer is only called with symbols from the symbol graph, which currently only supports Swift.

--- a/Sources/SwiftDocC/Infrastructure/External Data/ExternalSymbolResolver+SymbolKind.swift
+++ b/Sources/SwiftDocC/Infrastructure/External Data/ExternalSymbolResolver+SymbolKind.swift
@@ -25,7 +25,7 @@ extension ExternalSymbolResolver {
     /// everything should work as expected in practice — covering the exceptions with the known values and having "any symbol"
     /// value for the rest.
     static func symbolKind(forNodeKind kind: DocumentationNode.Kind) -> SymbolGraph.Symbol.Kind {
-        let symbolKind: SymbolGraph.Symbol.Kind.Swift
+        let symbolKind: SymbolGraph.Symbol.KindIdentifier
         
         switch kind {
         case .associatedType:
@@ -75,6 +75,6 @@ extension ExternalSymbolResolver {
             symbolKind = .class
         }
         
-        return .init(identifier: symbolKind.rawValue, displayName: kind.name)
+        return .init(parsedIdentifier: symbolKind, displayName: kind.name)
     }
 }

--- a/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphLoader.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphLoader.swift
@@ -71,6 +71,14 @@ struct SymbolGraphLoader {
                 case .concurrentlyEachFileInBatches:
                     symbolGraph = try SymbolGraphConcurrentDecoder.decode(data)
                 }
+                
+                if let firstSymbolLanguage = symbolGraph.symbols.first?.value.identifier.interfaceLanguage {
+                    guard FeatureFlags.current.isExperimentalObjectiveCSupportEnabled
+                            || InterfaceLanguage.from(string: firstSymbolLanguage) == .swift
+                    else {
+                        return
+                    }
+                }
 
                 // `moduleNameFor(_:at:)` is static because it's pure function.
                 let (moduleName, _) = Self.moduleNameFor(symbolGraph, at: symbolGraphURL)

--- a/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphRelationshipsBuilder.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphRelationshipsBuilder.swift
@@ -142,14 +142,14 @@ struct SymbolGraphRelationshipsBuilder {
         let relationshipConstraints = edge.mixins[SymbolGraph.Relationship.Swift.GenericConstraints.mixinKey] as? SymbolGraph.Relationship.Swift.GenericConstraints
 
         // Add relationships depending whether it's class inheritance or protocol conformance
-        if conformingSymbol.kind.identifier == SymbolGraph.Symbol.Kind.Swift.protocol.rawValue {
+        if conformingSymbol.kind.identifier == .protocol {
             conformingSymbol.relationships.addRelationship(.inheritsFrom(conformanceNodeReference))
         } else {
             conformingSymbol.relationships.addRelationship(.conformsTo(conformanceNodeReference, relationshipConstraints?.constraints))
         }
         
         if let conformanceSymbol = optionalConformanceNode?.semantic as? Symbol {
-            if let rawSymbol = conformingNode.symbol, rawSymbol.kind.identifier == SymbolGraph.Symbol.Kind.Swift.protocol.rawValue {
+            if let rawSymbol = conformingNode.symbol, rawSymbol.kind.identifier == .protocol {
                 conformanceSymbol.relationships.addRelationship(.inheritedBy(.successfullyResolved(conformingNode.reference)))
             } else {
                 conformanceSymbol.relationships.addRelationship(.conformingType(.successfullyResolved(conformingNode.reference), relationshipConstraints?.constraints))

--- a/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolReference.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolReference.swift
@@ -22,11 +22,7 @@ extension String {
 public struct SymbolReference {
     /// Returns `true` if the symbol is a known graph leaf symbol.
     static func isLeaf(_ symbol: SymbolGraph.Symbol) -> Bool {
-        guard let swiftKind = SymbolGraph.Symbol.Kind.Swift(rawValue: symbol.kind.identifier) else {
-            return true
-        }
-        
-        return !swiftKind.symbolCouldHaveChildren
+        return !symbol.kind.identifier.swiftSymbolCouldHaveChildren
     }
     
     /// Creates a new reference to a symbol.
@@ -56,7 +52,7 @@ public struct SymbolReference {
         }
 
         // A module reference does not have path as it's a root symbol in the topic graph.
-        if symbol.kind.identifier == SymbolGraph.Symbol.Kind.Swift.module.rawValue {
+        if symbol.kind.identifier == SymbolGraph.Symbol.KindIdentifier.module {
             path = ""
             return
         }
@@ -64,7 +60,7 @@ public struct SymbolReference {
         var name = symbol.pathComponents.joinedSymbolPathComponents
 
         if shouldAddKind {
-            name = name.appending("-\(symbol.kind.identifier)")
+            name = name.appending("-\(symbol.identifier.interfaceLanguage).\(symbol.kind.identifier.identifier)")
         }
         if shouldAddHash {
             name = name.appendingHashedIdentifier(identifier)

--- a/Sources/SwiftDocC/Infrastructure/Symbol Link Resolution/AbsoluteSymbolLink.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Link Resolution/AbsoluteSymbolLink.swift
@@ -224,10 +224,10 @@ extension AbsoluteSymbolLink.LinkComponent {
         case kindAndPreciseIdentifier(
             kindIdentifier: String, preciseIdentifierHash: String
         )
-        
-        private static let knownSymbolKindIdentifiers: Set<String> = {
-            Set(SymbolGraph.Symbol.Kind.Swift.allCases.map(\.rawValue))
-        }()
+
+        private static func isKnownSymbolKindIdentifier(identifier: String) -> Bool {
+            return SymbolGraph.Symbol.KindIdentifier.isKnownIdentifier(identifier)
+        }
         
         /// Creates a disambiguation suffix based on the given kind and precise
         /// identifiers.
@@ -261,7 +261,7 @@ extension AbsoluteSymbolLink.LinkComponent {
             if splitSuffix.count == 1 && splitSuffix[0] == string {
                 // The string didn't contain a "-" so now we check
                 // to see if the hash is a known symbol kind identifier.
-                if Self.knownSymbolKindIdentifiers.contains(string) {
+                if Self.isKnownSymbolKindIdentifier(identifier: string) {
                     self = .kindIdentifier(string)
                 } else {
                     // Since we've confirmed that it's not a symbol kind identifier
@@ -274,7 +274,7 @@ extension AbsoluteSymbolLink.LinkComponent {
                 //
                 // We expect the symbol kind identifier to come first, followed
                 // by a hash of the symbol's precise identifier.
-                if Self.knownSymbolKindIdentifiers.contains(String(splitSuffix[0])) {
+                if Self.isKnownSymbolKindIdentifier(identifier: String(splitSuffix[0])) {
                     self = .kindAndPreciseIdentifier(
                         kindIdentifier: String(splitSuffix[0]),
                         preciseIdentifierHash: String(splitSuffix[1])

--- a/Sources/SwiftDocC/Infrastructure/Symbol Link Resolution/DocCSymbolRepresentable.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Link Resolution/DocCSymbolRepresentable.swift
@@ -182,3 +182,29 @@ extension SymbolGraph.Symbol: DocCSymbolRepresentable {
         lhs.identifier.precise == rhs.identifier.precise
     }
 }
+
+extension UnifiedSymbolGraph.Symbol: DocCSymbolRepresentable {
+    public var preciseIdentifier: String? {
+        self.uniqueIdentifier
+    }
+
+    public var title: String {
+        guard let selector = self.swiftSelector else {
+            fatalError("only Swift is supported for now")
+        }
+
+        return self.names[selector]!.title
+    }
+
+    public var kindIdentifier: String? {
+        guard let selector = self.swiftSelector else {
+            fatalError("only Swift is supported for now")
+        }
+
+        return "\(selector.interfaceLanguage).\(self.kind[selector]!.identifier.identifier)"
+    }
+
+    public static func == (lhs: UnifiedSymbolGraph.Symbol, rhs: UnifiedSymbolGraph.Symbol) -> Bool {
+        lhs.uniqueIdentifier == rhs.uniqueIdentifier
+    }
+}

--- a/Sources/SwiftDocC/Infrastructure/Symbol Link Resolution/DocCSymbolRepresentable.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Link Resolution/DocCSymbolRepresentable.swift
@@ -189,16 +189,24 @@ extension UnifiedSymbolGraph.Symbol: DocCSymbolRepresentable {
     }
 
     public var title: String {
-        guard let selector = self.swiftSelector else {
-            fatalError("only Swift is supported for now")
+        guard let selector = self.defaultSelector else {
+            fatalError("""
+                Failed to find a supported default selector. \
+                Language unsupported or corrupt symbol graph provided.
+                """
+            )
         }
 
         return self.names[selector]!.title
     }
 
     public var kindIdentifier: String? {
-        guard let selector = self.swiftSelector else {
-            fatalError("only Swift is supported for now")
+        guard let selector = self.defaultSelector else {
+            fatalError("""
+                Failed to find a supported default selector. \
+                Language unsupported or corrupt symbol graph provided.
+                """
+            )
         }
 
         return "\(selector.interfaceLanguage).\(self.kind[selector]!.identifier.identifier)"

--- a/Sources/SwiftDocC/Infrastructure/Symbol Link Resolution/DocCSymbolRepresentable.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Link Resolution/DocCSymbolRepresentable.swift
@@ -175,7 +175,7 @@ extension SymbolGraph.Symbol: DocCSymbolRepresentable {
     }
     
     public var kindIdentifier: String? {
-        self.kind.identifier
+        "\(self.identifier.interfaceLanguage).\(self.kind.identifier.identifier)"
     }
     
     public static func == (lhs: SymbolGraph.Symbol, rhs: SymbolGraph.Symbol) -> Bool {

--- a/Sources/SwiftDocC/Infrastructure/Topic Graph/AutomaticCuration.swift
+++ b/Sources/SwiftDocC/Infrastructure/Topic Graph/AutomaticCuration.swift
@@ -28,7 +28,7 @@ public struct AutomaticCuration {
     }
     
     /// A mapping between a symbol kind and its matching group.
-    typealias ReferenceGroupIndex = [SymbolGraph.Symbol.Kind.Swift: ReferenceGroup]
+    typealias ReferenceGroupIndex = [SymbolGraph.Symbol.KindIdentifier: ReferenceGroup]
     
     /// A static list of predefined groups for each supported kind of symbol.
     static var groups: ReferenceGroupIndex {
@@ -65,12 +65,9 @@ public struct AutomaticCuration {
                 }
                 
                 let childNode = try context.entity(with: child.reference)
-                guard let childSymbol = childNode.semantic as? Symbol,
-                    let swiftKind = SymbolGraph.Symbol.Kind.Swift(rawValue: childSymbol.kind.identifier) else {
-                    return
+                if let childSymbol = childNode.semantic as? Symbol {
+                    groupsIndex[childSymbol.kind.identifier]?.references.append(child.reference)
                 }
-                
-                groupsIndex[swiftKind]?.references.append(child.reference)
             }
             .lazy
             // Sort the groups in the order intended for rendering
@@ -137,7 +134,7 @@ extension AutomaticCuration {
     /// Returns a topics group title for the given symbol kind.
     /// - Parameter symbolKind: A symbol kind, such as a protocol or a variable.
     /// - Returns: A group title for symbols of the given kind.
-    static func groupTitle(`for` symbolKind: SymbolGraph.Symbol.Kind.Swift) -> String {
+    static func groupTitle(`for` symbolKind: SymbolGraph.Symbol.KindIdentifier) -> String {
         switch symbolKind {
             case .`associatedtype`: return "Associated Types"
             case .`class`: return "Classes"
@@ -158,11 +155,12 @@ extension AutomaticCuration {
             case .`typealias`: return "Type Aliases"
             case .`var`: return "Variables"
             case .module: return "Modules"
+            case .unknown: return "Symbols"
         }
     }
 
     /// The order of symbol kinds when grouped automatically.
-    static let groupKindOrder: [SymbolGraph.Symbol.Kind.Swift] = [
+    static let groupKindOrder: [SymbolGraph.Symbol.KindIdentifier] = [
         .module,
 
         .`class`,

--- a/Sources/SwiftDocC/Infrastructure/Topic Graph/TopicGraph.swift
+++ b/Sources/SwiftDocC/Infrastructure/Topic Graph/TopicGraph.swift
@@ -30,7 +30,8 @@ struct TopicGraph {
     class Node: Hashable, CustomDebugStringConvertible {
         /// The location of the node's contents.
         enum ContentLocation: Hashable {
-            
+
+            // TODO: make this take multiple URLs?
             /// The node exists as a whole file at some URL.
             case file(url: URL)
             

--- a/Sources/SwiftDocC/Model/DocumentationNode.swift
+++ b/Sources/SwiftDocC/Model/DocumentationNode.swift
@@ -324,34 +324,32 @@ public struct DocumentationNode {
     /// - Parameter symbol: A symbol graph symbol.
     /// - Returns: A documentation node kind.
     static func kind(for symbol: SymbolGraph.Symbol) -> Kind {
-        // To be able to rely on this conversion from Swift kind to documentation kind,
-        // we need to get an exhaustive kind list from SymbolKit. The list below is
-        // less than complete with the current kind list (rdar://60264979).
-        if let swiftSymbolKind = SymbolGraph.Symbol.Kind.Swift(rawValue: symbol.kind.identifier) {
-            switch swiftSymbolKind  {
-            case .`associatedtype`: return .associatedType
-            case .`class`: return .class
-            case .`deinit`: return .deinitializer
-            case .`enum`: return .enumeration
-            case .`case`: return .enumerationCase
-            case .`func`: return .function
-            case .`operator`: return .operator
-            case .`init`: return .initializer
-            case .`method`: return .instanceMethod
-            case .`property`: return .instanceProperty
-            case .`protocol`: return .protocol
-            case .`struct`: return .structure
-            case .`subscript`: return .instanceSubscript
-            case .`typeMethod`: return .typeMethod
-            case .`typeProperty`: return .typeProperty
-            case .`typeSubscript`: return .typeSubscript
-            case .`typealias`: return .typeAlias
-            case .`var`: return .globalVariable
-                
-            case .module: return .module
-            }
-        } else {
-            return .unknown
+        return Self.kind(forKind: symbol.kind.identifier)
+    }
+
+    static func kind(forKind symbolKind: SymbolGraph.Symbol.KindIdentifier) -> Kind {
+        switch symbolKind  {
+        case .`associatedtype`: return .associatedType
+        case .`class`: return .class
+        case .`deinit`: return .deinitializer
+        case .`enum`: return .enumeration
+        case .`case`: return .enumerationCase
+        case .`func`: return .function
+        case .`operator`: return .operator
+        case .`init`: return .initializer
+        case .`method`: return .instanceMethod
+        case .`property`: return .instanceProperty
+        case .`protocol`: return .protocol
+        case .`struct`: return .structure
+        case .`subscript`: return .instanceSubscript
+        case .`typeMethod`: return .typeMethod
+        case .`typeProperty`: return .typeProperty
+        case .`typeSubscript`: return .typeSubscript
+        case .`typealias`: return .typeAlias
+        case .`var`: return .globalVariable
+
+        case .module: return .module
+        case .unknown: return .unknown
         }
     }
 

--- a/Sources/SwiftDocC/Model/Rendering/DocumentationContentRenderer.swift
+++ b/Sources/SwiftDocC/Model/Rendering/DocumentationContentRenderer.swift
@@ -75,7 +75,7 @@ public class DocumentationContentRenderer {
             if fragments.last?.text == "\n" { fragments.removeLast() }
             
             // TODO: Return an Objective-C subheading for Objective-C symbols (rdar://84195588)
-            return Swift.subHeading(for: fragments, symbolTitle: title, symbolKind: kind.identifier)
+            return Swift.subHeading(for: fragments, symbolTitle: title, symbolKind: kind.identifier.identifier)
         } ?? .init(defaultValue: nil)
     }
     
@@ -523,7 +523,8 @@ extension DocumentationContentRenderer {
             }
             
             // 2. Map the first found "keyword=init" to an "identifier" kind to enable syntax highlighting.
-            if symbolKind == SymbolGraph.Symbol.Kind.Swift.`init`.rawValue,
+            let parsedKind = SymbolGraph.Symbol.KindIdentifier(identifier: symbolKind)
+            if parsedKind == SymbolGraph.Symbol.KindIdentifier.`init`,
                 let initIndex = tokens.firstIndex(of: initKeyword) {
                 tokens[initIndex] = initIdentifier
             }

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator+Swift.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator+Swift.swift
@@ -77,7 +77,8 @@ extension RenderNodeTranslator {
             }
             
             // 2. Map the first found "keyword=init" to an "identifier" kind to enable syntax highlighting.
-            if symbolKind == SymbolGraph.Symbol.Kind.Swift.`init`.rawValue,
+            let parsedKind = SymbolGraph.Symbol.KindIdentifier(identifier: symbolKind)
+            if parsedKind == SymbolGraph.Symbol.KindIdentifier.`init`,
                 let initIndex = tokens.firstIndex(of: initKeyword) {
                 tokens[initIndex] = initIdentifier
             }

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -955,7 +955,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
         
         // Remove any optional namespace (e.g. "swift.") for rendering
         node.metadata.symbolKindVariants = VariantCollection<String?>(from: symbol.kindVariants) { _, kindVariants in
-            kindVariants.identifier.components(separatedBy: ".").last
+            kindVariants.identifier.identifier.components(separatedBy: ".").last
         } ?? .init(defaultValue: nil)
         
         node.metadata.conformance = contentRenderer.conformanceSectionFor(identifier, collectedConstraints: collectedConstraints)

--- a/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/DiscussionSectionTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/DiscussionSectionTranslator.swift
@@ -36,11 +36,7 @@ struct DiscussionSectionTranslator: RenderSectionTranslator {
                 case .dictionarySymbol?, .restRequestSymbol?:
                     title = "Discussion"
                 case .symbol?:
-                    if let swiftKind = SymbolGraph.Symbol.Kind.Swift(rawValue: symbol.kind.identifier) {
-                        title = swiftKind.symbolCouldHaveChildren ? "Overview" : "Discussion"
-                    } else {
-                        title = "Discussion"
-                    }
+                    title = symbol.kind.identifier.swiftSymbolCouldHaveChildren ? "Overview" : "Discussion"
                 default:
                     title = "Overview"
                 }

--- a/Sources/SwiftDocC/Semantics/Graph/SymbolKind.Swift.swift
+++ b/Sources/SwiftDocC/Semantics/Graph/SymbolKind.Swift.swift
@@ -11,37 +11,13 @@
 import Foundation
 import SymbolKit
 
-extension SymbolGraph.Symbol.Kind {
-    /// A static list of Swift-specific symbol kinds.
-    public enum Swift: String, Equatable, CaseIterable {
-        case `associatedtype` = "swift.associatedtype"
-        case `class` = "swift.class"
-        case `deinit` = "swift.deinit"
-        case `enum` = "swift.enum"
-        case `case` = "swift.enum.case"
-        case `func` = "swift.func"
-        case `operator` = "swift.func.op"
-        case `init` = "swift.init"
-        case `method` = "swift.method"
-        case `property` = "swift.property"
-        case `protocol` = "swift.protocol"
-        case `struct` = "swift.struct"
-        case `subscript` = "swift.subscript"
-        case `typeMethod` = "swift.type.method"
-        case `typeProperty` = "swift.type.property"
-        case `typeSubscript` = "swift.type.subscript"
-        case `typealias` = "swift.typealias"
-        case `var` = "swift.var"
-
-        case module = "module"
-        
-        /// The list of Swift-specific symbol kinds that could possibly have other symbols as children. 
-        var symbolCouldHaveChildren: Bool {
-            switch self {
-            case .associatedtype, .deinit, .case, .func, .operator, .`init`, .method, .property, .typeMethod, .typeProperty, .typealias, .var:
-                return false
-            default: return true
-            }
+extension SymbolGraph.Symbol.KindIdentifier {
+    /// The list of Swift-specific symbol kinds that could possibly have other symbols as children.
+    public var swiftSymbolCouldHaveChildren: Bool {
+        switch self {
+        case .associatedtype, .deinit, .case, .func, .operator, .`init`, .method, .property, .typeMethod, .typeProperty, .typealias, .var:
+            return false
+        default: return true
         }
     }
 }

--- a/Sources/SwiftDocC/Semantics/Symbol/Symbol.swift
+++ b/Sources/SwiftDocC/Semantics/Symbol/Symbol.swift
@@ -370,7 +370,7 @@ extension Symbol {
 }
 
 extension UnifiedSymbolGraph.Symbol {
-    var swiftSelector: UnifiedSymbolGraph.Selector? {
+    var defaultSelector: UnifiedSymbolGraph.Selector? {
         if let mainSelector = self.mainGraphSelectors.first, mainSelector.interfaceLanguage == "swift" {
             return mainSelector
         }
@@ -379,8 +379,12 @@ extension UnifiedSymbolGraph.Symbol {
 
         if self.pathComponents.keys.contains(defaultSelector) {
             return defaultSelector
+        } else if let firstSwiftSelector = self.pathComponents.keys.first(where: { $0.interfaceLanguage == "swift" }) {
+            return firstSwiftSelector
+        } else if FeatureFlags.current.isExperimentalObjectiveCSupportEnabled {
+            return mainGraphSelectors.first ?? pathComponents.keys.first
         } else {
-            return self.pathComponents.keys.first(where: { $0.interfaceLanguage == "swift" })
+            return nil
         }
     }
 
@@ -408,7 +412,7 @@ extension UnifiedSymbolGraph.Symbol {
     }
 
     var defaultSymbol: SymbolGraph.Symbol? {
-        symbol(forSelector: swiftSelector)
+        symbol(forSelector: defaultSelector)
     }
 
     func identifier(forLanguage interfaceLanguage: String) -> SymbolGraph.Symbol.Identifier {

--- a/Sources/SwiftDocC/Servers/FileServer.swift
+++ b/Sources/SwiftDocC/Servers/FileServer.swift
@@ -255,10 +255,10 @@ public class MemoryFileServerProvider: FileServerProvider {
     
 }
 
-/// A list of Swift symbol kinds which might interfere with the rendering engine while dealing with URLs.
-fileprivate var swiftEntitiesDefinition: Set<String> = {
-    Set(SymbolGraph.Symbol.Kind.Swift.allCases.map(\.rawValue))
-}()
+/// Checks whether the given string is a known entity definition which might interfere with the rendering engine while dealing with URLs.
+fileprivate func isKnownEntityDefinition(_ identifier: String) -> Bool {
+    return SymbolGraph.Symbol.KindIdentifier.isKnownIdentifier(identifier)
+}
 
 fileprivate extension String {
     
@@ -279,7 +279,7 @@ fileprivate extension String {
         let swiftEntityPattern = #"(?<=\-)swift\..*"#
         if let range = range(of: swiftEntityPattern, options: .regularExpression, range: nil, locale: nil) {
             let entityCheck = String(self[range])
-            return swiftEntitiesDefinition.contains(entityCheck)
+            return isKnownEntityDefinition(entityCheck)
         }
         return false
     }

--- a/Sources/SwiftDocC/SwiftDocC.docc/SwiftDocC/Utilities.md
+++ b/Sources/SwiftDocC/SwiftDocC.docc/SwiftDocC/Utilities.md
@@ -19,5 +19,6 @@
 ### Auxiliary 
 
 - ``Checksum``
+- ``FeatureFlags``
 
 <!-- Copyright (c) 2021 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Sources/SwiftDocC/Utility/FeatureFlags.swift
+++ b/Sources/SwiftDocC/Utility/FeatureFlags.swift
@@ -1,0 +1,37 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+/// A set of feature flags that conditionally enable (usually experimental) behavior in Swift-DocC.
+public struct FeatureFlags: Codable {
+    /// The current feature flags that Swift-DocC uses to conditionally enable
+    /// (usually experimental) behavior in Swift-DocC.
+    public static var current = FeatureFlags()
+    
+    /// Whether or not experimental language support for Objective-C is enabled.
+    ///
+    /// This can be enabled on the command-line by passing `--enable-experimental-objective-c-support`
+    /// to docc.
+    public var isExperimentalObjectiveCSupportEnabled = false
+    
+    /// Creates a set of feature flags with the given values.
+    ///
+    /// - Parameters:
+    ///   - enableObjectiveCSupport: Whether or not experimental language support for Objective-C should be enabled.
+    ///
+    ///   - additionalFlags: Any additional flags to set.
+    ///
+    ///     This field allows clients to set feature flags without adding new API.
+    public init(
+        enableExperimentalObjectiveCSupport: Bool = false,
+        additionalFlags: [String : Bool] = [:]
+    ) {
+        self.isExperimentalObjectiveCSupportEnabled = enableExperimentalObjectiveCSupport
+    }
+}

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/ActionExtensions/ConvertAction+CommandInitialization.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/ActionExtensions/ConvertAction+CommandInitialization.swift
@@ -20,6 +20,8 @@ extension ConvertAction {
         var standardError = LogHandle.standardError
         let outOfProcessResolver: OutOfProcessReferenceResolver?
 
+        FeatureFlags.current.isExperimentalObjectiveCSupportEnabled = convert.enableExperimentalObjectiveCSupport
+        
         // If the user-provided a URL for an external link resolver, attempt to
         // initialize an `OutOfProcessReferenceResolver` with the provided URL.
         if let linkResolverURL = convert.outOfProcessLinkResolverOption.linkResolverExecutableURL {

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Convert.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Convert.swift
@@ -105,6 +105,12 @@ extension Docc {
         /// Defaults to false
         @Flag(help: "Allows for custom templates, like `header.html`.")
         public var experimentalEnableCustomTemplates = false
+        
+        /// A user-provided value that is true if the user enables experimental Objective-C language support.
+        ///
+        /// Defaults to false.
+        @Flag(help: .hidden)
+        public var enableExperimentalObjectiveCSupport = false
 
         /// A user-provided value that is true if experimental documentation inheritance is to be enabled.
         ///

--- a/Sources/generate-symbol-graph/main.swift
+++ b/Sources/generate-symbol-graph/main.swift
@@ -210,7 +210,7 @@ let symbols: [SymbolGraph.Symbol] = supportedDirectives.map { directive in
         ],
         docComment: nil,
         accessLevel: .init(rawValue: "public"),
-        kind: .init(identifier: "swift.class", displayName: "Directive"),
+        kind: .init(parsedIdentifier: .class, displayName: "Directive"),
         mixins: [
             SymbolGraph.Symbol.DeclarationFragments.mixinKey: SymbolGraph.Symbol.DeclarationFragments(
                 declarationFragments: [

--- a/Tests/SwiftDocCTests/DocumentationService/ConvertService/ConvertServiceTests.swift
+++ b/Tests/SwiftDocCTests/DocumentationService/ConvertService/ConvertServiceTests.swift
@@ -846,6 +846,53 @@ class ConvertServiceTests: XCTestCase {
         #endif
     }
     
+    func testObjectiveCFeatureFlag() throws {
+        let symbolGraphFile = Bundle.module.url(
+            forResource: "DeckKit-Objective-C",
+            withExtension: "symbols.json",
+            subdirectory: "Test Resources"
+        )!
+        
+        let symbolGraph = try Data(contentsOf: symbolGraphFile)
+        
+        var request = ConvertRequest(
+            bundleInfo: testBundleInfo,
+            externalIDsToConvert: ["c:@EA@Rank"],
+            documentPathsToConvert: [],
+            symbolGraphs: [symbolGraph],
+            markupFiles: [],
+            miscResourceURLs: []
+        )
+        
+        try processAndAssert(request: request) { message in
+            XCTAssertEqual(message.type, "convert-response")
+            XCTAssertEqual(message.identifier, "test-identifier-response")
+            
+            let renderNodes = try JSONDecoder().decode(
+                ConvertResponse.self, from: XCTUnwrap(message.payload)).renderNodes
+            
+            XCTAssertTrue(
+                renderNodes.isEmpty,
+                "Expected empty response when converting obj-c symbol with experimental feature flag disabled."
+            )
+        }
+        
+        request.featureFlags.isExperimentalObjectiveCSupportEnabled = true
+        
+        try processAndAssert(request: request) { message in
+            XCTAssertEqual(message.type, "convert-response")
+            XCTAssertEqual(message.identifier, "test-identifier-response")
+            
+            let renderNodes = try JSONDecoder().decode(
+                ConvertResponse.self, from: XCTUnwrap(message.payload)).renderNodes
+            
+            XCTAssertFalse(
+                renderNodes.isEmpty,
+                "Expected non-empty response when converting obj-c symbol with experimental feature flag enabled."
+            )
+        }
+    }
+    
     func testReturnsRenderReferenceStoreWhenRequestedForOnDiskBundleWithCuratedArticles() throws {
         #if os(Linux)
         throw XCTSkip("""

--- a/Tests/SwiftDocCTests/Infrastructure/AutomaticCurationTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/AutomaticCurationTests.swift
@@ -20,7 +20,7 @@ class AutomaticCurationTests: XCTestCase {
             let (url, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], codeListings: [:], configureBundle: { url in
                 let sidekitURL = url.appendingPathComponent("sidekit.symbols.json")
                 let text = try String(contentsOf: sidekitURL)
-                    .replacingOccurrences(of: "\"identifier\" : \"swift.enum.case\"", with: "\"identifier\" : \"\(kind.rawValue)\"")
+                    .replacingOccurrences(of: "\"identifier\" : \"swift.enum.case\"", with: "\"identifier\" : \"\(kind.identifier)\"")
                 try text.write(to: sidekitURL, atomically: true, encoding: .utf8)
             })
             defer { try? FileManager.default.removeItem(at: url) }
@@ -33,7 +33,7 @@ class AutomaticCurationTests: XCTestCase {
             
             XCTAssertNotNil(renderNode.topicSections.first(where: { group -> Bool in
                 return group.title == AutomaticCuration.groupTitle(for: kind)
-            }), "\(kind.rawValue) was not automatically curated in a \(AutomaticCuration.groupTitle(for: kind).singleQuoted) topic group." )
+            }), "\(kind.identifier) was not automatically curated in a \(AutomaticCuration.groupTitle(for: kind).singleQuoted) topic group." )
         }
     }
 

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContextTests.swift
@@ -776,7 +776,7 @@ class DocumentationContextTests: XCTestCase {
         //
 
         // The two types are equatable but XCTAssertEqual doesn't catch that.
-        XCTAssertTrue(myClassSymbol.kind.identifier == SymbolGraph.Symbol.Kind.Swift.class.rawValue)
+        XCTAssertTrue(myClassSymbol.kind.identifier == SymbolGraph.Symbol.KindIdentifier.class)
         XCTAssertNotNil(myClassSymbol.availability?.availability.first(where: { (availability) -> Bool in
             if let domain = availability.domain, let introduced = availability.introducedVersion, domain.rawValue == "macOS", introduced.major == 10, introduced.minor == 15 {
                 return true
@@ -1471,7 +1471,7 @@ let expected = """
             {
               "accessLevel" : "public",
               "kind" : {
-                "identifier" : "swift.variable",
+                "identifier" : "swift.var",
                 "displayName" : "Type Variable"
               },
               "names" : { "title" : "test" },
@@ -1484,7 +1484,7 @@ let expected = """
             {
               "accessLevel" : "public",
               "kind" : {
-                "identifier" : "swift.variable",
+                "identifier" : "swift.var",
                 "displayName" : "Type Variable"
               },
               "names" : { "title" : "tEst" },
@@ -1502,8 +1502,8 @@ let expected = """
         
         // Verify the non-overload collisions were resolved
         XCTAssertNoThrow(try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/SideKit/SideClass/Test-swift.enum", sourceLanguage: .swift)))
-        XCTAssertNoThrow(try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/SideKit/SideClass/tEst-swift.variable-9053a", sourceLanguage: .swift)))
-        XCTAssertNoThrow(try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/SideKit/SideClass/test-swift.variable-959hd", sourceLanguage: .swift)))
+        XCTAssertNoThrow(try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/SideKit/SideClass/tEst-swift.var-9053a", sourceLanguage: .swift)))
+        XCTAssertNoThrow(try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/SideKit/SideClass/test-swift.var-959hd", sourceLanguage: .swift)))
     }
 
     func testUnknownSymbolKind() throws {

--- a/Tests/SwiftDocCTests/Infrastructure/SymbolGraph/SymbolGraphConcurrentDecoderTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/SymbolGraph/SymbolGraphConcurrentDecoderTests.swift
@@ -21,7 +21,7 @@ class SymbolGraphConcurrentDecoderTests: XCTestCase {
     
     private let lines = SymbolGraph.LineList(Array(repeating: SymbolGraph.LineList.Line(text: "Apple Banana Orange Pear Mango Kiwi Grapefruit Melon Watermelon", range: nil), count: 20))
     private func makeSymbol(index: Int) -> SymbolGraph.Symbol {
-        return SymbolGraph.Symbol(identifier: .init(precise: UUID().uuidString, interfaceLanguage: "swift"), names: .init(title: "Symbol \(index)", navigator: nil, subHeading: [SymbolGraph.Symbol.DeclarationFragments.Fragment(kind: .identifier, spelling: "Symbol \(index)", preciseIdentifier: UUID().uuidString)], prose: "Symbol \(index)"), pathComponents: ["Module", "Symbol\(index)"], docComment: lines, accessLevel: .init(rawValue: "public"), kind: .init(identifier: "swift.struct", displayName: "Struct"), mixins: [:])
+        return SymbolGraph.Symbol(identifier: .init(precise: UUID().uuidString, interfaceLanguage: "swift"), names: .init(title: "Symbol \(index)", navigator: nil, subHeading: [SymbolGraph.Symbol.DeclarationFragments.Fragment(kind: .identifier, spelling: "Symbol \(index)", preciseIdentifier: UUID().uuidString)], prose: "Symbol \(index)"), pathComponents: ["Module", "Symbol\(index)"], docComment: lines, accessLevel: .init(rawValue: "public"), kind: .init(parsedIdentifier: .struct, displayName: "Struct"), mixins: [:])
     }
     private func addSymbols(count: Int, graph: inout SymbolGraph) {
         for index in 0...count {

--- a/Tests/SwiftDocCTests/Infrastructure/SymbolGraph/SymbolGraphRelationshipsBuilderTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/SymbolGraph/SymbolGraphRelationshipsBuilderTests.swift
@@ -22,8 +22,8 @@ class SymbolGraphRelationshipsBuilderTests: XCTestCase {
         let sourceRef = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/A", sourceLanguage: .swift)
         let targetRef = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/B", sourceLanguage: .swift)
         
-        let sourceSymbol = SymbolGraph.Symbol(identifier: sourceIdentifier, names: SymbolGraph.Symbol.Names(title: "A", navigator: nil, subHeading: nil, prose: nil), pathComponents: ["MyKit", "A"], docComment: nil, accessLevel: .init(rawValue: "public"), kind: SymbolGraph.Symbol.Kind(identifier: "swift.class", displayName: "Class"), mixins: [:])
-        let targetSymbol = SymbolGraph.Symbol(identifier: targetIdentifier, names: SymbolGraph.Symbol.Names(title: "B", navigator: nil, subHeading: nil, prose: nil), pathComponents: ["MyKit", "B"], docComment: nil, accessLevel: .init(rawValue: "public"), kind: SymbolGraph.Symbol.Kind(identifier: "swift.protocol", displayName: "Protocol"), mixins: [:])
+        let sourceSymbol = SymbolGraph.Symbol(identifier: sourceIdentifier, names: SymbolGraph.Symbol.Names(title: "A", navigator: nil, subHeading: nil, prose: nil), pathComponents: ["MyKit", "A"], docComment: nil, accessLevel: .init(rawValue: "public"), kind: SymbolGraph.Symbol.Kind(parsedIdentifier: .class, displayName: "Class"), mixins: [:])
+        let targetSymbol = SymbolGraph.Symbol(identifier: targetIdentifier, names: SymbolGraph.Symbol.Names(title: "B", navigator: nil, subHeading: nil, prose: nil), pathComponents: ["MyKit", "B"], docComment: nil, accessLevel: .init(rawValue: "public"), kind: SymbolGraph.Symbol.Kind(parsedIdentifier: .class, displayName: "Protocol"), mixins: [:])
         
         let engine = DiagnosticEngine()
         symbolIndex["A"] = DocumentationNode(reference: sourceRef, symbol: sourceSymbol, platformName: "macOS", moduleName: "MyKit", article: nil, engine: engine)
@@ -38,7 +38,7 @@ class SymbolGraphRelationshipsBuilderTests: XCTestCase {
         var symbolIndex = [String: DocumentationNode]()
         let engine = DiagnosticEngine()
         
-        let edge = createSymbols(in: &symbolIndex, bundle: bundle, sourceType: .init(identifier: "swift.class", displayName: "Class"), targetType: .init(identifier: "swift.protocol", displayName: "Protocol"))
+        let edge = createSymbols(in: &symbolIndex, bundle: bundle, sourceType: .init(parsedIdentifier: .class, displayName: "Class"), targetType: .init(parsedIdentifier: .protocol, displayName: "Protocol"))
         
         // Adding the relationship
         SymbolGraphRelationshipsBuilder.addImplementationRelationship(edge: edge, in: bundle, context: context, symbolIndex: &symbolIndex, engine: engine)
@@ -52,7 +52,7 @@ class SymbolGraphRelationshipsBuilderTests: XCTestCase {
         var symbolIndex = [String: DocumentationNode]()
         let engine = DiagnosticEngine()
         
-        let edge = createSymbols(in: &symbolIndex, bundle: bundle, sourceType: .init(identifier: "swift.class", displayName: "Class"), targetType: .init(identifier: "swift.protocol", displayName: "Protocol"))
+        let edge = createSymbols(in: &symbolIndex, bundle: bundle, sourceType: .init(parsedIdentifier: .class, displayName: "Class"), targetType: .init(parsedIdentifier: .protocol, displayName: "Protocol"))
         
         // Adding the relationship
         SymbolGraphRelationshipsBuilder.addConformanceRelationship(edge: edge, in: bundle, symbolIndex: &symbolIndex, engine: engine)
@@ -81,7 +81,7 @@ class SymbolGraphRelationshipsBuilderTests: XCTestCase {
         var symbolIndex = [String: DocumentationNode]()
         let engine = DiagnosticEngine()
         
-        let edge = createSymbols(in: &symbolIndex, bundle: bundle, sourceType: .init(identifier: "swift.class", displayName: "Class"), targetType: .init(identifier: "swift.protocol", displayName: "Protocol"))
+        let edge = createSymbols(in: &symbolIndex, bundle: bundle, sourceType: .init(parsedIdentifier: .class, displayName: "Class"), targetType: .init(parsedIdentifier: .protocol, displayName: "Protocol"))
         
         // Adding the relationship
         SymbolGraphRelationshipsBuilder.addInheritanceRelationship(edge: edge, in: bundle, symbolIndex: &symbolIndex, engine: engine)
@@ -110,7 +110,7 @@ class SymbolGraphRelationshipsBuilderTests: XCTestCase {
         var symbolIndex = [String: DocumentationNode]()
         let engine = DiagnosticEngine()
         
-        let edge = createSymbols(in: &symbolIndex, bundle: bundle, sourceType: .init(identifier: "swift.class", displayName: "Class"), targetType: .init(identifier: "swift.protocol", displayName: "Protocol"))
+        let edge = createSymbols(in: &symbolIndex, bundle: bundle, sourceType: .init(parsedIdentifier: .class, displayName: "Class"), targetType: .init(parsedIdentifier: .protocol, displayName: "Protocol"))
         
         // Adding the relationship
         SymbolGraphRelationshipsBuilder.addRequirementRelationship(edge: edge, in: bundle, symbolIndex: &symbolIndex, engine: engine)

--- a/Tests/SwiftDocCTests/Infrastructure/SymbolReferenceTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/SymbolReferenceTests.swift
@@ -28,7 +28,7 @@ class SymbolReferenceTests: XCTestCase {
             pathComponents: ["test", "abcd"],
             docComment: nil,
             accessLevel: .init(rawValue: "public"),
-            kind: .init(identifier: "module", displayName: "Framework"),
+            kind: .init(parsedIdentifier: .module, displayName: "Framework"),
             mixins: [:])
         let leafRef = SymbolReference(symbol.identifier.precise, interfaceLanguage: .swift, symbol: symbol)
         XCTAssertEqual(leafRef.path, "")
@@ -41,7 +41,7 @@ class SymbolReferenceTests: XCTestCase {
             pathComponents: ["test", "abcd"],
             docComment: nil,
             accessLevel: .init(rawValue: "public"),
-            kind: .init(identifier: "swift.variable", displayName: "Variable"),
+            kind: .init(parsedIdentifier: .var, displayName: "Variable"),
             mixins: [:])
         let leafRef = SymbolReference(symbol.identifier.precise, interfaceLanguage: .swift, symbol: symbol)
         XCTAssertEqual(leafRef.path, "test/abcd")
@@ -54,7 +54,7 @@ class SymbolReferenceTests: XCTestCase {
             pathComponents: ["test", "abcd"],
             docComment: nil,
             accessLevel: .init(rawValue: "public"),
-            kind: .init(identifier: "swift.variable", displayName: "Variable"),
+            kind: .init(parsedIdentifier: .var, displayName: "Variable"),
             mixins: [:])
         let leafRef = SymbolReference(symbol.identifier.precise, interfaceLanguage: .swift, symbol: symbol, shouldAddHash: true)
         XCTAssertEqual(leafRef.path, "test/abcd-8ogy4")
@@ -69,7 +69,7 @@ class SymbolReferenceTests: XCTestCase {
                 pathComponents: ["test", "abcd()"],
                 docComment: nil,
                 accessLevel: .init(rawValue: "public"),
-                kind: .init(identifier: "swift.variable", displayName: "Variable"),
+                kind: .init(parsedIdentifier: .var, displayName: "Variable"),
                 mixins: [:])
             let leafRef = SymbolReference(symbol.identifier.precise, interfaceLanguage: .swift, symbol: symbol, shouldAddHash: false)
             XCTAssertEqual(leafRef.path, "test/abcd()")
@@ -83,7 +83,7 @@ class SymbolReferenceTests: XCTestCase {
                 pathComponents: ["test", "abcd(_:Int)"],
                 docComment: nil,
                 accessLevel: .init(rawValue: "public"),
-                kind: .init(identifier: "swift.variable", displayName: "Variable"),
+                kind: .init(parsedIdentifier: .var, displayName: "Variable"),
                 mixins: [:])
             let leafRef = SymbolReference(symbol.identifier.precise, interfaceLanguage: .swift, symbol: symbol, shouldAddHash: false)
             XCTAssertEqual(leafRef.path, "test/abcd(_:Int)")
@@ -97,7 +97,7 @@ class SymbolReferenceTests: XCTestCase {
                 pathComponents: ["test", "abcd(num:text:)"],
                 docComment: nil,
                 accessLevel: .init(rawValue: "public"),
-                kind: .init(identifier: "swift.variable", displayName: "Variable"),
+                kind: .init(parsedIdentifier: .var, displayName: "Variable"),
                 mixins: [:])
             let leafRef = SymbolReference(symbol.identifier.precise, interfaceLanguage: .swift, symbol: symbol, shouldAddHash: false)
             XCTAssertEqual(leafRef.path, "test/abcd(num:text:)")

--- a/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorSymbolVariantsTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorSymbolVariantsTests.swift
@@ -211,14 +211,14 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
     func testSymbolKindVariants() throws {
         try assertMultiVariantSymbol(
             configureSymbol: { symbol in
-                symbol.kindVariants[.swift] = .init(identifier: "swift.swift-kind", displayName: "Swift Kind")
-                symbol.kindVariants[.objectiveC] = .init(identifier: "objc.objc-kind", displayName: "Objective-C Kind")
+                symbol.kindVariants[.swift] = .init(rawIdentifier: "swift.method", displayName: "Swift Kind")
+                symbol.kindVariants[.objectiveC] = .init(rawIdentifier: "objc.func", displayName: "Objective-C Kind")
             },
             assertOriginalRenderNode: { renderNode in
-                XCTAssertEqual(renderNode.metadata.symbolKind, "swift-kind")
+                XCTAssertEqual(renderNode.metadata.symbolKind, "method")
             },
             assertAfterApplyingVariant: { renderNode in
-                XCTAssertEqual(renderNode.metadata.symbolKind, "objc-kind")
+                XCTAssertEqual(renderNode.metadata.symbolKind, "func")
             }
         )
     }
@@ -237,8 +237,8 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
                 symbol.titleVariants[.swift] = "Swift Title"
                 symbol.titleVariants[.objectiveC] = "Objective-C Title"
                 
-                symbol.kindVariants[.swift] = .init(identifier: "swift.swift-kind", displayName: "Swift Kind")
-                symbol.kindVariants[.objectiveC] = .init(identifier: "objc.objc-kind", displayName: "Objective-C Kind")
+                symbol.kindVariants[.swift] = .init(rawIdentifier: "swift.method", displayName: "Swift Kind")
+                symbol.kindVariants[.objectiveC] = .init(rawIdentifier: "objc.func", displayName: "Objective-C Kind")
             },
             assertOriginalRenderNode: { renderNode in
                 XCTAssertEqual(

--- a/Tests/SwiftDocCTests/Semantics/SymbolTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/SymbolTests.swift
@@ -665,7 +665,7 @@ class SymbolTests: XCTestCase {
             pathComponents: pathComponents,
             docComment: docComment,
             accessLevel: .init(rawValue: "public"),
-            kind: SymbolGraph.Symbol.Kind(identifier: "swift.function", displayName: "myFunction"),
+            kind: SymbolGraph.Symbol.Kind(parsedIdentifier: .func, displayName: "myFunction"),
             mixins: [
                 SymbolGraph.Symbol.Location.mixinKey: SymbolGraph.Symbol.Location(uri: "file:///path/to/my file.swift", position: range.start),
             ]

--- a/Tests/SwiftDocCTests/Test Resources/DeckKit-Objective-C.symbols.json
+++ b/Tests/SwiftDocCTests/Test Resources/DeckKit-Objective-C.symbols.json
@@ -1,0 +1,1881 @@
+{
+  "metadata" : {
+    "formatVersion" : {
+      "major" : 0,
+      "minor" : 5,
+      "patch" : 0
+    },
+    "generator" : "SymbolKit"
+  },
+  "module" : {
+    "name" : "DeckKit",
+    "platform" : {
+      "architecture" : "x86_64",
+      "operatingSystem" : {
+        "minimumVersion" : {
+          "major" : 11,
+          "minor" : 0,
+          "patch" : 0
+        },
+        "name" : "macos"
+      },
+      "vendor" : "apple"
+    }
+  },
+  "relationships" : [
+    {
+      "kind" : "memberOf",
+      "source" : "c:@E@EnumTest@one",
+      "target" : "c:@E@EnumTest",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:@E@EnumTest@two",
+      "target" : "c:@E@EnumTest",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:@E@OptionTest@first",
+      "target" : "c:@E@OptionTest",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:@E@OptionTest@second",
+      "target" : "c:@E@OptionTest",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:@EA@Rank@Ace",
+      "target" : "c:@EA@Rank",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:@EA@Rank@Eight",
+      "target" : "c:@EA@Rank",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:@EA@Rank@Five",
+      "target" : "c:@EA@Rank",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:@EA@Rank@Four",
+      "target" : "c:@EA@Rank",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:@EA@Rank@Jack",
+      "target" : "c:@EA@Rank",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:@EA@Rank@King",
+      "target" : "c:@EA@Rank",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:@EA@Rank@Nine",
+      "target" : "c:@EA@Rank",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:@EA@Rank@Queen",
+      "target" : "c:@EA@Rank",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:@EA@Rank@Seven",
+      "target" : "c:@EA@Rank",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:@EA@Rank@Six",
+      "target" : "c:@EA@Rank",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:@EA@Rank@Ten",
+      "target" : "c:@EA@Rank",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:@EA@Rank@Three",
+      "target" : "c:@EA@Rank",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:@EA@Rank@Two",
+      "target" : "c:@EA@Rank",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:@EA@Suit@Clubs",
+      "target" : "c:@EA@Suit",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:@EA@Suit@Diamonds",
+      "target" : "c:@EA@Suit",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:@EA@Suit@Hearts",
+      "target" : "c:@EA@Suit",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:@EA@Suit@Spades",
+      "target" : "c:@EA@Suit",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "inheritsFrom",
+      "source" : "c:objc(cs)PlayingCard",
+      "target" : "c:objc(cs)NSObject",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "conformsTo",
+      "source" : "c:objc(cs)PlayingCard",
+      "target" : "c:objc(pl)ColorDetecting",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "conformsTo",
+      "source" : "c:objc(cs)PlayingCard",
+      "target" : "c:objc(pl)NSCopying",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:objc(cs)PlayingCard(cm)newWithRank:ofSuit:",
+      "target" : "c:objc(cs)PlayingCard",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:objc(cs)PlayingCard(im)initWithRank:ofSuit:",
+      "target" : "c:objc(cs)PlayingCard",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:objc(cs)PlayingCard(im)isFaceCard",
+      "target" : "c:objc(cs)PlayingCard",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:objc(cs)PlayingCard(py)rank",
+      "target" : "c:objc(cs)PlayingCard",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:objc(cs)PlayingCard(py)suit",
+      "target" : "c:objc(cs)PlayingCard",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:objc(pl)ColorDetecting(im)isBlack",
+      "target" : "c:objc(pl)ColorDetecting",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:objc(pl)ColorDetecting(im)isGreen",
+      "target" : "c:objc(pl)ColorDetecting",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:objc(pl)ColorDetecting(im)isRed",
+      "target" : "c:objc(pl)ColorDetecting",
+      "targetFallback" : null
+    }
+  ],
+  "symbols" : [
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "(anonymous)"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "range" : {
+              "end" : {
+                "character" : 41,
+                "line" : 11
+              },
+              "start" : {
+                "character" : 4,
+                "line" : 11
+              }
+            },
+            "text" : "Enum used to represent a card's rank."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@EA@Rank"
+      },
+      "kind" : {
+        "displayName" : "Enumeration",
+        "identifier" : "occ.enum"
+      },
+      "location" : {
+        "position" : {
+          "character" : 8,
+          "line" : 12
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "(anonymous)"
+      },
+      "pathComponents" : [
+        "(anonymous)"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "(anonymous)"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "range" : {
+              "end" : {
+                "character" : 41,
+                "line" : 26
+              },
+              "start" : {
+                "character" : 4,
+                "line" : 26
+              }
+            },
+            "text" : "Enum used to represent a card's suit."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@EA@Suit"
+      },
+      "kind" : {
+        "displayName" : "Enumeration",
+        "identifier" : "occ.enum"
+      },
+      "location" : {
+        "position" : {
+          "character" : 8,
+          "line" : 27
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "(anonymous)"
+      },
+      "pathComponents" : [
+        "(anonymous)"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "Ace"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@EA@Rank@Ace"
+      },
+      "kind" : {
+        "displayName" : "Case",
+        "identifier" : "occ.enum.case"
+      },
+      "location" : {
+        "position" : {
+          "character" : 14,
+          "line" : 12
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "Ace"
+      },
+      "pathComponents" : [
+        "(anonymous)",
+        "Ace"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "Clubs"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "range" : {
+              "end" : {
+                "character" : 36,
+                "line" : 29
+              },
+              "start" : {
+                "character" : 20,
+                "line" : 29
+              }
+            },
+            "text" : "Black clover. "
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@EA@Suit@Clubs"
+      },
+      "kind" : {
+        "displayName" : "Case",
+        "identifier" : "occ.enum.case"
+      },
+      "location" : {
+        "position" : {
+          "character" : 4,
+          "line" : 29
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "Clubs"
+      },
+      "pathComponents" : [
+        "(anonymous)",
+        "Clubs"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "Diamonds"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "range" : {
+              "end" : {
+                "character" : 35,
+                "line" : 30
+              },
+              "start" : {
+                "character" : 20,
+                "line" : 30
+              }
+            },
+            "text" : "Red rhombus. "
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@EA@Suit@Diamonds"
+      },
+      "kind" : {
+        "displayName" : "Case",
+        "identifier" : "occ.enum.case"
+      },
+      "location" : {
+        "position" : {
+          "character" : 4,
+          "line" : 30
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "Diamonds"
+      },
+      "pathComponents" : [
+        "(anonymous)",
+        "Diamonds"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "Eight"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@EA@Rank@Eight"
+      },
+      "kind" : {
+        "displayName" : "Case",
+        "identifier" : "occ.enum.case"
+      },
+      "location" : {
+        "position" : {
+          "character" : 57,
+          "line" : 12
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "Eight"
+      },
+      "pathComponents" : [
+        "(anonymous)",
+        "Eight"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "Five"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@EA@Rank@Five"
+      },
+      "kind" : {
+        "displayName" : "Case",
+        "identifier" : "occ.enum.case"
+      },
+      "location" : {
+        "position" : {
+          "character" : 39,
+          "line" : 12
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "Five"
+      },
+      "pathComponents" : [
+        "(anonymous)",
+        "Five"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "Four"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@EA@Rank@Four"
+      },
+      "kind" : {
+        "displayName" : "Case",
+        "identifier" : "occ.enum.case"
+      },
+      "location" : {
+        "position" : {
+          "character" : 33,
+          "line" : 12
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "Four"
+      },
+      "pathComponents" : [
+        "(anonymous)",
+        "Four"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "Hearts"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "range" : {
+              "end" : {
+                "character" : 42,
+                "line" : 28
+              },
+              "start" : {
+                "character" : 20,
+                "line" : 28
+              }
+            },
+            "text" : "Red cardiovascular. "
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@EA@Suit@Hearts"
+      },
+      "kind" : {
+        "displayName" : "Case",
+        "identifier" : "occ.enum.case"
+      },
+      "location" : {
+        "position" : {
+          "character" : 4,
+          "line" : 28
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "Hearts"
+      },
+      "pathComponents" : [
+        "(anonymous)",
+        "Hearts"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "Jack"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@EA@Rank@Jack"
+      },
+      "kind" : {
+        "displayName" : "Case",
+        "identifier" : "occ.enum.case"
+      },
+      "location" : {
+        "position" : {
+          "character" : 75,
+          "line" : 12
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "Jack"
+      },
+      "pathComponents" : [
+        "(anonymous)",
+        "Jack"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "King"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@EA@Rank@King"
+      },
+      "kind" : {
+        "displayName" : "Case",
+        "identifier" : "occ.enum.case"
+      },
+      "location" : {
+        "position" : {
+          "character" : 88,
+          "line" : 12
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "King"
+      },
+      "pathComponents" : [
+        "(anonymous)",
+        "King"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "Nine"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@EA@Rank@Nine"
+      },
+      "kind" : {
+        "displayName" : "Case",
+        "identifier" : "occ.enum.case"
+      },
+      "location" : {
+        "position" : {
+          "character" : 64,
+          "line" : 12
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "Nine"
+      },
+      "pathComponents" : [
+        "(anonymous)",
+        "Nine"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "Queen"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@EA@Rank@Queen"
+      },
+      "kind" : {
+        "displayName" : "Case",
+        "identifier" : "occ.enum.case"
+      },
+      "location" : {
+        "position" : {
+          "character" : 81,
+          "line" : 12
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "Queen"
+      },
+      "pathComponents" : [
+        "(anonymous)",
+        "Queen"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "Seven"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@EA@Rank@Seven"
+      },
+      "kind" : {
+        "displayName" : "Case",
+        "identifier" : "occ.enum.case"
+      },
+      "location" : {
+        "position" : {
+          "character" : 50,
+          "line" : 12
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "Seven"
+      },
+      "pathComponents" : [
+        "(anonymous)",
+        "Seven"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "Six"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@EA@Rank@Six"
+      },
+      "kind" : {
+        "displayName" : "Case",
+        "identifier" : "occ.enum.case"
+      },
+      "location" : {
+        "position" : {
+          "character" : 45,
+          "line" : 12
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "Six"
+      },
+      "pathComponents" : [
+        "(anonymous)",
+        "Six"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "Spades"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "range" : {
+              "end" : {
+                "character" : 36,
+                "line" : 31
+              },
+              "start" : {
+                "character" : 20,
+                "line" : 31
+              }
+            },
+            "text" : "Black shovel. "
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@EA@Suit@Spades"
+      },
+      "kind" : {
+        "displayName" : "Case",
+        "identifier" : "occ.enum.case"
+      },
+      "location" : {
+        "position" : {
+          "character" : 4,
+          "line" : 31
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "Spades"
+      },
+      "pathComponents" : [
+        "(anonymous)",
+        "Spades"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "Ten"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@EA@Rank@Ten"
+      },
+      "kind" : {
+        "displayName" : "Case",
+        "identifier" : "occ.enum.case"
+      },
+      "location" : {
+        "position" : {
+          "character" : 70,
+          "line" : 12
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "Ten"
+      },
+      "pathComponents" : [
+        "(anonymous)",
+        "Ten"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "Three"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@EA@Rank@Three"
+      },
+      "kind" : {
+        "displayName" : "Case",
+        "identifier" : "occ.enum.case"
+      },
+      "location" : {
+        "position" : {
+          "character" : 26,
+          "line" : 12
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "Three"
+      },
+      "pathComponents" : [
+        "(anonymous)",
+        "Three"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "Two"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@EA@Rank@Two"
+      },
+      "kind" : {
+        "displayName" : "Case",
+        "identifier" : "occ.enum.case"
+      },
+      "location" : {
+        "position" : {
+          "character" : 21,
+          "line" : 12
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "Two"
+      },
+      "pathComponents" : [
+        "(anonymous)",
+        "Two"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "ColorDetecting"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "range" : {
+              "end" : {
+                "character" : 72,
+                "line" : 34
+              },
+              "start" : {
+                "character" : 4,
+                "line" : 34
+              }
+            },
+            "text" : "Protocol of methods that report whether an object is certain colors."
+          },
+          {
+            "range" : {
+              "end" : {
+                "character" : 3,
+                "line" : 35
+              },
+              "start" : {
+                "character" : 3,
+                "line" : 35
+              }
+            },
+            "text" : ""
+          },
+          {
+            "range" : {
+              "end" : {
+                "character" : 38,
+                "line" : 36
+              },
+              "start" : {
+                "character" : 4,
+                "line" : 36
+              }
+            },
+            "text" : "Only a few colors are implemented."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:objc(pl)ColorDetecting"
+      },
+      "kind" : {
+        "displayName" : "Protocol",
+        "identifier" : "occ.protocol"
+      },
+      "location" : {
+        "position" : {
+          "character" : 10,
+          "line" : 37
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "ColorDetecting"
+      },
+      "pathComponents" : [
+        "ColorDetecting"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "isBlack"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "range" : {
+              "end" : {
+                "character" : 48,
+                "line" : 41
+              },
+              "start" : {
+                "character" : 4,
+                "line" : 41
+              }
+            },
+            "text" : "Returns true if the card is of a black suit."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:objc(pl)ColorDetecting(im)isBlack"
+      },
+      "kind" : {
+        "displayName" : "Instance Method",
+        "identifier" : "occ.method"
+      },
+      "location" : {
+        "position" : {
+          "character" : 0,
+          "line" : 42
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "isBlack"
+      },
+      "pathComponents" : [
+        "ColorDetecting",
+        "isBlack"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "availability" : [
+        {
+          "domain" : "Unsupported OS: macos",
+          "isUnconditionallyUnavailable" : true
+        }
+      ],
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "isGreen"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "range" : {
+              "end" : {
+                "character" : 48,
+                "line" : 44
+              },
+              "start" : {
+                "character" : 4,
+                "line" : 44
+              }
+            },
+            "text" : "Returns true if the card is of a green suit."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:objc(pl)ColorDetecting(im)isGreen"
+      },
+      "kind" : {
+        "displayName" : "Instance Method",
+        "identifier" : "occ.method"
+      },
+      "location" : {
+        "position" : {
+          "character" : 0,
+          "line" : 45
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "isGreen"
+      },
+      "pathComponents" : [
+        "ColorDetecting",
+        "isGreen"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "isRed"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "range" : {
+              "end" : {
+                "character" : 46,
+                "line" : 38
+              },
+              "start" : {
+                "character" : 4,
+                "line" : 38
+              }
+            },
+            "text" : "Returns true if the card is of a red suit."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:objc(pl)ColorDetecting(im)isRed"
+      },
+      "kind" : {
+        "displayName" : "Instance Method",
+        "identifier" : "occ.method"
+      },
+      "location" : {
+        "position" : {
+          "character" : 0,
+          "line" : 39
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "isRed"
+      },
+      "pathComponents" : [
+        "ColorDetecting",
+        "isRed"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "EnumTest"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "range" : {
+              "end" : {
+                "character" : 35,
+                "line" : 14
+              },
+              "start" : {
+                "character" : 4,
+                "line" : 14
+              }
+            },
+            "text" : "Test doc comment for an NS_ENUM"
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@E@EnumTest"
+      },
+      "kind" : {
+        "displayName" : "Enumeration",
+        "identifier" : "occ.enum"
+      },
+      "location" : {
+        "position" : {
+          "character" : 8,
+          "line" : 15
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "EnumTest"
+      },
+      "pathComponents" : [
+        "EnumTest"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "EnumTest"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "range" : {
+              "end" : {
+                "character" : 35,
+                "line" : 14
+              },
+              "start" : {
+                "character" : 4,
+                "line" : 14
+              }
+            },
+            "text" : "Test doc comment for an NS_ENUM"
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:PlayingCard.h@T@EnumTest"
+      },
+      "kind" : {
+        "displayName" : "Typedef",
+        "identifier" : "occ.typealias"
+      },
+      "location" : {
+        "position" : {
+          "character" : 8,
+          "line" : 15
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "EnumTest"
+      },
+      "pathComponents" : [
+        "EnumTest"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "one"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@E@EnumTest@one"
+      },
+      "kind" : {
+        "displayName" : "Case",
+        "identifier" : "occ.enum.case"
+      },
+      "location" : {
+        "position" : {
+          "character" : 4,
+          "line" : 16
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "one"
+      },
+      "pathComponents" : [
+        "EnumTest",
+        "one"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "two"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@E@EnumTest@two"
+      },
+      "kind" : {
+        "displayName" : "Case",
+        "identifier" : "occ.enum.case"
+      },
+      "location" : {
+        "position" : {
+          "character" : 4,
+          "line" : 17
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "two"
+      },
+      "pathComponents" : [
+        "EnumTest",
+        "two"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "OptionTest"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "range" : {
+              "end" : {
+                "character" : 38,
+                "line" : 20
+              },
+              "start" : {
+                "character" : 4,
+                "line" : 20
+              }
+            },
+            "text" : "Test doc comment for an NS_OPTIONS"
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@E@OptionTest"
+      },
+      "kind" : {
+        "displayName" : "Enumeration",
+        "identifier" : "occ.enum"
+      },
+      "location" : {
+        "position" : {
+          "character" : 8,
+          "line" : 21
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "OptionTest"
+      },
+      "pathComponents" : [
+        "OptionTest"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "OptionTest"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "range" : {
+              "end" : {
+                "character" : 38,
+                "line" : 20
+              },
+              "start" : {
+                "character" : 4,
+                "line" : 20
+              }
+            },
+            "text" : "Test doc comment for an NS_OPTIONS"
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:PlayingCard.h@T@OptionTest"
+      },
+      "kind" : {
+        "displayName" : "Typedef",
+        "identifier" : "occ.typealias"
+      },
+      "location" : {
+        "position" : {
+          "character" : 8,
+          "line" : 21
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "OptionTest"
+      },
+      "pathComponents" : [
+        "OptionTest"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "first"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@E@OptionTest@first"
+      },
+      "kind" : {
+        "displayName" : "Case",
+        "identifier" : "occ.enum.case"
+      },
+      "location" : {
+        "position" : {
+          "character" : 4,
+          "line" : 22
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "first"
+      },
+      "pathComponents" : [
+        "OptionTest",
+        "first"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "second"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@E@OptionTest@second"
+      },
+      "kind" : {
+        "displayName" : "Case",
+        "identifier" : "occ.enum.case"
+      },
+      "location" : {
+        "position" : {
+          "character" : 4,
+          "line" : 23
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "second"
+      },
+      "pathComponents" : [
+        "OptionTest",
+        "second"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "PlayingCard"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:objc(cs)PlayingCard"
+      },
+      "kind" : {
+        "displayName" : "Class",
+        "identifier" : "occ.class"
+      },
+      "location" : {
+        "position" : {
+          "character" : 11,
+          "line" : 48
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "PlayingCard"
+      },
+      "pathComponents" : [
+        "PlayingCard"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "initWithRank:ofSuit:"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "range" : {
+              "end" : {
+                "character" : 51,
+                "line" : 53
+              },
+              "start" : {
+                "character" : 4,
+                "line" : 53
+              }
+            },
+            "text" : "Initialize a card with the given rank and suit."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:objc(cs)PlayingCard(im)initWithRank:ofSuit:"
+      },
+      "kind" : {
+        "displayName" : "Instance Method",
+        "identifier" : "occ.method"
+      },
+      "location" : {
+        "position" : {
+          "character" : 0,
+          "line" : 54
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "initWithRank:ofSuit:"
+      },
+      "pathComponents" : [
+        "PlayingCard",
+        "initWithRank:ofSuit:"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "availability" : [
+        {
+          "domain" : "Unsupported OS: macos",
+          "introduced" : {
+            "major" : 10,
+            "minor" : 11,
+            "patch" : 0
+          }
+        }
+      ],
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "isFaceCard"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "range" : {
+              "end" : {
+                "character" : 44,
+                "line" : 62
+              },
+              "start" : {
+                "character" : 4,
+                "line" : 62
+              }
+            },
+            "text" : "Returns true if the card is a face card."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:objc(cs)PlayingCard(im)isFaceCard"
+      },
+      "kind" : {
+        "displayName" : "Instance Method",
+        "identifier" : "occ.method"
+      },
+      "location" : {
+        "position" : {
+          "character" : 0,
+          "line" : 63
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "isFaceCard"
+      },
+      "pathComponents" : [
+        "PlayingCard",
+        "isFaceCard"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "newWithRank:ofSuit:"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "range" : {
+              "end" : {
+                "character" : 68,
+                "line" : 56
+              },
+              "start" : {
+                "character" : 4,
+                "line" : 56
+              }
+            },
+            "text" : "Allocate and initialize a new card with the given rank and suit."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:objc(cs)PlayingCard(cm)newWithRank:ofSuit:"
+      },
+      "kind" : {
+        "displayName" : "Class Method",
+        "identifier" : "occ.type.method"
+      },
+      "location" : {
+        "position" : {
+          "character" : 0,
+          "line" : 57
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "newWithRank:ofSuit:"
+      },
+      "pathComponents" : [
+        "PlayingCard",
+        "newWithRank:ofSuit:"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "rank"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:objc(cs)PlayingCard(py)rank"
+      },
+      "isReadOnly" : true,
+      "kind" : {
+        "displayName" : "Property",
+        "identifier" : "occ.property"
+      },
+      "location" : {
+        "position" : {
+          "character" : 26,
+          "line" : 50
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "rank"
+      },
+      "pathComponents" : [
+        "PlayingCard",
+        "rank"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "suit"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:objc(cs)PlayingCard(py)suit"
+      },
+      "isReadOnly" : true,
+      "kind" : {
+        "displayName" : "Property",
+        "identifier" : "occ.property"
+      },
+      "location" : {
+        "position" : {
+          "character" : 26,
+          "line" : 51
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "suit"
+      },
+      "pathComponents" : [
+        "PlayingCard",
+        "suit"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "Rank"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "range" : {
+              "end" : {
+                "character" : 41,
+                "line" : 11
+              },
+              "start" : {
+                "character" : 4,
+                "line" : 11
+              }
+            },
+            "text" : "Enum used to represent a card's rank."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@T@Rank"
+      },
+      "kind" : {
+        "displayName" : "Typedef",
+        "identifier" : "occ.typealias"
+      },
+      "location" : {
+        "position" : {
+          "character" : 94,
+          "line" : 12
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "Rank"
+      },
+      "pathComponents" : [
+        "Rank"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "Suit"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "range" : {
+              "end" : {
+                "character" : 41,
+                "line" : 26
+              },
+              "start" : {
+                "character" : 4,
+                "line" : 26
+              }
+            },
+            "text" : "Enum used to represent a card's suit."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@T@Suit"
+      },
+      "kind" : {
+        "displayName" : "Typedef",
+        "identifier" : "occ.typealias"
+      },
+      "location" : {
+        "position" : {
+          "character" : 2,
+          "line" : 32
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "Suit"
+      },
+      "pathComponents" : [
+        "Suit"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "_DeckKitVersionNumber"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "range" : {
+              "end" : {
+                "character" : 39,
+                "line" : 9
+              },
+              "start" : {
+                "character" : 4,
+                "line" : 9
+              }
+            },
+            "text" : "Project version number for DeckKit."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@DeckKitVersionNumber"
+      },
+      "kind" : {
+        "displayName" : "Global Variable",
+        "identifier" : "occ.var"
+      },
+      "location" : {
+        "position" : {
+          "character" : 25,
+          "line" : 10
+        },
+        "uri" : "DeckKit.h"
+      },
+      "names" : {
+        "title" : "_DeckKitVersionNumber"
+      },
+      "pathComponents" : [
+        "_DeckKitVersionNumber"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "_DeckKitVersionString"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "range" : {
+              "end" : {
+                "character" : 39,
+                "line" : 12
+              },
+              "start" : {
+                "character" : 4,
+                "line" : 12
+              }
+            },
+            "text" : "Project version string for DeckKit."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@DeckKitVersionString"
+      },
+      "kind" : {
+        "displayName" : "Global Variable",
+        "identifier" : "occ.var"
+      },
+      "location" : {
+        "position" : {
+          "character" : 38,
+          "line" : 13
+        },
+        "uri" : "DeckKit.h"
+      },
+      "names" : {
+        "title" : "_DeckKitVersionString"
+      },
+      "pathComponents" : [
+        "_DeckKitVersionString"
+      ]
+    }
+  ]
+}

--- a/Tests/SwiftDocCUtilitiesTests/OutOfProcessReferenceResolverTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/OutOfProcessReferenceResolverTests.swift
@@ -229,7 +229,7 @@ class OutOfProcessReferenceResolverTests: XCTestCase {
         
         XCTAssertNotNil(symbolNode.semantic as? Symbol)
         if let symbol = symbolNode.semantic as? Symbol {
-            XCTAssertEqual(symbol.kind.identifier, SymbolGraph.Symbol.Kind.Swift.class.rawValue,
+            XCTAssertEqual(symbol.kind.identifier, SymbolGraph.Symbol.KindIdentifier.class,
                            "When the node kind doesn't map to a known value it should fallback to a `.class` kind.")
             XCTAssertEqual(symbol.title, "Resolved Title")
         }

--- a/Tests/SwiftDocCUtilitiesTests/Test Resources/DeckKit-Objective-C.symbols.json
+++ b/Tests/SwiftDocCUtilitiesTests/Test Resources/DeckKit-Objective-C.symbols.json
@@ -1,0 +1,1881 @@
+{
+  "metadata" : {
+    "formatVersion" : {
+      "major" : 0,
+      "minor" : 5,
+      "patch" : 0
+    },
+    "generator" : "SymbolKit"
+  },
+  "module" : {
+    "name" : "DeckKit",
+    "platform" : {
+      "architecture" : "x86_64",
+      "operatingSystem" : {
+        "minimumVersion" : {
+          "major" : 11,
+          "minor" : 0,
+          "patch" : 0
+        },
+        "name" : "macos"
+      },
+      "vendor" : "apple"
+    }
+  },
+  "relationships" : [
+    {
+      "kind" : "memberOf",
+      "source" : "c:@E@EnumTest@one",
+      "target" : "c:@E@EnumTest",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:@E@EnumTest@two",
+      "target" : "c:@E@EnumTest",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:@E@OptionTest@first",
+      "target" : "c:@E@OptionTest",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:@E@OptionTest@second",
+      "target" : "c:@E@OptionTest",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:@EA@Rank@Ace",
+      "target" : "c:@EA@Rank",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:@EA@Rank@Eight",
+      "target" : "c:@EA@Rank",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:@EA@Rank@Five",
+      "target" : "c:@EA@Rank",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:@EA@Rank@Four",
+      "target" : "c:@EA@Rank",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:@EA@Rank@Jack",
+      "target" : "c:@EA@Rank",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:@EA@Rank@King",
+      "target" : "c:@EA@Rank",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:@EA@Rank@Nine",
+      "target" : "c:@EA@Rank",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:@EA@Rank@Queen",
+      "target" : "c:@EA@Rank",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:@EA@Rank@Seven",
+      "target" : "c:@EA@Rank",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:@EA@Rank@Six",
+      "target" : "c:@EA@Rank",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:@EA@Rank@Ten",
+      "target" : "c:@EA@Rank",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:@EA@Rank@Three",
+      "target" : "c:@EA@Rank",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:@EA@Rank@Two",
+      "target" : "c:@EA@Rank",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:@EA@Suit@Clubs",
+      "target" : "c:@EA@Suit",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:@EA@Suit@Diamonds",
+      "target" : "c:@EA@Suit",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:@EA@Suit@Hearts",
+      "target" : "c:@EA@Suit",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:@EA@Suit@Spades",
+      "target" : "c:@EA@Suit",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "inheritsFrom",
+      "source" : "c:objc(cs)PlayingCard",
+      "target" : "c:objc(cs)NSObject",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "conformsTo",
+      "source" : "c:objc(cs)PlayingCard",
+      "target" : "c:objc(pl)ColorDetecting",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "conformsTo",
+      "source" : "c:objc(cs)PlayingCard",
+      "target" : "c:objc(pl)NSCopying",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:objc(cs)PlayingCard(cm)newWithRank:ofSuit:",
+      "target" : "c:objc(cs)PlayingCard",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:objc(cs)PlayingCard(im)initWithRank:ofSuit:",
+      "target" : "c:objc(cs)PlayingCard",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:objc(cs)PlayingCard(im)isFaceCard",
+      "target" : "c:objc(cs)PlayingCard",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:objc(cs)PlayingCard(py)rank",
+      "target" : "c:objc(cs)PlayingCard",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:objc(cs)PlayingCard(py)suit",
+      "target" : "c:objc(cs)PlayingCard",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:objc(pl)ColorDetecting(im)isBlack",
+      "target" : "c:objc(pl)ColorDetecting",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:objc(pl)ColorDetecting(im)isGreen",
+      "target" : "c:objc(pl)ColorDetecting",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:objc(pl)ColorDetecting(im)isRed",
+      "target" : "c:objc(pl)ColorDetecting",
+      "targetFallback" : null
+    }
+  ],
+  "symbols" : [
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "(anonymous)"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "range" : {
+              "end" : {
+                "character" : 41,
+                "line" : 11
+              },
+              "start" : {
+                "character" : 4,
+                "line" : 11
+              }
+            },
+            "text" : "Enum used to represent a card's rank."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@EA@Rank"
+      },
+      "kind" : {
+        "displayName" : "Enumeration",
+        "identifier" : "occ.enum"
+      },
+      "location" : {
+        "position" : {
+          "character" : 8,
+          "line" : 12
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "(anonymous)"
+      },
+      "pathComponents" : [
+        "(anonymous)"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "(anonymous)"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "range" : {
+              "end" : {
+                "character" : 41,
+                "line" : 26
+              },
+              "start" : {
+                "character" : 4,
+                "line" : 26
+              }
+            },
+            "text" : "Enum used to represent a card's suit."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@EA@Suit"
+      },
+      "kind" : {
+        "displayName" : "Enumeration",
+        "identifier" : "occ.enum"
+      },
+      "location" : {
+        "position" : {
+          "character" : 8,
+          "line" : 27
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "(anonymous)"
+      },
+      "pathComponents" : [
+        "(anonymous)"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "Ace"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@EA@Rank@Ace"
+      },
+      "kind" : {
+        "displayName" : "Case",
+        "identifier" : "occ.enum.case"
+      },
+      "location" : {
+        "position" : {
+          "character" : 14,
+          "line" : 12
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "Ace"
+      },
+      "pathComponents" : [
+        "(anonymous)",
+        "Ace"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "Clubs"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "range" : {
+              "end" : {
+                "character" : 36,
+                "line" : 29
+              },
+              "start" : {
+                "character" : 20,
+                "line" : 29
+              }
+            },
+            "text" : "Black clover. "
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@EA@Suit@Clubs"
+      },
+      "kind" : {
+        "displayName" : "Case",
+        "identifier" : "occ.enum.case"
+      },
+      "location" : {
+        "position" : {
+          "character" : 4,
+          "line" : 29
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "Clubs"
+      },
+      "pathComponents" : [
+        "(anonymous)",
+        "Clubs"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "Diamonds"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "range" : {
+              "end" : {
+                "character" : 35,
+                "line" : 30
+              },
+              "start" : {
+                "character" : 20,
+                "line" : 30
+              }
+            },
+            "text" : "Red rhombus. "
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@EA@Suit@Diamonds"
+      },
+      "kind" : {
+        "displayName" : "Case",
+        "identifier" : "occ.enum.case"
+      },
+      "location" : {
+        "position" : {
+          "character" : 4,
+          "line" : 30
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "Diamonds"
+      },
+      "pathComponents" : [
+        "(anonymous)",
+        "Diamonds"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "Eight"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@EA@Rank@Eight"
+      },
+      "kind" : {
+        "displayName" : "Case",
+        "identifier" : "occ.enum.case"
+      },
+      "location" : {
+        "position" : {
+          "character" : 57,
+          "line" : 12
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "Eight"
+      },
+      "pathComponents" : [
+        "(anonymous)",
+        "Eight"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "Five"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@EA@Rank@Five"
+      },
+      "kind" : {
+        "displayName" : "Case",
+        "identifier" : "occ.enum.case"
+      },
+      "location" : {
+        "position" : {
+          "character" : 39,
+          "line" : 12
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "Five"
+      },
+      "pathComponents" : [
+        "(anonymous)",
+        "Five"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "Four"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@EA@Rank@Four"
+      },
+      "kind" : {
+        "displayName" : "Case",
+        "identifier" : "occ.enum.case"
+      },
+      "location" : {
+        "position" : {
+          "character" : 33,
+          "line" : 12
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "Four"
+      },
+      "pathComponents" : [
+        "(anonymous)",
+        "Four"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "Hearts"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "range" : {
+              "end" : {
+                "character" : 42,
+                "line" : 28
+              },
+              "start" : {
+                "character" : 20,
+                "line" : 28
+              }
+            },
+            "text" : "Red cardiovascular. "
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@EA@Suit@Hearts"
+      },
+      "kind" : {
+        "displayName" : "Case",
+        "identifier" : "occ.enum.case"
+      },
+      "location" : {
+        "position" : {
+          "character" : 4,
+          "line" : 28
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "Hearts"
+      },
+      "pathComponents" : [
+        "(anonymous)",
+        "Hearts"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "Jack"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@EA@Rank@Jack"
+      },
+      "kind" : {
+        "displayName" : "Case",
+        "identifier" : "occ.enum.case"
+      },
+      "location" : {
+        "position" : {
+          "character" : 75,
+          "line" : 12
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "Jack"
+      },
+      "pathComponents" : [
+        "(anonymous)",
+        "Jack"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "King"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@EA@Rank@King"
+      },
+      "kind" : {
+        "displayName" : "Case",
+        "identifier" : "occ.enum.case"
+      },
+      "location" : {
+        "position" : {
+          "character" : 88,
+          "line" : 12
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "King"
+      },
+      "pathComponents" : [
+        "(anonymous)",
+        "King"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "Nine"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@EA@Rank@Nine"
+      },
+      "kind" : {
+        "displayName" : "Case",
+        "identifier" : "occ.enum.case"
+      },
+      "location" : {
+        "position" : {
+          "character" : 64,
+          "line" : 12
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "Nine"
+      },
+      "pathComponents" : [
+        "(anonymous)",
+        "Nine"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "Queen"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@EA@Rank@Queen"
+      },
+      "kind" : {
+        "displayName" : "Case",
+        "identifier" : "occ.enum.case"
+      },
+      "location" : {
+        "position" : {
+          "character" : 81,
+          "line" : 12
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "Queen"
+      },
+      "pathComponents" : [
+        "(anonymous)",
+        "Queen"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "Seven"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@EA@Rank@Seven"
+      },
+      "kind" : {
+        "displayName" : "Case",
+        "identifier" : "occ.enum.case"
+      },
+      "location" : {
+        "position" : {
+          "character" : 50,
+          "line" : 12
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "Seven"
+      },
+      "pathComponents" : [
+        "(anonymous)",
+        "Seven"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "Six"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@EA@Rank@Six"
+      },
+      "kind" : {
+        "displayName" : "Case",
+        "identifier" : "occ.enum.case"
+      },
+      "location" : {
+        "position" : {
+          "character" : 45,
+          "line" : 12
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "Six"
+      },
+      "pathComponents" : [
+        "(anonymous)",
+        "Six"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "Spades"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "range" : {
+              "end" : {
+                "character" : 36,
+                "line" : 31
+              },
+              "start" : {
+                "character" : 20,
+                "line" : 31
+              }
+            },
+            "text" : "Black shovel. "
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@EA@Suit@Spades"
+      },
+      "kind" : {
+        "displayName" : "Case",
+        "identifier" : "occ.enum.case"
+      },
+      "location" : {
+        "position" : {
+          "character" : 4,
+          "line" : 31
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "Spades"
+      },
+      "pathComponents" : [
+        "(anonymous)",
+        "Spades"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "Ten"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@EA@Rank@Ten"
+      },
+      "kind" : {
+        "displayName" : "Case",
+        "identifier" : "occ.enum.case"
+      },
+      "location" : {
+        "position" : {
+          "character" : 70,
+          "line" : 12
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "Ten"
+      },
+      "pathComponents" : [
+        "(anonymous)",
+        "Ten"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "Three"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@EA@Rank@Three"
+      },
+      "kind" : {
+        "displayName" : "Case",
+        "identifier" : "occ.enum.case"
+      },
+      "location" : {
+        "position" : {
+          "character" : 26,
+          "line" : 12
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "Three"
+      },
+      "pathComponents" : [
+        "(anonymous)",
+        "Three"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "Two"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@EA@Rank@Two"
+      },
+      "kind" : {
+        "displayName" : "Case",
+        "identifier" : "occ.enum.case"
+      },
+      "location" : {
+        "position" : {
+          "character" : 21,
+          "line" : 12
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "Two"
+      },
+      "pathComponents" : [
+        "(anonymous)",
+        "Two"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "ColorDetecting"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "range" : {
+              "end" : {
+                "character" : 72,
+                "line" : 34
+              },
+              "start" : {
+                "character" : 4,
+                "line" : 34
+              }
+            },
+            "text" : "Protocol of methods that report whether an object is certain colors."
+          },
+          {
+            "range" : {
+              "end" : {
+                "character" : 3,
+                "line" : 35
+              },
+              "start" : {
+                "character" : 3,
+                "line" : 35
+              }
+            },
+            "text" : ""
+          },
+          {
+            "range" : {
+              "end" : {
+                "character" : 38,
+                "line" : 36
+              },
+              "start" : {
+                "character" : 4,
+                "line" : 36
+              }
+            },
+            "text" : "Only a few colors are implemented."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:objc(pl)ColorDetecting"
+      },
+      "kind" : {
+        "displayName" : "Protocol",
+        "identifier" : "occ.protocol"
+      },
+      "location" : {
+        "position" : {
+          "character" : 10,
+          "line" : 37
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "ColorDetecting"
+      },
+      "pathComponents" : [
+        "ColorDetecting"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "isBlack"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "range" : {
+              "end" : {
+                "character" : 48,
+                "line" : 41
+              },
+              "start" : {
+                "character" : 4,
+                "line" : 41
+              }
+            },
+            "text" : "Returns true if the card is of a black suit."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:objc(pl)ColorDetecting(im)isBlack"
+      },
+      "kind" : {
+        "displayName" : "Instance Method",
+        "identifier" : "occ.method"
+      },
+      "location" : {
+        "position" : {
+          "character" : 0,
+          "line" : 42
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "isBlack"
+      },
+      "pathComponents" : [
+        "ColorDetecting",
+        "isBlack"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "availability" : [
+        {
+          "domain" : "Unsupported OS: macos",
+          "isUnconditionallyUnavailable" : true
+        }
+      ],
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "isGreen"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "range" : {
+              "end" : {
+                "character" : 48,
+                "line" : 44
+              },
+              "start" : {
+                "character" : 4,
+                "line" : 44
+              }
+            },
+            "text" : "Returns true if the card is of a green suit."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:objc(pl)ColorDetecting(im)isGreen"
+      },
+      "kind" : {
+        "displayName" : "Instance Method",
+        "identifier" : "occ.method"
+      },
+      "location" : {
+        "position" : {
+          "character" : 0,
+          "line" : 45
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "isGreen"
+      },
+      "pathComponents" : [
+        "ColorDetecting",
+        "isGreen"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "isRed"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "range" : {
+              "end" : {
+                "character" : 46,
+                "line" : 38
+              },
+              "start" : {
+                "character" : 4,
+                "line" : 38
+              }
+            },
+            "text" : "Returns true if the card is of a red suit."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:objc(pl)ColorDetecting(im)isRed"
+      },
+      "kind" : {
+        "displayName" : "Instance Method",
+        "identifier" : "occ.method"
+      },
+      "location" : {
+        "position" : {
+          "character" : 0,
+          "line" : 39
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "isRed"
+      },
+      "pathComponents" : [
+        "ColorDetecting",
+        "isRed"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "EnumTest"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "range" : {
+              "end" : {
+                "character" : 35,
+                "line" : 14
+              },
+              "start" : {
+                "character" : 4,
+                "line" : 14
+              }
+            },
+            "text" : "Test doc comment for an NS_ENUM"
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@E@EnumTest"
+      },
+      "kind" : {
+        "displayName" : "Enumeration",
+        "identifier" : "occ.enum"
+      },
+      "location" : {
+        "position" : {
+          "character" : 8,
+          "line" : 15
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "EnumTest"
+      },
+      "pathComponents" : [
+        "EnumTest"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "EnumTest"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "range" : {
+              "end" : {
+                "character" : 35,
+                "line" : 14
+              },
+              "start" : {
+                "character" : 4,
+                "line" : 14
+              }
+            },
+            "text" : "Test doc comment for an NS_ENUM"
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:PlayingCard.h@T@EnumTest"
+      },
+      "kind" : {
+        "displayName" : "Typedef",
+        "identifier" : "occ.typealias"
+      },
+      "location" : {
+        "position" : {
+          "character" : 8,
+          "line" : 15
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "EnumTest"
+      },
+      "pathComponents" : [
+        "EnumTest"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "one"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@E@EnumTest@one"
+      },
+      "kind" : {
+        "displayName" : "Case",
+        "identifier" : "occ.enum.case"
+      },
+      "location" : {
+        "position" : {
+          "character" : 4,
+          "line" : 16
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "one"
+      },
+      "pathComponents" : [
+        "EnumTest",
+        "one"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "two"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@E@EnumTest@two"
+      },
+      "kind" : {
+        "displayName" : "Case",
+        "identifier" : "occ.enum.case"
+      },
+      "location" : {
+        "position" : {
+          "character" : 4,
+          "line" : 17
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "two"
+      },
+      "pathComponents" : [
+        "EnumTest",
+        "two"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "OptionTest"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "range" : {
+              "end" : {
+                "character" : 38,
+                "line" : 20
+              },
+              "start" : {
+                "character" : 4,
+                "line" : 20
+              }
+            },
+            "text" : "Test doc comment for an NS_OPTIONS"
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@E@OptionTest"
+      },
+      "kind" : {
+        "displayName" : "Enumeration",
+        "identifier" : "occ.enum"
+      },
+      "location" : {
+        "position" : {
+          "character" : 8,
+          "line" : 21
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "OptionTest"
+      },
+      "pathComponents" : [
+        "OptionTest"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "OptionTest"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "range" : {
+              "end" : {
+                "character" : 38,
+                "line" : 20
+              },
+              "start" : {
+                "character" : 4,
+                "line" : 20
+              }
+            },
+            "text" : "Test doc comment for an NS_OPTIONS"
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:PlayingCard.h@T@OptionTest"
+      },
+      "kind" : {
+        "displayName" : "Typedef",
+        "identifier" : "occ.typealias"
+      },
+      "location" : {
+        "position" : {
+          "character" : 8,
+          "line" : 21
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "OptionTest"
+      },
+      "pathComponents" : [
+        "OptionTest"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "first"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@E@OptionTest@first"
+      },
+      "kind" : {
+        "displayName" : "Case",
+        "identifier" : "occ.enum.case"
+      },
+      "location" : {
+        "position" : {
+          "character" : 4,
+          "line" : 22
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "first"
+      },
+      "pathComponents" : [
+        "OptionTest",
+        "first"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "second"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@E@OptionTest@second"
+      },
+      "kind" : {
+        "displayName" : "Case",
+        "identifier" : "occ.enum.case"
+      },
+      "location" : {
+        "position" : {
+          "character" : 4,
+          "line" : 23
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "second"
+      },
+      "pathComponents" : [
+        "OptionTest",
+        "second"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "PlayingCard"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:objc(cs)PlayingCard"
+      },
+      "kind" : {
+        "displayName" : "Class",
+        "identifier" : "occ.class"
+      },
+      "location" : {
+        "position" : {
+          "character" : 11,
+          "line" : 48
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "PlayingCard"
+      },
+      "pathComponents" : [
+        "PlayingCard"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "initWithRank:ofSuit:"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "range" : {
+              "end" : {
+                "character" : 51,
+                "line" : 53
+              },
+              "start" : {
+                "character" : 4,
+                "line" : 53
+              }
+            },
+            "text" : "Initialize a card with the given rank and suit."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:objc(cs)PlayingCard(im)initWithRank:ofSuit:"
+      },
+      "kind" : {
+        "displayName" : "Instance Method",
+        "identifier" : "occ.method"
+      },
+      "location" : {
+        "position" : {
+          "character" : 0,
+          "line" : 54
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "initWithRank:ofSuit:"
+      },
+      "pathComponents" : [
+        "PlayingCard",
+        "initWithRank:ofSuit:"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "availability" : [
+        {
+          "domain" : "Unsupported OS: macos",
+          "introduced" : {
+            "major" : 10,
+            "minor" : 11,
+            "patch" : 0
+          }
+        }
+      ],
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "isFaceCard"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "range" : {
+              "end" : {
+                "character" : 44,
+                "line" : 62
+              },
+              "start" : {
+                "character" : 4,
+                "line" : 62
+              }
+            },
+            "text" : "Returns true if the card is a face card."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:objc(cs)PlayingCard(im)isFaceCard"
+      },
+      "kind" : {
+        "displayName" : "Instance Method",
+        "identifier" : "occ.method"
+      },
+      "location" : {
+        "position" : {
+          "character" : 0,
+          "line" : 63
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "isFaceCard"
+      },
+      "pathComponents" : [
+        "PlayingCard",
+        "isFaceCard"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "newWithRank:ofSuit:"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "range" : {
+              "end" : {
+                "character" : 68,
+                "line" : 56
+              },
+              "start" : {
+                "character" : 4,
+                "line" : 56
+              }
+            },
+            "text" : "Allocate and initialize a new card with the given rank and suit."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:objc(cs)PlayingCard(cm)newWithRank:ofSuit:"
+      },
+      "kind" : {
+        "displayName" : "Class Method",
+        "identifier" : "occ.type.method"
+      },
+      "location" : {
+        "position" : {
+          "character" : 0,
+          "line" : 57
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "newWithRank:ofSuit:"
+      },
+      "pathComponents" : [
+        "PlayingCard",
+        "newWithRank:ofSuit:"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "rank"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:objc(cs)PlayingCard(py)rank"
+      },
+      "isReadOnly" : true,
+      "kind" : {
+        "displayName" : "Property",
+        "identifier" : "occ.property"
+      },
+      "location" : {
+        "position" : {
+          "character" : 26,
+          "line" : 50
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "rank"
+      },
+      "pathComponents" : [
+        "PlayingCard",
+        "rank"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "suit"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:objc(cs)PlayingCard(py)suit"
+      },
+      "isReadOnly" : true,
+      "kind" : {
+        "displayName" : "Property",
+        "identifier" : "occ.property"
+      },
+      "location" : {
+        "position" : {
+          "character" : 26,
+          "line" : 51
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "suit"
+      },
+      "pathComponents" : [
+        "PlayingCard",
+        "suit"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "Rank"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "range" : {
+              "end" : {
+                "character" : 41,
+                "line" : 11
+              },
+              "start" : {
+                "character" : 4,
+                "line" : 11
+              }
+            },
+            "text" : "Enum used to represent a card's rank."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@T@Rank"
+      },
+      "kind" : {
+        "displayName" : "Typedef",
+        "identifier" : "occ.typealias"
+      },
+      "location" : {
+        "position" : {
+          "character" : 94,
+          "line" : 12
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "Rank"
+      },
+      "pathComponents" : [
+        "Rank"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "Suit"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "range" : {
+              "end" : {
+                "character" : 41,
+                "line" : 26
+              },
+              "start" : {
+                "character" : 4,
+                "line" : 26
+              }
+            },
+            "text" : "Enum used to represent a card's suit."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@T@Suit"
+      },
+      "kind" : {
+        "displayName" : "Typedef",
+        "identifier" : "occ.typealias"
+      },
+      "location" : {
+        "position" : {
+          "character" : 2,
+          "line" : 32
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "title" : "Suit"
+      },
+      "pathComponents" : [
+        "Suit"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "_DeckKitVersionNumber"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "range" : {
+              "end" : {
+                "character" : 39,
+                "line" : 9
+              },
+              "start" : {
+                "character" : 4,
+                "line" : 9
+              }
+            },
+            "text" : "Project version number for DeckKit."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@DeckKitVersionNumber"
+      },
+      "kind" : {
+        "displayName" : "Global Variable",
+        "identifier" : "occ.var"
+      },
+      "location" : {
+        "position" : {
+          "character" : 25,
+          "line" : 10
+        },
+        "uri" : "DeckKit.h"
+      },
+      "names" : {
+        "title" : "_DeckKitVersionNumber"
+      },
+      "pathComponents" : [
+        "_DeckKitVersionNumber"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "_DeckKitVersionString"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "range" : {
+              "end" : {
+                "character" : 39,
+                "line" : 12
+              },
+              "start" : {
+                "character" : 4,
+                "line" : 12
+              }
+            },
+            "text" : "Project version string for DeckKit."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@DeckKitVersionString"
+      },
+      "kind" : {
+        "displayName" : "Global Variable",
+        "identifier" : "occ.var"
+      },
+      "location" : {
+        "position" : {
+          "character" : 38,
+          "line" : 13
+        },
+        "uri" : "DeckKit.h"
+      },
+      "names" : {
+        "title" : "_DeckKitVersionString"
+      },
+      "pathComponents" : [
+        "_DeckKitVersionString"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://69835303

## Summary

This PR changes how DocC loads symbol graphs to use a new "unified symbol graph" representation being introduced in SymbolKit. This enables us to emit symbols which have multiple "views" in different languages.

This PR also applies the "parsed symbol kinds" change that was also introduced in the same SymbolKit PR.

To ease the transition to proper "cross-language documentation", this PR opts to swap out the underlying infrastructure but adds in convenience properties and methods to allow a "unified symbol" to be treated as a "singular symbol" for the purposes of creating the topic graph. Full support for all a symbol's variants will be added in a later PR. The convenience methods are defined in `Sources/SwiftDocC/Semantics/Symbol/Symbol.swift`.

Support for loading non-Swift symbols is currently gated behind a new `--enable-experimental-objective-c-support` flag.

## Dependencies

https://github.com/apple/swift-docc-symbolkit/pull/3

## Testing

This PR should not change existing behavior.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary