### PR TITLE
Disable 'testNavigationTreeLargeDumpAndReadAsync()'

### DIFF
--- a/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
@@ -235,7 +235,10 @@ Root
 #endif
     }
     
-    func testNavigationTreeLargeDumpAndReadAsync() throws {
+    // This test has been disabled because of frequent failures in Swift CI.
+    //
+    // rdar://85055022 tracks updating this test to remove any flakiness.
+    func disabled_testNavigationTreeLargeDumpAndReadAsync() throws {
         let targetURL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
         try FileManager.default.createDirectory(at: targetURL, withIntermediateDirectories: true, attributes: nil)
         defer {


### PR DESCRIPTION
## Summary

This test has been failing frequently in Swift CI and is blocking other projects.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] ~~Added tests~~ N/A.
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
