### PR TITLE
Update swift-argument-parser

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
           "branch": null,
-          "revision": "83b23d940471b313427da226196661856f6ba3e0",
-          "version": "0.4.4"
+          "revision": "d2930e8fcf9c33162b9fcc1d522bc975e2d4179b",
+          "version": "1.0.1"
         }
       },
       {
@@ -51,7 +51,7 @@
         "repositoryURL": "https://github.com/apple/swift-markdown.git",
         "state": {
           "branch": "main",
-          "revision": "2ba1ed580d18b330f6e89d999b6e09f5f1343fde",
+          "revision": "9a9050095ec93853c0ed01930a9d108d79dc4776",
           "version": null
         }
       },

--- a/Package.swift
+++ b/Package.swift
@@ -114,7 +114,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(url: "https://github.com/apple/swift-nio-ssl.git", .upToNextMinor(from: "2.15.0")),
         .package(name: "swift-markdown", url: "https://github.com/apple/swift-markdown.git", .branch("main")),
         .package(name: "CLMDB", url: "https://github.com/apple/swift-lmdb.git", .branch("main")),
-        .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "0.4.4")),
+        .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "1.0.1")),
         .package(name: "SymbolKit", url: "https://github.com/apple/swift-docc-symbolkit", .branch("main")),
         .package(url: "https://github.com/apple/swift-crypto.git", .upToNextMinor(from: "1.1.2")),
     ]

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Convert.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Convert.swift
@@ -185,14 +185,6 @@ extension Docc {
         """))
         public var diagnosticLevel: String?
         
-        // Parse and ignore any unrecognized flags, options, and input.
-        //
-        // When we're adding new flags or options to the `convert` command. This behavior allows us to also land
-        // changes in other tools that pass these values to `docc convert` without coordinating the two releases.
-        
-        @Argument(parsing: .unconditionalRemaining, help: .hidden)
-        var unrecognizedArgumentsAndOptions: [String] = []
-        
         // MARK: - Computed Properties
 
         /// The path to the directory that all build output should be placed in.
@@ -220,10 +212,6 @@ extension Docc {
                 note: "\(level)" is not a valid diagnostic level.
                       Use one of "error", "warning", "information", or "hint"
                 """)
-            }
-            
-            if !unrecognizedArgumentsAndOptions.isEmpty {
-                print("note: The following arguments, options, and flags were not recognized and will be ignored: \(unrecognizedArgumentsAndOptions)")
             }
             
             if let outputParent = providedOutputURL?.deletingLastPathComponent() {

--- a/Tests/SwiftDocCUtilitiesTests/ArgumentParsing/ConvertSubcommandTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ArgumentParsing/ConvertSubcommandTests.swift
@@ -289,21 +289,6 @@ class ConvertSubcommandTests: XCTestCase {
         }
     }
     
-    func testExtraArgumentsAreIgnored() throws {
-        setenv(TemplateOption.environmentVariableKey, testTemplateURL.path, 1)
-        
-        let convertOptions = try Docc.Convert.parse([
-            testBundleURL.path,
-            // These are unrecognized
-            "--extra-option", "\"extra value\"",
-            "--extra-flag",
-            // This flag is recognized
-            "--analyze"
-        ])
-        
-        XCTAssertEqual(convertOptions.unrecognizedArgumentsAndOptions, ["--extra-option", "\"extra value\"", "--extra-flag"])
-    }
-    
     func testIndex() throws {
         setenv(TemplateOption.environmentVariableKey, testTemplateURL.path, 1)
         


### PR DESCRIPTION
## Summary

Updates swift-argument-paser to 1.0.1. This also removes support for parsing unknown arguments in `docc convert`

## Dependencies

https://github.com/apple/swift-markdown/pull/17
https://github.com/apple/swift/pull/40103
https://github.com/apple/swift-driver/pull/899
https://github.com/apple/sourcekit-lsp/pull/434
https://github.com/apple/swift-package-manager/pull/3843

## Testing

Run Cmd+U; ensure argument parsing still works.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
