### PR TITLE
Support Objective-C navigator index creation

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Symbol Graph/GeneratedDocumentationTopics.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Graph/GeneratedDocumentationTopics.swift
@@ -70,8 +70,15 @@ enum GeneratedDocumentationTopics {
     private static let defaultImplementationGroupTitle = "Default Implementations"
     
     private static func createCollectionNode(parent: ResolvedTopicReference, title: String, identifiers: [ResolvedTopicReference], context: DocumentationContext, bundle: DocumentationBundle) throws {
+        let automaticCurationSourceLanguage: SourceLanguage
+        if FeatureFlags.current.isExperimentalObjectiveCSupportEnabled {
+            automaticCurationSourceLanguage = identifiers.first?.sourceLanguage ?? .swift
+        } else {
+            automaticCurationSourceLanguage = .swift
+        }
+        
         // Create the collection topic reference
-        let collectionReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: NodeURLGenerator.Path.documentationCuration(parentPath: parent.path, articleName: title).stringValue, sourceLanguage: .swift)
+        let collectionReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: NodeURLGenerator.Path.documentationCuration(parentPath: parent.path, articleName: title).stringValue, sourceLanguage: automaticCurationSourceLanguage)
         
         // Add the topic graph node
         let collectionTopicGraphNode = TopicGraph.Node(reference: collectionReference, kind: .collection, source: .external, title: title, isResolvable: false)
@@ -128,7 +135,7 @@ enum GeneratedDocumentationTopics {
         let temporaryCollectionNode = DocumentationNode(
             reference: collectionReference,
             kind: .collectionGroup,
-            sourceLanguage: .swift,
+            sourceLanguage: automaticCurationSourceLanguage,
             name: DocumentationNode.Name.conceptual(title: title),
             markup: Document(parsing: ""),
             semantic: Article(markup: nil, metadata: nil, redirects: nil)
@@ -144,7 +151,7 @@ enum GeneratedDocumentationTopics {
         let collectionNode = DocumentationNode(
             reference: collectionReference,
             kind: .collectionGroup,
-            sourceLanguage: .swift,
+            sourceLanguage: automaticCurationSourceLanguage,
             name: DocumentationNode.Name.conceptual(title: title),
             markup: Document(parsing: ""),
             semantic: collectionArticle

--- a/Sources/SwiftDocC/Infrastructure/Symbol Graph/ResolvedTopicReference+Symbol.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Graph/ResolvedTopicReference+Symbol.swift
@@ -18,6 +18,16 @@ extension ResolvedTopicReference {
     ///   - bundle: A documentation bundle, to which the symbol belongs.
     init(symbolReference: SymbolReference, moduleName: String, bundle: DocumentationBundle) {
         let path = symbolReference.path.isEmpty ? "" : "/" + symbolReference.path
-        self = bundle.documentationRootReference.appendingPath(moduleName + path)
+        
+        if FeatureFlags.current.isExperimentalObjectiveCSupportEnabled {
+            self.init(
+                bundleIdentifier: bundle.documentationRootReference.bundleIdentifier,
+                path: bundle.documentationRootReference.appendingPath(moduleName + path).path,
+                fragment: nil,
+                sourceLanguage: symbolReference.interfaceLanguage
+            )
+        } else {
+            self = bundle.documentationRootReference.appendingPath(moduleName + path)
+        }
     }
 }

--- a/Sources/SwiftDocC/Model/DocumentationNode.swift
+++ b/Sources/SwiftDocC/Model/DocumentationNode.swift
@@ -152,13 +152,16 @@ public struct DocumentationNode {
     init(reference: ResolvedTopicReference, unifiedSymbol: UnifiedSymbolGraph.Symbol, platformName: String?, moduleName: String, bystanderModules: [String]? = nil) {
         self.reference = reference
         
-        guard reference.sourceLanguage == .swift,
-              let symbol = unifiedSymbol.defaultSymbol else {
+        guard reference.sourceLanguage == .swift || FeatureFlags.current.isExperimentalObjectiveCSupportEnabled else {
             fatalError("""
                 Only Swift symbols are currently supported. \
                 This initializer is only called with symbols from the symbol graph, which currently only supports Swift.
                 """
             )
+        }
+        
+        guard let symbol = unifiedSymbol.defaultSymbol else {
+            fatalError("Unexpectedly failed to get 'defaultSymbol' from 'unifiedSymbol'.")
         }
         
         self.kind = Self.kind(for: symbol)

--- a/Sources/SwiftDocC/Model/SourceLanguage.swift
+++ b/Sources/SwiftDocC/Model/SourceLanguage.swift
@@ -86,9 +86,26 @@ public struct SourceLanguage: Hashable, Codable {
             return nil
         }
     }
+    
+    /// Finds the programming language that matches a given identifier.
+    ///
+    /// If the language identifier doesn't match any known language, this initializer returns `nil`.
+    ///
+    /// - Parameter knownLanguageIdentifier: The identifier name of the programming language.
+    public init?(knownLanguageIdentifier: String) {
+        if let knownLanguage = SourceLanguage.firstKnownLanguage(withIdentifier: knownLanguageIdentifier) {
+            self = knownLanguage
+        } else {
+            return nil
+        }
+    }
 
     private static func firstKnownLanguage(withName name: String) -> SourceLanguage? {
         return SourceLanguage.knownLanguages.first { $0.name.lowercased() == name.lowercased() }
+    }
+    
+    private static func firstKnownLanguage(withIdentifier id: String) -> SourceLanguage? {
+        return SourceLanguage.knownLanguages.first { $0.id.lowercased() == id.lowercased() }
     }
     
     /// The Swift programming language.

--- a/Sources/SwiftDocC/Semantics/Symbol/Symbol.swift
+++ b/Sources/SwiftDocC/Semantics/Symbol/Symbol.swift
@@ -422,8 +422,16 @@ extension UnifiedSymbolGraph.Symbol {
         )
     }
 
-    var swiftIdentifier: SymbolGraph.Symbol.Identifier {
-        identifier(forLanguage: "swift")
+    var defaultIdentifier: SymbolGraph.Symbol.Identifier {
+        guard FeatureFlags.current.isExperimentalObjectiveCSupportEnabled else {
+            return identifier(forLanguage: "swift")
+        }
+        
+        if let defaultInterfaceLanguage = defaultSelector?.interfaceLanguage {
+            return identifier(forLanguage: defaultInterfaceLanguage)
+        } else {
+            return identifier(forLanguage: "swift")
+        }
     }
 }
 


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://84949759

## Summary

Removes some hard-coding of swift language identifiers to allow for creation of an Objective-C navigator index from Objective-C symbol graph data.

## Testing

Use the included Objective-C test fixture to build documentation and confirm that the generated RenderJSON contain Objective-C language identifiers and not Swift.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
