### PR TITLE
Disable concurrency encoding test

### DIFF
--- a/Tests/SwiftDocCTests/Converter/TopicRenderReferenceEncoderTests.swift
+++ b/Tests/SwiftDocCTests/Converter/TopicRenderReferenceEncoderTests.swift
@@ -107,8 +107,11 @@ class TopicRenderReferenceEncoderTests: XCTestCase {
         XCTAssertEqual(newRenderReference["title"] as? String, "NEW TITLE")
     }
     
+    // This test has been disabled because of failures in Swift CI.
+    // rdar://85428149 tracks updating this test to remove any flakiness.
+    //
     // Encodes concurrently 1000 nodes with 1000 references each.
-    func testTopicReferenceEncodingWithHighConcurrency() throws {
+    func skip_testTopicReferenceEncodingWithHighConcurrency() throws {
         // Create many references
         let references = (0..<1000)
             .map({ i in


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://85428149

## Summary

This disables the concurrency encoding test for topic references due to failures in Swift CI for CentOS.

## Dependencies

n/a

## Testing

n/a

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary
