### PR TITLE
Clean up fragment processing for non-Swift symbols

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/DocumentationContentRenderer.swift
+++ b/Sources/SwiftDocC/Model/Rendering/DocumentationContentRenderer.swift
@@ -67,15 +67,18 @@ public class DocumentationContentRenderer {
             from: symbol.subHeadingVariants,
             symbol.titleVariants,
             symbol.kindVariants
-        ) { _, subHeading, title, kind in
+        ) { trait, subHeading, title, kind in
             var fragments = subHeading
                 .map({ fragment -> DeclarationRenderSection.Token in
                     return DeclarationRenderSection.Token(fragment: fragment, identifier: nil)
                 })
             if fragments.last?.text == "\n" { fragments.removeLast() }
             
-            // TODO: Return an Objective-C subheading for Objective-C symbols (rdar://84195588)
-            return Swift.subHeading(for: fragments, symbolTitle: title, symbolKind: kind.identifier.identifier)
+            if trait == .swift {
+                return Swift.subHeading(for: fragments, symbolTitle: title, symbolKind: kind.identifier.identifier)
+            } else {
+                return fragments
+            }
         } ?? .init(defaultValue: nil)
     }
     
@@ -86,15 +89,19 @@ public class DocumentationContentRenderer {
         }
         
         return VariantCollection<[DeclarationRenderSection.Token]?>(
-            from: symbol.navigatorVariants
-        ) { _, navigator in
+            from: symbol.navigatorVariants,
+            symbol.titleVariants
+        ) { trait, navigator, title in
             var fragments = navigator.map { fragment -> DeclarationRenderSection.Token in
                 return DeclarationRenderSection.Token(fragment: fragment, identifier: nil)
             }
             if fragments.last?.text == "\n" { fragments.removeLast() }
             
-            // TODO: Return an Objective-C navigator title for Objective-C symbols (rdar://84195588)
-            return Swift.navigatorTitle(for: fragments, symbolTitle: symbol.title)
+            if trait == .swift {
+                return Swift.navigatorTitle(for: fragments, symbolTitle: title)
+            } else {
+                return fragments
+            }
         } ?? .init(defaultValue: nil)
     }
     

--- a/Sources/SwiftDocC/Model/Rendering/Variants/VariantCollection+Symbol.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Variants/VariantCollection+Symbol.swift
@@ -342,7 +342,7 @@ private func zipPairsByKey<Key, Value1, Value2>(
     )
 }
 
-/// Creates a dictionary out of three sequences of pairs of the same key type
+/// Creates a dictionary out of three sequences of pairs of the same key type.
 ///
 /// ```swift
 /// let words = [("a", "one"), ("b", "two")]

--- a/Tests/SwiftDocCTests/Rendering/DocumentationContentRendererTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/DocumentationContentRendererTests.swift
@@ -1,0 +1,230 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+import SymbolKit
+import Markdown
+@testable import SwiftDocC
+
+class DocumentationContentRendererTests: XCTestCase {
+    func testReplacesTypeIdentifierSubHeadingFragmentWithIdentifierForSwift() throws {
+        let subHeadingFragments = documentationContentRenderer
+            .subHeadingFragments(for: nodeWithSubheadingAndNavigatorVariants)
+        
+        XCTAssertEqual(
+            subHeadingFragments.defaultValue,
+            [
+                DeclarationRenderSection.Token(
+                    text: "class",
+                    kind: .keyword,
+                    identifier: nil,
+                    preciseIdentifier: nil
+                ),
+                DeclarationRenderSection.Token(
+                    text: " ",
+                    kind: .text,
+                    identifier: nil,
+                    preciseIdentifier: nil
+                ),
+                DeclarationRenderSection.Token(
+                    text: "ClassInSwift",
+                    
+                    // The 'typeIdentifier' value of the symbol's declaration is replaced with an 'identifier'.
+                    kind: .identifier,
+                    identifier: nil,
+                    preciseIdentifier: nil
+                )
+            ]
+        )
+    }
+    
+    func testDoesNotReplaceSubHeadingFragmentsForOtherLanguagesThanSwift() throws {
+        let subHeadingFragments = documentationContentRenderer
+            .subHeadingFragments(for: nodeWithSubheadingAndNavigatorVariants)
+        
+        guard case .replace(let fragments) = subHeadingFragments.variants.first?.patch.first else {
+            XCTFail("Unexpected patch")
+            return
+        }
+        
+        XCTAssertEqual(
+            fragments,
+            [
+                DeclarationRenderSection.Token(
+                    text: "class",
+                    kind: .keyword, identifier: nil, preciseIdentifier: nil
+                ),
+                DeclarationRenderSection.Token(
+                    text: " ",
+                    kind: .text, identifier: nil, preciseIdentifier: nil
+                ),
+                DeclarationRenderSection.Token(
+                    text: "ClassInAnotherLanguage",
+                    kind: .typeIdentifier, identifier: nil, preciseIdentifier: nil
+                )
+            ]
+        )
+    }
+    
+    func testReplacesTypeIdentifierNavigatorFragmentWithIdentifierForSwift() throws {
+        let navigatorFragments = documentationContentRenderer
+            .navigatorFragments(for: nodeWithSubheadingAndNavigatorVariants)
+        
+        XCTAssertEqual(
+            navigatorFragments.defaultValue,
+            [
+                DeclarationRenderSection.Token(
+                    text: "class",
+                    kind: .keyword,
+                    identifier: nil,
+                    preciseIdentifier: nil
+                ),
+                DeclarationRenderSection.Token(
+                    text: " ",
+                    kind: .text,
+                    identifier: nil,
+                    preciseIdentifier: nil
+                ),
+                DeclarationRenderSection.Token(
+                    text: "ClassInSwift",
+                    
+                    // The 'typeIdentifier' value of the symbol's declaration is replaced with an 'identifier'.
+                    kind: .identifier,
+                    identifier: nil,
+                    preciseIdentifier: nil
+                )
+            ]
+        )
+    }
+    
+    func testDoesNotReplacesNavigatorFragmentsForOtherLanguagesThanSwift() throws {
+        let navigatorFragments = documentationContentRenderer
+            .navigatorFragments(for: nodeWithSubheadingAndNavigatorVariants)
+        
+        guard case .replace(let fragments) = navigatorFragments.variants.first?.patch.first else {
+            XCTFail("Unexpected patch")
+            return
+        }
+        
+        XCTAssertEqual(
+            fragments,
+            [
+                DeclarationRenderSection.Token(
+                    text: "class",
+                    kind: .keyword, identifier: nil, preciseIdentifier: nil
+                ),
+                DeclarationRenderSection.Token(
+                    text: " ",
+                    kind: .text, identifier: nil, preciseIdentifier: nil
+                ),
+                DeclarationRenderSection.Token(
+                    text: "ClassInAnotherLanguage",
+                    kind: .typeIdentifier, identifier: nil, preciseIdentifier: nil
+                )
+            ]
+        )
+    }
+}
+
+private extension DocumentationDataVariantsTrait {
+    static var otherLanguage: DocumentationDataVariantsTrait { .init(interfaceLanguage: "otherLanguage") }
+}
+
+private extension DocumentationContentRendererTests {
+    var documentationContentRenderer: DocumentationContentRenderer {
+        DocumentationContentRenderer(
+            documentationContext: try! DocumentationContext(dataProvider: DocumentationWorkspace()),
+            bundle: DocumentationBundle(
+                info: DocumentationBundle.Info(
+                    displayName: "Test",
+                    identifier: "org.swift.test",
+                    version: Version(arrayLiteral: 1,2,3)
+                ),
+                baseURL: URL(string: "https://example.com/example")!,
+                symbolGraphURLs: [],
+                markupURLs: [],
+                miscResourceURLs: []
+            )
+        )
+    }
+    
+    var nodeWithSubheadingAndNavigatorVariants: DocumentationNode {
+        var node = DocumentationNode(
+            reference: ResolvedTopicReference(
+                bundleIdentifier: "org.swift.example",
+                path: "/documentation/class",
+                fragment: nil,
+                sourceLanguage: .swift
+            ),
+            kind: .class,
+            sourceLanguage: .swift,
+            availableSourceLanguages: [
+                .swift,
+                .init(id: DocumentationDataVariantsTrait.otherLanguage.interfaceLanguage!)
+            ],
+            name: DocumentationNode.Name.symbol(declaration: AttributedCodeListing.Line()),
+            markup: Document(parsing: ""),
+            semantic: nil,
+            platformNames: nil
+        )
+        
+        node.semantic = Symbol(
+            kindVariants: .init(values: [
+                .swift: SymbolGraph.Symbol.Kind(parsedIdentifier: .class, displayName: "Class"),
+                .otherLanguage: SymbolGraph.Symbol.Kind(parsedIdentifier: .class, displayName: "Class"),
+            ]),
+            titleVariants: .init(values: [
+                .swift: "ClassInSwift",
+                .otherLanguage: "ClassInAnotherLanguage",
+            ]),
+            subHeadingVariants: .init(values: [
+                .swift: [
+                    .init(kind: .keyword, spelling: "class", preciseIdentifier: nil),
+                    .init(kind: .text, spelling: " ", preciseIdentifier: nil),
+                    .init(kind: .typeIdentifier, spelling: "ClassInSwift", preciseIdentifier: nil),
+                ],
+                .otherLanguage: [
+                    .init(kind: .keyword, spelling: "class", preciseIdentifier: nil),
+                    .init(kind: .text, spelling: " ", preciseIdentifier: nil),
+                    .init(kind: .typeIdentifier, spelling: "ClassInAnotherLanguage", preciseIdentifier: nil),
+                ],
+            ]),
+            navigatorVariants: .init(values: [
+                .swift: [
+                    .init(kind: .keyword, spelling: "class", preciseIdentifier: nil),
+                    .init(kind: .text, spelling: " ", preciseIdentifier: nil),
+                    .init(kind: .typeIdentifier, spelling: "ClassInSwift", preciseIdentifier: nil),
+                ],
+                .otherLanguage: [
+                    .init(kind: .keyword, spelling: "class", preciseIdentifier: nil),
+                    .init(kind: .text, spelling: " ", preciseIdentifier: nil),
+                    .init(kind: .typeIdentifier, spelling: "ClassInAnotherLanguage", preciseIdentifier: nil),
+                ],
+            ]),
+            roleHeadingVariants: .init(swiftVariant: ""),
+            platformNameVariants: .init(swiftVariant: nil),
+            moduleNameVariants: .init(swiftVariant: ""),
+            externalIDVariants: .init(swiftVariant: nil),
+            accessLevelVariants: .init(swiftVariant: nil),
+            availabilityVariants: .init(swiftVariant: Availability(availability: [])),
+            deprecatedSummaryVariants: .init(swiftVariant: nil),
+            mixinsVariants: .init(swiftVariant: nil),
+            abstractSectionVariants: .init(swiftVariant: nil),
+            discussionVariants: .init(swiftVariant: nil),
+            topicsVariants: .init(swiftVariant: nil),
+            seeAlsoVariants: .init(swiftVariant: nil),
+            returnsSectionVariants: .init(swiftVariant: nil),
+            parametersSectionVariants: .init(swiftVariant: nil),
+            redirectsVariants: .init(swiftVariant: nil)
+        )
+        
+        return node
+    }
+}

--- a/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorSymbolVariantsTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorSymbolVariantsTests.swift
@@ -265,6 +265,9 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
                 symbol.navigatorVariants[.objectiveC] = [
                     .init(kind: .keyword, spelling: "objc", preciseIdentifier: nil)
                 ]
+                
+                symbol.titleVariants[.swift] = "Swift Title"
+                symbol.titleVariants[.objectiveC] = "Objective-C Title"
             },
             assertOriginalRenderNode: { renderNode in
                 XCTAssertEqual(


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://84969308

## Summary

Isolate the processing of subHeading and navigator fragments for rendering to Swift symbols.

This is cleanup work that should have no UX impact in practice. The code path that's been modified affects SGFs in languages other than Swift that use a declaration syntax that's similar to Swift's (e.g., `class MyClass {`), which there is no support known case of at the moment.

Also, added tests to cover existing subHeading and navigator fragments functionality for Swift symbols.

## Dependencies

None.

## Testing

For the reason described above, there should be no user-facing changes here.

## Checklist

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
