### PR TITLE
Update Dockerfile to run tests without root permissions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -209,28 +209,22 @@ by running the test suite in a Docker environment that simulates Swift on Linux.
 
 1. Install [Docker Desktop for Mac](https://www.docker.com/products/docker-desktop).
 
-2. Get the newest Swift Docker image with:
+2. Build Swift-DocC (see [Building Swift-DocC](#building-swift-docc)).
 
-    ```bash
-    docker pull swift
-    ```
-
-3. Build Swift-DocC (see [Building Swift-DocC](#building-swift-docc)).
-
-4. Run the following command from the root of this repository
+3. Run the following command from the root of this repository
    to build the Swift-DocC Docker image:
 
     ```bash
     docker build -t swift-docc:latest .
     ```
 
-5. Run the following command to run the test suite:
+4. Run the following command to run the test suite:
 
     ```bash
-    docker run -v `pwd`:/swift-docc swift-docc sh -c 'swift test --package-path /swift-docc --enable-test-discovery --skip-update'
+    docker run -v `pwd`:/swift-docc swift-docc sh -c 'swift test --package-path /swift-docc --parallel --skip-update'
     ```
 
-6. To interactively test the command line interface,
+5. To interactively test the command line interface,
    first log into the container with:
 
     ```bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,14 @@
 # See https://swift.org/LICENSE.txt for license information
 # See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 
-FROM swiftlang/swift:nightly-5.5 
+FROM swift:5.5
+
+# Set up the current build user in the same way done in the Swift.org CI system: 
+# https://github.com/apple/swift-docker/blob/main/swift-ci/master/ubuntu/20.04/Dockerfile.
+
+RUN groupadd -g 998 build-user && \
+  useradd -m -r -u 42 -g build-user build-user
+  
+USER build-user
+
+WORKDIR /home/build-user


### PR DESCRIPTION
## Summary

Fixes test failures that were occurring when using the included Dockerfile to run Swift-DocC's tests for Linux. The test suite does not expect to be run on a root user account. This also better emulates the way tests will be run on Linux in the Swift.org CI system.

The changes to the Dockerfile are based on the Dockerfiles used in swift-ci here: https://github.com/apple/swift-docker/blob/main/swift-ci/master/ubuntu/20.04/Dockerfile.

## Dependencies

None.

## Testing

Follow the instructions in the CONTRIBUTING documentation [here](https://github.com/ethan-kusters/swift-docc/blob/update-dockerfile-for-linux-testing/CONTRIBUTING.md#using-docker-to-test-swift-docc-for-linux) and confirm that all tests pass.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] ~~Added tests~~ N/A
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
