### PR TITLE
Increment render node version for variantOverrides

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/RenderNode.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNode.swift
@@ -109,7 +109,7 @@ public struct RenderNode: VariantContainer {
     /// > Note: The patch value is currently unused and always set to `0`.
     public var schemaVersion = SemanticVersion(
         major: 0,
-        minor: 1,
+        minor: 2,
         patch: 0
     )
     

--- a/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderNode.spec.json
+++ b/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderNode.spec.json
@@ -2,7 +2,7 @@
     "openapi": "3.0.0",
     "info": {
         "description": "Render Node API",
-        "version": "0.1.0",
+        "version": "0.2.0",
         "title": "Render Node API"
     },
     "paths": { },


### PR DESCRIPTION
Bug/issue #, if applicable: N/A

## Summary

Increments the patch value of the render node schema to 0.2.0 to account
for addition of the top-level `variantOverrides` property introduced in #11. 

## Dependencies

This is related to https://github.com/apple/swift-docc-render/pull/23.

## Testing

N/A

## Checklist

- ~[ ] Added tests~ N/A
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
