### PR TITLE
Remove the format requirements for the bundle's version information.

### DIFF
--- a/Sources/SwiftDocC/DocumentationService/Models/Services/Convert/ConvertRequest.swift
+++ b/Sources/SwiftDocC/DocumentationService/Models/Services/Convert/ConvertRequest.swift
@@ -92,10 +92,10 @@ public struct ConvertRequest: Codable {
     @available(*, deprecated, message: "Use 'bundleInfo.version' instead.")
     public var version: String {
         get {
-            return bundleInfo.version.description
+            return bundleInfo.version ?? "0.0.1"
         }
         set {
-            bundleInfo.version = Version(versionString: newValue) ?? bundleInfo.version
+            bundleInfo.version = newValue
         }
     }
     
@@ -159,7 +159,7 @@ public struct ConvertRequest: Codable {
         self.bundleInfo = DocumentationBundle.Info(
             displayName: displayName,
             identifier: identifier,
-            version: Version(versionString: version)!,
+            version: version,
             defaultCodeListingLanguage: defaultCodeListingLanguage
         )
     }

--- a/Sources/SwiftDocC/Infrastructure/DocumentationBundle.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationBundle.swift
@@ -63,17 +63,9 @@ public struct DocumentationBundle {
     /**
      The documentation bundle's version.
 
-     The build version number should be a string comprised of three non-negative, period-separated integers with the first integer being greater than zero—for example, `3.1.2`. The string should only contain numeric (0-9) and period (.) characters. Leading zeros are truncated from each integer and will be ignored (that is, `1.02.3` is equivalent to `1.2.3`).
-
-     The meaning of each element is as follows:
-
-     - The first number represents the most recent major release and is limited to a maximum length of four digits.
-     - The second number represents the most recent significant revision and is limited to a maximum length of two digits.
-     - The third number represents the most recent minor bug fix and is limited to a maximum length of two digits.
-
-     If the value of the third number is 0, you can omit it and the second period.
+     It's not safe to make computations based on assumptions about the format of bundle's version. The version can be in any format.
      */
-    public var version: Version {
+    public var version: String? {
         info.version
     }
     
@@ -133,7 +125,7 @@ public struct DocumentationBundle {
             info: Info(
                 displayName: displayName,
                 identifier: identifier,
-                version: version,
+                version: version.description,
                 defaultCodeListingLanguage: defaultCodeListingLanguage,
                 defaultAvailability: defaultAvailability
             ),

--- a/Sources/SwiftDocC/Infrastructure/Workspace/DocumentationBundle+Info.swift
+++ b/Sources/SwiftDocC/Infrastructure/Workspace/DocumentationBundle+Info.swift
@@ -22,7 +22,7 @@ extension DocumentationBundle {
         public var identifier: String
         
         /// The version of the bundle.
-        public var version: Version
+        public var version: String?
         
         /// The default language identifier for code listings in the bundle.
         public var defaultCodeListingLanguage: String?
@@ -34,7 +34,7 @@ extension DocumentationBundle {
         public var defaultModuleKind: String?
         
         /// The keys that must be present in an Info.plist file in order for doc compilation to proceed.
-        static let requiredKeys: Set<CodingKeys> = [.displayName, .identifier, .version]
+        static let requiredKeys: Set<CodingKeys> = [.displayName, .identifier]
         
         enum CodingKeys: String, CodingKey, CaseIterable {
             case displayName = "CFBundleDisplayName"
@@ -162,7 +162,7 @@ extension DocumentationBundle {
             
             self.displayName = try decodeOrFallback(String.self, with: .displayName)
             self.identifier = try decodeOrFallback(String.self, with: .identifier)
-            self.version = try decodeOrFallback(Version.self, with: .version)
+            self.version = try decodeOrFallbackIfPresent(String.self, with: .version)
             
             // Finally, decode the optional keys if they're present.
             
@@ -174,7 +174,7 @@ extension DocumentationBundle {
         init(
             displayName: String,
             identifier: String,
-            version: Version,
+            version: String? = nil,
             defaultCodeListingLanguage: String? = nil,
             defaultModuleKind: String? = nil,
             defaultAvailability: DefaultAvailability? = nil

--- a/Tests/SwiftDocCTests/DocumentationService/ConvertService/ConvertServiceTests.swift
+++ b/Tests/SwiftDocCTests/DocumentationService/ConvertService/ConvertServiceTests.swift
@@ -17,7 +17,7 @@ class ConvertServiceTests: XCTestCase {
     private let testBundleInfo = DocumentationBundle.Info(
         displayName: "TestBundle",
         identifier: "identifier",
-        version: Version(versionString: "1.0.0")!
+        version: "1.0.0"
     )
     
     func testConvertSinglePage() throws {
@@ -966,7 +966,7 @@ class ConvertServiceTests: XCTestCase {
             bundleInfo: DocumentationBundle.Info(
                 displayName: "TestBundle",
                 identifier: "com.test.bundle",
-                version: Version(versionString: "1.0.0")!
+                version: "1.0.0"
             ),
             externalIDsToConvert: ["s:5MyKit0A5ClassC10myFunctionyyF"],
             documentPathsToConvert: [],
@@ -1252,7 +1252,7 @@ class ConvertServiceTests: XCTestCase {
             bundleInfo: DocumentationBundle.Info(
                 displayName: "TestBundleDisplayName",
                 identifier: "com.test.bundle",
-                version: Version(versionString: "1.0.0")!
+                version: "1.0.0"
             ),
             externalIDsToConvert: ["s:21SmallTestingFramework40EnumerationWithSingleUnresolvableDocLinkO"],
             documentPathsToConvert: [],
@@ -1299,7 +1299,7 @@ class ConvertServiceTests: XCTestCase {
             bundleInfo: DocumentationBundle.Info(
                 displayName: "TestBundleDisplayName",
                 identifier: "com.test.bundle",
-                version: Version(versionString: "1.0.0")!
+                version: "1.0.0"
             ),
             externalIDsToConvert: ["s:21SmallTestingFramework15TestEnumerationO06NesteddE0O0D6StructV06deeplyfD31FunctionWithUnresolvableDocLinkyyF"],
             documentPathsToConvert: [],
@@ -1339,7 +1339,7 @@ class ConvertServiceTests: XCTestCase {
             bundleInfo: DocumentationBundle.Info(
                 displayName: "TestBundleDisplayName",
                 identifier: "com.test.bundle",
-                version: Version(versionString: "1.0.0")!
+                version: "1.0.0"
             ),
             externalIDsToConvert: ["s:21SmallTestingFramework43EnumerationWithSingleUnresolvableSymbolLinkO"],
             documentPathsToConvert: [],

--- a/Tests/SwiftDocCTests/DocumentationService/DocumentationServer+DefaultTests.swift
+++ b/Tests/SwiftDocCTests/DocumentationService/DocumentationServer+DefaultTests.swift
@@ -69,7 +69,7 @@ class DocumentationServer_DefaultTests: XCTestCase {
             bundleInfo: DocumentationBundle.Info(
                 displayName: "TestBundle",
                 identifier: "identifier",
-                version: Version(versionString: "1.0.0")!
+                version: "1.0.0"
             ),
             externalIDsToConvert: ["s:5MyKit0A5ClassC10myFunctionyyF"],
             symbolGraphs: [symbolGraph],

--- a/Tests/SwiftDocCTests/Infrastructure/BundleDiscoveryTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/BundleDiscoveryTests.swift
@@ -279,7 +279,7 @@ class BundleDiscoveryTests: XCTestCase {
         // The bundle information was specified via the options
         XCTAssertEqual(bundle.identifier, "com.fallback.bundle.identifier")
         XCTAssertEqual(bundle.displayName, "Fallback Display Name")
-        XCTAssertEqual(bundle.version, Version(arrayLiteral: 1, 2, 3))
+        XCTAssertEqual(bundle.version, "1.2.3")
     }
 
     func testNoCustomTemplates() throws {

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationBundleInfoTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationBundleInfoTests.swift
@@ -23,7 +23,7 @@ class DocumentationBundleInfoTests: XCTestCase {
         
         XCTAssertEqual(info.displayName, "Test Bundle")
         XCTAssertEqual(info.identifier, "org.swift.docc.example")
-        XCTAssertEqual(info.version.description, "0.1.0")
+        XCTAssertEqual(info.version, "0.1.0")
         XCTAssertEqual(info.defaultCodeListingLanguage, "swift")
     }
 
@@ -57,7 +57,7 @@ class DocumentationBundleInfoTests: XCTestCase {
         
         let infoPlistWithAllFieldsData = Data(infoPlistWithAllFields.utf8)
         
-        let infoPlistWithSomeFields = """
+        let infoPlistWithoutDisplayName = """
         <plist version="1.0">
         <dict>
             <key>CFBundleIdentifier</key>
@@ -68,7 +68,7 @@ class DocumentationBundleInfoTests: XCTestCase {
         </plist>
         """
         
-        let infoPlistWithSomeFieldsData = Data(infoPlistWithSomeFields.utf8)
+        let infoPlistWithoutDisplayNameData = Data(infoPlistWithoutDisplayName.utf8)
         
         let bundleDiscoveryOptions = BundleDiscoveryOptions(
             infoPlistFallbacks: [
@@ -86,7 +86,7 @@ class DocumentationBundleInfoTests: XCTestCase {
             DocumentationBundle.Info(
                 displayName: "Info Plist Display Name",
                 identifier: "com.info.Plist",
-                version: Version(arrayLiteral: 1,0,0)
+                version: "1.0.0"
             )
         )
         
@@ -98,19 +98,44 @@ class DocumentationBundleInfoTests: XCTestCase {
             DocumentationBundle.Info(
                 displayName: "Fallback Display Name",
                 identifier: "com.fallback.Identifier",
-                version: Version(arrayLiteral: 2,0,0)
+                version: "2.0.0"
             )
         )
         
         XCTAssertEqual(
             try DocumentationBundle.Info(
-                from: infoPlistWithSomeFieldsData,
+                from: infoPlistWithoutDisplayNameData,
                 bundleDiscoveryOptions: bundleDiscoveryOptions
             ),
             DocumentationBundle.Info(
                 displayName: "Fallback Display Name",
                 identifier: "com.info.Plist",
-                version: Version(arrayLiteral: 1,0,0)
+                version: "1.0.0"
+            )
+        )
+        
+        let infoPlistWithoutVersion = """
+        <plist version="1.0">
+        <dict>
+            <key>CFBundleDisplayName</key>
+            <string>Info Plist Display Name</string>
+            <key>CFBundleIdentifier</key>
+            <string>com.info.Plist</string>
+        </dict>
+        </plist>
+        """
+        
+        let infoPlistWithoutVersionData = Data(infoPlistWithoutVersion.utf8)
+        
+        XCTAssertEqual(
+            try DocumentationBundle.Info(
+                from: infoPlistWithoutVersionData,
+                bundleDiscoveryOptions: nil
+            ),
+            DocumentationBundle.Info(
+                displayName: "Info Plist Display Name",
+                identifier: "com.info.Plist",
+                version: nil
             )
         )
     }
@@ -217,7 +242,7 @@ class DocumentationBundleInfoTests: XCTestCase {
             DocumentationBundle.Info(
                 displayName: "Display Name",
                 identifier: "swift.org.Identifier",
-                version: Version(arrayLiteral: 1,0,0),
+                version: "1.0.0",
                 defaultCodeListingLanguage: "swift",
                 defaultModuleKind: "Executable",
                 defaultAvailability: DefaultAvailability(
@@ -238,7 +263,7 @@ class DocumentationBundleInfoTests: XCTestCase {
         let info = DocumentationBundle.Info(
             displayName: "Display Name",
             identifier: "swift.org.Identifier",
-            version: Version(arrayLiteral: 1,0,0),
+            version: "1.0.0",
             defaultCodeListingLanguage: "swift",
             defaultModuleKind: "Executable",
             defaultAvailability: DefaultAvailability(

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationWorkspaceTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationWorkspaceTests.swift
@@ -149,7 +149,7 @@ class DocumentationWorkspaceTests: XCTestCase {
                 info: DocumentationBundle.Info(
                     displayName: "Test" + suffix,
                     identifier: "com.example.test" + suffix,
-                    version: Version(versionString: "0.1.0")!
+                    version: "0.1.0"
                 ),
                 symbolGraphURLs: [testSymbolGraphFile],
                 markupURLs: [testMarkupFile],

--- a/Tests/SwiftDocCTests/Infrastructure/PresentationURLGeneratorTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/PresentationURLGeneratorTests.swift
@@ -39,7 +39,7 @@ class PresentationURLGeneratorTests: XCTestCase {
             info: DocumentationBundle.Info(
                 displayName: "Test",
                 identifier: "com.example.test",
-                version: Version(versionString: "1.0")!
+                version: "1.0"
             ),
             baseURL: URL(string: "https://example.com/example")!,
             symbolGraphURLs: [],
@@ -91,7 +91,7 @@ class PresentationURLGeneratorTests: XCTestCase {
             info: DocumentationBundle.Info(
                 displayName: "Test",
                 identifier: "com.example.test",
-                version: Version(versionString: "1.0")!
+                version: "1.0"
             ),
             baseURL: URL(string: "https://example.com/example")!,
             symbolGraphURLs: [],

--- a/Tests/SwiftDocCTests/Infrastructure/SymbolGraph/SymbolGraphLoaderTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/SymbolGraph/SymbolGraphLoaderTests.swift
@@ -355,7 +355,7 @@ class SymbolGraphLoaderTests: XCTestCase {
             info: DocumentationBundle.Info(
                 displayName: "Test",
                 identifier: "com.example.test",
-                version: Version(arrayLiteral: 1,2,3)
+                version: "1.2.3"
             ),
             baseURL: URL(string: "https://example.com/example")!,
             symbolGraphURLs: symbolGraphURLs,

--- a/Tests/SwiftDocCTests/Rendering/DocumentationContentRendererTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/DocumentationContentRendererTests.swift
@@ -145,7 +145,7 @@ private extension DocumentationContentRendererTests {
                 info: DocumentationBundle.Info(
                     displayName: "Test",
                     identifier: "org.swift.test",
-                    version: Version(arrayLiteral: 1,2,3)
+                    version: "1.2.3"
                 ),
                 baseURL: URL(string: "https://example.com/example")!,
                 symbolGraphURLs: [],

--- a/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
@@ -366,9 +366,6 @@ class ConvertActionTests: XCTestCase {
             Missing value for 'CFBundleDisplayName'.
             Use the '--fallback-display-name' argument or add 'CFBundleDisplayName' to the bundle Info.plist.
             
-            Missing value for 'CFBundleVersion'.
-            Use the '--fallback-bundle-version' argument or add 'CFBundleVersion' to the bundle Info.plist.
-            
             """)
         }
     }

--- a/Tests/SwiftDocCUtilitiesTests/Utility/TestFileSystem.swift
+++ b/Tests/SwiftDocCUtilitiesTests/Utility/TestFileSystem.swift
@@ -93,7 +93,7 @@ class TestFileSystem: FileManagerProtocol, DocumentationWorkspaceDataProvider {
                     info: DocumentationBundle.Info(
                         displayName: info.content.displayName,
                         identifier: info.content.identifier,
-                        version: Version(versionString: info.content.versionString)!
+                        version: info.content.versionString
                     ),
                     symbolGraphURLs: graphs,
                     markupURLs: markupFiles,


### PR DESCRIPTION
Bug/issue #, if applicable: [SR-15372](https://bugs.swift.org/browse/SR-15372)

## Summary

This removes the format requirements for the documentation bundle's version information and makes the version information optional.

## Dependencies

n/a

## Testing

- Convert a documentation catalog where the version in the Info.plist is an arbitrary string.
- Convert a documentation catalog where the version passed as fallback command line arguments an arbitrary string.
- Convert a documentation catalog where no version information is specified.

In all three cases the documentation should build without errors about the version information.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
