### PR TITLE
Generate documentation content based on the symbol graph module names

### DIFF
--- a/Sources/SwiftDocCUtilities/Action/Actions/Convert/ConvertAction.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Convert/ConvertAction.swift
@@ -150,7 +150,7 @@ public struct ConvertAction: Action, RecreatingContext {
             dataProvider = try LocalFileSystemDataProvider(rootURL: rootURL)
         } else {
             self.context.externalMetadata.isGeneratedBundle = true
-            dataProvider = try GeneratedDataProvider(options: bundleDiscoveryOptions, symbolGraphDataLoader: { url in
+            dataProvider = GeneratedDataProvider(symbolGraphDataLoader: { url in
                 fileManager.contents(atPath: url.path)
             })
         }

--- a/Tests/SwiftDocCTests/Infrastructure/GeneratedDataProvider.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/GeneratedDataProvider.swift
@@ -1,0 +1,87 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+@testable import SwiftDocC
+import SymbolKit
+
+class GeneratedDataProviderTests: XCTestCase {
+
+    func testGeneratingBundles() throws {
+        let firstSymbolGraph = SymbolGraph(
+            metadata: .init(
+                formatVersion: .init(major: 0, minor: 0, patch: 1),
+                generator: "unit-test"
+            ),
+            module: .init(
+                name: "FirstModuleName",
+                platform: .init()
+            ),
+            symbols: [],
+            relationships: []
+        )
+        var secondSymbolGraph = firstSymbolGraph
+        secondSymbolGraph.module.name = "SecondModuleName"
+        
+        let thirdSymbolGraph = firstSymbolGraph // Another symbol graph with the same module name
+        
+        let dataProvider = GeneratedDataProvider(
+            symbolGraphDataLoader: {
+                switch $0.lastPathComponent {
+                case "first.symbols.json":
+                    return try? JSONEncoder().encode(firstSymbolGraph)
+                case "second.symbols.json":
+                    return try? JSONEncoder().encode(secondSymbolGraph)
+                case "third.symbols.json":
+                    return try? JSONEncoder().encode(thirdSymbolGraph)
+                default:
+                    return nil
+                }
+            }
+        )
+        
+        let options = BundleDiscoveryOptions(
+            infoPlistFallbacks: [
+                "CFBundleDisplayName": "Custom Display Name",
+                "CFBundleIdentifier": "com.test.example",
+            ],
+            additionalSymbolGraphFiles: [
+                URL(fileURLWithPath: "first.symbols.json"),
+                URL(fileURLWithPath: "second.symbols.json"),
+                URL(fileURLWithPath: "third.symbols.json"),
+            ]
+        )
+        let bundles = try dataProvider.bundles(options: options)
+        XCTAssertEqual(bundles.count, 1)
+        let bundle = try XCTUnwrap(bundles.first)
+        
+        XCTAssertEqual(bundle.displayName, "Custom Display Name")
+        XCTAssertEqual(bundle.symbolGraphURLs.map { $0.lastPathComponent }.sorted(), [
+            "first.symbols.json",
+            "second.symbols.json",
+            "third.symbols.json",
+            
+        ])
+        XCTAssertEqual(bundle.markupURLs.map { $0.path }.sorted(), [
+            "FirstModuleName.md",
+            "SecondModuleName.md",
+            // No third file since that symbol graph has the same module name as the first
+        ])
+
+        XCTAssertEqual(
+            try String(data: dataProvider.contentsOfURL(URL(fileURLWithPath: "FirstModuleName.md")), encoding: .utf8),
+            "# ``FirstModuleName``"
+        )
+        XCTAssertEqual(
+            try String(data: dataProvider.contentsOfURL(URL(fileURLWithPath: "SecondModuleName.md")), encoding: .utf8),
+            "# ``SecondModuleName``"
+        )
+    }
+}

--- a/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
@@ -345,21 +345,22 @@ class ConvertActionTests: XCTestCase {
         var infoPlistFallbacks = [String: Any]()
         infoPlistFallbacks["CFBundleIdentifier"] = "com.example.test"
         
-        XCTAssertThrowsError(try ConvertAction(
-                documentationBundleURL: nil,
-                outOfProcessResolver: nil,
-                analyze: false,
-                targetDirectory: outputLocation.absoluteURL,
-                htmlTemplateDirectory: Folder.emptyHTMLTemplateDirectory.absoluteURL,
-                emitDigest: false,
-                currentPlatforms: nil,
-                fileManager: testDataProvider,
-                bundleDiscoveryOptions: BundleDiscoveryOptions(
-                    infoPlistFallbacks: infoPlistFallbacks,
-                    additionalSymbolGraphFiles: [URL(fileURLWithPath: "/Not-a-doc-bundle/MyKit.symbols.json")]
-                )
+        var action = try ConvertAction(
+            documentationBundleURL: nil,
+            outOfProcessResolver: nil,
+            analyze: false,
+            targetDirectory: outputLocation.absoluteURL,
+            htmlTemplateDirectory: Folder.emptyHTMLTemplateDirectory.absoluteURL,
+            emitDigest: false,
+            currentPlatforms: nil,
+            fileManager: testDataProvider,
+            bundleDiscoveryOptions: BundleDiscoveryOptions(
+                infoPlistFallbacks: infoPlistFallbacks,
+                additionalSymbolGraphFiles: [URL(fileURLWithPath: "/Not-a-doc-bundle/MyKit.symbols.json")]
             )
-        ) { error in
+        )
+        let logStorage = LogHandle.LogStorage()
+        XCTAssertThrowsError(try action.perform(logHandle: .memory(logStorage))) { error in
             XCTAssertEqual(error.localizedDescription, """
             The information provided as command line arguments is not enough to generate a documentation bundle:
             


### PR DESCRIPTION
Bug/issue #, if applicable: [SR-15408](https://bugs.swift.org/browse/SR-15408) rdar://84810134

## Summary

This updates the `GeneratedDataProvider` to generate top level documentation extension files based on the module names from the available symbol graph files instead of the fallback display name. This means that:
- the documentation extension file will match one of the module symbols 
- if there are multiple modules there will be multiple generated documentation extension files

This PR also removes a small amount of ambiguity regarding the provider's use of `BundleDiscoveryOptions` by removing the options argument to the initializer. Previously, this value wasn't used when providing the bundles but it was used when providing their raw content. 

## Dependencies

n/a

## Testing

Call `docc convert` or `docc preview` with a fallback display name that doesn't match the name of any module in any symbol graph file. 

For example, with the example symbol graph file from [SR-15408](https://bugs.swift.org/browse/SR-15408):
```
docc preview \
 --fallback-display-name "Tiny Framework"\
 --fallback-bundle-identifier "test.tiny-framework" \
 --additional-symbol-graph-files /path/to/Tiny_Framework.symbols.json
```

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
