### PR TITLE
save custom ordered list start index in render JSON

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -57,10 +57,10 @@
       },
       {
         "package": "swift-markdown",
-        "repositoryURL": "https://github.com/apple/swift-markdown.git",
+        "repositoryURL": "https://github.com/QuietMisdreavus/swift-markdown.git",
         "state": {
-          "branch": "main",
-          "revision": "69f31f83a5dca9a3401d3e8fc8ff74804b0dd0ca",
+          "branch": "list-numbering",
+          "revision": "0cdc7269aa395115e50b25f388ffd184a4f04787",
           "version": null
         }
       },

--- a/Package.resolved
+++ b/Package.resolved
@@ -57,10 +57,10 @@
       },
       {
         "package": "swift-markdown",
-        "repositoryURL": "https://github.com/QuietMisdreavus/swift-markdown.git",
+        "repositoryURL": "https://github.com/apple/swift-markdown.git",
         "state": {
-          "branch": "list-numbering",
-          "revision": "0cdc7269aa395115e50b25f388ffd184a4f04787",
+          "branch": "main",
+          "revision": "d491147940587dbadfb3472354f4d0c6e063e061",
           "version": null
         }
       },

--- a/Package.swift
+++ b/Package.swift
@@ -123,7 +123,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     package.dependencies += [
         .package(url: "https://github.com/apple/swift-nio.git", .upToNextMinor(from: "2.31.2")),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", .upToNextMinor(from: "2.15.0")),
-        .package(name: "swift-markdown", url: "https://github.com/QuietMisdreavus/swift-markdown.git", .branch("list-numbering")),
+        .package(name: "swift-markdown", url: "https://github.com/apple/swift-markdown.git", .branch("main")),
         .package(name: "CLMDB", url: "https://github.com/apple/swift-lmdb.git", .branch("main")),
         .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "1.0.1")),
         .package(name: "SymbolKit", url: "https://github.com/apple/swift-docc-symbolkit", .branch("main")),

--- a/Package.swift
+++ b/Package.swift
@@ -123,7 +123,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     package.dependencies += [
         .package(url: "https://github.com/apple/swift-nio.git", .upToNextMinor(from: "2.31.2")),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", .upToNextMinor(from: "2.15.0")),
-        .package(name: "swift-markdown", url: "https://github.com/apple/swift-markdown.git", .branch("main")),
+        .package(name: "swift-markdown", url: "https://github.com/QuietMisdreavus/swift-markdown.git", .branch("list-numbering")),
         .package(name: "CLMDB", url: "https://github.com/apple/swift-lmdb.git", .branch("main")),
         .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "1.0.1")),
         .package(name: "SymbolKit", url: "https://github.com/apple/swift-docc-symbolkit", .branch("main")),

--- a/Sources/SwiftDocC/Model/Rendering/RenderContentCompiler.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderContentCompiler.swift
@@ -62,7 +62,10 @@ struct RenderContentCompiler: MarkupVisitor {
     
     mutating func visitOrderedList(_ orderedList: OrderedList) -> [RenderContent] {
         let renderListItems = orderedList.listItems.reduce(into: [], { result, item in result.append(contentsOf: visitListItem(item))})
-        return [RenderBlockContent.orderedList(.init(items: renderListItems as! [RenderBlockContent.ListItem]))]
+        return [RenderBlockContent.orderedList(.init(
+            items: renderListItems as! [RenderBlockContent.ListItem],
+            startIndex: orderedList.startIndex
+        ))]
     }
     
     mutating func visitUnorderedList(_ unorderedList: UnorderedList) -> [RenderContent] {

--- a/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderNode.spec.json
+++ b/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderNode.spec.json
@@ -822,6 +822,9 @@
                             "orderedList"
                         ]
                     },
+                    "start": {
+                        "type": "integer"
+                    },
                     "items": {
                         "type": "array",
                         "items": {

--- a/Tests/SwiftDocCTests/Indexing/IndexingTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/IndexingTests.swift
@@ -237,7 +237,7 @@ class IndexingTests: XCTestCase {
                                       title: "MyProtocol",
                                       summary: "An abstract of a protocol using a String id value.",
                                       headings: ["Return Value", "Discussion"],
-                                      rawIndexableTextContent: "An abstract of a protocol using a String id value.  A name of the item to find. Return Value A String id value. Discussion Further discussion. Exercise links to symbols: relative MyClass and absolute MyClass. Exercise unresolved symbols: unresolved MyUnresolvedSymbol. Exercise known unresolvable symbols: know unresolvable NSCodable. Exercise external references: doc://com.test.external/ExternalPage One ordered Two ordered Three ordered One unordered Two unordered Three unordered",
+                                      rawIndexableTextContent: "An abstract of a protocol using a String id value.  A name of the item to find. Return Value A String id value. Discussion Further discussion. Exercise links to symbols: relative MyClass and absolute MyClass. Exercise unresolved symbols: unresolved MyUnresolvedSymbol. Exercise known unresolvable symbols: know unresolvable NSCodable. Exercise external references: doc://com.test.external/ExternalPage One ordered Two ordered Three ordered One unordered Two unordered Three unordered Two ordered with custom start Three ordered with custom start Four ordered with custom start",
                                      platforms: expectedPlatformInformation),
                        indexingRecords[0])
     }

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -886,6 +886,17 @@ class DocumentationContextTests: XCTestCase {
                         └─ ListItem
                            └─ Paragraph
                               └─ Text "Three unordered"
+
+                        OrderedList startIndex: 2
+                        ├─ ListItem
+                        │  └─ Paragraph
+                        │     └─ Text "Two ordered with custom start"
+                        ├─ ListItem
+                        │  └─ Paragraph
+                        │     └─ Text "Three ordered with custom start"
+                        └─ ListItem
+                           └─ Paragraph
+                              └─ Text "Four ordered with custom start"
                         """)
 
         XCTAssertEqual(myProtocolSymbol.declaration.values.first?.declarationFragments.map({ $0.spelling }), ["protocol", " ", "MyProtocol", " : ", "Hashable"])

--- a/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorTests.swift
@@ -103,6 +103,7 @@ class RenderNodeTranslatorTests: XCTestCase {
         
         XCTAssert(discussion.content.contains(where: { block in
             if case .orderedList(let l) = block,
+                l.startIndex == 1,
                 l.items.count == 3,
                 l.items[0].content.first == .paragraph(.init(inlineContent: [.text("One ordered")])),
                 l.items[1].content.first == .paragraph(.init(inlineContent: [.text("Two ordered")])),
@@ -120,6 +121,20 @@ class RenderNodeTranslatorTests: XCTestCase {
                 l.items[0].content.first == .paragraph(.init(inlineContent: [.text("One unordered")])),
                 l.items[1].content.first == .paragraph(.init(inlineContent: [.text("Two unordered")])),
                 l.items[2].content.first == .paragraph(.init(inlineContent: [.text("Three unordered")]))
+            {
+                return true
+            } else {
+                return false
+            }
+        }))
+
+        XCTAssert(discussion.content.contains(where: { block in
+            if case .orderedList(let l) = block,
+               l.startIndex == 2,
+               l.items.count == 3,
+               l.items[0].content.first == .paragraph(.init(inlineContent: [.text("Two ordered with custom start")])),
+               l.items[1].content.first == .paragraph(.init(inlineContent: [.text("Three ordered with custom start")])),
+               l.items[2].content.first == .paragraph(.init(inlineContent: [.text("Four ordered with custom start")]))
             {
                 return true
             } else {

--- a/Tests/SwiftDocCTests/Test Bundles/TestBundle.docc/documentation/myprotocol.md
+++ b/Tests/SwiftDocCTests/Test Bundles/TestBundle.docc/documentation/myprotocol.md
@@ -22,6 +22,10 @@ Exercise external references: <doc://com.test.external/ExternalPage>
 - Two unordered
 - Three unordered
 
+2. Two ordered with custom start
+3. Three ordered with custom start
+4. Four ordered with custom start
+
 - Returns: A `String` id value.
 
 - Parameter input: A name of the item to find.


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://73847907

## Summary

While cmark-gfm saves the starting index for an ordered list, swift-markdown currently discards this information. This PR is part of a set to preserve this starting index when rendering documentation.

## Dependencies

https://github.com/apple/swift-markdown/pull/22

## Testing

Add the following markdown to `Sources/SwiftDocC/SwiftDocC.docc/SwiftDocC.md`:

```markdown
2. this is a test
3. this is a test
```

Steps:
1. Build the associated swift-docc-render branch (https://github.com/apple/swift-docc-render/pull/30) and set `$DOCC_HTML_DIR` to the resulting `dist` directory.
2. `bin/preview-docs`
3. Ensure that the added list correctly starts with the index 2.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
