### PR TITLE
[5.6] Support converting catalogs that include mixed languages

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -33,7 +33,7 @@
         "repositoryURL": "https://github.com/apple/swift-docc-symbolkit",
         "state": {
           "branch": "main",
-          "revision": "cdaf2be26bca2a24d788cd58449348ef6e66ba87",
+          "revision": "c46163870115c497d99ee44158bc086c5956fe3d",
           "version": null
         }
       },

--- a/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
+++ b/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
@@ -411,7 +411,41 @@ public class NavigatorIndex {
     }
 }
 
+extension ResolvedTopicReference {
+    func navigatorIndexIdentifier(
+        forLanguage languageIdentifier: InterfaceLanguage.ID
+    ) -> NavigatorIndex.Identifier {
+        return NavigatorIndex.Identifier(
+            bundleIdentifier: bundleIdentifier,
+            path: path,
+            fragment: fragment,
+            languageIdentifier: languageIdentifier
+        )
+    }
+}
+
 extension NavigatorIndex {
+    /// A unique identifier for navigator index items.
+    ///
+    /// Used to identify relationships in the navigator index during the index build process.
+    public struct Identifier: Hashable {
+        let bundleIdentifier: String
+        let path: String
+        let fragment: String?
+        let languageIdentifier: InterfaceLanguage.ID
+        
+        init(
+            bundleIdentifier: String,
+            path: String,
+            fragment: String? = nil,
+            languageIdentifier: InterfaceLanguage.ID
+        ) {
+            self.bundleIdentifier = bundleIdentifier
+            self.path = path
+            self.fragment = fragment
+            self.languageIdentifier = languageIdentifier
+        }
+    }
     
     /**
      A `Builder` is a utility class to build a navigator index.
@@ -450,22 +484,22 @@ extension NavigatorIndex {
         public private(set) var isCompleted = false
         
         /// The map of identifier to navigation item.
-        private var identifierToNode = [ResolvedTopicReference: NavigatorTree.Node]()
+        private var identifierToNode = [Identifier: NavigatorTree.Node]()
         
         /// The map of identifier to children.
-        private var identifierToChildren = [ResolvedTopicReference: [ResolvedTopicReference]]()
+        private var identifierToChildren = [Identifier: [Identifier]]()
         
         /// A temporary list of pending references that are waiting for their parent to be indexed.
-        private var pendingUncuratedReferences = Set<ResolvedTopicReference>()
+        private var pendingUncuratedReferences = Set<Identifier>()
         
         /// A map with all nodes that are curated mutliple times in the tree and need to be processed at the very end.
-        private var multiCurated = [ResolvedTopicReference: NavigatorTree.Node]()
+        private var multiCurated = [Identifier: NavigatorTree.Node]()
         
         /// A set with all nodes that are curated mutliple times, but still have to be visited.
-        private var multiCuratedUnvisited = Set<ResolvedTopicReference>()
+        private var multiCuratedUnvisited = Set<Identifier>()
         
         /// A set with all nodes that are curated.
-        private var curatedIdentifiers = Set<ResolvedTopicReference>()
+        private var curatedIdentifiers = Set<Identifier>()
         
         /// Maps an arbitrary InterfaceLanguage string to an InterfaceLanguage.
         private var nameToLanguage = [String: InterfaceLanguage]()
@@ -547,14 +581,6 @@ extension NavigatorIndex {
             guard let title = (usePageTitle) ? renderNode.metadata.title : renderNode.navigatorTitle() else {
                 throw Error.missingTitle(description: "\(renderNode.identifier.absoluteString.singleQuoted) has an empty title and so can't have a usable entry in the index.")
             }
-
-            let identifier = renderNode.identifier
-            guard identifierToNode[identifier] == nil else {
-                return // skip as item exists already.
-            }
-            
-            // Get the identifier path
-            let identifierPath = NodeURLGenerator().urlForReference(identifier, lowercased: true).path
             
             // Process the language
             let interfaceLanguage = renderNode.identifier.sourceLanguage.id
@@ -566,6 +592,14 @@ extension NavigatorIndex {
                 let language = InterfaceLanguage(interfaceLanguage, id: nameToLanguage.count)
                 nameToLanguage[interfaceLanguage.lowercased()] = language
             }
+
+            let identifier = renderNode.identifier.navigatorIndexIdentifier(forLanguage: language.mask)
+            guard identifierToNode[identifier] == nil else {
+                return // skip as item exists already.
+            }
+            
+            // Get the identifier path
+            let identifierPath = NodeURLGenerator().urlForReference(renderNode.identifier, lowercased: true).path
             
             // Store the language inside the availability index.
             navigatorIndex.availabilityIndex.add(language: language)
@@ -634,7 +668,7 @@ extension NavigatorIndex {
             let navigatorNode = NavigatorTree.Node(item: navigationItem, bundleIdentifier: bundleIdentifier)
             
             // Process the children
-            var children = [ResolvedTopicReference]()
+            var children = [Identifier]()
             for (index, child) in childrenRelationship.enumerated() {
                 guard let title = child.name else {
                      throw Error.missingTitle(description: "\(renderNode.identifier.absoluteString.singleQuoted) has an empty title for a task group.")
@@ -642,10 +676,12 @@ extension NavigatorIndex {
                 
                 let fragment = "\(title)#\(index)".addingPercentEncoding(withAllowedCharacters: .urlPathAllowed)!
                 
-                let groupIdentifier = ResolvedTopicReference(bundleIdentifier: identifier.bundleIdentifier,
-                                                             path: identifierPath,
-                                                             fragment: fragment,
-                                                             sourceLanguage: identifier.sourceLanguage)
+                let groupIdentifier = Identifier(
+                    bundleIdentifier: identifier.bundleIdentifier,
+                    path: identifierPath,
+                    fragment: fragment,
+                    languageIdentifier: language.mask
+                )
                 
                 let groupItem = NavigatorItem(pageType: UInt8(PageType.groupMarker.rawValue),
                                               languageID: language.mask,
@@ -659,13 +695,15 @@ extension NavigatorIndex {
                 identifierToNode[groupIdentifier] = navigatorGroup
                 children.append(groupIdentifier)
                 
-                let identifiers = child.references.map { (reference: TopicRenderReference) -> ResolvedTopicReference in
-                    return ResolvedTopicReference(bundleIdentifier: bundleIdentifier.lowercased(),
-                                                  path: reference.url.lowercased(),
-                                                  sourceLanguage: identifier.sourceLanguage)
+                let identifiers = child.references.map { reference in
+                    return Identifier(
+                        bundleIdentifier: bundleIdentifier.lowercased(),
+                        path: reference.url.lowercased(),
+                        languageIdentifier: language.mask
+                    )
                 }
                 
-                var nestedChildren = [ResolvedTopicReference]()
+                var nestedChildren = [Identifier]()
                 for identifier in identifiers {
                     if child.referencesAreNested {
                         nestedChildren.append(identifier)
@@ -688,7 +726,10 @@ extension NavigatorIndex {
                 }
             }
             
-            let normalizedIdentifier = identifier.normalizedForNavigation
+            let normalizedIdentifier = renderNode
+                .identifier
+                .normalizedForNavigation
+                .navigatorIndexIdentifier(forLanguage: language.mask)
             
             // Keep track of the node
             identifierToNode[normalizedIdentifier] = navigatorNode
@@ -701,8 +742,20 @@ extension NavigatorIndex {
                 multiCuratedUnvisited.remove(normalizedIdentifier)
             }
             
+            // Bump the nodes counter.
+            counter += 1
+            
+            // We only want to check for an objective-c variant
+            // if we're currently indexing a swift variant.
+            guard language == .swift else {
+                return
+            }
+            
             // Check if the render node has a variant for Objective-C
-            let objCVariantTrait = renderNode.variantOverrides?.values.flatMap({ $0.traits }).first { trait in
+            //
+            // Note that we need to check the `variants` property here, not the `variantsOverride`
+            // property because `variantsOverride` is only populated when the RenderNode is encoded.
+            let objCVariantTrait = renderNode.variants?.flatMap(\.traits).first { trait in
                 switch trait {
                 case .interfaceLanguage(let language):
                     return InterfaceLanguage.from(string: language) == .objc
@@ -716,9 +769,6 @@ extension NavigatorIndex {
                 let variantRenderNode = try RenderNode.decode(fromJSON: transformedData)
                 try index(renderNode: variantRenderNode)
             }
-            
-            // Bump the nodes counter.
-            counter += 1
         }
         
         /// An internal struct to store data about a single navigator entry.
@@ -741,8 +791,8 @@ extension NavigatorIndex {
             
             // Assign the children to the parents, starting with multi curated nodes
             var nodesMultiCurated = multiCurated.map { ($0, $1) }
-            var index = 0
-            while index < nodesMultiCurated.count {
+            
+            for index in 0..<nodesMultiCurated.count {
                 let (nodeID, parent) = nodesMultiCurated[index]
                 let placeholders = identifierToChildren[nodeID]!
                 for reference in placeholders {
@@ -759,8 +809,6 @@ extension NavigatorIndex {
                 }
                 // Once assigned, placeholders can be removed as we use copy later.
                 identifierToChildren[nodeID]!.removeAll()
-                // Increase the counter
-                index += 1
             }
             
             for (nodeIdentifier, placeholders) in identifierToChildren {
@@ -991,7 +1039,7 @@ extension ResolvedTopicReference {
         return ResolvedTopicReference(bundleIdentifier: bundleIdentifier.lowercased(),
                                       path: normalizedPath.lowercased(),
                                       fragment: fragment,
-                                      sourceLanguage: sourceLanguage)
+                                      sourceLanguages: sourceLanguages)
     }
     
 }

--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -454,7 +454,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
             externallyResolvedLinks[pair.url] = pair.resolved
             if case .success(let resolvedReference) = pair.resolved,
                 pair.url.absoluteString != resolvedReference.absoluteString,
-                let url = resolvedReference.url.flatMap(ValidatedURL.init) {
+                let url = ValidatedURL(resolvedReference.url) {
                 // If the resolved reference has a different URL than the link cache both URLs
                 // so we can resolve both unresolved and resolved references.
                 externallyResolvedLinks[url] = pair.resolved
@@ -1110,7 +1110,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
                 }
                 
                 // If it's an existing module, update the interface languages
-                moduleReferences[moduleName]?.sourceLanguages.formUnion(moduleInterfaceLanguages)
+                moduleReferences[moduleName] = moduleReferences[moduleName]?.addingSourceLanguages(moduleInterfaceLanguages)
                 
                 // Import the symbol graph symbols
                 let moduleReference: ResolvedTopicReference

--- a/Sources/SwiftDocC/Infrastructure/DocumentationCurator.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationCurator.swift
@@ -99,7 +99,7 @@ struct DocumentationCurator {
         let reference = ResolvedTopicReference(
             bundleIdentifier: resolved.bundleIdentifier,
             path: sourceArticlePath,
-            sourceLanguage: resolved.sourceLanguage)
+            sourceLanguages: resolved.sourceLanguages)
         
         guard let currentArticle = self.context.uncuratedArticles[reference],
             let documentationNode = try? DocumentationNode(reference: reference, article: currentArticle.value) else { return nil }

--- a/Sources/SwiftDocC/Infrastructure/Symbol Graph/ResolvedTopicReference+Symbol.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Graph/ResolvedTopicReference+Symbol.swift
@@ -24,7 +24,7 @@ extension ResolvedTopicReference {
                 bundleIdentifier: bundle.documentationRootReference.bundleIdentifier,
                 path: bundle.documentationRootReference.appendingPath(moduleName + path).path,
                 fragment: nil,
-                sourceLanguage: symbolReference.interfaceLanguage
+                sourceLanguages: symbolReference.interfaceLanguages
             )
         } else {
             self = bundle.documentationRootReference.appendingPath(moduleName + path)

--- a/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolReference.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolReference.swift
@@ -37,12 +37,18 @@ public struct SymbolReference {
     /// to append a hash of the symbol name at the end of the path to make the two paths distinct.
     /// - Parameters:
     ///   - identifier: The precise identifier of a symbol.
-    ///   - interfaceLanguage: The source language of the symbol.
-    ///   - symbol: A symbol graph node, if available.
+    ///   - interfaceLanguages: The source languages of the symbol.
+    ///   - symbol: The default symbol graph node representing this symbol, if available.
     ///   - shouldAddHash: If `true`, the new reference has a hash appended to its path.
     ///   - shouldAddKind: If `true`, the new reference has the referenced-symbol kind appended to its path.
-    public init(_ identifier: String, interfaceLanguage: SourceLanguage, symbol: SymbolGraph.Symbol? = nil, shouldAddHash: Bool = false, shouldAddKind: Bool = false) {
-        self.interfaceLanguage = interfaceLanguage
+    public init(
+        _ identifier: String,
+        interfaceLanguages: Set<SourceLanguage>,
+        defaultSymbol symbol: SymbolGraph.Symbol? = nil,
+        shouldAddHash: Bool = false,
+        shouldAddKind: Bool = false
+    ) {
+        self.interfaceLanguages = Set(interfaceLanguages)
         
         guard let symbol = symbol else {
             path = shouldAddHash ?
@@ -69,21 +75,91 @@ public struct SymbolReference {
         path = name
     }
     
-    /// Creates a new symbol reference with the given components and language.
+    /// Creates a new reference to a symbol.
+    ///
+    /// - Parameters:
+    ///   - identifier: The precise identifier of a symbol.
+    ///   - unifiedSymbol: The unified symbol graph node representing this symbol, if available.
+    ///   - shouldAddHash: If `true`, the new reference has a hash appended to its path.
+    ///   - shouldAddKind: If `true`, the new reference has the referenced-symbol kind appended to its path.
+    public init(
+        _ identifier: String,
+        unifiedSymbol: UnifiedSymbolGraph.Symbol? = nil,
+        shouldAddHash: Bool = false,
+        shouldAddKind: Bool = false
+    ) {
+        self.init(
+            identifier,
+            interfaceLanguages: unifiedSymbol?.sourceLanguages ?? [],
+            defaultSymbol: unifiedSymbol?.defaultSymbol,
+            shouldAddHash: shouldAddHash,
+            shouldAddKind: shouldAddKind
+        )
+    }
+    
+    /// Creates a new reference to a symbol.
+    ///
+    /// - Parameters:
+    ///   - identifier: The precise identifier of a symbol.
+    ///   - interfaceLanguage: The source language of the symbol.
+    ///   - symbol: The symbol graph node representing this symbol, if available.
+    ///   - shouldAddHash: If `true`, the new reference has a hash appended to its path.
+    ///   - shouldAddKind: If `true`, the new reference has the referenced-symbol kind appended to its path.
+    public init(
+        _ identifier: String,
+        interfaceLanguage: SourceLanguage,
+        symbol: SymbolGraph.Symbol? = nil,
+        shouldAddHash: Bool = false,
+        shouldAddKind: Bool = false
+    ) {
+        self.init(
+            identifier,
+            interfaceLanguages: [interfaceLanguage],
+            defaultSymbol: symbol,
+            shouldAddHash: shouldAddHash,
+            shouldAddKind: shouldAddKind
+        )
+    }
+    
+    /// Creates a new symbol reference with the given components and source languages.
+    ///
+    /// - Parameters:
+    ///   - pathComponents: The relative path components from the module or framework to the symbol.
+    ///   - interfaceLanguages: The source languages of the symbol.
+    public init<SourceLanguages: Collection>(
+        pathComponents: [String],
+        interfaceLanguages: SourceLanguages
+    ) where SourceLanguages.Element == SourceLanguage {
+        self.path = pathComponents.joinedSymbolPathComponents
+        self.interfaceLanguages = Set(interfaceLanguages)
+    }
+    
+    /// Creates a new symbol reference with the given components and source language.
     ///
     /// - Parameters:
     ///   - pathComponents: The relative path components from the module or framework to the symbol.
     ///   - interfaceLanguage: The source language of the symbol.
     public init(pathComponents: [String], interfaceLanguage: SourceLanguage) {
         self.path = pathComponents.joinedSymbolPathComponents
-        self.interfaceLanguage = interfaceLanguage
+        self.interfaceLanguages = [interfaceLanguage]
     }
     
     /// The relative path from the module or framework to the symbol itself.
     public let path: String
     
     /// The interface language for the reference.
-    public let interfaceLanguage: SourceLanguage
+    public let interfaceLanguages: Set<SourceLanguage>
+    
+    @available(*, deprecated, message: "Use 'interfaceLanguages' instead.")
+    public var interfaceLanguage: SourceLanguage {
+        if interfaceLanguages.contains(.swift) {
+            return .swift
+        } else if let firstInterfaceLanguage = interfaceLanguages.first {
+            return firstInterfaceLanguage
+        } else {
+            return .swift
+        }
+    }
 }
 
 private extension Array where Element == String {
@@ -91,5 +167,22 @@ private extension Array where Element == String {
         return joined(separator: "/").components(
             separatedBy: CharacterSet.urlPathAllowed.inverted
         ).joined(separator: "_")
+    }
+}
+
+extension UnifiedSymbolGraph.Symbol {
+    var sourceLanguages: Set<SourceLanguage> {
+        guard FeatureFlags.current.isExperimentalObjectiveCSupportEnabled else {
+            return [.swift]
+        }
+        
+        // FIXME: Replace with new SymbolKit API once available.
+        // Adding a dedicated SymbolKit API for this purpose is tracked
+        // with SR-15551 and rdar://85982095.
+        return Set(
+            pathComponents.keys.compactMap { selector in
+                return SourceLanguage(knownLanguageIdentifier: selector.interfaceLanguage)
+            }
+        )
     }
 }

--- a/Sources/SwiftDocC/Infrastructure/Topic Graph/AutomaticCuration.swift
+++ b/Sources/SwiftDocC/Infrastructure/Topic Graph/AutomaticCuration.swift
@@ -45,10 +45,23 @@ public struct AutomaticCuration {
     ///   - node: A node for which to generate topics groups.
     ///   - context: A documentation context.
     /// - Returns: An array of title and references list tuples.
-    static func topics(for node: DocumentationNode, context: DocumentationContext) throws -> [TaskGroup] {
+    static func topics(
+        for node: DocumentationNode,
+        withTrait variantsTrait: DocumentationDataVariantsTrait?,
+        context: DocumentationContext
+    ) throws -> [TaskGroup] {
         // Get any default implementation relationships for this symbol
+        //
+        // It's okay to include all variants here because we just use this set to filter
+        // out these values from automatic curation.
         let defaultImplementationReferences = Set<String>(
-            (node.semantic as? Symbol)?.defaultImplementations.implementations.compactMap { $0.reference.url?.absoluteString } ?? []
+            (node.semantic as? Symbol)?.defaultImplementationsVariants.allValues
+                .lazy
+                .map(\.variant)
+                .flatMap(\.implementations)
+                .compactMap { implementation in
+                    implementation.reference.url?.absoluteString
+                } ?? []
         )
         
         return try context.children(of: node.reference)
@@ -65,15 +78,28 @@ public struct AutomaticCuration {
                 }
                 
                 let childNode = try context.entity(with: child.reference)
-                if let childSymbol = childNode.semantic as? Symbol {
-                    groupsIndex[childSymbol.kind.identifier]?.references.append(child.reference)
+                guard let childSymbol = childNode.semantic as? Symbol else {
+                    return
+                }
+                
+                // If we have a specific trait to collect topics for, we only want
+                // to include children that have a kind available for that trait.
+                //
+                // Otherwise, we'll fall back to the first kind variant.
+                let childSymbolKindIdentifier: SymbolGraph.Symbol.KindIdentifier?
+                if let variantsTrait = variantsTrait {
+                    childSymbolKindIdentifier = childSymbol.kindVariants[variantsTrait]?.identifier
+                } else {
+                    childSymbolKindIdentifier = childSymbol.kindVariants.firstValue?.identifier
+                }
+                
+                if let childSymbolKindIdentifier = childSymbolKindIdentifier {
+                    groupsIndex[childSymbolKindIdentifier]?.references.append(child.reference)
                 }
             }
             .lazy
             // Sort the groups in the order intended for rendering
-            .sorted(by: { (lhs, rhs) -> Bool in
-                return lhs.value.sortOrder < rhs.value.sortOrder
-            })
+            .sorted(by: \.value.sortOrder)
             // Map to sorted tuples
             .compactMap { groupIndex in
                 let group = groupIndex.value

--- a/Sources/SwiftDocC/Model/DocumentationNode.swift
+++ b/Sources/SwiftDocC/Model/DocumentationNode.swift
@@ -29,6 +29,15 @@ public struct DocumentationNode {
     /// All the languages in which the node is available.
     public var availableSourceLanguages: Set<SourceLanguage>
     
+    /// All of the traits that make up the different variants of this node.
+    public var availableVariantTraits: Set<DocumentationDataVariantsTrait> {
+        return Set(
+            availableSourceLanguages
+                .map(\.id)
+                .map(DocumentationDataVariantsTrait.init(interfaceLanguage:))
+        )
+    }
+    
     /// The names of the platforms for which the node is available.
     public var platformNames: Set<String>?
     
@@ -79,16 +88,16 @@ public struct DocumentationNode {
     /// linked to from other nodes' content.
     private mutating func updateAnchorSections() {
         // Scrub article discussion headings.
-        var discussion: DiscussionSection?
-        switch semantic {
-            case let article as Article:
-                discussion = article.discussion
-            case let symbol as Symbol:
-                discussion = symbol.discussion
-            default: break
+        let discussionSections: [DiscussionSection]
+        if let discussion = (semantic as? Article)?.discussion {
+            discussionSections = [discussion]
+        } else if let discussionVariants = (semantic as? Symbol)?.discussionVariants {
+            discussionSections = discussionVariants.allValues.map(\.variant)
+        } else {
+            return
         }
         
-        if let discussion = discussion {
+        for discussion in discussionSections {
             for child in discussion.content {
                 // For any H2/H3 sections found in the topic's discussion
                 // create an `AnchorSection` and add it to `anchorSections`
@@ -160,71 +169,134 @@ public struct DocumentationNode {
             )
         }
         
-        guard let symbol = unifiedSymbol.defaultSymbol else {
+        guard let defaultSymbol = unifiedSymbol.defaultSymbol else {
             fatalError("Unexpectedly failed to get 'defaultSymbol' from 'unifiedSymbol'.")
         }
         
-        self.kind = Self.kind(for: symbol)
+        self.kind = Self.kind(for: defaultSymbol)
         self.sourceLanguage = reference.sourceLanguage
-        self.name = .symbol(declaration: .init([.plain(symbol.names.title)]))
-        self.symbol = symbol
+        self.name = .symbol(declaration: .init([.plain(defaultSymbol.names.title)]))
+        self.symbol = defaultSymbol
         self.unifiedSymbol = unifiedSymbol
         
         self.markup = Document()
         self.docChunks = []
         self.tags = (returns: [], throws: [], parameters: [])
         
-        let symbolAvailability = symbol.mixins[SymbolGraph.Symbol.Availability.mixinKey] as? SymbolGraph.Symbol.Availability
+        let symbolAvailabilityVariants = DocumentationDataVariants(
+            symbolData: unifiedSymbol.mixins,
+            platformName: platformName
+        ) { mixins in
+            mixins[SymbolGraph.Symbol.Availability.mixinKey] as? SymbolGraph.Symbol.Availability
+        }
+        
         var languages = Set([reference.sourceLanguage])
         var operatingSystemName = platformName.map({ Set([$0]) }) ?? []
         
-        let availabilityDomains = symbolAvailability?.availability.compactMap({ $0.domain?.rawValue })
-        if let (sourceLanguages, otherDomains) = availabilityDomains?.categorize(where: SourceLanguage.init(knownLanguageName:)) {
+        for (_, symbolAvailability) in symbolAvailabilityVariants.allValues {
+            let (sourceLanguages, otherDomains) = symbolAvailability.availability
+                .compactMap({ $0.domain?.rawValue })
+                .categorize(where: SourceLanguage.init(knownLanguageName:))
+            
             languages.formUnion(sourceLanguages)
             operatingSystemName.formUnion(otherDomains)
         }
-        platformNames = Set(operatingSystemName.map { PlatformName(operatingSystemName: $0).rawValue })
-        availableSourceLanguages = languages
         
-        let extendedModule = (symbol.mixins[SymbolGraph.Symbol.Swift.Extension.mixinKey] as? SymbolGraph.Symbol.Swift.Extension)?.extendedModule
-
-        let sema = Symbol(
-            kindVariants: .init(swiftVariant: symbol.kind),
-            titleVariants: .init(swiftVariant: symbol.names.title),
-            subHeadingVariants: .init(swiftVariant: symbol.names.subHeading),
-            navigatorVariants: .init(swiftVariant: symbol.names.navigator),
-            roleHeadingVariants: .init(swiftVariant: symbol.kind.displayName),
-            platformNameVariants: .init(swiftVariant: platformName.map(PlatformName.init(operatingSystemName:))),
-            moduleNameVariants: .init(swiftVariant: moduleName),
-            extendedModuleVariants: .init(swiftVariant: extendedModule),
-            externalIDVariants: .init(swiftVariant: symbol.identifier.precise),
-            accessLevelVariants: .init(swiftVariant: symbol.accessLevel.rawValue),
-            availabilityVariants: .init(swiftVariant: symbolAvailability),
-            deprecatedSummaryVariants: .init(swiftVariant: nil),
-            mixinsVariants: .init(swiftVariant: symbol.mixins),
-            relationshipsVariants: .init(swiftVariant: RelationshipsSection()),
-            abstractSectionVariants: .init(swiftVariant: AbstractSection(paragraph: .init([Text("Placeholder Abstract")]))),
-            discussionVariants: .init(swiftVariant: nil),
-            topicsVariants: .init(swiftVariant: nil),
-            seeAlsoVariants: .init(swiftVariant: nil),
-            returnsSectionVariants: .init(swiftVariant: nil),
-            parametersSectionVariants: .init(swiftVariant: nil),
-            redirectsVariants: .init(swiftVariant: nil),
-            bystanderModuleNamesVariants: .init(swiftVariant: bystanderModules)
+        self.platformNames = Set(
+            operatingSystemName.map { name in
+                PlatformName(operatingSystemName: name).rawValue
+            }
+        )
+        
+        self.availableSourceLanguages = reference.sourceLanguages
+        
+        let extendedModuleVariants = DocumentationDataVariants(
+            symbolData: unifiedSymbol.mixins,
+            platformName: platformName
+        ) { mixins in
+            return mixins.getValueIfPresent(
+                for: SymbolGraph.Symbol.Swift.Extension.self
+            )?.extendedModule
+        }
+        
+        let semanticSymbol = Symbol(
+            kindVariants: DocumentationDataVariants(
+                symbolData: unifiedSymbol.kind,
+                platformName: platformName
+            ),
+            titleVariants: DocumentationDataVariants(
+                symbolData: unifiedSymbol.names,
+                platformName: platformName,
+                keyPath: \.title
+            ),
+            subHeadingVariants: DocumentationDataVariants(
+                symbolData: unifiedSymbol.names,
+                platformName: platformName,
+                keyPath: \.subHeading
+            ),
+            navigatorVariants: DocumentationDataVariants(
+                symbolData: unifiedSymbol.names,
+                platformName: platformName,
+                keyPath: \.navigator
+            ),
+            roleHeadingVariants: DocumentationDataVariants(
+                symbolData: unifiedSymbol.kind,
+                platformName: platformName,
+                keyPath: \.displayName
+            ),
+            platformNameVariants: DocumentationDataVariants(
+                defaultVariantValue: platformName.map(PlatformName.init(operatingSystemName:))
+            ),
+            moduleNameVariants: DocumentationDataVariants(defaultVariantValue: moduleName),
+            extendedModuleVariants: extendedModuleVariants,
+            externalIDVariants: DocumentationDataVariants(defaultVariantValue: unifiedSymbol.uniqueIdentifier),
+            accessLevelVariants: DocumentationDataVariants(
+                symbolData: unifiedSymbol.accessLevel,
+                platformName: platformName,
+                keyPath: \.rawValue
+            ),
+            availabilityVariants: symbolAvailabilityVariants,
+            deprecatedSummaryVariants: .empty,
+            mixinsVariants: DocumentationDataVariants(
+                symbolData: unifiedSymbol.mixins,
+                platformName: platformName
+            ),
+            relationshipsVariants: DocumentationDataVariants(
+                defaultVariantValue: RelationshipsSection()
+            ),
+            abstractSectionVariants: DocumentationDataVariants(
+                defaultVariantValue: AbstractSection(
+                    paragraph: .init([Text("Placeholder Abstract")])
+                )
+            ),
+            discussionVariants: .empty,
+            topicsVariants: .empty,
+            seeAlsoVariants: .empty,
+            returnsSectionVariants: .empty,
+            parametersSectionVariants: .empty,
+            redirectsVariants: .empty,
+            bystanderModuleNamesVariants: DocumentationDataVariants(
+                defaultVariantValue: bystanderModules
+            )
         )
 
-        try! sema.mergeDeclarations(unifiedSymbol: unifiedSymbol)
-
-        self.semantic = sema
+        try! semanticSymbol.mergeDeclarations(unifiedSymbol: unifiedSymbol)
+        self.semantic = semanticSymbol
     }
 
-    /// Given an optional article updates the node's content.
+    /// Given an optional documentation extension, initializes the node's documentation content.
+    ///
     /// - Parameters:
     ///   - article: An optional documentation extension article.
     ///   - engine: A diagnostics engine.
-    mutating func initializeSymbolContent(article: Article?, engine: DiagnosticEngine) {
-        precondition(symbol != nil, "You can only call initializeSymbolContent() on a symbol node.")
-        let (markup, docChunks) = Self.contentFrom(symbol: symbol!, article: article, engine: engine)
+    mutating func initializeSymbolContent(documentationExtension: Article?, engine: DiagnosticEngine) {
+        precondition(unifiedSymbol != nil && symbol != nil, "You can only call initializeSymbolContent() on a symbol node.")
+        
+        let (markup, docChunks) = Self.contentFrom(
+            documentedSymbol: unifiedSymbol?.documentedSymbol,
+            documentationExtension: documentationExtension,
+            engine: engine
+        )
         
         self.markup = markup
         self.docChunks = docChunks
@@ -232,7 +304,7 @@ public struct DocumentationNode {
         // Parse the structured markup
         let markupModel = DocumentationMarkup(markup: markup)
         
-        let symbolAvailability = symbol!.mixins[SymbolGraph.Symbol.Availability.mixinKey] as? SymbolGraph.Symbol.Availability
+        let symbolAvailability = symbol!.mixins.getValueIfPresent(for: SymbolGraph.Symbol.Availability.self)
         
         // Use a deprecation summary from the symbol docs or article content.
         var deprecated: DeprecatedSection? = markupModel.deprecation.map { DeprecatedSection.init(content: $0.elements) }
@@ -247,19 +319,35 @@ public struct DocumentationNode {
         let semantic = self.semantic as! Symbol
         
         // Symbol is a by-reference type so we're updating the original `semantic` property instance.
-        semantic.abstractSection = markupModel.abstractSection
-        semantic.discussion = markupModel.discussionSection
-        semantic.topics = markupModel.topicsSection
-        semantic.seeAlso = markupModel.seeAlsoSection
-        semantic.deprecatedSummary = deprecated
-        semantic.redirects = article?.redirects
+        semantic.abstractSectionVariants = DocumentationDataVariants(
+            defaultVariantValue: markupModel.abstractSection
+        )
+        semantic.discussionVariants = DocumentationDataVariants(
+            defaultVariantValue: markupModel.discussionSection
+        )
+        semantic.topicsVariants = DocumentationDataVariants(
+            defaultVariantValue: markupModel.topicsSection
+        )
+        semantic.seeAlsoVariants = DocumentationDataVariants(
+            defaultVariantValue: markupModel.seeAlsoSection
+        )
+        semantic.deprecatedSummaryVariants = DocumentationDataVariants(
+            defaultVariantValue: deprecated
+        )
+        semantic.redirectsVariants = DocumentationDataVariants(
+            defaultVariantValue: documentationExtension?.redirects
+        )
         
         if let returns = markupModel.discussionTags?.returns, !returns.isEmpty {
-            semantic.returnsSection = ReturnsSection(content: returns[0].contents)
+            semantic.returnsSectionVariants = DocumentationDataVariants(
+                defaultVariantValue: ReturnsSection(content: returns[0].contents)
+            )
         }
         
         if let parameters = markupModel.discussionTags?.parameters, !parameters.isEmpty {
-            semantic.parametersSection = ParametersSection(parameters: parameters)
+            semantic.parametersSectionVariants = DocumentationDataVariants(
+                defaultVariantValue: ParametersSection(parameters: parameters)
+            )
         }
         
         updateAnchorSections()
@@ -271,29 +359,33 @@ public struct DocumentationNode {
     ///   - article: An optional article with documentation content.
     ///   - engine: A diagnostics engine to use for problems found while parsing content.
     /// - Returns: The prepared node documentation content.
-    static func contentFrom(symbol: SymbolGraph.Symbol, article: Article?, engine: DiagnosticEngine)
-        -> (markup: Markup, docChunks: [DocumentationChunk]) {
-        
+    static func contentFrom(
+        documentedSymbol: SymbolGraph.Symbol?,
+        documentationExtension: Article?,
+        engine: DiagnosticEngine
+    ) -> (markup: Markup, docChunks: [DocumentationChunk]) {
         let markup: Markup
-        let docChunks: [DocumentationChunk]
+        var documentationChunks: [DocumentationChunk]
         
-        switch (article?.markup.flatMap{_ in article}, symbol.docComment) {
-        case (nil, nil):
-            markup = Document()
-            docChunks = [DocumentationChunk(source: .sourceCode(location: nil), markup: markup)]
-            
-        case (let article?, nil),
-             (let article?, _) where article.metadata?.documentationOptions?.behavior == .override:
-            markup = article.markup!
-            docChunks = [DocumentationChunk(source: .documentationExtension, markup: markup)]
-            
-        case (_, let docComment?):
+        // We should ignore the symbol's documentation comment if it wasn't provided
+        // or if the documentation extension was set to override.
+        let ignoreDocComment = documentedSymbol?.docComment == nil
+            || documentationExtension?.metadata?.documentationOptions?.behavior == .override
+        
+        if let documentationExtensionMarkup = documentationExtension?.markup, ignoreDocComment {
+            markup = documentationExtensionMarkup
+            documentationChunks = [
+                DocumentationChunk(source: .documentationExtension, markup: documentationExtensionMarkup)
+            ]
+        } else if let symbol = documentedSymbol, let docComment = symbol.docComment {
             let docCommentString = docComment.lines.map { $0.text }.joined(separator: "\n")
             let docCommentMarkup = Document(parsing: docCommentString, options: [.parseBlockDirectives, .parseSymbolLinks])
             
             let docCommentDirectives = docCommentMarkup.children.compactMap({ $0 as? BlockDirective })
             if !docCommentDirectives.isEmpty {
-                let location = (symbol.mixins[SymbolGraph.Symbol.Location.mixinKey] as? SymbolGraph.Symbol.Location)?.url()
+                let location = symbol.mixins.getValueIfPresent(
+                    for: SymbolGraph.Symbol.Location.self
+                )?.url()
                 
                 for comment in docCommentDirectives {
                     let range = docCommentMarkup.child(at: comment.indexInParent)?.range
@@ -315,21 +407,29 @@ public struct DocumentationNode {
                 }
             }
 
-            var docs: [DocumentationChunk] = [DocumentationChunk(source: .sourceCode(location: symbol.mixins[SymbolGraph.Symbol.Location.mixinKey] as? SymbolGraph.Symbol.Location), markup: docCommentMarkup)]
+            documentationChunks = [
+                DocumentationChunk(
+                    source: .sourceCode(location: symbol.mixins.getValueIfPresent(for: SymbolGraph.Symbol.Location.self)),
+                    markup: docCommentMarkup
+                )
+            ]
 
-            if let articleMarkup = article?.markup {
+            if let documentationExtensionMarkup = documentationExtension?.markup {
                 // An `Article` always starts with a level 1 heading (and return `nil` if that's not the first child).
                 // For documentation extension files, this heading is a link to the symbol—which isn't part of the content—so it is ignored.
-                let articleChildren = articleMarkup.children.dropFirst().compactMap { $0 as? BlockMarkup }
-                docs.append(DocumentationChunk(source: .documentationExtension, markup: articleMarkup))
-                markup = Document(Array(docCommentMarkup.blockChildren) + articleChildren)
+                let documentationExtensionChildren = documentationExtensionMarkup.children.dropFirst().compactMap { $0 as? BlockMarkup }
+                
+                documentationChunks.append(DocumentationChunk(source: .documentationExtension, markup: documentationExtensionMarkup))
+                markup = Document(Array(docCommentMarkup.blockChildren) + documentationExtensionChildren)
             } else {
                 markup = docCommentMarkup
             }
-            docChunks = docs
+        } else {
+            markup = Document()
+            documentationChunks = [DocumentationChunk(source: .sourceCode(location: nil), markup: markup)]
         }
         
-        return (markup: markup, docChunks: docChunks)
+        return (markup: markup, docChunks: documentationChunks)
     }
 
     /// Returns a documentation node kind for the given symbol kind.
@@ -393,7 +493,7 @@ public struct DocumentationNode {
         // Prefer content sections coming from an article (documentation extension file)
         var deprecated: DeprecatedSection?
         
-        let (markup, docChunks) = Self.contentFrom(symbol: symbol, article: article, engine: engine)
+        let (markup, docChunks) = Self.contentFrom(documentedSymbol: symbol, documentationExtension: article, engine: engine)
         self.markup = markup
         self.docChunks = docChunks
         

--- a/Sources/SwiftDocC/Model/Identifier.swift
+++ b/Sources/SwiftDocC/Model/Identifier.swift
@@ -78,13 +78,6 @@ public struct ResolvedTopicReference: Hashable, Codable, Equatable, CustomString
     /// A synchronized reference cache to store resolved references.
     static var sharedPool = Synchronized([ReferenceBundleIdentifier: [ReferenceKey: ResolvedTopicReference]]())
     
-    /// Adds a reference to the reference pool.
-    /// - Note: This method is synchronized over ``sharedPool``.
-    static func addToPool(_ reference: ResolvedTopicReference) {
-        sharedPool.sync {
-            $0[reference.bundleIdentifier, default: [:]][reference.cacheKey] = reference
-        }
-    }
     /// Clears cached references belonging to the bundle with the given identifier.
     /// - Parameter bundleIdentifier: The identifier of the bundle to which the method should clear belonging references.
     static func purgePool(for bundleIdentifier: String) {
@@ -124,11 +117,6 @@ public struct ResolvedTopicReference: Hashable, Codable, Equatable, CustomString
     /// The source languages for which this topic is relevant.
     public var sourceLanguages: Set<SourceLanguage>
     
-    /// The reference cache key
-    var cacheKey: String {
-        return Self.cacheKey(path: path, fragment: fragment, sourceLanguages: sourceLanguages)
-    }
-    
     /// - Note: The `path` parameter is escaped to a path readable string.
     public init(bundleIdentifier: String, path: String, fragment: String? = nil, sourceLanguage: SourceLanguage) {
         self.init(bundleIdentifier: bundleIdentifier, path: path, fragment: fragment, sourceLanguages: [sourceLanguage])
@@ -152,7 +140,7 @@ public struct ResolvedTopicReference: Hashable, Codable, Equatable, CustomString
         updateURL()
 
         // Cache the reference
-        Self.sharedPool.sync { $0[bundleIdentifier, default: [:]][cacheKey] = self }
+        Self.sharedPool.sync { $0[bundleIdentifier, default: [:]][key] = self }
     }
     
     private static func cacheKey(
@@ -244,7 +232,6 @@ public struct ResolvedTopicReference: Hashable, Codable, Equatable, CustomString
             sourceLanguages: sourceLanguages
         )
         
-        Self.addToPool(newReference)
         return newReference
     }
     
@@ -260,7 +247,6 @@ public struct ResolvedTopicReference: Hashable, Codable, Equatable, CustomString
             path: url.appendingPathComponent(urlReadablePath(path), isDirectory: false).path,
             sourceLanguages: sourceLanguages
         )
-        Self.addToPool(newReference)
         return newReference
     }
     
@@ -283,7 +269,6 @@ public struct ResolvedTopicReference: Hashable, Codable, Equatable, CustomString
             fragment: reference.fragment,
             sourceLanguages: sourceLanguages
         )
-        Self.addToPool(newReference)
         return newReference
     }
     
@@ -296,7 +281,6 @@ public struct ResolvedTopicReference: Hashable, Codable, Equatable, CustomString
             fragment: fragment,
             sourceLanguages: sourceLanguages
         )
-        Self.addToPool(newReference)
         return newReference
     }
     

--- a/Sources/SwiftDocC/Model/Identifier.swift
+++ b/Sources/SwiftDocC/Model/Identifier.swift
@@ -364,11 +364,24 @@ public struct ResolvedTopicReference: Hashable, Codable, Equatable, CustomString
         let path: String
         let fragment: String?
         let sourceLanguages: Set<SourceLanguage>
-        let url: URL
-        let pathComponents: [String]
-        let absoluteString: String
-        
         let identifierPathAndFragment: String
+        
+        lazy var url: URL = {
+            var components = URLComponents()
+            components.scheme = ResolvedTopicReference.urlScheme
+            components.host = bundleIdentifier
+            components.path = path
+            components.fragment = fragment
+            return components.url!
+        }()
+        
+        lazy var pathComponents: [String] = {
+            return url.pathComponents
+        }()
+        
+        lazy var absoluteString: String = {
+            return url.absoluteString
+        }()
         
         init(
             bundleIdentifier: String,
@@ -381,15 +394,6 @@ public struct ResolvedTopicReference: Hashable, Codable, Equatable, CustomString
             self.fragment = fragment
             self.sourceLanguages = sourceLanguages
             self.identifierPathAndFragment = "\(bundleIdentifier)\(path)\(fragment ?? "")"
-            
-            var components = URLComponents()
-            components.scheme = ResolvedTopicReference.urlScheme
-            components.host = bundleIdentifier
-            components.path = path
-            components.fragment = fragment
-            url = components.url!
-            pathComponents = url.pathComponents
-            absoluteString = url.absoluteString
         }
     }
 }

--- a/Sources/SwiftDocC/Model/Identifier.swift
+++ b/Sources/SwiftDocC/Model/Identifier.swift
@@ -324,6 +324,23 @@ public struct ResolvedTopicReference: Hashable, Codable, Equatable, CustomString
         )
     }
     
+    /// Returns a topic reference based on the current one but with the given source languages.
+    ///
+    /// If the current topic reference's source languages equal the given source languages,
+    /// this returns the original topic reference.
+    public func withSourceLanguages(_ sourceLanguages: Set<SourceLanguage>) -> ResolvedTopicReference {
+        guard sourceLanguages != self.sourceLanguages else {
+            return self
+        }
+        
+        return ResolvedTopicReference(
+            bundleIdentifier: bundleIdentifier,
+            urlReadablePath: path,
+            urlReadableFragment: fragment,
+            sourceLanguages: sourceLanguages
+        )
+    }
+    
     /// The last path component of this topic reference.
     public var lastPathComponent: String {
         // There is always at least one component, so we can unwrap `last`.

--- a/Sources/SwiftDocC/Model/Rendering/DocumentationContentRenderer.swift
+++ b/Sources/SwiftDocC/Model/Rendering/DocumentationContentRenderer.swift
@@ -313,7 +313,11 @@ public class DocumentationContentRenderer {
         var abstractedNode = node
         if kind == .section {
             // Sections don't have their own abstract so take the one of the container symbol.
-            let containerReference = ResolvedTopicReference(bundleIdentifier: reference.bundleIdentifier, path: reference.path, sourceLanguage: reference.sourceLanguage)
+            let containerReference = ResolvedTopicReference(
+                bundleIdentifier: reference.bundleIdentifier,
+                path: reference.path,
+                sourceLanguages: reference.sourceLanguages
+            )
             abstractedNode = try? documentationContext.entity(with: containerReference)
         }
         
@@ -446,13 +450,21 @@ public class DocumentationContentRenderer {
                 
                 // For external links, verify they've resolved successfully and return `nil` otherwise.
                 if linkHost != reference.bundleIdentifier {
-                    let externalReference = ResolvedTopicReference(bundleIdentifier: linkHost, path: destination.path, sourceLanguage: node.sourceLanguage)
+                    let externalReference = ResolvedTopicReference(
+                        bundleIdentifier: linkHost,
+                        path: destination.path,
+                        sourceLanguages: node.availableSourceLanguages
+                    )
                     if documentationContext.externallyResolvedSymbols.contains(externalReference) {
                         return externalReference
                     }
                     return nil
                 }
-                return ResolvedTopicReference(bundleIdentifier: reference.bundleIdentifier, path: destination.path, sourceLanguage: node.sourceLanguage)
+                return ResolvedTopicReference(
+                    bundleIdentifier: reference.bundleIdentifier,
+                    path: destination.path,
+                    sourceLanguages: node.availableSourceLanguages
+                )
             }
             
             resolvedTaskGroups.append(

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -804,7 +804,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
                 title: group.title,
                 abstract: nil,
                 discussion: nil,
-                identifiers: group.references.compactMap(\.url?.absoluteString),
+                identifiers: group.references.map(\.url.absoluteString),
                 generated: true
             )
         }
@@ -892,10 +892,8 @@ public struct RenderNodeTranslator: SemanticVisitor {
     public mutating func visitSymbol(_ symbol: Symbol) -> RenderTree? {
         let documentationNode = try! context.entity(with: identifier)
         
-        var identifier = identifier
+        let identifier = identifier.addingSourceLanguages(documentationNode.availableSourceLanguages)
         
-        // Add the source languages declared in the documentation node.
-        identifier.sourceLanguages = identifier.sourceLanguages.union(documentationNode.availableSourceLanguages)
         var node = RenderNode(identifier: identifier, kind: .symbol)
         var contentCompiler = RenderContentCompiler(context: context, bundle: bundle, identifier: identifier)
 

--- a/Sources/SwiftDocC/Model/Rendering/Variants/JSONPointer.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Variants/JSONPointer.swift
@@ -35,6 +35,10 @@ public struct JSONPointer: Codable, CustomStringConvertible {
         JSONPointer(pathComponents: pathComponents.dropFirst())
     }
     
+    func prependingPathComponents(_ components: [String]) -> JSONPointer {
+        JSONPointer(pathComponents: components + pathComponents)
+    }
+    
     /// An enum representing characters that need escaping in JSON Pointer values.
     ///
     /// The characters that need to be escaped in JSON Pointer values are defined in

--- a/Sources/SwiftDocC/Model/Rendering/Variants/VariantCollection+Symbol.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Variants/VariantCollection+Symbol.swift
@@ -84,6 +84,45 @@ public extension VariantCollection {
         self.init(defaultValue: defaultValue, variants: variants)
     }
     
+    /// Creates a variant collection from a given set of variant traits.
+    ///
+    /// If there are no variants for the given traits, this initializer returns `nil`.
+    ///
+    /// This initializer picks a variant (the Swift variant, if available)
+    /// of the given symbol data as the default value for the variant collection. Other variants
+    /// are encoded in the variant collection's ``variants``.
+    ///
+    /// - Parameters:
+    ///   - traits: The traits to consider when creating a variant collection.
+    ///   - fallbackDefaultValue: A fallback value to use if the given `transform` function
+    ///     returns nil for the default trait.
+    ///   - transform: The function that should be used to transform the a given variant trait
+    ///     to a value for the variant collection
+    init?(
+        from traits: Set<DocumentationDataVariantsTrait>,
+        fallbackDefaultValue: Value,
+        transform: (DocumentationDataVariantsTrait) -> Value?
+    ) {
+        var traits = traits
+        guard let defaultTrait = traits.removeFirstTraitForRendering() else {
+            return nil
+        }
+        
+        let defaultValue = transform(defaultTrait) ?? fallbackDefaultValue
+        
+        let variants = traits.compactMap { trait in
+            guard let value = transform(trait) else {
+                return nil
+            }
+            
+            return (trait, value)
+        }.compactMap { trait, value in
+            Self.createVariant(trait: trait, value: value)
+        }
+        
+        self.init(defaultValue: defaultValue, variants: variants)
+    }
+    
     /// Creates a variant collection from two symbol variants data using the given transformation closure.
     ///
     /// If the first symbol data variants value is empty, this initializer returns `nil`. If the second data variants value is empty, the transform closure is passed
@@ -269,6 +308,21 @@ private extension DocumentationDataVariants {
         let (trait, variant) = allValues[index]
         self[trait] = nil
         return (trait, variant)
+    }
+}
+
+private extension Set where Element == DocumentationDataVariantsTrait {
+    /// Removes and returns the trait that should be considered as the default value
+    /// for rendering.
+    ///
+    /// The default value used for rendering is the Swift variant of the symbol data if available,
+    /// otherwise it's the first one that's been registered.
+    mutating func removeFirstTraitForRendering() -> DocumentationDataVariantsTrait? {
+        if isEmpty {
+            return nil
+        } else {
+            return remove(.swift) ?? removeFirst()
+        }
     }
 }
 

--- a/Sources/SwiftDocC/Model/Rendering/Variants/VariantCollection.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Variants/VariantCollection.swift
@@ -77,9 +77,13 @@ public struct VariantCollection<Value: Codable>: Codable {
                         patchOperation = .add(value: value)
                     }
                     
+                    let jsonPointer = (
+                        pointer ?? JSONPointer(from: encoder.codingPath)
+                    ).prependingPathComponents(encoder.baseJSONPatchPath ?? [])
+                    
                     return JSONPatchOperation(
                         variantPatchOperation: patchOperation,
-                        pointer: pointer ?? JSONPointer(from: encoder.codingPath)
+                        pointer: jsonPointer
                     )
                 }
             )

--- a/Sources/SwiftDocC/Model/Rendering/Variants/VariantOverrides.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Variants/VariantOverrides.swift
@@ -28,7 +28,7 @@ public class VariantOverrides: Codable {
     
     /// Initializes a value given overrides.
     public init(values: [VariantOverride] = []) {
-        self.values = values
+        add(contentsOf: values)
     }
     
     /// Adds the given override.

--- a/Sources/SwiftDocC/Semantics/ReferenceResolver.swift
+++ b/Sources/SwiftDocC/Semantics/ReferenceResolver.swift
@@ -373,23 +373,23 @@ struct ReferenceResolver: SemanticVisitor {
     }
     
     mutating func visitSymbol(_ symbol: Symbol) -> Semantic {
-        let newAbstract = symbol.abstractSection.map {
+        let newAbstractVariants = symbol.abstractSectionVariants.map {
             AbstractSection(paragraph: visitMarkup($0.paragraph) as! Paragraph)
         }
-        let newDiscussion = symbol.discussion.map {
+        let newDiscussionVariants = symbol.discussionVariants.map {
             DiscussionSection(content: $0.content.map { visitMarkup($0) })
         }
-        let newTopics = symbol.topics.map { topic -> TopicsSection in
+        let newTopicsVariants = symbol.topicsVariants.map { topic -> TopicsSection in
             return TopicsSection(content: topic.content.map { visitMarkup($0) }, originalLinkRangesByGroup: topic.originalLinkRangesByGroup)
         }
-        let newSeeAlso = symbol.seeAlso.map {
+        let newSeeAlsoVariants = symbol.seeAlsoVariants.map {
             SeeAlsoSection(content: $0.content.map { visitMarkup($0) })
         }
-        let newReturns = symbol.returnsSection.map {
+        let newReturnsVariants = symbol.returnsSectionVariants.map {
             ReturnsSection(content: $0.content.map { visitMarkup($0) })
         }
-        let newParameters: ParametersSection? = symbol.parametersSection.map {
-            let parameters = $0.parameters.map {
+        let newParametersVariants = symbol.parametersSectionVariants.map { parametersSection -> ParametersSection in
+            let parameters = parametersSection.parameters.map {
                 Parameter(name: $0.name, contents: $0.contents.map { visitMarkup($0) })
             }
             return ParametersSection(parameters: parameters)
@@ -416,12 +416,12 @@ struct ReferenceResolver: SemanticVisitor {
             declarationVariants: symbol.declarationVariants,
             defaultImplementationsVariants: symbol.defaultImplementationsVariants,
             relationshipsVariants: symbol.relationshipsVariants,
-            abstractSectionVariants: .init(swiftVariant: newAbstract),
-            discussionVariants: .init(swiftVariant: newDiscussion),
-            topicsVariants: .init(swiftVariant: newTopics),
-            seeAlsoVariants: .init(swiftVariant: newSeeAlso),
-            returnsSectionVariants: .init(swiftVariant: newReturns),
-            parametersSectionVariants: .init(swiftVariant: newParameters),
+            abstractSectionVariants: newAbstractVariants,
+            discussionVariants: newDiscussionVariants,
+            topicsVariants: newTopicsVariants,
+            seeAlsoVariants: newSeeAlsoVariants,
+            returnsSectionVariants: newReturnsVariants,
+            parametersSectionVariants: newParametersVariants,
             redirectsVariants: symbol.redirectsVariants,
             bystanderModuleNamesVariants: symbol.bystanderModuleNamesVariants,
             originVariants: symbol.originVariants,

--- a/Sources/SwiftDocC/Semantics/Symbol/DocumentationDataVariants+SymbolGraphSymbol.swift
+++ b/Sources/SwiftDocC/Semantics/Symbol/DocumentationDataVariants+SymbolGraphSymbol.swift
@@ -1,0 +1,74 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+import SymbolKit
+
+extension DocumentationDataVariants {
+    init<V>(
+        symbolData: [UnifiedSymbolGraph.Selector: V],
+        platformName: String?,
+        transform: ((V) -> Variant)
+    ) {
+        self.init(
+            values: Dictionary(
+                uniqueKeysWithValues: symbolData.compactMap { selector, value in
+                    guard selector.platform == platformName else { return nil }
+                    
+                    return (
+                        DocumentationDataVariantsTrait(interfaceLanguage: selector.interfaceLanguage),
+                        transform(value)
+                    )
+                }
+            )
+        )
+    }
+    
+    init<V>(
+        symbolData: [UnifiedSymbolGraph.Selector: V],
+        platformName: String?,
+        transform: ((V) -> Variant?)
+    ) {
+        self.init(
+            values: Dictionary(
+                uniqueKeysWithValues: symbolData.compactMap { selector, value in
+                    guard selector.platform == platformName,
+                          let value = transform(value)
+                    else { return nil }
+                    
+                    return (
+                        DocumentationDataVariantsTrait(interfaceLanguage: selector.interfaceLanguage),
+                        value
+                    )
+                }
+            )
+        )
+    }
+    
+    init<V>(
+        symbolData: [UnifiedSymbolGraph.Selector: V],
+        platformName: String?,
+        keyPath: KeyPath<V, Variant>
+    ) {
+        self.init(symbolData: symbolData, platformName: platformName, transform: { $0[keyPath: keyPath] })
+    }
+    
+    init<V>(
+        symbolData: [UnifiedSymbolGraph.Selector: V],
+        platformName: String?,
+        keyPath: KeyPath<V, Variant?>
+    ) {
+        self.init(symbolData: symbolData, platformName: platformName, transform: { $0[keyPath: keyPath] })
+    }
+    
+    init(symbolData: [UnifiedSymbolGraph.Selector: Variant], platformName: String?) {
+        self.init(symbolData: symbolData, platformName: platformName, transform: { $0 })
+    }
+}

--- a/Sources/SwiftDocC/Semantics/Symbol/DocumentationDataVariants.swift
+++ b/Sources/SwiftDocC/Semantics/Symbol/DocumentationDataVariants.swift
@@ -57,11 +57,35 @@ public struct DocumentationDataVariants<Variant> {
         }
     }
     
+    /// Accesses the variant for the given trait,
+    /// falling back to the given default variant if the key isn’t found.
+    public subscript(trait: DocumentationDataVariantsTrait, default defaultValue: Variant) -> Variant {
+        get { values[trait] ?? defaultValue }
+        set {
+            if trait == .fallback {
+                defaultVariantValue = newValue
+            } else {
+                values[trait] = newValue
+            }
+        }
+    }
+    
     /// Whether a variant for the given trait has been registered.
     ///
     /// - Parameter trait: The trait to look up a variant for.
     public func hasVariant(for trait: DocumentationDataVariantsTrait) -> Bool {
         values.keys.contains(trait)
+    }
+    
+    func map<NewVariant>(transform: (Variant) -> NewVariant) -> DocumentationDataVariants<NewVariant> {
+        return DocumentationDataVariants<NewVariant>(
+            values: Dictionary(
+                uniqueKeysWithValues: values.map { (trait, variant) in
+                    return (trait, transform(variant))
+                }
+            ),
+            defaultVariantValue: defaultVariantValue.map(transform)
+        )
     }
 }
 
@@ -73,6 +97,10 @@ extension DocumentationDataVariants {
         } else {
             self.init()
         }
+    }
+    
+    static var empty: DocumentationDataVariants<Variant> {
+        return DocumentationDataVariants<Variant>(values: [:], defaultVariantValue: nil)
     }
     
     /// Convenience API to access the first variant, or the default value if there are no registered variants.

--- a/Sources/SwiftDocC/SwiftDocC.docc/SwiftDocC/RenderingModel/RenderingModel.md
+++ b/Sources/SwiftDocC/SwiftDocC.docc/SwiftDocC/RenderingModel/RenderingModel.md
@@ -42,6 +42,7 @@ Hereto a rendering node contains data not only about a single specific topic (a 
 ### References
 
 - ``RenderReference``
+- ``RenderReferenceCache``
 - ``URLReference``
 - ``RenderReferenceType``
 

--- a/Sources/SwiftDocC/Utility/FoundationExtensions/CharacterSet.swift
+++ b/Sources/SwiftDocC/Utility/FoundationExtensions/CharacterSet.swift
@@ -1,0 +1,19 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+
+extension CharacterSet {
+    /// Returns the character set for characters **not** allowed in a path URL component.
+    static let urlPathNotAllowed = CharacterSet.urlPathAllowed.inverted
+    
+    /// Returns the union of the `whitespaces` and `punctuationCharacters` character sets.
+    static let whitespacesAndPunctuation = CharacterSet.whitespaces.union(.punctuationCharacters)
+}

--- a/Sources/SwiftDocCUtilities/Action/Actions/Convert/JSONEncodingRenderNodeWriter.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Convert/JSONEncodingRenderNodeWriter.swift
@@ -29,7 +29,7 @@ class JSONEncodingRenderNodeWriter {
     
     private let urlGenerator: NodeURLGenerator
     private let fileManager: FileManagerProtocol
-    private let renderReferenceCache = Synchronized<[String: Data]>([:])
+    private let renderReferenceCache = RenderReferenceCache([:])
     
     /// Creates a writer object that write render node JSON into a given folder.
     ///

--- a/Tests/SwiftDocCTests/Infrastructure/AutomaticCurationTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/AutomaticCurationTests.swift
@@ -349,4 +349,64 @@ class AutomaticCurationTests: XCTestCase {
             )
         }
     }
+    
+    func testRelevantLanguagesAreAutoCuratedInMixedLanguageFramework() throws {
+        enableFeatureFlag(\.isExperimentalObjectiveCSupportEnabled)
+        
+        let (bundle, context) = try testBundleAndContext(named: "MixedLanguageFramework")
+        
+        let frameworkDocumentationNode = try context.entity(
+            with: ResolvedTopicReference(
+                bundleIdentifier: bundle.identifier,
+                path: "/documentation/MixedLanguageFramework",
+                sourceLanguages: [.swift, .objectiveC]
+            )
+        )
+        
+        let swiftTopics = try AutomaticCuration.topics(
+            for: frameworkDocumentationNode,
+            withTrait: .swift,
+            context: context
+        )
+        
+        XCTAssertEqual(
+            swiftTopics.flatMap { taskGroup in
+                [taskGroup.title] + taskGroup.references.map(\.path)
+            },
+            [
+                "Classes",
+                "/documentation/MixedLanguageFramework/Bar",
+                
+                "Structures",
+                "/documentation/MixedLanguageFramework/Foo-swift.struct",
+                "/documentation/MixedLanguageFramework/SwiftOnlyStruct",
+            ]
+        )
+        
+        let objectiveCTopics = try AutomaticCuration.topics(
+            for: frameworkDocumentationNode,
+            withTrait: DocumentationDataVariantsTrait(interfaceLanguage: "occ"),
+            context: context
+        )
+        
+        XCTAssertEqual(
+            objectiveCTopics.flatMap { taskGroup in
+                [taskGroup.title] + taskGroup.references.map(\.path)
+            },
+            [
+                "Classes",
+                "/documentation/MixedLanguageFramework/Bar",
+                
+                "Variables",
+                "/documentation/MixedLanguageFramework/_MixedLanguageFrameworkVersionNumber",
+                "/documentation/MixedLanguageFramework/_MixedLanguageFrameworkVersionString",
+                
+                "Type Aliases",
+                "/documentation/MixedLanguageFramework/Foo-occ.typealias",
+                
+                "Enumerations",
+                "/documentation/MixedLanguageFramework/Foo-swift.struct",
+            ]
+        )
+    }
 }

--- a/Tests/SwiftDocCTests/Infrastructure/ResolvedTopicReferenceTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/ResolvedTopicReferenceTests.swift
@@ -15,21 +15,27 @@ import XCTest
 
 class ResolvedTopicReferenceTests: XCTestCase {
     func testReferenceURL() {
-        var reference = ResolvedTopicReference(bundleIdentifier: "bundleID", path: "/path/sub-path", fragment: "fragment", sourceLanguage: .swift)
-        XCTAssertEqual(reference.absoluteString, "doc://bundleID/path/sub-path#fragment")
+        let firstTopicReference = ResolvedTopicReference(
+            bundleIdentifier: "bundleID",
+            path: "/path/sub-path",
+            fragment: "fragment",
+            sourceLanguage: .swift
+        )
+        XCTAssertEqual(firstTopicReference.absoluteString, "doc://bundleID/path/sub-path#fragment")
         
-        reference.bundleIdentifier = "new-bundleID"
-        XCTAssertEqual(reference.absoluteString, "doc://new-bundleID/path/sub-path#fragment")
+        let secondTopicReference = ResolvedTopicReference(
+            bundleIdentifier: "new-bundleID",
+            path: "/new-path/sub-path",
+            fragment: firstTopicReference.fragment,
+            sourceLanguage: firstTopicReference.sourceLanguage
+        )
+        XCTAssertEqual(secondTopicReference.absoluteString, "doc://new-bundleID/new-path/sub-path#fragment")
         
-        reference.path = "/new-path/sub-path"
-        XCTAssertEqual(reference.absoluteString, "doc://new-bundleID/new-path/sub-path#fragment")
-        
-        reference.fragment = nil
-        XCTAssertEqual(reference.absoluteString, "doc://new-bundleID/new-path/sub-path")
+        let thirdTopicReference = secondTopicReference.withFragment(nil)
+        XCTAssertEqual(thirdTopicReference.absoluteString, "doc://new-bundleID/new-path/sub-path")
         
         // Changing the language does not change the url
-        reference.sourceLanguage = .metal
-        XCTAssertEqual(reference.absoluteString, "doc://new-bundleID/new-path/sub-path")
+        XCTAssertEqual(thirdTopicReference.addingSourceLanguages([.metal]).absoluteString, "doc://new-bundleID/new-path/sub-path")
     }
     
     func testAppendingReferenceWithEmptyPath() {

--- a/Tests/SwiftDocCTests/Infrastructure/Symbol Link Resolution/AbsoluteSymbolLinkTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/Symbol Link Resolution/AbsoluteSymbolLinkTests.swift
@@ -524,9 +524,7 @@ class AbsoluteSymbolLinkTests: XCTestCase {
         XCTAssertEqual(expectedDescriptions.count, context.symbolIndex.count)
         
         let validatedSymbolLinkDescriptions = context.symbolIndex.values
-            .map(\.reference)
-            .compactMap(\.url)
-            .map(\.absoluteString)
+            .map(\.reference.url.absoluteString)
             .sorted()
             .compactMap(AbsoluteSymbolLink.init(string:))
             .map(\.description)
@@ -850,9 +848,7 @@ class AbsoluteSymbolLinkTests: XCTestCase {
         XCTAssertEqual(expectedDescriptions.count, context.symbolIndex.count)
         
         let validatedSymbolLinkDescriptions = context.symbolIndex.values
-            .map(\.reference)
-            .compactMap(\.url)
-            .map(\.absoluteString)
+            .map(\.reference.url.absoluteString)
             .sorted()
             .compactMap(AbsoluteSymbolLink.init(string:))
             .map(\.description)
@@ -872,10 +868,7 @@ class AbsoluteSymbolLinkTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: url) }
         
         let bundlePathComponents = context.symbolIndex.values
-            .map(\.reference)
-            .compactMap(\.url)
-            .map(\.pathComponents)
-            .flatMap { $0 }
+            .flatMap(\.reference.pathComponents)
         
         
         bundlePathComponents.forEach { component in

--- a/Tests/SwiftDocCTests/Model/IdentifierTests.swift
+++ b/Tests/SwiftDocCTests/Model/IdentifierTests.swift
@@ -121,4 +121,14 @@ class IdentifierTests: XCTestCase {
         ref1 = ref1.removingLastPathComponent()
         XCTAssertEqual(ref1.absoluteString, "doc://bundle/MyClass")
     }
+    
+    func testResolvedTopicReferenceDoesNotCopyStorageIfNotModified() {
+         let reference1 = ResolvedTopicReference(bundleIdentifier: "bundle", path: "/", sourceLanguage: .swift)
+         let reference2 = reference1
+
+         XCTAssertEqual(
+             ObjectIdentifier(reference1._storage),
+             ObjectIdentifier(reference2._storage)
+         )
+     }
 }

--- a/Tests/SwiftDocCTests/Model/IdentifierTests.swift
+++ b/Tests/SwiftDocCTests/Model/IdentifierTests.swift
@@ -130,5 +130,28 @@ class IdentifierTests: XCTestCase {
              ObjectIdentifier(reference1._storage),
              ObjectIdentifier(reference2._storage)
          )
-     }
+    }
+    
+    func testWithSourceLanguages() {
+        let swiftReference = ResolvedTopicReference(
+            bundleIdentifier: "bundle",
+            path: "/",
+            sourceLanguage: .swift
+        )
+        
+        XCTAssertEqual(
+            swiftReference.withSourceLanguages([.objectiveC]).sourceLanguages,
+            [.objectiveC]
+        )
+        
+        XCTAssertEqual(
+            swiftReference.withSourceLanguages([.swift]).sourceLanguages,
+            [.swift]
+        )
+        
+        XCTAssertEqual(
+            swiftReference.withSourceLanguages([.objectiveC, .swift]).sourceLanguages,
+            Set([.swift, .objectiveC])
+        )
+    }
 }

--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeMultiLanguageTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeMultiLanguageTests.swift
@@ -1,0 +1,478 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+@testable import SwiftDocC
+import XCTest
+
+class SemaToRenderNodeMixedLanguageTests: ExperimentalObjectiveCTestCase {
+    func testBaseRenderNodeFromMixedLanguageFramework() throws {
+        let (_, context) = try testBundleAndContext(named: "MixedLanguageFramework")
+        
+        for documentationNode in context.documentationCache.values {
+            let symbolUSR = try XCTUnwrap((documentationNode.semantic as? Symbol)?.externalID)
+            
+            let expectedSwiftOnlyUSRs: Set<String> = [
+                // Swift-only struct - ``SwiftOnlyStruct``:
+                "s:22MixedLanguageFramework15SwiftOnlyStructV",
+                
+                // Member of Swift-only struct - ``SwiftOnlyStruct/tada()``:
+                "s:22MixedLanguageFramework15SwiftOnlyStructV4tadayyF",
+                
+                // Swift-only synthesized struct initializer - ``Foo/init(rawValue:)``:
+                "s:So3FooV8rawValueABSu_tcfc",
+            ]
+            
+            let expectedObjectiveCOnlyUSRs: Set<String> = [
+                // Objective-C only variable - ``_MixedLanguageFrameworkVersionNumber``:
+                "c:@MixedLanguageFrameworkVersionNumber",
+                
+                // Objective-C only variable - ``_MixedLanguageFrameworkVersionString``:
+                "c:@MixedLanguageFrameworkVersionString",
+                
+                // Objective-C only typealias - ``Foo-occ.typealias``
+                "c:MixedLanguageFramework.h@T@Foo",
+            ]
+            
+            if expectedSwiftOnlyUSRs.contains(symbolUSR) {
+                XCTAssertEqual(
+                    documentationNode.availableSourceLanguages,
+                    [.swift],
+                    "Swift-only node should be only available in Swift: '\(symbolUSR)'"
+                )
+            } else if expectedObjectiveCOnlyUSRs.contains(symbolUSR) {
+                XCTAssertEqual(
+                    documentationNode.availableSourceLanguages,
+                    [.objectiveC],
+                    "Objective-C-only node should be only available in Objective-C: '\(symbolUSR)'"
+                )
+            } else {
+                XCTAssertEqual(
+                    documentationNode.availableSourceLanguages,
+                    [.swift, .objectiveC],
+                    "Multi-language node should be available in Swift and Objective-C: '\(symbolUSR)'"
+                )
+            }
+        }
+    }
+    
+    func testOutputsMultiLanguageRenderNodes() throws {
+        let outputConsumer = try TestRenderNodeOutputConsumer.mixedLanguageFrameworkConsumer()
+        
+        XCTAssertEqual(
+            Set(
+                outputConsumer.renderNodes(withInterfaceLanguages: ["swift"])
+                    .map { $0.metadata.externalID }
+            ),
+            [
+                // Swift-only struct - ``SwiftOnlyStruct``:
+                "s:22MixedLanguageFramework15SwiftOnlyStructV",
+                
+                // Member of Swift-only struct - ``SwiftOnlyStruct/tada()``:
+                "s:22MixedLanguageFramework15SwiftOnlyStructV4tadayyF",
+                
+                // Swift-only synthesized struct initializer - ``Foo/init(rawValue:)``:
+                "s:So3FooV8rawValueABSu_tcfc",
+            ]
+        )
+        
+        XCTAssertEqual(
+            Set(
+                outputConsumer.renderNodes(withInterfaceLanguages: ["occ"])
+                    .map { $0.metadata.externalID }
+            ),
+            [
+                // Objective-C only variable - ``_MixedLanguageFrameworkVersionNumber``:
+                "c:@MixedLanguageFrameworkVersionNumber",
+                
+                // Objective-C only variable - ``_MixedLanguageFrameworkVersionString``:
+                "c:@MixedLanguageFrameworkVersionString",
+                
+                // Objective-C only typealias - ``Foo-occ.typealias``
+                "c:MixedLanguageFramework.h@T@Foo",
+            ]
+        )
+        
+        XCTAssertEqual(
+            Set(
+                outputConsumer.renderNodes(withInterfaceLanguages: ["swift", "occ"])
+                    .map { $0.metadata.externalID }
+            ),
+            [
+                "MixedLanguageFramework",
+                "c:@E@Foo",
+                "c:@E@Foo@first",
+                "c:@E@Foo@fourth",
+                "c:@E@Foo@second",
+                "c:@E@Foo@third",
+                "c:objc(cs)Bar",
+                "c:objc(cs)Bar(cm)MyStringFunction:error:",
+            ]
+        )
+    }
+    
+    func testFrameworkRenderNodeHasExpectedContentAcrossLanguages() throws {
+        let outputConsumer = try TestRenderNodeOutputConsumer.mixedLanguageFrameworkConsumer()
+        let mixedLanguageFrameworkRenderNode = try outputConsumer.renderNode(
+            withIdentifier: "MixedLanguageFramework"
+        )
+        
+        assertExpectedContent(
+            mixedLanguageFrameworkRenderNode,
+            sourceLanguage: "swift",
+            symbolKind: "module",
+            title: "MixedLanguageFramework",
+            navigatorTitle: nil,
+            abstract: "No overview available.",
+            declarationTokens: nil,
+            discussionSection: nil,
+            topicSectionIdentifiers: [
+                "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/Bar",
+                "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/Foo-swift.struct",
+                "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/SwiftOnlyStruct",
+            ],
+            referenceTitles: [
+                "Bar",
+                "Foo",
+                "Foo",
+                "MixedLanguageFramework",
+                "SwiftOnlyStruct",
+                "_MixedLanguageFrameworkVersionNumber",
+                "_MixedLanguageFrameworkVersionString"
+            ],
+            referenceFragments: [
+                "class Bar",
+                "struct Foo",
+                "struct SwiftOnlyStruct",
+            ],
+            failureMessage: { fieldName in
+                "Swift variant of 'MixedLanguageFramework' module has unexpected content for '\(fieldName)'."
+            }
+        )
+        
+        let objectiveCVariantData = try RenderNodeVariantOverridesApplier().applyVariantOverrides(
+            in: RenderJSONEncoder.makeEncoder().encode(mixedLanguageFrameworkRenderNode),
+            for: [.interfaceLanguage("occ")]
+        )
+        
+        let objectiveCVariantNode = try RenderJSONDecoder.makeDecoder().decode(
+            RenderNode.self,
+            from: objectiveCVariantData
+        )
+        
+        assertExpectedContent(
+            objectiveCVariantNode,
+            sourceLanguage: "occ",
+            symbolKind: "module",
+            title: "MixedLanguageFramework",
+            navigatorTitle: nil,
+            abstract: "No overview available.",
+            declarationTokens: nil,
+            discussionSection: nil,
+            topicSectionIdentifiers: [
+                "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/Bar",
+                "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/_MixedLanguageFrameworkVersionNumber",
+                "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/_MixedLanguageFrameworkVersionString",
+                "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/Foo-occ.typealias",
+                "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/Foo-swift.struct",
+            ],
+            referenceTitles: [
+                "Bar",
+                "Foo",
+                "Foo",
+                "MixedLanguageFramework",
+                "SwiftOnlyStruct",
+                "_MixedLanguageFrameworkVersionNumber",
+                "_MixedLanguageFrameworkVersionString"
+            ],
+            referenceFragments: [
+                "class Bar",
+                "struct Foo",
+                "struct SwiftOnlyStruct",
+            ],
+            failureMessage: { fieldName in
+                "Objective-C variant of 'MixedLanguageFramework' module has unexpected content for '\(fieldName)'."
+            }
+        )
+    }
+    
+    func testObjectiveCAuthoredRenderNodeHasExpectedContentAcrossLanguages() throws {
+        let outputConsumer = try TestRenderNodeOutputConsumer.mixedLanguageFrameworkConsumer()
+        let fooRenderNode = try outputConsumer.renderNode(withIdentifier: "c:@E@Foo")
+        
+        assertExpectedContent(
+            fooRenderNode,
+            sourceLanguage: "swift",
+            symbolKind: "struct",
+            title: "Foo",
+            navigatorTitle: "Foo",
+            abstract: "A foo.",
+            declarationTokens: [
+                "struct",
+                " ",
+                "Foo",
+            ],
+            discussionSection: [
+                "This is the foo’s description.",
+            ],
+            topicSectionIdentifiers: [
+                "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/Foo-swift.struct/init(rawValue:)",
+                "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/Foo-swift.struct/first",
+                "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/Foo-swift.struct/fourth",
+                "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/Foo-swift.struct/second",
+                "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/Foo-swift.struct/third",
+            ],
+            referenceTitles: [
+                "Foo",
+                "MixedLanguageFramework",
+                "first",
+                "fourth",
+                "init(rawValue:)",
+                "second",
+                "third",
+            ],
+            referenceFragments: [
+                "init(rawValue: UInt)",
+                "static var first: Foo",
+                "static var fourth: Foo",
+                "static var second: Foo",
+                "static var third: Foo",
+                "struct Foo",
+            ],
+            failureMessage: { fieldName in
+                "Swift variant of 'Foo' symbol has unexpected content for '\(fieldName)'."
+            }
+        )
+        
+        let objectiveCVariantData = try RenderNodeVariantOverridesApplier().applyVariantOverrides(
+            in: RenderJSONEncoder.makeEncoder().encode(fooRenderNode),
+            for: [.interfaceLanguage("occ")]
+        )
+        
+        let objectiveCVariantNode = try RenderJSONDecoder.makeDecoder().decode(
+            RenderNode.self,
+            from: objectiveCVariantData
+        )
+        
+        assertExpectedContent(
+            objectiveCVariantNode,
+            sourceLanguage: "occ",
+            symbolKind: "enum",
+            title: "Foo",
+            navigatorTitle: "Foo",
+            abstract: "A foo.",
+            declarationTokens: [
+                "FOO",
+            ],
+            discussionSection: [
+                "This is the foo’s description.",
+            ],
+            topicSectionIdentifiers: [
+                "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/Foo-swift.struct/first",
+                "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/Foo-swift.struct/fourth",
+                "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/Foo-swift.struct/second",
+                "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/Foo-swift.struct/third",
+            ],
+            referenceTitles: [
+                "Foo",
+                "MixedLanguageFramework",
+                "first",
+                "fourth",
+                "init(rawValue:)",
+                "second",
+                "third",
+            ],
+            referenceFragments: [
+                "init(rawValue: UInt)",
+                "static var first: Foo",
+                "static var fourth: Foo",
+                "static var second: Foo",
+                "static var third: Foo",
+                "struct Foo",
+            ],
+            failureMessage: { fieldName in
+                "Objective-C variant of 'Foo' symbol has unexpected content for '\(fieldName)'."
+            }
+        )
+    }
+    
+    func assertExpectedContent(
+        _ renderNode: RenderNode,
+        sourceLanguage expectedSourceLanguage: String,
+        symbolKind expectedSymbolKind: String,
+        title expectedTitle: String,
+        navigatorTitle expectedNavigatorTitle: String?,
+        abstract expectedAbstract: String,
+        declarationTokens expectedDeclarationTokens: [String]?,
+        discussionSection expectedDiscussionSection: [String]?,
+        topicSectionIdentifiers expectedTopicSectionIdentifiers: [String],
+        referenceTitles expectedReferenceTitles: [String],
+        referenceFragments expectedReferenceFragments: [String],
+        failureMessage failureMessageForField: (_ field: String) -> String,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        XCTAssertEqual(
+            renderNode.abstract?.plainText,
+            expectedAbstract,
+            failureMessageForField("abstract"),
+            file: file,
+            line: line
+        )
+        
+        XCTAssertEqual(
+            (renderNode.primaryContentSections.last as? ContentRenderSection)?.content.paragraphText,
+            expectedDiscussionSection,
+            failureMessageForField("discussion section"),
+            file: file,
+            line: line
+        )
+        
+        XCTAssertEqual(
+            renderNode.identifier.sourceLanguage.id,
+            expectedSourceLanguage,
+            failureMessageForField("source language id"),
+            file: file,
+            line: line
+        )
+        
+        XCTAssertEqual(
+            (renderNode.primaryContentSections.first as? DeclarationsRenderSection)?
+                .declarations
+                .flatMap(\.tokens)
+                .map(\.text),
+            expectedDeclarationTokens,
+            failureMessageForField("declaration tokens"),
+            file: file,
+            line: line
+        )
+        
+        XCTAssertEqual(
+            renderNode.metadata.navigatorTitle?.map(\.text).joined(),
+            expectedNavigatorTitle,
+            failureMessageForField("navigator title"),
+            file: file,
+            line: line
+        )
+        
+        XCTAssertEqual(
+            renderNode.metadata.title,
+            expectedTitle,
+            failureMessageForField("title"),
+            file: file,
+            line: line
+        )
+        
+        XCTAssertEqual(
+            renderNode.metadata.symbolKind,
+            expectedSymbolKind,
+            failureMessageForField("symbol kind"),
+            file: file,
+            line: line
+        )
+        
+        XCTAssertEqual(
+            renderNode.topicSections.flatMap(\.identifiers),
+            expectedTopicSectionIdentifiers,
+            failureMessageForField("topic sections identifiers"),
+            file: file,
+            line: line
+        )
+        
+        XCTAssertEqual(
+            renderNode.references.map(\.value).compactMap { reference in
+                (reference as? TopicRenderReference)?.title
+            }.sorted(),
+            expectedReferenceTitles,
+            failureMessageForField("reference titles"),
+            file: file,
+            line: line
+        )
+        
+        XCTAssertEqual(
+            renderNode.references.map(\.value).compactMap { reference in
+                (reference as? TopicRenderReference)?.fragments?.map(\.text).joined()
+            }.sorted(),
+            expectedReferenceFragments,
+            failureMessageForField("reference fragments"),
+            file: file,
+            line: line
+        )
+    }
+}
+
+private class TestRenderNodeOutputConsumer: ConvertOutputConsumer {
+    var renderNodes = Synchronized<[RenderNode]>([])
+    
+    func consume(renderNode: RenderNode) throws {
+        renderNodes.sync { renderNodes in
+            renderNodes.append(renderNode)
+        }
+    }
+    
+    func consume(problems: [Problem]) throws { }
+    func consume(assetsInBundle bundle: DocumentationBundle) throws { }
+    func consume(linkableElementSummaries: [LinkDestinationSummary]) throws { }
+    func consume(indexingRecords: [IndexingRecord]) throws { }
+    func consume(assets: [RenderReferenceType: [RenderReference]]) throws { }
+    func consume(benchmarks: Benchmark) throws { }
+    func consume(documentationCoverageInfo: [CoverageDataEntry]) throws { }
+    func consume(renderReferenceStore: RenderReferenceStore) throws { }
+    func consume(buildMetadata: BuildMetadata) throws { }
+}
+
+extension TestRenderNodeOutputConsumer {
+    func renderNodes(withInterfaceLanguages interfaceLanguages: Set<String>) -> [RenderNode] {
+        renderNodes.sync { renderNodes in
+            renderNodes.filter { renderNode in
+                let actualInterfaceLanguages: [String] = renderNode.variants?.flatMap { variant in
+                    variant.traits.compactMap { trait in
+                        guard case .interfaceLanguage(let interfaceLanguage) = trait else {
+                            return nil
+                        }
+                        return interfaceLanguage
+                    }
+                } ?? []
+                
+                return Set(actualInterfaceLanguages) == interfaceLanguages
+            }
+        }
+    }
+    
+    func renderNode(withIdentifier identifier: String) throws -> RenderNode {
+        let renderNode = renderNodes.sync { renderNodes in
+            renderNodes.first { renderNode in
+                renderNode.metadata.externalID == identifier
+            }
+        }
+        
+        return try XCTUnwrap(renderNode)
+    }
+    
+    static func mixedLanguageFrameworkConsumer() throws -> TestRenderNodeOutputConsumer {
+        let (bundleURL, _, context) = try testBundleAndContext(copying: "MixedLanguageFramework")
+        
+        var converter = DocumentationConverter(
+            documentationBundleURL: bundleURL,
+            emitDigest: false,
+            documentationCoverageOptions: .noCoverage,
+            currentPlatforms: nil,
+            workspace: context.dataProvider as! DocumentationWorkspace,
+            context: context,
+            dataProvider: try LocalFileSystemDataProvider(rootURL: bundleURL),
+            bundleDiscoveryOptions: BundleDiscoveryOptions()
+        )
+        
+        let outputConsumer = TestRenderNodeOutputConsumer()
+        let (_, _) = try converter.convert(outputConsumer: outputConsumer)
+        
+        return outputConsumer
+    }
+}

--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
@@ -914,17 +914,6 @@ class SemaToRenderNodeTests: XCTestCase {
         )
     }
     
-    private func extractParagraphText(_ block: RenderBlockContent) -> String? {
-        switch block {
-        case .paragraph(inlineContent: let children):
-            switch children[0] {
-            case .text(let text): return text
-            default: return nil
-            }
-        default: return nil
-        }
-    }
-    
     func testCompileSymbol() throws {
         let (bundleURL, bundle, context) = try testBundleAndContext(copying: "TestBundle") { url in
             // Remove the SideClass sub heading to match the expectations of this test
@@ -1010,7 +999,7 @@ class SemaToRenderNodeTests: XCTestCase {
         }
         XCTAssertEqual(content.kind, RenderSectionKind.content)
         
-        let discussionParagraphPrefixes = content.content.compactMap(extractParagraphText)
+        let discussionParagraphPrefixes = content.content.paragraphText
         
         XCTAssertEqual(discussionParagraphPrefixes, [
             "Further discussion.",
@@ -1051,7 +1040,7 @@ class SemaToRenderNodeTests: XCTestCase {
 
         // Test all identifiers have been resolved to the ``MyClass`` symbol
         XCTAssertEqual(renderNode.topicSections[0].title, "Task Group Excercising Symbol Links")
-        XCTAssertEqual(renderNode.topicSections[0].abstract?.map{ RenderBlockContent.paragraph(inlineContent: [$0]) }.compactMap(extractParagraphText).joined(), "Task Group abstract text.")
+        XCTAssertEqual(renderNode.topicSections[0].abstract?.map{ RenderBlockContent.paragraph(inlineContent: [$0]) }.paragraphText.joined(), "Task Group abstract text.")
         
         guard let discussion = renderNode.topicSections[0].discussion as? ContentRenderSection else {
             XCTFail("Could not find group discussion")
@@ -1065,7 +1054,7 @@ class SemaToRenderNodeTests: XCTestCase {
         XCTAssertEqual(children.first?.name, "Task Group Excercising Symbol Links")
         XCTAssertEqual(children.first?.references.count, 3)
         
-        let groupDiscussionParagraphPrefixes = discussion.content.compactMap(extractParagraphText)
+        let groupDiscussionParagraphPrefixes = discussion.content.paragraphText
         
         // Check the text content of the discussion
         XCTAssertEqual(groupDiscussionParagraphPrefixes, [
@@ -1095,7 +1084,7 @@ class SemaToRenderNodeTests: XCTestCase {
 
         // Test all identifiers have been resolved to the ``MyClass`` symbol
         XCTAssertEqual(renderNode.seeAlsoSections[0].title, "Related Documentation")
-        XCTAssertEqual(renderNode.seeAlsoSections[0].abstract?.map{ RenderBlockContent.paragraph(inlineContent: [$0]) }.compactMap(extractParagraphText).joined(), "Further Reading abstract text.")
+        XCTAssertEqual(renderNode.seeAlsoSections[0].abstract?.map{ RenderBlockContent.paragraph(inlineContent: [$0]) }.paragraphText.joined(), "Further Reading abstract text.")
         XCTAssertNil(renderNode.seeAlsoSections[0].discussion)
         guard renderNode.seeAlsoSections[0].identifiers.count == 5 else {
             XCTFail("The amount of identifiers in See Also was not expected")

--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
@@ -1240,10 +1240,10 @@ class SemaToRenderNodeTests: XCTestCase {
                     reference: reference,
                     kind: .collection,
                     sourceLanguage: .swift,
-                    name: .conceptual(title: "Title for \(reference.url!.path)"),
+                    name: .conceptual(title: "Title for \(reference.url.path)"),
                     markup: Document(
                         Paragraph(
-                            Text("Abstract for \(reference.url!.path)")
+                            Text("Abstract for \(reference.url.path)")
                         )
                     ),
                     semantic: nil

--- a/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorSymbolVariantsTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorSymbolVariantsTests.swift
@@ -639,7 +639,7 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
                 )
             },
             assertAfterApplyingVariant: { renderNode in
-                XCTAssertEqual(renderNode.topicSections.count, 3)
+                XCTAssertEqual(renderNode.topicSections.count, 1)
                 let taskGroup = try XCTUnwrap(renderNode.topicSections.first)
                 XCTAssertEqual(taskGroup.title, "Objective-C Task Group")
                 
@@ -654,6 +654,9 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
     func testTopicsSectionVariantsNoUserProvidedTopics() throws {
         try assertMultiVariantSymbol(
             configureSymbol: { symbol in
+                symbol.automaticTaskGroupsVariants[.fallback] = []
+                symbol.topicsVariants[.fallback] = nil
+                
                 symbol.automaticTaskGroupsVariants[.swift] = []
                 symbol.topicsVariants[.swift] = nil
                 
@@ -861,6 +864,7 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
         )
         
         try configureContext(context, identifier)
+        context.documentationCache[identifier]?.availableSourceLanguages = [.swift, .objectiveC]
         
         let node = try context.entity(with: identifier)
         

--- a/Tests/SwiftDocCTests/Rendering/Variants/JSONPointerTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/Variants/JSONPointerTests.swift
@@ -48,6 +48,15 @@ class JSONPointerTests: XCTestCase {
         )
     }
     
+    func testPrependingPathComponents() {
+        XCTAssertEqual(
+            JSONPointer(pathComponents: ["c", "d", "e"])
+                .prependingPathComponents(["a", "b"])
+                .pathComponents,
+            ["a", "b", "c", "d", "e"]
+        )
+    }
+    
     /// Returns a coding path for testing.
     ///
     /// The coding path is composed of the following components:

--- a/Tests/SwiftDocCTests/Semantics/SymbolTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/SymbolTests.swift
@@ -672,7 +672,7 @@ class SymbolTests: XCTestCase {
         )
         
         let engine = DiagnosticEngine()
-        let _ = DocumentationNode.contentFrom(symbol: symbol, article: nil, engine: engine)
+        let _ = DocumentationNode.contentFrom(documentedSymbol: symbol, documentationExtension: nil, engine: engine)
         XCTAssertEqual(engine.problems.count, 1)
         let problem = try XCTUnwrap(engine.problems.first)
         XCTAssertEqual(problem.diagnostic.source?.path, "/path/to/my file.swift")

--- a/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFramework.docc/Info.plist
+++ b/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFramework.docc/Info.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleName</key>
+	<string>MixedLanguageFramework</string>
+	<key>CFBundleDisplayName</key>
+	<string>MixedLanguageFramework</string>
+	<key>CFBundleIdentifier</key>
+	<string>org.swift.MixedLanguageFramework</string>
+	<key>CFBundleVersion</key>
+	<string>0.1.0</string>
+</dict>
+</plist>

--- a/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFramework.docc/symbol-graphs/clang/MixedLanguageFramework.symbols.json
+++ b/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFramework.docc/symbol-graphs/clang/MixedLanguageFramework.symbols.json
@@ -1,0 +1,545 @@
+{
+  "metadata" : {
+    "formatVersion" : {
+      "major" : 0,
+      "minor" : 5,
+      "patch" : 3
+    },
+    "generator" : "clang"
+  },
+  "module" : {
+    "name" : "MixedLanguageFramework",
+    "platform" : {
+      "architecture" : "x86_64",
+      "operatingSystem" : {
+        "minimumVersion" : {
+          "major" : 11,
+          "minor" : 0,
+          "patch" : 0
+        },
+        "name" : "macos"
+      },
+      "vendor" : "apple"
+    }
+  },
+  "relationships" : [
+    {
+      "kind" : "memberOf",
+      "source" : "c:@E@Foo@first",
+      "target" : "c:@E@Foo",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:@E@Foo@fourth",
+      "target" : "c:@E@Foo",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:@E@Foo@second",
+      "target" : "c:@E@Foo",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:@E@Foo@third",
+      "target" : "c:@E@Foo",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "inheritsFrom",
+      "source" : "c:objc(cs)Bar",
+      "target" : "c:objc(cs)NSObject",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:objc(cs)Bar(cm)MyStringFunction:error:",
+      "target" : "c:objc(cs)Bar",
+      "targetFallback" : null
+    }
+  ],
+  "symbols" : [
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "BAR"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "range" : {
+              "end" : {
+                "character" : 10,
+                "line" : 30
+              },
+              "start" : {
+                "character" : 4,
+                "line" : 30
+              }
+            },
+            "text" : "A bar."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:objc(cs)Bar"
+      },
+      "kind" : {
+        "displayName" : "Class",
+        "identifier" : "class"
+      },
+      "location" : {
+        "position" : {
+          "character" : 11,
+          "line" : 31
+        },
+        "uri" : "MixedLanguageFramework.h"
+      },
+      "names" : {
+        "title" : "Bar"
+      },
+      "pathComponents" : [
+        "Bar"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "MYSTRINGFUNCTION:ERROR:"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "range" : {
+              "end" : {
+                "character" : 27,
+                "line" : 34
+              },
+              "start" : {
+                "character" : 4,
+                "line" : 34
+              }
+            },
+            "text" : "Does a string function."
+          },
+          {
+            "range" : {
+              "end" : {
+                "character" : 41,
+                "line" : 35
+              },
+              "start" : {
+                "character" : 4,
+                "line" : 35
+              }
+            },
+            "text" : "- parameter string: The given string."
+          },
+          {
+            "range" : {
+              "end" : {
+                "character" : 24,
+                "line" : 36
+              },
+              "start" : {
+                "character" : 4,
+                "line" : 36
+              }
+            },
+            "text" : "- returns: A string."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:objc(cs)Bar(cm)MyStringFunction:error:"
+      },
+      "kind" : {
+        "displayName" : "Class Method",
+        "identifier" : "type.method"
+      },
+      "location" : {
+        "position" : {
+          "character" : 0,
+          "line" : 37
+        },
+        "uri" : "MixedLanguageFramework.h"
+      },
+      "names" : {
+        "title" : "MyStringFunction:error:"
+      },
+      "pathComponents" : [
+        "Bar",
+        "MyStringFunction:error:"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "FOO"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@E@Foo"
+      },
+      "kind" : {
+        "displayName" : "Enumeration",
+        "identifier" : "enum"
+      },
+      "location" : {
+        "position" : {
+          "character" : 8,
+          "line" : 18
+        },
+        "uri" : "MixedLanguageFramework.h"
+      },
+      "names" : {
+        "title" : "Foo"
+      },
+      "pathComponents" : [
+        "Foo"
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "text" : "A foo."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "This is the foo's description."
+          }
+        ]
+      },
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "FOO"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:MixedLanguageFramework.h@T@Foo"
+      },
+      "kind" : {
+        "displayName" : "Typedef",
+        "identifier" : "typealias"
+      },
+      "location" : {
+        "position" : {
+          "character" : 8,
+          "line" : 18
+        },
+        "uri" : "MixedLanguageFramework.h"
+      },
+      "names" : {
+        "title" : "Foo"
+      },
+      "pathComponents" : [
+        "Foo"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "FIRST"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "range" : {
+              "end" : {
+                "character" : 25,
+                "line" : 20
+              },
+              "start" : {
+                "character" : 8,
+                "line" : 20
+              }
+            },
+            "text" : "The first option."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@E@Foo@first"
+      },
+      "kind" : {
+        "displayName" : "Case",
+        "identifier" : "enum.case"
+      },
+      "location" : {
+        "position" : {
+          "character" : 4,
+          "line" : 21
+        },
+        "uri" : "MixedLanguageFramework.h"
+      },
+      "names" : {
+        "title" : "first"
+      },
+      "pathComponents" : [
+        "Foo",
+        "first"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "FOURTH"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "range" : {
+              "end" : {
+                "character" : 26,
+                "line" : 26
+              },
+              "start" : {
+                "character" : 8,
+                "line" : 26
+              }
+            },
+            "text" : "The fourth option."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@E@Foo@fourth"
+      },
+      "kind" : {
+        "displayName" : "Case",
+        "identifier" : "enum.case"
+      },
+      "location" : {
+        "position" : {
+          "character" : 4,
+          "line" : 27
+        },
+        "uri" : "MixedLanguageFramework.h"
+      },
+      "names" : {
+        "title" : "fourth"
+      },
+      "pathComponents" : [
+        "Foo",
+        "fourth"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "SECOND"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "range" : {
+              "end" : {
+                "character" : 26,
+                "line" : 22
+              },
+              "start" : {
+                "character" : 8,
+                "line" : 22
+              }
+            },
+            "text" : "The second option."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@E@Foo@second"
+      },
+      "kind" : {
+        "displayName" : "Case",
+        "identifier" : "enum.case"
+      },
+      "location" : {
+        "position" : {
+          "character" : 4,
+          "line" : 23
+        },
+        "uri" : "MixedLanguageFramework.h"
+      },
+      "names" : {
+        "title" : "second"
+      },
+      "pathComponents" : [
+        "Foo",
+        "second"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "THIRD"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "range" : {
+              "end" : {
+                "character" : 25,
+                "line" : 24
+              },
+              "start" : {
+                "character" : 8,
+                "line" : 24
+              }
+            },
+            "text" : "The third option."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@E@Foo@third"
+      },
+      "kind" : {
+        "displayName" : "Case",
+        "identifier" : "enum.case"
+      },
+      "location" : {
+        "position" : {
+          "character" : 4,
+          "line" : 25
+        },
+        "uri" : "MixedLanguageFramework.h"
+      },
+      "names" : {
+        "title" : "third"
+      },
+      "pathComponents" : [
+        "Foo",
+        "third"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "_MIXEDLANGUAGEFRAMEWORKVERSIONNUMBER"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "range" : {
+              "end" : {
+                "character" : 54,
+                "line" : 9
+              },
+              "start" : {
+                "character" : 4,
+                "line" : 9
+              }
+            },
+            "text" : "Project version number for MixedLanguageFramework."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@MixedLanguageFrameworkVersionNumber"
+      },
+      "kind" : {
+        "displayName" : "Global Variable",
+        "identifier" : "var"
+      },
+      "location" : {
+        "position" : {
+          "character" : 25,
+          "line" : 10
+        },
+        "uri" : "MixedLanguageFramework.h"
+      },
+      "names" : {
+        "title" : "_MixedLanguageFrameworkVersionNumber"
+      },
+      "pathComponents" : [
+        "_MixedLanguageFrameworkVersionNumber"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "_MIXEDLANGUAGEFRAMEWORKVERSIONSTRING"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "range" : {
+              "end" : {
+                "character" : 54,
+                "line" : 12
+              },
+              "start" : {
+                "character" : 4,
+                "line" : 12
+              }
+            },
+            "text" : "Project version string for MixedLanguageFramework."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@MixedLanguageFrameworkVersionString"
+      },
+      "kind" : {
+        "displayName" : "Global Variable",
+        "identifier" : "var"
+      },
+      "location" : {
+        "position" : {
+          "character" : 38,
+          "line" : 13
+        },
+        "uri" : "MixedLanguageFramework.h"
+      },
+      "names" : {
+        "title" : "_MixedLanguageFrameworkVersionString"
+      },
+      "pathComponents" : [
+        "_MixedLanguageFrameworkVersionString"
+      ]
+    }
+  ]
+}

--- a/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFramework.docc/symbol-graphs/swift/MixedLanguageFramework.symbols.json
+++ b/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFramework.docc/symbol-graphs/swift/MixedLanguageFramework.symbols.json
@@ -1,0 +1,1004 @@
+{
+    "metadata": {
+        "formatVersion": {
+            "major": 0,
+            "minor": 5,
+            "patch": 3
+        },
+        "generator": "Apple Swift version 5.5"
+    },
+    "module": {
+        "name": "MixedLanguageFramework",
+        "platform": {
+            "architecture": "x86_64",
+            "vendor": "apple",
+            "operatingSystem": {
+                "name": "macosx",
+                "minimumVersion": {
+                    "major": 11,
+                    "minor": 0,
+                    "patch": 0
+                }
+            }
+        }
+    },
+    "symbols": [
+        {
+            "kind": {
+                "identifier": "swift.class",
+                "displayName": "Class"
+            },
+            "identifier": {
+                "precise": "c:objc(cs)Bar",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "Bar"
+            ],
+            "names": {
+                "title": "Bar",
+                "navigator": [
+                    {
+                        "kind": "identifier",
+                        "spelling": "Bar"
+                    }
+                ],
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "class"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "Bar"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "class"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "Bar"
+                }
+            ],
+            "accessLevel": "open"
+        },
+        {
+            "kind": {
+                "identifier": "swift.init",
+                "displayName": "Initializer"
+            },
+            "identifier": {
+                "precise": "s:So3FooV8rawValueABSu_tcfc",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "Foo",
+                "init(rawValue:)"
+            ],
+            "names": {
+                "title": "init(rawValue:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "init"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "externalParam",
+                        "spelling": "rawValue"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ": "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "UInt",
+                        "preciseIdentifier": "s:Su"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ")"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "init"
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "externalParam",
+                    "spelling": "rawValue"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "UInt",
+                    "preciseIdentifier": "s:Su"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ")"
+                }
+            ],
+            "accessLevel": "public"
+        },
+        {
+            "kind": {
+                "identifier": "swift.struct",
+                "displayName": "Structure"
+            },
+            "identifier": {
+                "precise": "c:@E@Foo",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "Foo"
+            ],
+            "names": {
+                "title": "Foo",
+                "navigator": [
+                    {
+                        "kind": "identifier",
+                        "spelling": "Foo"
+                    }
+                ],
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "struct"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "Foo"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "struct"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "Foo"
+                }
+            ],
+            "accessLevel": "public"
+        },
+        {
+            "kind": {
+                "identifier": "swift.type.property",
+                "displayName": "Type Property"
+            },
+            "identifier": {
+                "precise": "c:@E@Foo@second",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "Foo",
+                "second"
+            ],
+            "names": {
+                "title": "second",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "var"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "second"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ": "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Foo",
+                        "preciseIdentifier": "c:@E@Foo"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "var"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "second"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Foo",
+                    "preciseIdentifier": "c:@E@Foo"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " { "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "get"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " }"
+                }
+            ],
+            "accessLevel": "public"
+        },
+        {
+            "kind": {
+                "identifier": "swift.struct",
+                "displayName": "Structure"
+            },
+            "identifier": {
+                "precise": "s:22MixedLanguageFramework15SwiftOnlyStructV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "SwiftOnlyStruct"
+            ],
+            "names": {
+                "title": "SwiftOnlyStruct",
+                "navigator": [
+                    {
+                        "kind": "identifier",
+                        "spelling": "SwiftOnlyStruct"
+                    }
+                ],
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "struct"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "SwiftOnlyStruct"
+                    }
+                ]
+            },
+            "docComment": {
+                "lines": [
+                    {
+                        "range": {
+                            "start": {
+                                "line": 9,
+                                "character": 4
+                            },
+                            "end": {
+                                "line": 9,
+                                "character": 51
+                            }
+                        },
+                        "text": "This is a struct that is only exposed to Swift."
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "struct"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "SwiftOnlyStruct"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///Users/ethankusters/Downloads/MixedLanguageFramework/MixedLanguageFramework/SwiftFile.swift",
+                "position": {
+                    "line": 10,
+                    "character": 14
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.method",
+                "displayName": "Instance Method"
+            },
+            "identifier": {
+                "precise": "s:22MixedLanguageFramework15SwiftOnlyStructV4tadayyF",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "SwiftOnlyStruct",
+                "tada()"
+            ],
+            "names": {
+                "title": "tada()",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "tada"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "docComment": {
+                "lines": [
+                    {
+                        "range": {
+                            "start": {
+                                "line": 11,
+                                "character": 8
+                            },
+                            "end": {
+                                "line": 11,
+                                "character": 12
+                            }
+                        },
+                        "text": "🥳"
+                    }
+                ]
+            },
+            "functionSignature": {
+                "returns": [
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "tada"
+                },
+                {
+                    "kind": "text",
+                    "spelling": "()"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///Users/ethankusters/Downloads/MixedLanguageFramework/MixedLanguageFramework/SwiftFile.swift",
+                "position": {
+                    "line": 12,
+                    "character": 16
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.type.property",
+                "displayName": "Type Property"
+            },
+            "identifier": {
+                "precise": "c:@E@Foo@first",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "Foo",
+                "first"
+            ],
+            "names": {
+                "title": "first",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "var"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "first"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ": "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Foo",
+                        "preciseIdentifier": "c:@E@Foo"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "var"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "first"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Foo",
+                    "preciseIdentifier": "c:@E@Foo"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " { "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "get"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " }"
+                }
+            ],
+            "accessLevel": "public"
+        },
+        {
+            "kind": {
+                "identifier": "swift.type.property",
+                "displayName": "Type Property"
+            },
+            "identifier": {
+                "precise": "c:@E@Foo@fourth",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "Foo",
+                "fourth"
+            ],
+            "names": {
+                "title": "fourth",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "var"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "fourth"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ": "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Foo",
+                        "preciseIdentifier": "c:@E@Foo"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "var"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "fourth"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Foo",
+                    "preciseIdentifier": "c:@E@Foo"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " { "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "get"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " }"
+                }
+            ],
+            "accessLevel": "public"
+        },
+        {
+            "kind": {
+                "identifier": "swift.type.method",
+                "displayName": "Type Method"
+            },
+            "identifier": {
+                "precise": "c:objc(cs)Bar(cm)MyStringFunction:error:",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "Bar",
+                "myStringFunction(_:)"
+            ],
+            "names": {
+                "title": "myStringFunction(_:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "class"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "myStringFunction"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "String",
+                        "preciseIdentifier": "s:SS"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ") "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "throws"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " -> "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "String",
+                        "preciseIdentifier": "s:SS"
+                    }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "string",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "string"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "String",
+                                "preciseIdentifier": "s:SS"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "String",
+                        "preciseIdentifier": "s:SS"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "class"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "myStringFunction"
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "externalParam",
+                    "spelling": "_"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "string"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "String",
+                    "preciseIdentifier": "s:SS"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ") "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "throws"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " -> "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "String",
+                    "preciseIdentifier": "s:SS"
+                }
+            ],
+            "accessLevel": "open"
+        },
+        {
+            "kind": {
+                "identifier": "swift.type.property",
+                "displayName": "Type Property"
+            },
+            "identifier": {
+                "precise": "c:@E@Foo@third",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "Foo",
+                "third"
+            ],
+            "names": {
+                "title": "third",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "var"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "third"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ": "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Foo",
+                        "preciseIdentifier": "c:@E@Foo"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "var"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "third"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Foo",
+                    "preciseIdentifier": "c:@E@Foo"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " { "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "get"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " }"
+                }
+            ],
+            "accessLevel": "public"
+        }
+    ],
+    "relationships": [
+        {
+            "kind": "conformsTo",
+            "source": "c:objc(cs)Bar",
+            "target": "s:s7CVarArgP",
+            "targetFallback": "Swift.CVarArg"
+        },
+        {
+            "kind": "conformsTo",
+            "source": "c:objc(cs)Bar",
+            "target": "s:SQ",
+            "targetFallback": "Swift.Equatable"
+        },
+        {
+            "kind": "conformsTo",
+            "source": "c:@E@Foo",
+            "target": "s:SQ",
+            "targetFallback": "Swift.Equatable"
+        },
+        {
+            "kind": "memberOf",
+            "source": "c:@E@Foo@first",
+            "target": "c:@E@Foo"
+        },
+        {
+            "kind": "conformsTo",
+            "source": "c:objc(cs)Bar",
+            "target": "s:s28CustomDebugStringConvertibleP",
+            "targetFallback": "Swift.CustomDebugStringConvertible"
+        },
+        {
+            "kind": "memberOf",
+            "source": "c:objc(cs)Bar(cm)MyStringFunction:error:",
+            "target": "c:objc(cs)Bar"
+        },
+        {
+            "kind": "memberOf",
+            "source": "c:@E@Foo@fourth",
+            "target": "c:@E@Foo"
+        },
+        {
+            "kind": "conformsTo",
+            "source": "c:@E@Foo",
+            "target": "s:s8SendableP",
+            "targetFallback": "Swift.Sendable"
+        },
+        {
+            "kind": "memberOf",
+            "source": "c:@E@Foo@third",
+            "target": "c:@E@Foo"
+        },
+        {
+            "kind": "conformsTo",
+            "source": "c:@E@Foo",
+            "target": "s:s25ExpressibleByArrayLiteralP",
+            "targetFallback": "Swift.ExpressibleByArrayLiteral"
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:22MixedLanguageFramework15SwiftOnlyStructV4tadayyF",
+            "target": "s:22MixedLanguageFramework15SwiftOnlyStructV"
+        },
+        {
+            "kind": "inheritsFrom",
+            "source": "c:objc(cs)Bar",
+            "target": "c:objc(cs)NSObject",
+            "targetFallback": "ObjectiveC.NSObject"
+        },
+        {
+            "kind": "conformsTo",
+            "source": "c:objc(cs)Bar",
+            "target": "s:s23CustomStringConvertibleP",
+            "targetFallback": "Swift.CustomStringConvertible"
+        },
+        {
+            "kind": "conformsTo",
+            "source": "c:@E@Foo",
+            "target": "s:s9OptionSetP",
+            "targetFallback": "Swift.OptionSet"
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:So3FooV8rawValueABSu_tcfc",
+            "target": "c:@E@Foo"
+        },
+        {
+            "kind": "conformsTo",
+            "source": "c:objc(cs)Bar",
+            "target": "s:SH",
+            "targetFallback": "Swift.Hashable"
+        },
+        {
+            "kind": "conformsTo",
+            "source": "c:objc(cs)Bar",
+            "target": "c:objc(pl)NSObject",
+            "targetFallback": "ObjectiveC.NSObjectProtocol"
+        },
+        {
+            "kind": "conformsTo",
+            "source": "c:@E@Foo",
+            "target": "s:SY",
+            "targetFallback": "Swift.RawRepresentable"
+        },
+        {
+            "kind": "conformsTo",
+            "source": "c:@E@Foo",
+            "target": "s:s10SetAlgebraP",
+            "targetFallback": "Swift.SetAlgebra"
+        },
+        {
+            "kind": "memberOf",
+            "source": "c:@E@Foo@second",
+            "target": "c:@E@Foo"
+        }
+    ]
+}

--- a/Tests/SwiftDocCTests/Test Resources/DeckKit-Objective-C.symbols.json
+++ b/Tests/SwiftDocCTests/Test Resources/DeckKit-Objective-C.symbols.json
@@ -5,7 +5,7 @@
       "minor" : 5,
       "patch" : 0
     },
-    "generator" : "SymbolKit"
+    "generator" : "clang"
   },
   "module" : {
     "name" : "DeckKit",

--- a/Tests/SwiftDocCTests/Utility/ExperimentalObjectiveCTestCase.swift
+++ b/Tests/SwiftDocCTests/Utility/ExperimentalObjectiveCTestCase.swift
@@ -1,0 +1,20 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+
+/// A test case that enables the experimental Objective-C support feature flag
+/// before running.
+class ExperimentalObjectiveCTestCase: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        enableFeatureFlag(\.isExperimentalObjectiveCSupportEnabled)
+    }
+}

--- a/Tests/SwiftDocCTests/Utility/RenderBlockContentTextExtraction.swift
+++ b/Tests/SwiftDocCTests/Utility/RenderBlockContentTextExtraction.swift
@@ -1,0 +1,27 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+import SwiftDocC
+
+extension Sequence where Element == RenderBlockContent {
+    var paragraphText: [String] {
+        compactMap { block in
+            switch block {
+            case .paragraph(inlineContent: let children):
+                switch children[0] {
+                case .text(let text): return text
+                default: return nil
+                }
+            default: return nil
+            }
+        }
+    }
+}

--- a/Tests/SwiftDocCTests/Utility/XCTestCase+enableFeatureFlag.swift
+++ b/Tests/SwiftDocCTests/Utility/XCTestCase+enableFeatureFlag.swift
@@ -1,0 +1,25 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import SwiftDocC
+import XCTest
+
+extension XCTestCase {
+    /// Enables the feature flag at the given key path until the end of current the test case.
+    func enableFeatureFlag(_ featureFlagPath: WritableKeyPath<FeatureFlags, Bool>) {
+        let defaultValues = FeatureFlags.current
+        FeatureFlags.current[keyPath: featureFlagPath] = true
+        
+        addTeardownBlock {
+            FeatureFlags.current = defaultValues
+        }
+    }
+}
+

--- a/Tests/SwiftDocCUtilitiesTests/Test Bundles/MixedLanguageFramework.docc/Info.plist
+++ b/Tests/SwiftDocCUtilitiesTests/Test Bundles/MixedLanguageFramework.docc/Info.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleName</key>
+	<string>MixedLanguageFramework</string>
+	<key>CFBundleDisplayName</key>
+	<string>MixedLanguageFramework</string>
+	<key>CFBundleIdentifier</key>
+	<string>org.swift.MixedLanguageFramework</string>
+	<key>CFBundleVersion</key>
+	<string>0.1.0</string>
+</dict>
+</plist>

--- a/Tests/SwiftDocCUtilitiesTests/Test Bundles/MixedLanguageFramework.docc/symbol-graphs/clang/MixedLanguageFramework.symbols.json
+++ b/Tests/SwiftDocCUtilitiesTests/Test Bundles/MixedLanguageFramework.docc/symbol-graphs/clang/MixedLanguageFramework.symbols.json
@@ -1,0 +1,532 @@
+{
+  "metadata" : {
+    "formatVersion" : {
+      "major" : 0,
+      "minor" : 5,
+      "patch" : 3
+    },
+    "generator" : "clang"
+  },
+  "module" : {
+    "name" : "MixedLanguageFramework",
+    "platform" : {
+      "architecture" : "x86_64",
+      "operatingSystem" : {
+        "minimumVersion" : {
+          "major" : 11,
+          "minor" : 0,
+          "patch" : 0
+        },
+        "name" : "macos"
+      },
+      "vendor" : "apple"
+    }
+  },
+  "relationships" : [
+    {
+      "kind" : "memberOf",
+      "source" : "c:@E@Foo@first",
+      "target" : "c:@E@Foo",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:@E@Foo@fourth",
+      "target" : "c:@E@Foo",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:@E@Foo@second",
+      "target" : "c:@E@Foo",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:@E@Foo@third",
+      "target" : "c:@E@Foo",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "inheritsFrom",
+      "source" : "c:objc(cs)Bar",
+      "target" : "c:objc(cs)NSObject",
+      "targetFallback" : null
+    },
+    {
+      "kind" : "memberOf",
+      "source" : "c:objc(cs)Bar(cm)MyStringFunction:error:",
+      "target" : "c:objc(cs)Bar",
+      "targetFallback" : null
+    }
+  ],
+  "symbols" : [
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "BAR"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "range" : {
+              "end" : {
+                "character" : 10,
+                "line" : 30
+              },
+              "start" : {
+                "character" : 4,
+                "line" : 30
+              }
+            },
+            "text" : "A bar."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:objc(cs)Bar"
+      },
+      "kind" : {
+        "displayName" : "Class",
+        "identifier" : "class"
+      },
+      "location" : {
+        "position" : {
+          "character" : 11,
+          "line" : 31
+        },
+        "uri" : "MixedLanguageFramework.h"
+      },
+      "names" : {
+        "title" : "Bar"
+      },
+      "pathComponents" : [
+        "Bar"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "MYSTRINGFUNCTION:ERROR:"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "range" : {
+              "end" : {
+                "character" : 27,
+                "line" : 34
+              },
+              "start" : {
+                "character" : 4,
+                "line" : 34
+              }
+            },
+            "text" : "Does a string function."
+          },
+          {
+            "range" : {
+              "end" : {
+                "character" : 41,
+                "line" : 35
+              },
+              "start" : {
+                "character" : 4,
+                "line" : 35
+              }
+            },
+            "text" : "- parameter string: The given string."
+          },
+          {
+            "range" : {
+              "end" : {
+                "character" : 24,
+                "line" : 36
+              },
+              "start" : {
+                "character" : 4,
+                "line" : 36
+              }
+            },
+            "text" : "- returns: A string."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:objc(cs)Bar(cm)MyStringFunction:error:"
+      },
+      "kind" : {
+        "displayName" : "Class Method",
+        "identifier" : "type.method"
+      },
+      "location" : {
+        "position" : {
+          "character" : 0,
+          "line" : 37
+        },
+        "uri" : "MixedLanguageFramework.h"
+      },
+      "names" : {
+        "title" : "MyStringFunction:error:"
+      },
+      "pathComponents" : [
+        "Bar",
+        "MyStringFunction:error:"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "FOO"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@E@Foo"
+      },
+      "kind" : {
+        "displayName" : "Enumeration",
+        "identifier" : "enum"
+      },
+      "location" : {
+        "position" : {
+          "character" : 8,
+          "line" : 18
+        },
+        "uri" : "MixedLanguageFramework.h"
+      },
+      "names" : {
+        "title" : "Foo"
+      },
+      "pathComponents" : [
+        "Foo"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "FOO"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:MixedLanguageFramework.h@T@Foo"
+      },
+      "kind" : {
+        "displayName" : "Typedef",
+        "identifier" : "typealias"
+      },
+      "location" : {
+        "position" : {
+          "character" : 8,
+          "line" : 18
+        },
+        "uri" : "MixedLanguageFramework.h"
+      },
+      "names" : {
+        "title" : "Foo"
+      },
+      "pathComponents" : [
+        "Foo"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "FIRST"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "range" : {
+              "end" : {
+                "character" : 25,
+                "line" : 20
+              },
+              "start" : {
+                "character" : 8,
+                "line" : 20
+              }
+            },
+            "text" : "The first option."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@E@Foo@first"
+      },
+      "kind" : {
+        "displayName" : "Case",
+        "identifier" : "enum.case"
+      },
+      "location" : {
+        "position" : {
+          "character" : 4,
+          "line" : 21
+        },
+        "uri" : "MixedLanguageFramework.h"
+      },
+      "names" : {
+        "title" : "first"
+      },
+      "pathComponents" : [
+        "Foo",
+        "first"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "FOURTH"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "range" : {
+              "end" : {
+                "character" : 26,
+                "line" : 26
+              },
+              "start" : {
+                "character" : 8,
+                "line" : 26
+              }
+            },
+            "text" : "The fourth option."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@E@Foo@fourth"
+      },
+      "kind" : {
+        "displayName" : "Case",
+        "identifier" : "enum.case"
+      },
+      "location" : {
+        "position" : {
+          "character" : 4,
+          "line" : 27
+        },
+        "uri" : "MixedLanguageFramework.h"
+      },
+      "names" : {
+        "title" : "fourth"
+      },
+      "pathComponents" : [
+        "Foo",
+        "fourth"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "SECOND"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "range" : {
+              "end" : {
+                "character" : 26,
+                "line" : 22
+              },
+              "start" : {
+                "character" : 8,
+                "line" : 22
+              }
+            },
+            "text" : "The second option."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@E@Foo@second"
+      },
+      "kind" : {
+        "displayName" : "Case",
+        "identifier" : "enum.case"
+      },
+      "location" : {
+        "position" : {
+          "character" : 4,
+          "line" : 23
+        },
+        "uri" : "MixedLanguageFramework.h"
+      },
+      "names" : {
+        "title" : "second"
+      },
+      "pathComponents" : [
+        "Foo",
+        "second"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "THIRD"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "range" : {
+              "end" : {
+                "character" : 25,
+                "line" : 24
+              },
+              "start" : {
+                "character" : 8,
+                "line" : 24
+              }
+            },
+            "text" : "The third option."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@E@Foo@third"
+      },
+      "kind" : {
+        "displayName" : "Case",
+        "identifier" : "enum.case"
+      },
+      "location" : {
+        "position" : {
+          "character" : 4,
+          "line" : 25
+        },
+        "uri" : "MixedLanguageFramework.h"
+      },
+      "names" : {
+        "title" : "third"
+      },
+      "pathComponents" : [
+        "Foo",
+        "third"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "_MIXEDLANGUAGEFRAMEWORKVERSIONNUMBER"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "range" : {
+              "end" : {
+                "character" : 54,
+                "line" : 9
+              },
+              "start" : {
+                "character" : 4,
+                "line" : 9
+              }
+            },
+            "text" : "Project version number for MixedLanguageFramework."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@MixedLanguageFrameworkVersionNumber"
+      },
+      "kind" : {
+        "displayName" : "Global Variable",
+        "identifier" : "var"
+      },
+      "location" : {
+        "position" : {
+          "character" : 25,
+          "line" : 10
+        },
+        "uri" : "MixedLanguageFramework.h"
+      },
+      "names" : {
+        "title" : "_MixedLanguageFrameworkVersionNumber"
+      },
+      "pathComponents" : [
+        "_MixedLanguageFrameworkVersionNumber"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "text",
+          "spelling" : "_MIXEDLANGUAGEFRAMEWORKVERSIONSTRING"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "range" : {
+              "end" : {
+                "character" : 54,
+                "line" : 12
+              },
+              "start" : {
+                "character" : 4,
+                "line" : 12
+              }
+            },
+            "text" : "Project version string for MixedLanguageFramework."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:@MixedLanguageFrameworkVersionString"
+      },
+      "kind" : {
+        "displayName" : "Global Variable",
+        "identifier" : "var"
+      },
+      "location" : {
+        "position" : {
+          "character" : 38,
+          "line" : 13
+        },
+        "uri" : "MixedLanguageFramework.h"
+      },
+      "names" : {
+        "title" : "_MixedLanguageFrameworkVersionString"
+      },
+      "pathComponents" : [
+        "_MixedLanguageFrameworkVersionString"
+      ]
+    }
+  ]
+}

--- a/Tests/SwiftDocCUtilitiesTests/Test Bundles/MixedLanguageFramework.docc/symbol-graphs/swift/MixedLanguageFramework.symbols.json
+++ b/Tests/SwiftDocCUtilitiesTests/Test Bundles/MixedLanguageFramework.docc/symbol-graphs/swift/MixedLanguageFramework.symbols.json
@@ -1,0 +1,1004 @@
+{
+    "metadata": {
+        "formatVersion": {
+            "major": 0,
+            "minor": 5,
+            "patch": 3
+        },
+        "generator": "Apple Swift version 5.5"
+    },
+    "module": {
+        "name": "MixedLanguageFramework",
+        "platform": {
+            "architecture": "x86_64",
+            "vendor": "apple",
+            "operatingSystem": {
+                "name": "macosx",
+                "minimumVersion": {
+                    "major": 11,
+                    "minor": 0,
+                    "patch": 0
+                }
+            }
+        }
+    },
+    "symbols": [
+        {
+            "kind": {
+                "identifier": "swift.class",
+                "displayName": "Class"
+            },
+            "identifier": {
+                "precise": "c:objc(cs)Bar",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "Bar"
+            ],
+            "names": {
+                "title": "Bar",
+                "navigator": [
+                    {
+                        "kind": "identifier",
+                        "spelling": "Bar"
+                    }
+                ],
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "class"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "Bar"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "class"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "Bar"
+                }
+            ],
+            "accessLevel": "open"
+        },
+        {
+            "kind": {
+                "identifier": "swift.init",
+                "displayName": "Initializer"
+            },
+            "identifier": {
+                "precise": "s:So3FooV8rawValueABSu_tcfc",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "Foo",
+                "init(rawValue:)"
+            ],
+            "names": {
+                "title": "init(rawValue:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "init"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "externalParam",
+                        "spelling": "rawValue"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ": "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "UInt",
+                        "preciseIdentifier": "s:Su"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ")"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "init"
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "externalParam",
+                    "spelling": "rawValue"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "UInt",
+                    "preciseIdentifier": "s:Su"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ")"
+                }
+            ],
+            "accessLevel": "public"
+        },
+        {
+            "kind": {
+                "identifier": "swift.struct",
+                "displayName": "Structure"
+            },
+            "identifier": {
+                "precise": "c:@E@Foo",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "Foo"
+            ],
+            "names": {
+                "title": "Foo",
+                "navigator": [
+                    {
+                        "kind": "identifier",
+                        "spelling": "Foo"
+                    }
+                ],
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "struct"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "Foo"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "struct"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "Foo"
+                }
+            ],
+            "accessLevel": "public"
+        },
+        {
+            "kind": {
+                "identifier": "swift.type.property",
+                "displayName": "Type Property"
+            },
+            "identifier": {
+                "precise": "c:@E@Foo@second",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "Foo",
+                "second"
+            ],
+            "names": {
+                "title": "second",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "var"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "second"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ": "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Foo",
+                        "preciseIdentifier": "c:@E@Foo"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "var"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "second"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Foo",
+                    "preciseIdentifier": "c:@E@Foo"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " { "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "get"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " }"
+                }
+            ],
+            "accessLevel": "public"
+        },
+        {
+            "kind": {
+                "identifier": "swift.struct",
+                "displayName": "Structure"
+            },
+            "identifier": {
+                "precise": "s:22MixedLanguageFramework15SwiftOnlyStructV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "SwiftOnlyStruct"
+            ],
+            "names": {
+                "title": "SwiftOnlyStruct",
+                "navigator": [
+                    {
+                        "kind": "identifier",
+                        "spelling": "SwiftOnlyStruct"
+                    }
+                ],
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "struct"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "SwiftOnlyStruct"
+                    }
+                ]
+            },
+            "docComment": {
+                "lines": [
+                    {
+                        "range": {
+                            "start": {
+                                "line": 9,
+                                "character": 4
+                            },
+                            "end": {
+                                "line": 9,
+                                "character": 51
+                            }
+                        },
+                        "text": "This is a struct that is only exposed to Swift."
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "struct"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "SwiftOnlyStruct"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///Users/ethankusters/Downloads/MixedLanguageFramework/MixedLanguageFramework/SwiftFile.swift",
+                "position": {
+                    "line": 10,
+                    "character": 14
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.method",
+                "displayName": "Instance Method"
+            },
+            "identifier": {
+                "precise": "s:22MixedLanguageFramework15SwiftOnlyStructV4tadayyF",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "SwiftOnlyStruct",
+                "tada()"
+            ],
+            "names": {
+                "title": "tada()",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "tada"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "docComment": {
+                "lines": [
+                    {
+                        "range": {
+                            "start": {
+                                "line": 11,
+                                "character": 8
+                            },
+                            "end": {
+                                "line": 11,
+                                "character": 12
+                            }
+                        },
+                        "text": "🥳"
+                    }
+                ]
+            },
+            "functionSignature": {
+                "returns": [
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "tada"
+                },
+                {
+                    "kind": "text",
+                    "spelling": "()"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///Users/ethankusters/Downloads/MixedLanguageFramework/MixedLanguageFramework/SwiftFile.swift",
+                "position": {
+                    "line": 12,
+                    "character": 16
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.type.property",
+                "displayName": "Type Property"
+            },
+            "identifier": {
+                "precise": "c:@E@Foo@first",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "Foo",
+                "first"
+            ],
+            "names": {
+                "title": "first",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "var"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "first"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ": "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Foo",
+                        "preciseIdentifier": "c:@E@Foo"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "var"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "first"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Foo",
+                    "preciseIdentifier": "c:@E@Foo"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " { "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "get"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " }"
+                }
+            ],
+            "accessLevel": "public"
+        },
+        {
+            "kind": {
+                "identifier": "swift.type.property",
+                "displayName": "Type Property"
+            },
+            "identifier": {
+                "precise": "c:@E@Foo@fourth",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "Foo",
+                "fourth"
+            ],
+            "names": {
+                "title": "fourth",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "var"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "fourth"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ": "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Foo",
+                        "preciseIdentifier": "c:@E@Foo"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "var"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "fourth"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Foo",
+                    "preciseIdentifier": "c:@E@Foo"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " { "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "get"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " }"
+                }
+            ],
+            "accessLevel": "public"
+        },
+        {
+            "kind": {
+                "identifier": "swift.type.method",
+                "displayName": "Type Method"
+            },
+            "identifier": {
+                "precise": "c:objc(cs)Bar(cm)MyStringFunction:error:",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "Bar",
+                "myStringFunction(_:)"
+            ],
+            "names": {
+                "title": "myStringFunction(_:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "class"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "myStringFunction"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "String",
+                        "preciseIdentifier": "s:SS"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ") "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "throws"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " -> "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "String",
+                        "preciseIdentifier": "s:SS"
+                    }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "string",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "string"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "String",
+                                "preciseIdentifier": "s:SS"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "String",
+                        "preciseIdentifier": "s:SS"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "class"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "myStringFunction"
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "externalParam",
+                    "spelling": "_"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "string"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "String",
+                    "preciseIdentifier": "s:SS"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ") "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "throws"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " -> "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "String",
+                    "preciseIdentifier": "s:SS"
+                }
+            ],
+            "accessLevel": "open"
+        },
+        {
+            "kind": {
+                "identifier": "swift.type.property",
+                "displayName": "Type Property"
+            },
+            "identifier": {
+                "precise": "c:@E@Foo@third",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "Foo",
+                "third"
+            ],
+            "names": {
+                "title": "third",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "var"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "third"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ": "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Foo",
+                        "preciseIdentifier": "c:@E@Foo"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "var"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "third"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Foo",
+                    "preciseIdentifier": "c:@E@Foo"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " { "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "get"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " }"
+                }
+            ],
+            "accessLevel": "public"
+        }
+    ],
+    "relationships": [
+        {
+            "kind": "conformsTo",
+            "source": "c:objc(cs)Bar",
+            "target": "s:s7CVarArgP",
+            "targetFallback": "Swift.CVarArg"
+        },
+        {
+            "kind": "conformsTo",
+            "source": "c:objc(cs)Bar",
+            "target": "s:SQ",
+            "targetFallback": "Swift.Equatable"
+        },
+        {
+            "kind": "conformsTo",
+            "source": "c:@E@Foo",
+            "target": "s:SQ",
+            "targetFallback": "Swift.Equatable"
+        },
+        {
+            "kind": "memberOf",
+            "source": "c:@E@Foo@first",
+            "target": "c:@E@Foo"
+        },
+        {
+            "kind": "conformsTo",
+            "source": "c:objc(cs)Bar",
+            "target": "s:s28CustomDebugStringConvertibleP",
+            "targetFallback": "Swift.CustomDebugStringConvertible"
+        },
+        {
+            "kind": "memberOf",
+            "source": "c:objc(cs)Bar(cm)MyStringFunction:error:",
+            "target": "c:objc(cs)Bar"
+        },
+        {
+            "kind": "memberOf",
+            "source": "c:@E@Foo@fourth",
+            "target": "c:@E@Foo"
+        },
+        {
+            "kind": "conformsTo",
+            "source": "c:@E@Foo",
+            "target": "s:s8SendableP",
+            "targetFallback": "Swift.Sendable"
+        },
+        {
+            "kind": "memberOf",
+            "source": "c:@E@Foo@third",
+            "target": "c:@E@Foo"
+        },
+        {
+            "kind": "conformsTo",
+            "source": "c:@E@Foo",
+            "target": "s:s25ExpressibleByArrayLiteralP",
+            "targetFallback": "Swift.ExpressibleByArrayLiteral"
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:22MixedLanguageFramework15SwiftOnlyStructV4tadayyF",
+            "target": "s:22MixedLanguageFramework15SwiftOnlyStructV"
+        },
+        {
+            "kind": "inheritsFrom",
+            "source": "c:objc(cs)Bar",
+            "target": "c:objc(cs)NSObject",
+            "targetFallback": "ObjectiveC.NSObject"
+        },
+        {
+            "kind": "conformsTo",
+            "source": "c:objc(cs)Bar",
+            "target": "s:s23CustomStringConvertibleP",
+            "targetFallback": "Swift.CustomStringConvertible"
+        },
+        {
+            "kind": "conformsTo",
+            "source": "c:@E@Foo",
+            "target": "s:s9OptionSetP",
+            "targetFallback": "Swift.OptionSet"
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:So3FooV8rawValueABSu_tcfc",
+            "target": "c:@E@Foo"
+        },
+        {
+            "kind": "conformsTo",
+            "source": "c:objc(cs)Bar",
+            "target": "s:SH",
+            "targetFallback": "Swift.Hashable"
+        },
+        {
+            "kind": "conformsTo",
+            "source": "c:objc(cs)Bar",
+            "target": "c:objc(pl)NSObject",
+            "targetFallback": "ObjectiveC.NSObjectProtocol"
+        },
+        {
+            "kind": "conformsTo",
+            "source": "c:@E@Foo",
+            "target": "s:SY",
+            "targetFallback": "Swift.RawRepresentable"
+        },
+        {
+            "kind": "conformsTo",
+            "source": "c:@E@Foo",
+            "target": "s:s10SetAlgebraP",
+            "targetFallback": "Swift.SetAlgebra"
+        },
+        {
+            "kind": "memberOf",
+            "source": "c:@E@Foo@second",
+            "target": "c:@E@Foo"
+        },
+    ]
+}

--- a/Tests/SwiftDocCUtilitiesTests/Test Resources/DeckKit-Objective-C.symbols.json
+++ b/Tests/SwiftDocCUtilitiesTests/Test Resources/DeckKit-Objective-C.symbols.json
@@ -5,7 +5,7 @@
       "minor" : 5,
       "patch" : 0
     },
-    "generator" : "SymbolKit"
+    "generator" : "clang"
   },
   "module" : {
     "name" : "DeckKit",

--- a/Tests/SwiftDocCUtilitiesTests/Utility/XCTestCase+enableFeatureFlag.swift
+++ b/Tests/SwiftDocCUtilitiesTests/Utility/XCTestCase+enableFeatureFlag.swift
@@ -1,0 +1,25 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import SwiftDocC
+import XCTest
+
+extension XCTestCase {
+    /// Enables the feature flag at the given key path until the end of current the test case.
+    func enableFeatureFlag(_ featureFlagPath: WritableKeyPath<FeatureFlags, Bool>) {
+        let defaultValues = FeatureFlags.current
+        FeatureFlags.current[keyPath: featureFlagPath] = true
+        
+        addTeardownBlock {
+            FeatureFlags.current = defaultValues
+        }
+    }
+}
+


### PR DESCRIPTION
- **Rationale:** Adds base support for converting DocC Catalogs that include multiple languages by expanding symbol semantic models to hold language-specific variants.
- **Risk:** Medium/High
- **Risk Detail:** This is a large change that touches much of the compiler but it has been throughly tested for both performance and usage regressions.
- **Reward:** High
- **Reward Details:** Without this change, we are only able to process a single language at a time and cannot support mixed-language frameworks.
- **Original PR:** #47
- **Issue:** rdar://84169407
- **Code Reviewed By:** Franklin Schrans
- **Testing Details:** New tests covering changes have been added. Manual testing and performance testing has been performed.