### PR TITLE
Sort output to avoid relying on the undefined order of directory content

### DIFF
--- a/Tests/SwiftDocCUtilitiesTests/StaticHostableTransformerTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/StaticHostableTransformerTests.swift
@@ -77,7 +77,7 @@ class StaticHostableTransformerTests: StaticHostingBaseTests {
         
         // Test the content of the output folder.
         let expectedContent = ["documentation", "tutorials"]
-        let output = try fileManager.contentsOfDirectory(atPath: outputURL.path)
+        let output = try fileManager.contentsOfDirectory(atPath: outputURL.path).sorted()
         
         XCTAssertEqual(output, expectedContent, "Unexpected output")
         for item in output {


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://86300654

## Summary

This updates `StaticHostableTransformerTests.testStaticHostableTransformerOutput` so that it doesn't rely on the order that the directory content is returned.

## Dependencies

n/a

## Testing

n/a

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary
