### PR TITLE
Add `ResolvedTopicReference.withSourceLanguages` API

### DIFF
--- a/Sources/SwiftDocC/Model/Identifier.swift
+++ b/Sources/SwiftDocC/Model/Identifier.swift
@@ -324,6 +324,23 @@ public struct ResolvedTopicReference: Hashable, Codable, Equatable, CustomString
         )
     }
     
+    /// Returns a topic reference based on the current one but with the given source languages.
+    ///
+    /// If the current topic reference's source languages equal the given source languages,
+    /// this returns the original topic reference.
+    public func withSourceLanguages(_ sourceLanguages: Set<SourceLanguage>) -> ResolvedTopicReference {
+        guard sourceLanguages != self.sourceLanguages else {
+            return self
+        }
+        
+        return ResolvedTopicReference(
+            bundleIdentifier: bundleIdentifier,
+            urlReadablePath: path,
+            urlReadableFragment: fragment,
+            sourceLanguages: sourceLanguages
+        )
+    }
+    
     /// The last path component of this topic reference.
     public var lastPathComponent: String {
         // There is always at least one component, so we can unwrap `last`.

--- a/Tests/SwiftDocCTests/Model/IdentifierTests.swift
+++ b/Tests/SwiftDocCTests/Model/IdentifierTests.swift
@@ -130,5 +130,28 @@ class IdentifierTests: XCTestCase {
              ObjectIdentifier(reference1._storage),
              ObjectIdentifier(reference2._storage)
          )
-     }
+    }
+    
+    func testWithSourceLanguages() {
+        let swiftReference = ResolvedTopicReference(
+            bundleIdentifier: "bundle",
+            path: "/",
+            sourceLanguage: .swift
+        )
+        
+        XCTAssertEqual(
+            swiftReference.withSourceLanguages([.objectiveC]).sourceLanguages,
+            [.objectiveC]
+        )
+        
+        XCTAssertEqual(
+            swiftReference.withSourceLanguages([.swift]).sourceLanguages,
+            [.swift]
+        )
+        
+        XCTAssertEqual(
+            swiftReference.withSourceLanguages([.objectiveC, .swift]).sourceLanguages,
+            Set([.swift, .objectiveC])
+        )
+    }
 }


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://86338175

## Summary

Introduces a new API that restores the ability for clients to replace a topic reference's source languages value that was removed in e76ef474.

## Dependencies

None.

## Testing

No user-facing functionality modified- confirm that unit tests pass.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
