### PR TITLE
Document supported languages for syntax highlighting

### DIFF
--- a/Sources/DocCDocumentation/DocCDocumentation.docc/formatting-your-documentation-content.md
+++ b/Sources/DocCDocumentation/DocCDocumentation.docc/formatting-your-documentation-content.md
@@ -157,6 +157,33 @@ struct Sightseeing: Activity {
 }
  ```
 
+ The following table lists the names of programming languages that can be used
+ to specify the syntax highlighting for a given code listing. Each one may have
+ aliases that can also be used to specify the same language.
+
+| Name       | Aliases                                                |
+| ---------- | ------------------------------------------------------ |
+| bash       | sh, zsh                                                |
+| c          | h                                                      |
+| cpp        | cc, c++, h++, hpp, hh, hxx, cxx                        |
+| css        |                                                        |
+| diff       | patch                                                  |
+| http       | https                                                  |
+| java       | jsp                                                    |
+| javascript | js, jsx, mjs, cjs                                      |
+| json       |                                                        |
+| llvm       |                                                        |
+| markdown   | md, mkdown, mkd                                        |
+| objectivec | mm, objc, obj-c                                        |
+| perl       | pl, pm                                                 |
+| php        |                                                        |
+| python     | py, gyp, ipython                                       |
+| ruby       | rb, gemspec, podspec, thor, irb                        |
+| scss       |                                                        |
+| shell      | console, shellsession                                  |
+| swift      |                                                        |
+| xml        | html, xhtml, rss, atom, xjb, xsd, xsl, plist, wsf, svg |
+
 ### Link to Symbols and Other Content
 
 DocC supports the following link types to enable navigation between pages:


### PR DESCRIPTION
Bug/issue #, if applicable: 83398954

## Summary

Adds documentation that lists the programming languages names (and aliases) that can be used in code listings for syntax highlighting purposes.

## Testing

Steps:
1. Run `bin/preview-docs DocC`.
2. Verify that the documentation at http://localhost:8000/documentation/docc/formatting-your-documentation-content is updated with a new table showing all the supported options.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] ~~Added tests~~ (updated documentation only)
- [X] Ran the `./bin/test` script and it succeeded
- [X] Updated documentation if necessary
