### PR TITLE
Add missing `RenderContentMetadata` schema to Linkable Entities spec

### DIFF
--- a/Sources/SwiftDocC/SwiftDocC.docc/Resources/LinkableEntities.json
+++ b/Sources/SwiftDocC/SwiftDocC.docc/Resources/LinkableEntities.json
@@ -531,6 +531,23 @@
                         "type": "string"
                     }
                 }
+            },
+            "RenderContentMetadata" : {
+                "type": "object",
+                "properties": {
+                    "anchor": {
+                        "type": "string"
+                    },
+                    "title": {
+                        "type": "string"
+                    },
+                    "abstract": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/RenderInlineContent"
+                        }
+                    }
+                }
             }
         },
         "requestBodies": {},


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://87100087

## Summary

This adds a missing `RenderContentMetadata` schema to LinkableEntities spec, making it a valid OpenAPI spec.

Note: like the RenderNode spec, this one is recursive because `RenderInlineContent` can be `Image` which has a `RenderContentMetadata` which has a `RenderInlineContent`. This is valid for OpenAPI specs.

## Dependencies

n/a

## Testing

n/a

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [ ] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary
