### PR TITLE
[5.6] Support indexing within the SwiftPM plugin sandbox

### DIFF
--- a/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
+++ b/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
@@ -189,7 +189,7 @@ public class NavigatorIndex {
      */
     fileprivate init(withEmptyTree url: URL, bundleIdentifier: String) throws {
         self.url = url
-        self.environment = try LMDB.Environment(path: url.path, flags: [], maxDBs: 4, mapSize: 100 * 1024 * 1024) // mapSize = 100MB
+        self.environment = try LMDB.Environment(path: url.path, flags: [.noLock], maxDBs: 4, mapSize: 100 * 1024 * 1024) // mapSize = 100MB
         self.database = try environment.openDatabase(named: "index", flags: [.create])
         self.information = try environment.openDatabase(named: "information", flags: [.create])
         self.availability = try environment.openDatabase(named: "availability", flags: [.create])


### PR DESCRIPTION
- **Rationale:** Allows for docc to emit an index when generating documentation within a SwiftPM plugin.
- **Risk:** Low.
- **Risk Detail:** This is an isolated change that touches very little existing DocC code. We had no need for LMDBs locking functionality so disabling it has no consequence for `docc`.
- **Reward:** High
- **Reward Details:** Enables `docc` to be used within SwiftPM plugins.
- **Original PR:** #66
- **Issue:** rdar://86786641
- **Code Reviewed By:** @bontoJR
- **Testing Details:** Existing tests continue to pass. An integration test that confirms DocC is able to build a DocC archive that includes an index when run as part of a SwiftPM plugin will be included in the Swift-DocC-Plugin project and run as part of CI when the plugin is published.