### PR TITLE
Disable testNavigationTreeLargeDumpAndReadAsync

### DIFF
--- a/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
@@ -227,7 +227,10 @@ Root
 #endif
     }
     
-    func testNavigationTreeLargeDumpAndReadAsync() throws {
+    // This test has been disabled because of frequent failures in Swift CI.
+    //
+    // rdar://87737744 tracks updating this test to remove any flakiness.
+    func disabled_testNavigationTreeLargeDumpAndReadAsync() throws {
         let targetURL = try createTemporaryDirectory()
         let indexURL = targetURL.appendingPathComponent("nav.index")
         


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://87744339

## Summary

This disables `testNavigationTreeLargeDumpAndReadAsync` which is creating some noise on the Swift CI for Linux:
https://ci.swift.org/job/swift-corelibs-foundation-PR-Linux/5230/

## Dependencies

n/a

## Testing

n/a

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary
