### PR TITLE
[5.6] Disable testNavigationTreeLargeDumpAndReadAsync 

### DIFF
--- a/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
@@ -227,7 +227,10 @@ Root
 #endif
     }
     
-    func testNavigationTreeLargeDumpAndReadAsync() throws {
+    // This test has been disabled because of frequent failures in Swift CI.
+    //
+    // rdar://87737744 tracks updating this test to remove any flakiness.
+    func disabled_testNavigationTreeLargeDumpAndReadAsync() throws {
         let targetURL = try createTemporaryDirectory()
         let indexURL = targetURL.appendingPathComponent("nav.index")
         


### PR DESCRIPTION
- **Rationale:** This disables a flaky test. The reason for wanting this on the 5.6 branch is to avoid disrupting other work with flaky tests in Swift CI.
- **Risk:** Low.
- **Risk Detail:** This only disables a flaky test.
- **Reward:** Medium
- **Reward Details:** Cherry-picking this change avoids potential test failures for other projects in Swift CI that build the full toolchain.
- **Original PR:** #70
- **Issue:**  rdar://87744339 
- **Code Reviewed By:** @ethan-kusters 
- **Testing Details:** This is only a test change.