### PR TITLE
Disable running tests in Swift CI

### DIFF
--- a/build-script-helper.py
+++ b/build-script-helper.py
@@ -108,17 +108,7 @@ def run(args):
       sys.exit(1)
 
   if should_run_action('test', args.build_actions):
-    print("** Testing %s **" % package_name)
-    try:
-      invoke_swift(action='test',
-        products=['SwiftDocCPackageTests'],
-        env=env,
-        args=args,
-        swiftpm_args=get_swiftpm_options('test', args))
-    except subprocess.CalledProcessError as e:
-      printerr('FAIL: Testing %s failed' % package_name)
-      printerr('Executing: %s' % ' '.join(e.cmd))
-      sys.exit(1)
+    print("** Skipping testing %s (rdar://87784021) **" % package_name)
   
   if should_run_action('install', args.build_actions):
     print("** Installing %s **" % package_name)


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://87784021

## Summary

This makes the test action in the build-script-helper a no-op to disable running tests in Swift CI.

## Dependencies

n/a

## Testing

n/a

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [ ] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary
