### PR TITLE
Fix incorrect warning when tutorial content references an article

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -1761,6 +1761,13 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
         
         try shouldContinueRegistration()
         
+        // Articles that will be automatically curated can be resolved but they need to be pre registered before resolving links.
+        let rootNodeForAutomaticCuration = rootModules.count == 1 ? rootModules.first.flatMap(topicGraph.nodeWithReference) : nil
+        if rootNodeForAutomaticCuration != nil {
+            registerArticles(otherArticles, in: bundle)
+            try shouldContinueRegistration()
+        }
+        
         // Third, any processing that relies on resolving other content is done, mainly resolving links.
         try preResolveExternalLinks(semanticObjects:
             technologies.map(referencedSemanticObject) +
@@ -1797,8 +1804,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
         
         // Automatically curate articles that haven't been manually curated
         // Article curation is only done automatically if there is only one root module
-        if rootModules.count == 1, let root = rootModules.first, let rootNode = topicGraph.nodeWithReference(root) {
-            registerArticles(otherArticles, in: bundle)
+        if let rootNode = rootNodeForAutomaticCuration {
             let articleReferences = try autoCurateArticles(otherArticles, in: bundle, startingFrom: rootNode)
             try preResolveExternalLinks(references: articleReferences, bundle: bundle)
             resolveLinks(curatedReferences: Set(articleReferences), bundle: bundle)


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://87552238

## Summary

This fixed an incorrect warning when a tutorial references an article that's automatically curated. 

Because the article isn't registered yet when the tutorial resolves its references, this always raises a warning about the unresolved reference, but during rendering the reference may still resolve.

## Dependencies

n/a

## Testing

In a documentation catalog with som tutorial content and wit symbol graph files from a single module;
- Add a new article without curating it
- Reference that article from some tutorial content.
There shouldn't be a warning about the article reference failing to resolve (and when viewing that tutorial page.

> Note that these changes only affect the warning. Even without these changes the reference may still resolve during rendering and display the expected link on the rendered tutorial page.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary
