### PR TITLE
fixing symbol in internal docs

### DIFF
--- a/Sources/SwiftDocCUtilities/SwiftDocCUtilities.docc/SwiftDocCUtilities/Extensions/Docc.md
+++ b/Sources/SwiftDocCUtilities/SwiftDocCUtilities.docc/SwiftDocCUtilities/Extensions/Docc.md
@@ -8,7 +8,7 @@
 
 ### Command Line Options
 
-- ``DocumentationArchiveOption``
+- ``DocCArchiveOption``
 - ``DocumentationBundleOption``
 - ``OutOfProcessLinkResolverOption``
 - ``PreviewExternalConnectionOptions``


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

Very minor update - noticed a DocC warning building the internal documentation for DocC itself, so I dug around and it looks like a type was renamed but the update missed in the internal docs.

## Dependencies

none

## Testing

Steps:
1. open Package.swift in Xcode with commit prior to this
2. Build Documentation, note warning
3. Update code, repeat build process.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [ ] Ran the `./bin/test` script and it succeeded
- [X] Updated documentation if necessary

I didn't see any existing tests verifying that the internal docs build without warning, so I thought this minor change was likely appropriate without tests.