### PR TITLE
Sort JSON output for any platform that supports it

### DIFF
--- a/Sources/SwiftDocC/Converter/RenderNode+Coding.swift
+++ b/Sources/SwiftDocC/Converter/RenderNode+Coding.swift
@@ -12,7 +12,8 @@ import Foundation
 
 /// An environmental variable to control the output formatting of the encoded render JSON.
 ///
-/// If this environment variable is set to "YES", DocC will format render node JSON with spacing and indentation to make it easy to read.
+/// If this environment variable is set to "YES", DocC will format render node JSON with spacing and indentation,
+/// and sort the keys (on supported platforms), to make it deterministic and easy to read.
 let jsonFormattingKey = "DOCC_JSON_PRETTYPRINT"
 public internal(set) var shouldPrettyPrintOutputJSON = NSString(string: ProcessInfo.processInfo.environment[jsonFormattingKey] ?? "NO").boolValue
 
@@ -114,7 +115,7 @@ public enum RenderJSONEncoder {
         let encoder = JSONEncoder()
         
         if prettyPrint {
-            if #available(OSX 10.13, *) {
+            if #available(macOS 10.13, iOS 11.0, watchOS 4.0, tvOS 11.0, *) {
                 encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
             } else {
                 encoder.outputFormatting = [.prettyPrinted]

--- a/Tests/SwiftDocCTests/Converter/RenderNodeCodableTests.swift
+++ b/Tests/SwiftDocCTests/Converter/RenderNodeCodableTests.swift
@@ -95,6 +95,20 @@ class RenderNodeCodableTests: XCTestCase {
         }
     }
     
+    func testSortedKeys() throws {
+        guard #available(macOS 10.13, iOS 11.0, watchOS 4.0, tvOS 11.0, *) else {
+            throw XCTSkip("Skipped on platforms that don't support JSONEncoder.OutputFormatting.sortedKeys")
+        }
+
+        // When prettyPrint is enabled, keys are sorted
+        let encoderPretty = RenderJSONEncoder.makeEncoder(prettyPrint: true)
+        XCTAssertTrue(encoderPretty.outputFormatting.contains(.sortedKeys))
+
+        // When prettyPrint is disabled, keys are not sorted
+        let encoderNotPretty = RenderJSONEncoder.makeEncoder(prettyPrint: false)
+        XCTAssertFalse(encoderNotPretty.outputFormatting.contains(.sortedKeys))
+    }
+
     func testEncodesVariantOverridesSetAsProperty() throws {
         var renderNode = bareRenderNode
         renderNode.variantOverrides = VariantOverrides(values: [testVariantOverride])

--- a/bin/check-source
+++ b/bin/check-source
@@ -29,7 +29,7 @@ unacceptable_terms=(
     -e whitelis[t]
     -e slav[e]
 )
-# Ignore the NonInclusiveLangeChecker source and tests
+# Ignore the NonInclusiveLanguageChecker source and tests
 if git grep --color=never -i "${unacceptable_terms[@]}" -- :/**/^NonInclusiveLanguageChecker*.swift > /dev/null; then
     printf "\033[0;31mUnacceptable language found.\033[0m\n"
     git grep -i "${unacceptable_terms[@]}"


### PR DESCRIPTION
Bug/issue #, if applicable: n/a

## Summary

Update the availability check for sorting JSON keys to include all supported platforms.

## Dependencies

n/a

## Testing

Run `docc` with `DOCC_JSON_PRETTYPRINT` enabled on any platforms that supports `.sortedKeys` and observe that the JSON output is sorted.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
