### PR TITLE
Emit language variants for articles

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -138,15 +138,9 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
     }
     
     /// The root module nodes of the Topic Graph.
-    public var rootModules: [ResolvedTopicReference] {
-        return topicGraph.nodes.values.compactMap { node in
-            guard node.kind == .module,
-                  !onlyHasSnippetRelatedChildren(for: node.reference) else {
-                return nil
-            }
-            return node.reference
-        }
-    }
+    ///
+    /// This property is initialized during the registration of a documentation bundle.
+    public private(set) var rootModules: [ResolvedTopicReference]!
     
     /// The topic reference of the root module, if it's the only registered module.
     var soleRootModuleReference: ResolvedTopicReference? {
@@ -1858,6 +1852,16 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
         symbolGraphLoader = nil
         
         try shouldContinueRegistration()
+        
+        // Keep track of the root modules registered from symbol graph files, we'll need them to automatically
+        // curate articles.
+        rootModules = topicGraph.nodes.values.compactMap { node in
+            guard node.kind == .module,
+                  !onlyHasSnippetRelatedChildren(for: node.reference) else {
+                return nil
+            }
+            return node.reference
+        }
         
         // Articles that will be automatically curated can be resolved but they need to be pre registered before resolving links.
         let rootNodeForAutomaticCuration = soleRootModuleReference.flatMap(topicGraph.nodeWithReference(_:))

--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -147,6 +147,11 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
             return node.reference
         }
     }
+    
+    /// The topic reference of the root module, if it's the only registered module.
+    var soleRootModuleReference: ResolvedTopicReference? {
+        rootModules.count == 1 ? rootModules.first : nil
+    }
         
     /// Map of document URLs to topic references.
     var documentLocationMap = BidirectionalMap<URL, ResolvedTopicReference>()
@@ -1624,9 +1629,23 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
     /// - Parameters:
     ///   - articles: Articles to register with the documentation cache.
     ///   - bundle: The bundle containing the articles.
-    private func registerArticles(_ articles: DocumentationContext.Articles, in bundle: DocumentationBundle) {
-        for article in articles {
-            guard let (documentation, title) = DocumentationContext.documentationNodeAndTitle(for: article, kind: .article, in: bundle) else { continue }
+    /// - Returns: The articles that were registered, with their topic graph node updated to what's been added to the topic graph.
+    private func registerArticles(
+        _ articles: DocumentationContext.Articles,
+        in bundle: DocumentationBundle
+    ) -> DocumentationContext.Articles {
+        articles.map { article in
+            guard let (documentation, title) = DocumentationContext.documentationNodeAndTitle(
+                for: article,
+                
+                // Articles are available in the same languages the only root module is available in. If there is more
+                // than one module, we cannot determine what languages it's available in and default to Swift.
+                availableSourceLanguages: soleRootModuleReference?.sourceLanguages,
+                kind: .article,
+                in: bundle
+            ) else {
+                return article
+            }
             let reference = documentation.reference
             
             documentationCache[reference] = documentation
@@ -1638,6 +1657,11 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
             for anchor in documentation.anchorSections {
                 nodeAnchorSections[anchor.reference] = anchor
             }
+            
+            var article = article
+            // Update the article's topic graph node with the one we just added to the topic graph.
+            article.topicGraphNode = graphNode
+            return article
         }
     }
     
@@ -1648,16 +1672,45 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
     ///   - kind: The kind that should be used to create the returned documentation node.
     ///   - bundle: The documentation bundle this article belongs to.
     /// - Returns: A documentation node and title for the given article semantic result.
-    static func documentationNodeAndTitle(for article: DocumentationContext.SemanticResult<Article>, kind: DocumentationNode.Kind, in bundle: DocumentationBundle) -> (node: DocumentationNode, title: String)? {
+    static func documentationNodeAndTitle(
+        for article: DocumentationContext.SemanticResult<Article>,
+        availableSourceLanguages: Set<SourceLanguage>? = nil,
+        kind: DocumentationNode.Kind,
+        in bundle: DocumentationBundle
+    ) -> (node: DocumentationNode, title: String)? {
         guard let articleMarkup = article.value.markup else {
             return nil
         }
         
         let path = NodeURLGenerator.pathForSemantic(article.value, source: article.source, bundle: bundle)
-        let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: path, sourceLanguage: .swift)
+        
+        // If available source languages are provided and it contains Swift, use Swift as the default language of
+        // the article.
+        let defaultSourceLanguage = availableSourceLanguages.map { availableSourceLanguages in
+            if availableSourceLanguages.contains(.swift) {
+                return .swift
+            } else {
+                return availableSourceLanguages.first ?? .swift
+            }
+        } ?? SourceLanguage.swift
+        
+        let reference = ResolvedTopicReference(
+            bundleIdentifier: bundle.identifier,
+            path: path,
+            sourceLanguages: availableSourceLanguages ?? [.swift]
+        )
+        
         let title = article.topicGraphNode.title
         
-        let documentationNode = DocumentationNode(reference: reference, kind: kind, sourceLanguage: .swift, name: .conceptual(title: title), markup: articleMarkup, semantic: article.value)
+        let documentationNode = DocumentationNode(
+            reference: reference,
+            kind: kind,
+            sourceLanguage: defaultSourceLanguage,
+            availableSourceLanguages: availableSourceLanguages,
+            name: .conceptual(title: title),
+            markup: articleMarkup,
+            semantic: article.value
+        )
         
         return (documentationNode, title)
     }
@@ -1693,11 +1746,29 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
         }
         
         let articleReferences = autoCuratedArticles.map(\.topicGraphNode.reference)
-        let autoArticlesSection = AutomaticTaskGroupSection(title: "Articles", references: articleReferences, renderPositionPreference: .top)
+        
+        func createAutomaticTaskGroupSection(references: [ResolvedTopicReference]) -> AutomaticTaskGroupSection {
+            AutomaticTaskGroupSection(
+                title: "Articles",
+                references: references,
+                renderPositionPreference: .top
+            )
+        }
         
         let node = try entity(with: rootNode.reference)
-        if var taskGroupProviding = node.semantic as? AutomaticTaskGroupsProviding {
-            taskGroupProviding.automaticTaskGroups = [autoArticlesSection]
+        
+        // If the node we're automatically curating the article under is a symbol, automatically curate the article
+        // for each language it's available in.
+        if let symbol = node.semantic as? Symbol {
+            for sourceLanguage in node.availableSourceLanguages {
+                symbol.automaticTaskGroupsVariants[
+                    .init(interfaceLanguage: sourceLanguage.id)
+                ] = [createAutomaticTaskGroupSection(references: articleReferences)]
+            }
+        } else if var taskGroupProviding = node.semantic as? AutomaticTaskGroupsProviding {
+            taskGroupProviding.automaticTaskGroups = [
+                createAutomaticTaskGroupSection(references: articleReferences)
+            ]
         }
         
         return articleReferences
@@ -1779,7 +1850,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
         
         // All discovery went well, process the inputs.
         let (technologies, tutorials, tutorialArticles, allArticles) = result
-        let (otherArticles, rootPageArticles) = splitArticles(allArticles)
+        var (otherArticles, rootPageArticles) = splitArticles(allArticles)
 
         let rootPages = registerRootPages(from: rootPageArticles, in: bundle)
         let (moduleReferences, symbolsURLHierarchy) = try registerSymbols(from: bundle, symbolGraphLoader: symbolGraphLoader)
@@ -1789,9 +1860,9 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
         try shouldContinueRegistration()
         
         // Articles that will be automatically curated can be resolved but they need to be pre registered before resolving links.
-        let rootNodeForAutomaticCuration = rootModules.count == 1 ? rootModules.first.flatMap(topicGraph.nodeWithReference) : nil
+        let rootNodeForAutomaticCuration = soleRootModuleReference.flatMap(topicGraph.nodeWithReference(_:))
         if rootNodeForAutomaticCuration != nil {
-            registerArticles(otherArticles, in: bundle)
+            otherArticles = registerArticles(otherArticles, in: bundle)
             try shouldContinueRegistration()
         }
         
@@ -2548,32 +2619,6 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
         }
         
         return results
-    }
-    
-    /// Finds the presentation language the symbol is curated under by walking
-    /// the documentation graph upwards and finding a parent that has an interface language.
-    /// Will return `nil` if no parent with assigned interface language is found
-    /// (e.g. in a tutorials only bundle).
-    func interfaceLanguageFor(_ reference: ResolvedTopicReference) throws -> SourceLanguage? {
-        let node = try entity(with: reference)
-        guard !(node.semantic is Symbol) else {
-            // For symbols just return the source language
-            return node.sourceLanguage
-        }
-        
-        // `pathsTo()` returns the canonical path first
-        guard let canonical = pathsTo(reference).first else {
-            // Uncurated symbol, if not expected a warning will be emitted elsewhere
-            return nil
-        }
-
-        // Return the language of the first symbol entity
-        return canonical.mapFirst { reference -> SourceLanguage? in
-            guard let node = try? entity(with: reference), node.semantic is Symbol else {
-                return nil
-            }
-            return node.sourceLanguage
-        }
     }
     
     func dumpGraph() -> String {

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -586,16 +586,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
         collectedTopicReferences.append(contentsOf: hierarchyTranslator.collectedTopicReferences)
         node.hierarchy = hierarchy
         
-        // Find the language of the symbol that curated the article in the graph
-        // and use it as the interface language for that article.
-        if let language = try! context.interfaceLanguageFor(identifier)?.id {
-            let generator = PresentationURLGenerator(context: context, baseURL: bundle.baseURL)
-            node.variants = [
-                .init(traits: [.interfaceLanguage(language)], paths: [
-                    generator.presentationURLForReference(identifier).path
-                ])
-            ]
-        }
+        node.variants = variants(for: documentationNode)
         
         if let abstract = article.abstractSection,
             let abstractContent = visitMarkup(abstract.content) as? [RenderInlineContent] {
@@ -960,25 +951,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
         node.metadata.fragmentsVariants = contentRenderer.subHeadingFragments(for: documentationNode)
         node.metadata.navigatorTitleVariants = contentRenderer.navigatorFragments(for: documentationNode)
         
-        let generator = PresentationURLGenerator(context: context, baseURL: bundle.baseURL)
-        
-        node.variants = documentationNode.availableSourceLanguages
-            .sorted(by: { language1, language2 in
-                // Emit Swift first, then alphabetically.
-                switch (language1, language2) {
-                case (.swift, _): return true
-                case (_, .swift): return false
-                default: return language1.id < language2.id
-                }
-            })
-            .map { sourceLanguage in
-                RenderNode.Variant(
-                    traits: [.interfaceLanguage(sourceLanguage.id)],
-                    paths: [
-                        generator.presentationURLForReference(identifier).path
-                    ]
-                )
-            }
+        node.variants = variants(for: documentationNode)
         
         collectedTopicReferences.append(identifier)
         
@@ -1404,6 +1377,28 @@ public struct RenderNodeTranslator: SemanticVisitor {
         translators.compactMap { translator in
             translator.translateSection(for: symbol, renderNode: &renderNode, renderNodeTranslator: &self)
         }
+    }
+    
+    private func variants(for documentationNode: DocumentationNode) -> [RenderNode.Variant] {
+        let generator = PresentationURLGenerator(context: context, baseURL: bundle.baseURL)
+        
+        return documentationNode.availableSourceLanguages
+            .sorted(by: { language1, language2 in
+                // Emit Swift first, then alphabetically.
+                switch (language1, language2) {
+                case (.swift, _): return true
+                case (_, .swift): return false
+                default: return language1.id < language2.id
+                }
+            })
+            .map { sourceLanguage in
+                RenderNode.Variant(
+                    traits: [.interfaceLanguage(sourceLanguage.id)],
+                    paths: [
+                        generator.presentationURLForReference(identifier).path
+                    ]
+                )
+            }
     }
     
     init(


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://88464797

## Summary

Articles that document a module available in multiple languages now inherit that module's languages. This ensures that we generate multiple language variants for article pages.

While investigating the performance impact of this change, I found that the repeated accesses to the `DocumentationContext.rootModules` (a computed property that iterates over all topic graph nodes) was causing a large performance regression. To resolve this, in the second commit I made the property a stored property instead that's initialised once during bundle registration, right after symbols have been loaded in the symbol graph.

### Performance impact

No statistically significant impact.

```
Size 10
+-----------------------------------------------------------------------------------------------------+
| Metric                                   | Change     | Before               | After                |
+-----------------------------------------------------------------------------------------------------+
| Compiled output size (MB)                | no change  | 114.68               | 114.68               |
| Duration for 'bundle-registration' (sec) | +1.58%     | 5.76                 | 5.85                 |
| Duration for 'convert-action' (sec)      | +2.93%     | 7.78                 | 8.00                 |
| Peak memory footprint (MB)               | -1.18%     | 354.33               | 350.14               |
| Topic Anchor Checksum                    | no change  | c8f03d4e81da8e3b6d7f | c8f03d4e81da8e3b6d7f |
| Topic Graph Checksum                     | no change  | edce22bce4f8de475a5e | edce22bce4f8de475a5e |
+-----------------------------------------------------------------------------------------------------+

Size 25
+-----------------------------------------------------------------------------------------------------+
| Metric                                   | Change     | Before               | After                |
+-----------------------------------------------------------------------------------------------------+
| Compiled output size (MB)                | no change  | 287.62               | 287.62               |
| Duration for 'bundle-registration' (sec) | +0.26%     | 14.75                | 14.79                |
| Duration for 'convert-action' (sec)      | -0.03%     | 20.09                | 20.08                |
| Peak memory footprint (MB)               | -0.68%     | 816.43               | 810.91               |
| Topic Anchor Checksum                    | no change  | 9a675b9ad6d69f8b7f0c | 9a675b9ad6d69f8b7f0c |
| Topic Graph Checksum                     | no change  | 665713509084b5131a37 | 665713509084b5131a37 |
+-----------------------------------------------------------------------------------------------------+

Size 5
+-----------------------------------------------------------------------------------------------------+
| Metric                                   | Change     | Before               | After                |
+-----------------------------------------------------------------------------------------------------+
| Compiled output size (MB)                | no change  | 57.36                | 57.36                |
| Duration for 'bundle-registration' (sec) | -0.31%     | 2.94                 | 2.93                 |
| Duration for 'convert-action' (sec)      | -0.51%     | 3.95                 | 3.93                 |
| Peak memory footprint (MB)               | -5.21%     | 209.86               | 198.93               |
| Topic Anchor Checksum                    | no change  | 65d4ff3050cd1106a21b | 65d4ff3050cd1106a21b |
| Topic Graph Checksum                     | no change  | 0a64c740a2ed5a246836 | 0a64c740a2ed5a246836 |
+-----------------------------------------------------------------------------------------------------+

Size 50
+-----------------------------------------------------------------------------------------------------+
| Metric                                   | Change     | Before               | After                |
+-----------------------------------------------------------------------------------------------------+
| Compiled output size (MB)                | no change  | 578.63               | 578.63               |
| Duration for 'bundle-registration' (sec) | -1.07%     | 30.17                | 29.84                |
| Duration for 'convert-action' (sec)      | +0.47%     | 41.06                | 41.25                |
| Peak memory footprint (MB)               | -0.90%     | 1552.76              | 1538.81              |
| Topic Anchor Checksum                    | no change  | 08d0a84bec913460905f | 08d0a84bec913460905f |
| Topic Graph Checksum                     | no change  | 74d25c4f1ee185ad5676 | 74d25c4f1ee185ad5676 |
+-----------------------------------------------------------------------------------------------------+
```

## Dependencies

None.

## Testing

When documenting a framework that supports Swift and Objective-C, verify that articles, whether they're automatically or manually curated, get the language switcher in the sidebar. The syntax used in symbol references should reflect the currently selected language.

## TODO

- [x] Investigate performance impact

## Checklist

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
