### PR TITLE
Add external media support in documentation

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/References/ImageReference.swift
+++ b/Sources/SwiftDocC/Model/Rendering/References/ImageReference.swift
@@ -74,9 +74,7 @@ public struct ImageReference: MediaReference, URLReference {
         var result = [VariantProxy]()
         // sort assets by URL path for deterministic sorting of images
         asset.variants.sorted(by: \.value.path).forEach { (key, value) in
-            // If a scheme is present it means it's an absolute URL
-            let isAbsoluteWebURL = !value.isFileURL && value.scheme?.isEmpty == false
-            let url = isAbsoluteWebURL ? value : destinationURL(for: value.lastPathComponent)
+            let url = value.isAbsoluteWebURL ? value : destinationURL(for: value.lastPathComponent)
             result.append(VariantProxy(url: url, traits: key))
         }
         try container.encode(result, forKey: .variants)

--- a/Sources/SwiftDocC/Model/Rendering/References/VideoReference.swift
+++ b/Sources/SwiftDocC/Model/Rendering/References/VideoReference.swift
@@ -81,9 +81,7 @@ public struct VideoReference: MediaReference, URLReference {
         // convert the data asset to a serializable object
         var result = [VariantProxy]()
         asset.variants.sorted(by: \.value.path).forEach { (key, value) in
-            // If a scheme is present it means it's an absolute URL
-            let isAbsoluteWebURL = !value.isFileURL && value.scheme?.isEmpty == false
-            let url = isAbsoluteWebURL ? value : destinationURL(for: value.lastPathComponent)
+            let url = value.isAbsoluteWebURL ? value : destinationURL(for: value.lastPathComponent)
             result.append(VariantProxy(url: url, traits: key))
         }
         try container.encode(result, forKey: .variants)

--- a/Sources/SwiftDocC/Model/Rendering/Tutorial/References/DownloadReference.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Tutorial/References/DownloadReference.swift
@@ -62,7 +62,6 @@ public struct DownloadReference: RenderReference, URLReference {
 
 extension DownloadReference {
     private func renderURL(for url: URL) -> URL {
-        let isAbsoluteWebURL = !url.isFileURL && url.scheme?.isEmpty == false && url.scheme != ResolvedTopicReference.urlScheme // if scheme is present it means it's an absolute URL
-        return isAbsoluteWebURL ? url : destinationURL(for: url.lastPathComponent)
+        url.isAbsoluteWebURL ? url : destinationURL(for: url.lastPathComponent)
     }
 }

--- a/Sources/SwiftDocC/Utility/FoundationExtensions/URL+IsAbsoluteWebURL.swift
+++ b/Sources/SwiftDocC/Utility/FoundationExtensions/URL+IsAbsoluteWebURL.swift
@@ -1,0 +1,26 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+
+extension URL {
+    /// Returns true if the scheme is not `nil` , not `file:`, not `ResolvedTopicReference.urlScheme`.
+    ///
+    /// - Returns: A Boolean value indicating whether the url is an absolute web URL.
+    var isAbsoluteWebURL: Bool {
+        guard !isFileURL,
+              let scheme = scheme ,
+              !scheme.isEmpty,
+              scheme != ResolvedTopicReference.urlScheme else {
+            return false
+        }
+        return true
+    }
+}

--- a/Sources/SwiftDocCUtilities/Action/Actions/Convert/ConvertFileWritingConsumer.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Convert/ConvertFileWritingConsumer.swift
@@ -55,7 +55,7 @@ struct ConvertFileWritingConsumer: ConvertOutputConsumer {
     
     func consume(assetsInBundle bundle: DocumentationBundle) throws {
         func copyAsset(_ asset: DataAsset, to destinationFolder: URL) throws {
-            for sourceURL in asset.variants.values {
+            for sourceURL in asset.variants.values where !sourceURL.isAbsoluteWebURL  {
                 let assetName = sourceURL.lastPathComponent
                 try fileManager.copyItem(
                     at: sourceURL,

--- a/Sources/SwiftDocCUtilities/Utility/FoundationExtensions/URL+IsAbsoluteWebURL.swift
+++ b/Sources/SwiftDocCUtilities/Utility/FoundationExtensions/URL+IsAbsoluteWebURL.swift
@@ -1,0 +1,25 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+
+extension URL {
+    /// Returns true if the scheme is not `nil` , not `file:`.
+    ///
+    /// - Returns: A Boolean value indicating whether the url is an absolute web URL.
+    var isAbsoluteWebURL: Bool {
+        guard !isFileURL,
+              let scheme = scheme ,
+              !scheme.isEmpty else {
+            return false
+        }
+        return true
+    }
+}

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContextTests.swift
@@ -510,6 +510,26 @@ class DocumentationContextTests: XCTestCase {
         )
     }
     
+    func testExternalAssets() throws {
+        let workspace = DocumentationWorkspace()
+        let context = try DocumentationContext(dataProvider: workspace)
+        let bundle = try testBundle(named: "TestBundle")
+        
+        let image = context.resolveAsset(named: "https://example.com/figure.png", in: bundle.rootReference)
+        XCTAssertNotNil(image)
+        guard let image = image else {
+            return
+        }
+        XCTAssertEqual(image.context, .display)
+        XCTAssertEqual(image.variants, [DataTraitCollection(userInterfaceStyle: .light, displayScale: .standard): URL(string: "https://example.com/figure.png")!])
+        
+        let video = context.resolveAsset(named: "https://example.com/introvideo.mp4", in: bundle.rootReference)
+        XCTAssertNotNil(video)
+        guard let video = video else { return }
+        XCTAssertEqual(video.context, .display)
+        XCTAssertEqual(video.variants, [DataTraitCollection(userInterfaceStyle: .light, displayScale: .standard): URL(string: "https://example.com/introvideo.mp4")!])
+    }
+    
     func testDownloadAssets() throws {
         let workspace = DocumentationWorkspace()
         let context = try DocumentationContext(dataProvider: workspace)

--- a/Tests/SwiftDocCTests/Utility/URL+IsAbsoluteWebURLTests.swift
+++ b/Tests/SwiftDocCTests/Utility/URL+IsAbsoluteWebURLTests.swift
@@ -1,0 +1,26 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+@testable import SwiftDocC
+import XCTest
+
+class URL_IsAbsoluteWebURLTests: XCTestCase {
+    func testisAbsoluteWebURL() throws {
+        let localURL = URL(fileURLWithPath: "/Users/username/Documents/Some Folder/Some Document.txt")
+        let topReferenceURL = try XCTUnwrap(URL(string: "doc://swift-doc"))
+        let webURL = try XCTUnwrap(URL(string: "swift.org"))
+        let absoluteWebURL = try XCTUnwrap(URL(string: "https://swift.org"))
+
+        XCTAssertEqual(localURL.isAbsoluteWebURL, false)
+        XCTAssertEqual(topReferenceURL.isAbsoluteWebURL, false)
+        XCTAssertEqual(webURL.isAbsoluteWebURL, false)
+        XCTAssertEqual(absoluteWebURL.isAbsoluteWebURL, true)
+    }
+}

--- a/Tests/SwiftDocCUtilitiesTests/Utility/URL+IsAbsoluteWebURLTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/Utility/URL+IsAbsoluteWebURLTests.swift
@@ -1,0 +1,26 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+@testable import SwiftDocCUtilities
+import XCTest
+
+class URL_IsAbsoluteWebURLTests: XCTestCase {
+    func testisAbsoluteWebURL() throws {
+        let localURL = URL(fileURLWithPath: "/Users/username/Documents/Some Folder/Some Document.txt")
+        let topReferenceURL = try XCTUnwrap(URL(string: "doc://swift-doc"))
+        let webURL = try XCTUnwrap(URL(string: "swift.org"))
+        let absoluteWebURL = try XCTUnwrap(URL(string: "https://swift.org"))
+
+        XCTAssertEqual(localURL.isAbsoluteWebURL, false)
+        XCTAssertEqual(topReferenceURL.isAbsoluteWebURL, true)
+        XCTAssertEqual(webURL.isAbsoluteWebURL, false)
+        XCTAssertEqual(absoluteWebURL.isAbsoluteWebURL, true)
+    }
+}


### PR DESCRIPTION
Bug/issue #, if applicable: [SR-15839](https://bugs.swift.org/browse/SR-15839)
Forum discussion: https://forums.swift.org/t/can-we-link-and-render-external-images-that-is-from-urls

## Summary

Add a new ExternalMediaResolver to support external media reference.

## Dependencies

None

## Testing

Test external image and video support in docs and articles.

## Checklist

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary

## TODO
- [x] Currently this PR does not support external media in tutorials. Will solve it in a follow-up PR.
