### PR TITLE
Fix warning for unreachable code after XCTSkip

### DIFF
--- a/Tests/SwiftDocCUtilitiesTests/OutOfProcessReferenceResolverTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/OutOfProcessReferenceResolverTests.swift
@@ -371,32 +371,32 @@ class OutOfProcessReferenceResolverTests: XCTestCase {
     func testForwardsErrorOutputProcess() throws {
         throw XCTSkip("This test is flaky rdar://88498898")
 
-        #if os(macOS)
-        let temporaryFolder = try createTemporaryDirectory()
-        
-        let executableLocation = temporaryFolder.appendingPathComponent("link-resolver-executable")
-        try """
-        #!/bin/bash
-        echo "Some error output" 1>&2                   # Write to stderr
-        echo '{"bundleIdentifier":"com.test.bundle"}'   # Write this resolver's bundle identifier
-        read                                            # Wait for docc to send a topic URL
-        """.write(to: executableLocation, atomically: true, encoding: .utf8)
-        
-        // `0o0700` is `-rwx------` (read, write, & execute only for owner)
-        try FileManager.default.setAttributes([.posixPermissions: 0o0700], ofItemAtPath: executableLocation.path)
-        XCTAssert(FileManager.default.isExecutableFile(atPath: executableLocation.path))
-         
-        let didReadErrorOutputExpectation = AsyncronousExpectation(description: "Did read forwarded error output.")
-        DispatchQueue.global().async {
-            let resolver = try? OutOfProcessReferenceResolver(processLocation: executableLocation, errorOutputHandler: {
-                errorMessage in
-                XCTAssertEqual(errorMessage, "Some error output\n")
-                didReadErrorOutputExpectation.fulfill()
-            })
-            XCTAssertEqual(resolver?.bundleIdentifier, "com.test.bundle")
-        }
-        XCTAssertNotEqual(didReadErrorOutputExpectation.wait(timeout: 20.0), .timedOut)
-        #endif
+//        #if os(macOS)
+//        let temporaryFolder = try createTemporaryDirectory()
+//        
+//        let executableLocation = temporaryFolder.appendingPathComponent("link-resolver-executable")
+//        try """
+//        #!/bin/bash
+//        echo "Some error output" 1>&2                   # Write to stderr
+//        echo '{"bundleIdentifier":"com.test.bundle"}'   # Write this resolver's bundle identifier
+//        read                                            # Wait for docc to send a topic URL
+//        """.write(to: executableLocation, atomically: true, encoding: .utf8)
+//        
+//        // `0o0700` is `-rwx------` (read, write, & execute only for owner)
+//        try FileManager.default.setAttributes([.posixPermissions: 0o0700], ofItemAtPath: executableLocation.path)
+//        XCTAssert(FileManager.default.isExecutableFile(atPath: executableLocation.path))
+//         
+//        let didReadErrorOutputExpectation = AsyncronousExpectation(description: "Did read forwarded error output.")
+//        DispatchQueue.global().async {
+//            let resolver = try? OutOfProcessReferenceResolver(processLocation: executableLocation, errorOutputHandler: {
+//                errorMessage in
+//                XCTAssertEqual(errorMessage, "Some error output\n")
+//                didReadErrorOutputExpectation.fulfill()
+//            })
+//            XCTAssertEqual(resolver?.bundleIdentifier, "com.test.bundle")
+//        }
+//        XCTAssertNotEqual(didReadErrorOutputExpectation.wait(timeout: 20.0), .timedOut)
+//        #endif
     }
     
     func assertForwardsResolverErrors(resolver: OutOfProcessReferenceResolver) throws {


### PR DESCRIPTION
Bug/issue #, if applicable: N/A

## Summary

Comments out code after an XCTSkip call in `OutOfProcessReferenceResolverTests.testForwardsErrorOutputProcess` to avoid an unreachable code warning.

## Dependencies

None.

## Testing

N/A, no functional changes.

## Checklist

- ~[ ] Added tests~ N/A
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
