### PR TITLE
Fix typo in AsynchronousExpectation test API

### DIFF
--- a/Tests/SwiftDocCUtilitiesTests/OutOfProcessReferenceResolverTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/OutOfProcessReferenceResolverTests.swift
@@ -386,7 +386,7 @@ class OutOfProcessReferenceResolverTests: XCTestCase {
         try FileManager.default.setAttributes([.posixPermissions: 0o0700], ofItemAtPath: executableLocation.path)
         XCTAssert(FileManager.default.isExecutableFile(atPath: executableLocation.path))
          
-        let didReadErrorOutputExpectation = AsyncronousExpectation(description: "Did read forwarded error output.")
+        let didReadErrorOutputExpectation = AsynchronousExpectation(description: "Did read forwarded error output.")
         DispatchQueue.global().async {
             let resolver = try? OutOfProcessReferenceResolver(processLocation: executableLocation, errorOutputHandler: {
                 errorMessage in

--- a/Tests/SwiftDocCUtilitiesTests/PreviewServer/PreviewServerTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/PreviewServer/PreviewServerTests.swift
@@ -49,7 +49,7 @@ class PreviewServerTests {
         let server = try PreviewServer(contentURL: tempFolderURL, bindTo: .socket(path: socketURL.path), username: "username", password: "password", logHandle: &log)
 
         // Assert server starts
-        let expectationStarted = AsyncronousExpectation(description: "Server before start")
+        let expectationStarted = AsynchronousExpectation(description: "Server before start")
         DispatchQueue.global().async {
             do {
                 try server.start() {
@@ -129,7 +129,7 @@ class PreviewServerTests {
         let server = try PreviewServer(contentURL: tempFolderURL, bindTo: .socket(path: socketURL.path), username: "username", password: "password", logHandle: &log)
 
         // Start the server
-        let expectationStarted = AsyncronousExpectation(description: "Server before start")
+        let expectationStarted = AsynchronousExpectation(description: "Server before start")
         DispatchQueue.global().async {
             do {
                 try server.start() {
@@ -176,7 +176,7 @@ class PreviewServerTests {
         let server = try PreviewServer(contentURL: tempFolderURL, bindTo: .socket(path: socketURL.path), username: "username", password: "password", logHandle: &log)
 
         // Start the server
-        let expectationStarted = AsyncronousExpectation(description: "Server before start")
+        let expectationStarted = AsynchronousExpectation(description: "Server before start")
         DispatchQueue.global().async {
             do {
                 try server.start() {

--- a/Tests/SwiftDocCUtilitiesTests/Utility/AsynchronousExpectationTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/Utility/AsynchronousExpectationTests.swift
@@ -12,7 +12,7 @@ import Foundation
 import XCTest
 
 /// Asynchronous expectation that works on Linux.
-class AsyncronousExpectation {
+class AsynchronousExpectation {
     enum Result {
         case success
         case timedOut
@@ -56,15 +56,15 @@ class AsyncronousExpectation {
     }
 }
 
-class AsyncronousExpectationTests: XCTestCase {
+class AsynchronousExpectationTests: XCTestCase {
     func testExpectationTimesOut() throws {
-        let expectation1 = AsyncronousExpectation(description: "expectation")
+        let expectation1 = AsynchronousExpectation(description: "expectation")
         let result = expectation1.wait(timeout: 2)
         XCTAssertEqual(result, .timedOut)
     }
 
     func testExpectationFulfills() throws {
-        let expectation1 = AsyncronousExpectation(description: "expectation")
+        let expectation1 = AsynchronousExpectation(description: "expectation")
         DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.5) { 
             expectation1.fulfill()
         }


### PR DESCRIPTION
Bug/issue #, if applicable: N/A

## Summary

Fixes a small typo in the AsynchronousExpectation test API.

## Dependencies

None.

## Testing

N/A, no functional changes.

## Checklist

- ~[ ] Added tests~ N/A
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
