### PR TITLE
Drop unconditionally unavailable symbols

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphConcurrentDecoder.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphConcurrentDecoder.swift
@@ -61,7 +61,7 @@ enum SymbolGraphConcurrentDecoder {
         let symbols = Synchronized<[String: SymbolGraph.Symbol]>([:])
 
         let group = DispatchGroup()
-        let queue = DispatchQueue(label: "com.swift.SymbolGraphConcurrentDecoder", qos: .unspecified, attributes: .concurrent)
+        let queue = DispatchQueue(label: "org.swift.docc.SymbolGraphConcurrentDecoder", qos: .unspecified, attributes: .concurrent)
         
         // Concurrently decode metadata and relationships.
         group.async(queue: queue) {

--- a/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphLoader.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphLoader.swift
@@ -79,6 +79,16 @@ struct SymbolGraphLoader {
                         return
                     }
                 }
+                
+                // Only keep symbols that are available on at least one platform.
+                symbolGraph.symbols = symbolGraph.symbols.filter { (_, symbol) in
+                    guard let availability = symbol.availability?.availability else {
+                        // If the symbol doesn't have availability information, keep it.
+                        return true
+                    }
+                    
+                    return availability.contains { !$0.isUnconditionallyUnavailable }
+                }
 
                 // `moduleNameFor(_:at:)` is static because it's pure function.
                 let (moduleName, _) = Self.moduleNameFor(symbolGraph, at: symbolGraphURL)
@@ -387,5 +397,11 @@ extension SymbolGraph.Symbol.Availability.AvailabilityItem {
         var newValue = self
         newValue.introducedVersion = platformVersion
         return newValue
+    }
+}
+
+private extension SymbolGraph.Symbol {
+    var availability: SymbolGraph.Symbol.Availability? {
+        mixins[SymbolGraph.Symbol.Availability.mixinKey] as? SymbolGraph.Symbol.Availability
     }
 }


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://87973644

## Summary

Drop symbols that are unconditionally unavailable on all platforms. They cannot be called from client code, hence are not interesting to keep in documentation.

During symbol graph loading, we filter the symbol graph's `symbols` dictionary before we add its symbols to the topic graph. Initially, I thought we'd also need to update the `relationships` array to remove the ones that refer to symbols we've removed, but it turns out that that isn't required.

### Performance Impact

I was interested in seeing if there is a noticeable performance impact in traversing all symbols to filter them. It doesn't look like there is.

```
Size 10
+-----------------------------------------------------------------------------------------------------+
| Metric                                   | Change     | Before               | After                |
+-----------------------------------------------------------------------------------------------------+
| Compiled output size (MB)                | no change  | 114.77               | 114.77               |
| Duration for 'bundle-registration' (sec) | -0.93%     | 5.80                 | 5.75                 |
| Duration for 'convert-action' (sec)      | -1.39%     | 7.90                 | 7.79                 |
| Peak memory footprint (MB)               | +1.15%     | 339.99               | 343.89               |
| Topic Anchor Checksum                    | no change  | c8f03d4e81da8e3b6d7f | c8f03d4e81da8e3b6d7f |
| Topic Graph Checksum                     | no change  | edce22bce4f8de475a5e | edce22bce4f8de475a5e |
+-----------------------------------------------------------------------------------------------------+

Size 25
+-----------------------------------------------------------------------------------------------------+
| Metric                                   | Change     | Before               | After                |
+-----------------------------------------------------------------------------------------------------+
| Compiled output size (MB)                | no change  | 287.76               | 287.76               |
| Duration for 'bundle-registration' (sec) | +0.79%     | 14.61                | 14.72                |
| Duration for 'convert-action' (sec)      | -0.10%     | 20.01                | 19.99                |
| Peak memory footprint (MB)               | -0.64%     | 809.84               | 804.68               |
| Topic Anchor Checksum                    | no change  | 9a675b9ad6d69f8b7f0c | 9a675b9ad6d69f8b7f0c |
| Topic Graph Checksum                     | no change  | 665713509084b5131a37 | 665713509084b5131a37 |
+-----------------------------------------------------------------------------------------------------+

Size 5
+-----------------------------------------------------------------------------------------------------+
| Metric                                   | Change     | Before               | After                |
+-----------------------------------------------------------------------------------------------------+
| Compiled output size (MB)                | no change  | 57.39                | 57.39                |
| Duration for 'bundle-registration' (sec) | +0.76%     | 2.90                 | 2.93                 |
| Duration for 'convert-action' (sec)      | +0.66%     | 3.93                 | 3.96                 |
| Peak memory footprint (MB)               | -3.91%     | 203.02               | 195.08               |
| Topic Anchor Checksum                    | no change  | 65d4ff3050cd1106a21b | 65d4ff3050cd1106a21b |
| Topic Graph Checksum                     | no change  | 0a64c740a2ed5a246836 | 0a64c740a2ed5a246836 |
+-----------------------------------------------------------------------------------------------------+

Size 50
+-----------------------------------------------------------------------------------------------------+
| Metric                                   | Change     | Before               | After                |
+-----------------------------------------------------------------------------------------------------+
| Compiled output size (MB)                | no change  | 578.45               | 578.45               |
| Duration for 'bundle-registration' (sec) | -1.64%     | 30.38                | 29.88                |
| Duration for 'convert-action' (sec)      | -1.24%     | 41.95                | 41.43                |
| Peak memory footprint (MB)               | -2.14%     | 1572.81              | 1539.17              |
| Topic Anchor Checksum                    | no change  | 08d0a84bec913460905f | 08d0a84bec913460905f |
| Topic Graph Checksum                     | no change  | 74d25c4f1ee185ad5676 | 74d25c4f1ee185ad5676 |
+-----------------------------------------------------------------------------------------------------+
```

## Dependencies

None.

## Testing

Steps:
1. Annotate a symbol as unavailable in source code.
2. Build documentation and verify the symbol doesn't appear in documentation.

## Checklist

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
