### PR TITLE
Add API to query documentation extension URLs

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -2227,15 +2227,26 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
         return topicGraph.reverseEdges[reference] ?? []
     }
     
-    /// Attempt to locate the file for a given `reference`.
+    /// Returns the file URL for the given article reference.
     ///
     /// - Parameter reference: The identifier for the topic whose file URL to locate.
-    /// - Returns: The absolute file URL of the topic if it could be found in a matching registered documentation bundle, otherwise `nil`.
+    /// - Returns: If the reference is a reference to a known article, this function returns the article's URL, otherwise `nil`.
     public func fileURL(for reference: ResolvedTopicReference) -> URL? {
         if let node = topicGraph.nodes[reference], case .file(let url) = node.source {
             return url
         }
         return nil
+    }
+    
+    /// Returns the URL of the documentation extension of the given reference.
+    ///
+    /// - Parameter reference: The reference to the symbol this function should return the documentation extension URL for.
+    /// - Returns: The document URL of the given symbol reference. If the given reference is not a symbol reference, returns `nil`.
+    public func documentationExtensionURL(for reference: ResolvedTopicReference) -> URL? {
+        guard (try? entity(with: reference))?.kind.isSymbol == true else {
+            return nil
+        }
+        return documentLocationMap[reference]
     }
     
     /// Attempt to locate the reference for a given file.

--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -2227,11 +2227,20 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
         return topicGraph.reverseEdges[reference] ?? []
     }
     
-    /// Returns the file URL for the given article reference.
+    /// Returns the document URL for the given article or tutorial reference.
     ///
     /// - Parameter reference: The identifier for the topic whose file URL to locate.
-    /// - Returns: If the reference is a reference to a known article, this function returns the article's URL, otherwise `nil`.
+    /// - Returns: If the reference is a reference to a known Markdown document, this function returns the article's URL, otherwise `nil`.
+    @available(*, deprecated, renamed: "documentURL(for:)")
     public func fileURL(for reference: ResolvedTopicReference) -> URL? {
+        documentURL(for: reference)
+    }
+    
+    /// Returns the document URL for the given article or tutorial reference.
+    ///
+    /// - Parameter reference: The identifier for the topic whose file URL to locate.
+    /// - Returns: If the reference is a reference to a known Markdown document, this function returns the article's URL, otherwise `nil`.
+    public func documentURL(for reference: ResolvedTopicReference) -> URL? {
         if let node = topicGraph.nodes[reference], case .file(let url) = node.source {
             return url
         }

--- a/Sources/SwiftDocC/Infrastructure/DocumentationConverter.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationConverter.swift
@@ -268,7 +268,7 @@ public struct DocumentationConverter: DocumentationConverterProtocol {
             // If cancelled skip all concurrent conversion work in this block.
             guard !isConversionCancelled() else { return }
 
-            let source = context.fileURL(for: identifier)
+            let source = context.documentURL(for: identifier)
             
             // Wrap JSON encoding in an autorelease pool to avoid retaining the autoreleased ObjC objects returned by `JSONSerialization`
             autoreleasepool {

--- a/Sources/SwiftDocC/Semantics/Tutorial/Tutorial.swift
+++ b/Sources/SwiftDocC/Semantics/Tutorial/Tutorial.swift
@@ -147,7 +147,7 @@ public final class Tutorial: Semantic, DirectiveConvertible, Abstracted, Titled,
 
 extension Tutorial {
     static func analyze(_ node: TopicGraph.Node, completedContext context: DocumentationContext, engine: DiagnosticEngine) {
-        let url = context.fileURL(for: node.reference)
+        let url = context.documentURL(for: node.reference)
 
         if let project = try? context.entity(with: node.reference).semantic as? Tutorial, let projectFiles = project.projectFiles {
             if context.resolveAsset(named: projectFiles.url.lastPathComponent, in: node.reference) == nil {

--- a/Sources/SwiftDocC/Semantics/TutorialArticle/TutorialArticle.swift
+++ b/Sources/SwiftDocC/Semantics/TutorialArticle/TutorialArticle.swift
@@ -178,7 +178,7 @@ extension TutorialArticle {
             .compactMap({ context.topicGraph.nodeWithReference($0) })
             .first(where: { $0.kind == .technology || $0.kind == .chapter || $0.kind == .volume })
         guard technologyParent != nil else {
-            let url = context.fileURL(for: node.reference)
+            let url = context.documentURL(for: node.reference)
             engine.emit(.init(
                 diagnostic: Diagnostic(source: url, severity: .warning, range: nil, identifier: "org.swift.docc.Unreferenced\(TutorialArticle.self)", summary: "The article \(node.reference.path.components(separatedBy: "/").last!.singleQuoted) must be referenced from a Tutorial Table of Contents"),
                 possibleSolutions: [

--- a/Sources/SwiftDocC/SwiftDocC.docc/SwiftDocC/DocumentationContextGroup.md
+++ b/Sources/SwiftDocC/SwiftDocC.docc/SwiftDocC/DocumentationContextGroup.md
@@ -37,7 +37,7 @@ let node = try context.entity(with: reference)
 To find out the location of the source file for a given documentation node use:
 
 ```swift
-let sourceFileURL = try context.fileURL(for: reference)
+let sourceFileURL = try context.documentURL(for: reference)
 ```
 
 And finally to print all known paths in the context:

--- a/Tests/SwiftDocCTests/Indexing/IndexingTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/IndexingTests.swift
@@ -19,7 +19,7 @@ class IndexingTests: XCTestCase {
         let tutorialReference = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/tutorials/Test-Bundle/TestTutorial", sourceLanguage: .swift)
         let node = try context.entity(with: tutorialReference)
         let tutorial = node.semantic as! Tutorial
-        var converter = RenderNodeTranslator(context: context, bundle: bundle, identifier: tutorialReference, source: context.fileURL(for: tutorialReference))
+        var converter = RenderNodeTranslator(context: context, bundle: bundle, identifier: tutorialReference, source: context.documentURL(for: tutorialReference))
         let renderNode = converter.visit(tutorial) as! RenderNode
         let indexingRecords = try renderNode.indexingRecords(onPage: tutorialReference)
         XCTAssertEqual(4, indexingRecords.count)
@@ -93,7 +93,7 @@ class IndexingTests: XCTestCase {
         let articleReference = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/tutorials/Test-Bundle/TestTutorialArticle", sourceLanguage: .swift)
         let node = try context.entity(with: articleReference)
         let article = node.semantic as! TutorialArticle
-        var converter = RenderNodeTranslator(context: context, bundle: bundle, identifier: articleReference, source: context.fileURL(for: articleReference))
+        var converter = RenderNodeTranslator(context: context, bundle: bundle, identifier: articleReference, source: context.documentURL(for: articleReference))
         let renderNode = converter.visit(article) as! RenderNode
         let indexingRecords = try renderNode.indexingRecords(onPage: articleReference)
         
@@ -191,7 +191,7 @@ class IndexingTests: XCTestCase {
         let articleReference = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit", sourceLanguage: .swift)
         let node = try context.entity(with: articleReference)
         let article = node.semantic as! Symbol
-        var converter = RenderNodeTranslator(context: context, bundle: bundle, identifier: articleReference, source: context.fileURL(for: articleReference))
+        var converter = RenderNodeTranslator(context: context, bundle: bundle, identifier: articleReference, source: context.documentURL(for: articleReference))
         let renderNode = converter.visit(article) as! RenderNode
         let indexingRecords = try renderNode.indexingRecords(onPage: articleReference)
         
@@ -211,7 +211,7 @@ class IndexingTests: XCTestCase {
         let articleReference = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit/MyProtocol", sourceLanguage: .swift)
         let node = try context.entity(with: articleReference)
         let article = node.semantic as! Symbol
-        var converter = RenderNodeTranslator(context: context, bundle: bundle, identifier: articleReference, source: context.fileURL(for: articleReference))
+        var converter = RenderNodeTranslator(context: context, bundle: bundle, identifier: articleReference, source: context.documentURL(for: articleReference))
         let renderNode = converter.visit(article) as! RenderNode
         let indexingRecords = try renderNode.indexingRecords(onPage: articleReference)
         

--- a/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
@@ -356,7 +356,7 @@ Root
             builder.setup()
             
             for identifier in context.knownPages {
-                let source = context.fileURL(for: identifier)
+                let source = context.documentURL(for: identifier)
                 let entity = try context.entity(with: identifier)
                 let renderNode = try XCTUnwrap(converter.renderNode(for: entity, at: source))
                 try builder.index(renderNode: renderNode)
@@ -505,7 +505,7 @@ Root
             builder.setup()
             
             for identifier in context.knownPages {
-                let source = context.fileURL(for: identifier)
+                let source = context.documentURL(for: identifier)
                 let entity = try context.entity(with: identifier)
                 let renderNode = try XCTUnwrap(converter.renderNode(for: entity, at: source))
                 try builder.index(renderNode: renderNode)
@@ -554,7 +554,7 @@ Root
             builder.setup()
             
             for identifier in context.knownPages {
-                let source = context.fileURL(for: identifier)
+                let source = context.documentURL(for: identifier)
                 let entity = try context.entity(with: identifier)
                 let renderNode = try converter.convert(entity, at: source)
                 try builder.index(renderNode: renderNode)
@@ -607,7 +607,7 @@ Root
         builder.setup()
         
         for identifier in context.knownPages {
-            let source = context.fileURL(for: identifier)
+            let source = context.documentURL(for: identifier)
             let entity = try context.entity(with: identifier)
             let renderNode = try XCTUnwrap(converter.renderNode(for: entity, at: source))
             try builder.index(renderNode: renderNode)
@@ -657,7 +657,7 @@ Root
             builder.setup()
             
             for identifier in context.knownPages {
-                let source = context.fileURL(for: identifier)
+                let source = context.documentURL(for: identifier)
                 let entity = try context.entity(with: identifier)
                 var renderNode = try XCTUnwrap(converter.renderNode(for: entity, at: source))
                 
@@ -717,7 +717,7 @@ Root
         builder.setup()
         
         for identifier in context.knownPages {
-            let source = context.fileURL(for: identifier)
+            let source = context.documentURL(for: identifier)
             let entity = try context.entity(with: identifier)
             let renderNode = try XCTUnwrap(converter.renderNode(for: entity, at: source))
             try builder.index(renderNode: renderNode)
@@ -817,7 +817,7 @@ Root
         builder.navigatorIndex?.pathHasher = .fnv1
         
         for identifier in context.knownPages {
-            let source = context.fileURL(for: identifier)
+            let source = context.documentURL(for: identifier)
             let entity = try context.entity(with: identifier)
             let renderNode = try XCTUnwrap(converter.renderNode(for: entity, at: source))
             try builder.index(renderNode: renderNode)
@@ -1223,7 +1223,7 @@ Root
         builder.setup()
         
         for identifier in context.knownPages {
-            let source = context.fileURL(for: identifier)
+            let source = context.documentURL(for: identifier)
             let entity = try context.entity(with: identifier)
             let renderNode = try converter.convert(entity, at: source)
             try builder.index(renderNode: renderNode)

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContextTests.swift
@@ -3103,6 +3103,24 @@ let expected = """
             expectedArticleDefaultLanguage: .objectiveC
         )
     }
+    
+    func testDocumentationExtensionURLForReference() throws {
+        let (bundleURL, _, context) = try testBundleAndContext(copying: "TestBundle")
+        
+        XCTAssertEqual(
+            context.documentationExtensionURL(
+                for: ResolvedTopicReference(
+                    bundleIdentifier: "org.swift.docc.example",
+                    path: "/documentation/MyKit/MyClass",
+                    fragment: nil,
+                    sourceLanguage: .swift
+                )
+            ),
+            bundleURL
+                .appendingPathComponent("documentation")
+                .appendingPathComponent("myclass.md")
+        )
+    }
 }
 
 func assertEqualDumps(_ lhs: String, _ rhs: String, file: StaticString = #file, line: UInt = #line) {

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContextTests.swift
@@ -66,7 +66,7 @@ class DocumentationContextTests: XCTestCase {
         let expectedURL = URL(string: "doc://org.swift.docc.example/tutorials/Test-Bundle/TestTutorial")
         XCTAssertEqual(expectedURL, resolved.url)
         
-        guard context.fileURL(for: resolved) != nil else {
+        guard context.documentURL(for: resolved) != nil else {
             XCTFail("Couldn't resolve file URL for \(resolved)")
             return
         }
@@ -1156,7 +1156,7 @@ class DocumentationContextTests: XCTestCase {
             
             let converter = DocumentationContextConverter(bundle: bundle, context: context, renderContext: renderContext)
             
-            let source = context.fileURL(for: identifier)
+            let source = context.documentURL(for: identifier)
             let renderNode = try XCTUnwrap(converter.renderNode(for: node, at: source))
             
             XCTAssertEqual(
@@ -3104,7 +3104,7 @@ let expected = """
         )
     }
     
-    func testDocumentationExtensionURLForReference() throws {
+    func testDocumentationExtensionURLForReferenceReturnsURLForSymbolReference() throws {
         let (bundleURL, _, context) = try testBundleAndContext(copying: "TestBundle")
         
         XCTAssertEqual(
@@ -3119,6 +3119,22 @@ let expected = """
             bundleURL
                 .appendingPathComponent("documentation")
                 .appendingPathComponent("myclass.md")
+        )
+    }
+    
+    func testDocumentationExtensionURLForReferenceReturnsNilForTutorialReference() throws {
+        let (_, _, context) = try testBundleAndContext(copying: "TestBundle")
+        
+        XCTAssertNil(
+            context.documentationExtensionURL(
+                for: ResolvedTopicReference(
+                    bundleIdentifier: "org.swift.docc.example",
+                    path: "/tutorials/TestOverview",
+                    fragment: nil,
+                    sourceLanguage: .swift
+                )
+            ),
+            "Expectedly returned non-nil value for non-symbol content."
         )
     }
 }

--- a/Tests/SwiftDocCTests/Infrastructure/ExternalReferenceResolverTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/ExternalReferenceResolverTests.swift
@@ -245,7 +245,7 @@ Document @1:1-1:35
             let converter = DocumentationNodeConverter(bundle: bundle, context: context)
             let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/tutorials/Test-Bundle/TestTutorial", sourceLanguage: .swift))
             
-            guard let fileURL = context.fileURL(for: node.reference) else {
+            guard let fileURL = context.documentURL(for: node.reference) else {
                 XCTFail("Unable to find the file for \(node.reference.path)")
                 return
             }
@@ -300,7 +300,7 @@ Document @1:1-1:35
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
         let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/SideKit/SideClass", sourceLanguage: .swift))
         
-        guard let fileURL = context.fileURL(for: node.reference) else {
+        guard let fileURL = context.documentURL(for: node.reference) else {
             XCTFail("Unable to find the file for \(node.reference.path)")
             return
         }
@@ -348,7 +348,7 @@ Document @1:1-1:35
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
         let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/SideKit/SideClass", sourceLanguage: .swift))
         
-        guard let fileURL = context.fileURL(for: node.reference) else {
+        guard let fileURL = context.documentURL(for: node.reference) else {
             XCTFail("Unable to find the file for \(node.reference.path)")
             return
         }

--- a/Tests/SwiftDocCTests/Rendering/DefaultAvailabilityTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/DefaultAvailabilityTests.swift
@@ -50,7 +50,7 @@ class DefaultAvailabilityTests: XCTestCase {
         // Test if the default availability is used for modules
         do {
             let identifier = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit", fragment: nil, sourceLanguage: .swift)
-            let source = context.fileURL(for: identifier)
+            let source = context.documentURL(for: identifier)
             let node = try context.entity(with: identifier)
             var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: source)
             let renderNode = translator.visit(node.semantic) as! RenderNode
@@ -61,7 +61,7 @@ class DefaultAvailabilityTests: XCTestCase {
         // Test if the default availability is used for symbols with no explicit availability
         do {
             let identifier = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit/MyClass/init()-3743d", fragment: nil, sourceLanguage: .swift)
-            let source = context.fileURL(for: identifier)
+            let source = context.documentURL(for: identifier)
             let node = try context.entity(with: identifier)
             var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: source)
             let renderNode = translator.visit(node.semantic) as! RenderNode
@@ -72,7 +72,7 @@ class DefaultAvailabilityTests: XCTestCase {
         // Test if the default availability is NOT used for symbols with explicit availability
         do {
             let identifier = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit/MyClass", fragment: nil, sourceLanguage: .swift)
-            let source = context.fileURL(for: identifier)
+            let source = context.documentURL(for: identifier)
             let node = try context.entity(with: identifier)
             var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: source)
             let renderNode = translator.visit(node.semantic) as! RenderNode
@@ -100,7 +100,7 @@ class DefaultAvailabilityTests: XCTestCase {
         // verify that the Mac Catalyst platform's name (including a space) is rendered correctly
         do {
             let identifier = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit", fragment: nil, sourceLanguage: .swift)
-            let source = context.fileURL(for: identifier)
+            let source = context.documentURL(for: identifier)
             let node = try context.entity(with: identifier)
             var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: source)
             let renderNode = translator.visit(node.semantic) as! RenderNode
@@ -116,7 +116,7 @@ class DefaultAvailabilityTests: XCTestCase {
         // Test whether we:
         // 1) Fallback on iOS when Mac Catalyst availability is missing
         // 2) Render [Beta] or not for Mac Catalyst's inherited iOS availability
-        let source = context.fileURL(for: reference)
+        let source = context.documentURL(for: reference)
         let node = try context.entity(with: reference)
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference, source: source)
         let renderNode = translator.visit(node.semantic) as! RenderNode
@@ -190,7 +190,7 @@ class DefaultAvailabilityTests: XCTestCase {
         // Test if the module availability is not "beta" for the "macOS" platform (since 10.15.1 != 10.16)
         do {
             let identifier = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit", fragment: nil, sourceLanguage: .swift)
-            let source = context.fileURL(for: identifier)
+            let source = context.documentURL(for: identifier)
             let node = try context.entity(with: identifier)
             var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: source)
             let renderNode = translator.visit(node.semantic) as! RenderNode
@@ -212,7 +212,7 @@ class DefaultAvailabilityTests: XCTestCase {
         
         do {
             let identifier = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit/MyClass/myFunction()", fragment: nil, sourceLanguage: .swift)
-            let source = context.fileURL(for: identifier)
+            let source = context.documentURL(for: identifier)
             let node = try context.entity(with: identifier)
             
             // Add some available and unavailable platforms to the symbol

--- a/Tests/SwiftDocCTests/Rendering/DefaultCodeListingSyntaxTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/DefaultCodeListingSyntaxTests.swift
@@ -29,7 +29,7 @@ class DefaultCodeBlockSyntaxTests: XCTestCase {
         func renderSection(for bundle: DocumentationBundle, in context: DocumentationContext) -> ContentRenderSection {
             let identifier = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/Test-Bundle/Default-Code-Listing-Syntax", fragment: nil, sourceLanguage: .swift)
 
-            let source = context.fileURL(for: identifier)
+            let source = context.documentURL(for: identifier)
 
             let node = try! context.entity(with: identifier)
             var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: source)

--- a/Tests/SwiftDocCTests/Rendering/RenderMetadataTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/RenderMetadataTests.swift
@@ -78,7 +78,7 @@ class RenderMetadataTests: XCTestCase {
             let renderContext = RenderContext(documentationContext: context, bundle: bundle)
             let converter = DocumentationContextConverter(bundle: bundle, context: context, renderContext: renderContext)
             for identifier in context.knownPages {
-                let source = context.fileURL(for: identifier)
+                let source = context.documentURL(for: identifier)
                 
                 let entity = try context.entity(with: identifier)
                 let renderNode = try XCTUnwrap(converter.renderNode(for: entity, at: source))

--- a/Tests/SwiftDocCTests/Rendering/RoleTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/RoleTests.swift
@@ -31,7 +31,7 @@ class RoleTests: XCTestCase {
         // Compile docs and verify contents
         for (path, expectedRole) in expectedRoles {
             let identifier = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: path, fragment: nil, sourceLanguage: .swift)
-            let source = context.fileURL(for: identifier)
+            let source = context.documentURL(for: identifier)
             do {
                 let node = try context.entity(with: identifier)
                 var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: source)
@@ -49,7 +49,7 @@ class RoleTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: url) }
 
         let identifier = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit", fragment: nil, sourceLanguage: .swift)
-        let source = context.fileURL(for: identifier)
+        let source = context.documentURL(for: identifier)
         let node = try context.entity(with: identifier)
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: source)
         let renderNode = translator.visit(node.semantic) as! RenderNode
@@ -64,7 +64,7 @@ class RoleTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: url) }
 
         let identifier = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/tutorials/Test-Bundle/TestTutorial", fragment: nil, sourceLanguage: .swift)
-        let source = context.fileURL(for: identifier)
+        let source = context.documentURL(for: identifier)
         let node = try context.entity(with: identifier)
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: source)
         let renderNode = translator.visit(node.semantic) as! RenderNode


### PR DESCRIPTION
Bug/issue #, if applicable: N/A

## Summary

Add `DocumentationContext.documentationExtensionURL(for:)` API to query
a symbol's documentation extension.

## Dependencies

None.

## Testing

No user-facing changes.

## Checklist

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
