### PR TITLE
Fall back to Swift when module has no symbols

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -1125,9 +1125,13 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
                     // This is a very inefficient way to gather the source languages
                     // represented in a symbol graph. Adding a dedicated SymbolKit API is tracked
                     // with SR-15551 and rdar://85982095.
-                    moduleInterfaceLanguages = Set(
+                    let symbolGraphLanguages = Set(
                         unifiedSymbolGraph.symbols.flatMap(\.value.sourceLanguages)
                     )
+                    
+                    // If the symbol graph has no symbols, we cannot determine what languages is it available for,
+                    // so fall back to Swift.
+                    moduleInterfaceLanguages = symbolGraphLanguages.isEmpty ? [.swift] : symbolGraphLanguages
                 } else {
                     moduleInterfaceLanguages = [.swift]
                 }


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://87228981

## Summary

When loading a symbol graph that has no symbols with Objective-C support enabled, we cannot determine what language the module is meant to be used in. This resolves that by falling back to Swift in those cases.

Without this fix DocC crashes due to force-unwraps that assume the module has at least one available language.

## Dependencies

None.

## Testing

Verify that `docc` no longer crashes when building a DocC catalog that contains a symbol graph file with 0 symbols.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
