### PR TITLE
Support all Darwin platforms for CLI Utility

### DIFF
--- a/Sources/docc/main.swift
+++ b/Sources/docc/main.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-#if os(macOS) || os(Linux) || os(Android)
+#if os(macOS) || os(tvOS) || os(iOS) || os(watchOS) || os(Linux) || os(Android)
 import SwiftDocCUtilities
 
 Docc.main()


### PR DESCRIPTION
## Summary

Adds support for All Darwin Platforms for the Command Line Utility

## Testing

Definitely doesn't need testing but I guess u can compile with the target being arm64-apple-ios14.0 
then run it on a jailbroken device

Steps:
1. Compile with the target mentioned above
2. Copy the binary over to a jailbroken device
3. Sign it 
4. Run it
5. Profit!

## Checklist

- [ ] Added tests
- [ ] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary 
