### PR TITLE
Make RenderIndex changes backwards compatible

### DIFF
--- a/Sources/SwiftDocC/Indexing/IndexJSON/Index.swift
+++ b/Sources/SwiftDocC/Indexing/IndexJSON/Index.swift
@@ -201,7 +201,7 @@ extension NavigatorIndex.PageType {
         }
     }
     
-    var renderIndexPageType: String {
+    var renderIndexPageType: String? {
         switch self {
         case .root:
             return "root"

--- a/Sources/SwiftDocC/Indexing/Navigator/AvailabilityIndex+Ext.swift
+++ b/Sources/SwiftDocC/Indexing/Navigator/AvailabilityIndex+Ext.swift
@@ -86,6 +86,13 @@ public struct InterfaceLanguage: Hashable, CustomStringConvertible, Codable, Equ
     /// A mask to use to identify the interface language..
     public let mask: ID
     
+    
+    enum CodingKeys: String, CodingKey {
+        case name
+        case id
+        case mask
+    }
+    
     /// Initialize an instance of interface language.
     private init(name: String, id: String, mask: ID) {
         self.name = name
@@ -96,6 +103,25 @@ public struct InterfaceLanguage: Hashable, CustomStringConvertible, Codable, Equ
     // This would return "Swift" or "Objective-C" for example.
     public var description: String {
         return name
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        
+        let name = try values.decode(String.self, forKey: .name)
+        self.name = name
+        
+        let id = try values.decodeIfPresent(String.self, forKey: .id)
+        if let id = id {
+            self.id = id
+        } else {
+            // Default to a lowercased version of the name if an ID isn't provided
+            // to allow for backwards compatibility with existing availability indexes
+            // that do not include an id.
+            self.id = name.lowercased()
+        }
+        
+        self.mask = try values.decode(ID.self, forKey: .mask)
     }
     
     /**

--- a/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
@@ -1085,6 +1085,45 @@ Root
         #endif
     }
     
+    func testAvailabilityIndexInterfaceLanguageBackwardsCompatibility() throws {
+        // Tests for backwards compatibility with an encoded `InterfaceLanguage` that does not include
+        // an `id`.
+        
+        let plistWithoutLanguageID = """
+            <plist version="1.0">
+            <dict>
+                <key>data</key>
+                <dict>
+                </dict>
+                <key>interfaceLanguages</key>
+                <array>
+                    <dict>
+                        <key>mask</key>
+                        <integer>1</integer>
+                        <key>name</key>
+                        <string>Swift</string>
+                    </dict>
+                </array>
+                <key>languageToPlatforms</key>
+                <array>
+                </array>
+                <key>platforms</key>
+                <array>
+                </array>
+            </dict>
+            </plist>
+            """
+        
+        let availabilityIndex = try PropertyListDecoder().decode(
+            AvailabilityIndex.self,
+            from: Data(plistWithoutLanguageID.utf8)
+        )
+        
+        XCTAssertEqual(availabilityIndex.interfaceLanguages.first?.name, "Swift")
+        XCTAssertEqual(availabilityIndex.interfaceLanguages.first?.id, "swift")
+        XCTAssertEqual(availabilityIndex.interfaceLanguages.first?.mask, 1)
+    }
+    
     func testRenderNodeToPageType() {
         
         XCTAssertEqual(PageType(role: "symbol"), .symbol)


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://89093219

## Summary

Changes made in support of the RenderIndexJSON broke backwards compatibility with existing NavigatorIndex clients. This resolves the regression by adding custom decoding to AvailabilityIndex.InterfaceLanguage.

## Testing

Confirm unit tests pass and a NavigatorIndex produced with a prior version of DocC is compatible.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
