### PR TITLE
Use targetFallback in inheritsFrom relationships

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphRelationshipsBuilder.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphRelationshipsBuilder.swift
@@ -208,6 +208,14 @@ struct SymbolGraphRelationshipsBuilder {
                 return
             }
             parentNodeReference = .unresolved(unresolved)
+            
+            // At this point the parent node we are inheriting from is unresolved, so let's add a fallback in case we can not resolve it later.
+            if let targetFallback = edge.targetFallback {
+                childSymbol.relationshipsVariants[
+                    DocumentationDataVariantsTrait(interfaceLanguage: language.id),
+                    default: RelationshipsSection()
+                ].targetFallbacks[.unresolved(unresolved)] = targetFallback
+            }
         }
         
         // Add relationships


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://80090675

## Summary

If the super class is in another framework, we can not get a
ResolvedTopicReference to create the inheritsFrom relationship. In this case we
use the targetFallback to populate the render node.
## Dependencies

None

## Testing

Build documentation for a symbol that inherits from a class in another framework and verify that the "Inherits From" section in the generated doccarchive contains the name of the super class.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran the `./bin/test` script and it succeeded
- [X] Updated documentation if necessary
