### PR TITLE
Deprecated symbols sidenav

### DIFF
--- a/Sources/SwiftDocC/Indexing/IndexJSON/Index.swift
+++ b/Sources/SwiftDocC/Indexing/IndexJSON/Index.swift
@@ -69,7 +69,7 @@ extension RenderIndex {
             case path
             case type
             case children
-            case isExternal
+            case external
         }
 
         public func encode(to encoder: Encoder) throws {
@@ -83,7 +83,7 @@ extension RenderIndex {
             
             // `isExternal` defaults to false so only encode it if it's true
             if isExternal {
-                try container.encode(isExternal, forKey: .isExternal)
+                try container.encode(isExternal, forKey: .external)
             }
         }
         
@@ -97,7 +97,7 @@ extension RenderIndex {
             children = try values.decodeIfPresent([Node].self, forKey: .children)
             
             // `isExternal` defaults to false if it's not specified
-            isExternal = try values.decodeIfPresent(Bool.self, forKey: .isExternal) ?? false
+            isExternal = try values.decodeIfPresent(Bool.self, forKey: .external) ?? false
         }
         
         /// Creates a new node with the given title, path, type, and children.

--- a/Sources/SwiftDocC/Indexing/IndexJSON/Index.swift
+++ b/Sources/SwiftDocC/Indexing/IndexJSON/Index.swift
@@ -68,6 +68,11 @@ extension RenderIndex {
         /// Allows renderers to use a specific design treatment for render index nodes
         /// that lead to external documentation content.
         public let isExternal: Bool
+        
+        /// A Boolean value that is true if the current node has been marked as is beta
+        ///
+        /// Allows renderers to use a specific design treatment for render index nodes that mark the node as in beta.
+        public let isBeta: Bool
 
         enum CodingKeys: String, CodingKey {
             case title
@@ -76,6 +81,7 @@ extension RenderIndex {
             case children
             case deprecated
             case external
+            case beta
         }
 
         public func encode(to encoder: Encoder) throws {
@@ -96,6 +102,11 @@ extension RenderIndex {
             if isExternal {
                 try container.encode(isExternal, forKey: .external)
             }
+            
+            // `isBeta` defaults to false so only encode it if it's true
+            if isBeta {
+                try container.encode(isBeta, forKey: .beta)
+            }
         }
         
         public init(from decoder: Decoder) throws {
@@ -112,6 +123,9 @@ extension RenderIndex {
             
             // `isExternal` defaults to false if it's not specified
             isExternal = try values.decodeIfPresent(Bool.self, forKey: .external) ?? false
+            
+            // `isBeta` defaults to false if it's not specified
+            isBeta = try values.decodeIfPresent(Bool.self, forKey: .beta) ?? false
         }
         
         /// Creates a new node with the given title, path, type, and children.
@@ -124,6 +138,7 @@ extension RenderIndex {
         ///   - isDeprecated : If the current node has been marked as deprecated.
         ///   - isExternal: If the current node belongs to an external
         ///     documentation archive.
+        ///   - isBeta: If the current node is in beta.
         public init(
             title: String,
             path: String?,
@@ -131,6 +146,7 @@ extension RenderIndex {
             children: [Node]?,
             isDeprecated: Bool,
             isExternal: Bool,
+            isBeta: Bool
         ) {
             self.title = title
             self.path = path
@@ -138,6 +154,7 @@ extension RenderIndex {
             self.children = children
             self.isDeprecated = isDeprecated
             self.isExternal = isExternal
+            self.isBeta = isBeta
         }
         
         init(
@@ -155,6 +172,8 @@ extension RenderIndex {
             // Currently Swift-DocC doesn't support resolving links to external DocC archives
             // so we default to `false` here.
             self.isExternal = false
+            
+            self.isBeta = false
             
             guard let pageType = pageType else {
                 self.type = nil

--- a/Sources/SwiftDocC/Indexing/IndexJSON/Index.swift
+++ b/Sources/SwiftDocC/Indexing/IndexJSON/Index.swift
@@ -57,6 +57,11 @@ extension RenderIndex {
         /// The children of this node.
         public let children: [Node]?
         
+        /// A Boolean value that is true if the current node has been marked as deprecated on any platform.
+        ///
+        /// Allows renderers to use a specific design treatment for render index nodes that mark the node as deprecated.
+        public let isDeprecated: Bool
+
         /// A Boolean value that is true if the current node belongs to an external
         /// documentation archive.
         ///
@@ -69,6 +74,7 @@ extension RenderIndex {
             case path
             case type
             case children
+            case deprecated
             case external
         }
 
@@ -80,6 +86,11 @@ extension RenderIndex {
             try container.encodeIfPresent(path, forKey: .path)
             try container.encodeIfPresent(type, forKey: .type)
             try container.encodeIfPresent(children, forKey: .children)
+            
+            // `isDeprecated` defaults to false so only encode it if it's true
+            if isDeprecated {
+                try container.encode(isDeprecated, forKey: .deprecated)
+            }
             
             // `isExternal` defaults to false so only encode it if it's true
             if isExternal {
@@ -96,6 +107,9 @@ extension RenderIndex {
             type = try values.decodeIfPresent(String.self, forKey: .type)
             children = try values.decodeIfPresent([Node].self, forKey: .children)
             
+            // `isDeprecated` defaults to false if it's not specified
+            isDeprecated = try values.decodeIfPresent(Bool.self, forKey: .deprecated) ?? false
+            
             // `isExternal` defaults to false if it's not specified
             isExternal = try values.decodeIfPresent(Bool.self, forKey: .external) ?? false
         }
@@ -107,6 +121,7 @@ extension RenderIndex {
         ///   - path: The relative path to the page represented by this node.
         ///   - type: The type of this node.
         ///   - children: The children of this node.
+        ///   - isDeprecated : If the current node has been marked as deprecated.
         ///   - isExternal: If the current node belongs to an external
         ///     documentation archive.
         public init(
@@ -114,12 +129,14 @@ extension RenderIndex {
             path: String?,
             type: String,
             children: [Node]?,
-            isExternal: Bool
+            isDeprecated: Bool,
+            isExternal: Bool,
         ) {
             self.title = title
             self.path = path
             self.type = type
             self.children = children
+            self.isDeprecated = isDeprecated
             self.isExternal = isExternal
         }
         
@@ -127,10 +144,13 @@ extension RenderIndex {
             title: String,
             path: String,
             pageType: NavigatorIndex.PageType?,
+            isDeprecated: Bool,
             children: [Node]
         ) {
             self.title = title
             self.children = children.isEmpty ? nil : children
+            
+            self.isDeprecated = isDeprecated
             
             // Currently Swift-DocC doesn't support resolving links to external DocC archives
             // so we default to `false` here.
@@ -154,7 +174,7 @@ extension RenderIndex {
 }
 
 extension RenderIndex {
-    static func fromNavigatorIndex(_ navigatorIndex: NavigatorIndex) -> RenderIndex {
+    static func fromNavigatorIndex(_ navigatorIndex: NavigatorIndex, with builder: NavigatorIndex.Builder) -> RenderIndex {
         // The immediate children of the root represent the interface languages
         // described in this navigator tree.
         let interfaceLanguageRoots = navigatorIndex.navigatorTree.root.children
@@ -171,7 +191,9 @@ extension RenderIndex {
                     
                     return (
                         language: languageID,
-                        children: interfaceLanguageRoot.children.map(RenderIndex.Node.fromNavigatorTreeNode)
+                        children: interfaceLanguageRoot.children.map {
+                            RenderIndex.Node.fromNavigatorTreeNode($0, in: navigatorIndex, with: builder)
+                        }
                     )
                 },
                 uniquingKeysWith: +
@@ -181,12 +203,27 @@ extension RenderIndex {
 }
 
 extension RenderIndex.Node {
-    static func fromNavigatorTreeNode(_ node: NavigatorTree.Node) -> RenderIndex.Node {
+    static func fromNavigatorTreeNode(_ node: NavigatorTree.Node, in navigatorIndex: NavigatorIndex, with builder: NavigatorIndex.Builder) -> RenderIndex.Node {
+        // If this node was deprecated on any platform version mark it as deprecated.
+        let isDeprecated: Bool
+        
+        let availabilityIndexEntryIDsForNode = builder.availabilityEntryIDs(for: node.item.availabilityID)
+        if let entryIDs = availabilityIndexEntryIDsForNode {
+            let availabilityInfosForNode = entryIDs.map { ID in navigatorIndex.availabilityIndex.info(for: ID) }
+            // Mark node as deprecated if we have an explicit deprecation version
+            isDeprecated = availabilityInfosForNode.contains { $0?.deprecated != nil }
+        } else {
+            isDeprecated = false
+        }
+        
         return RenderIndex.Node(
             title: node.item.title,
             path: node.item.path,
             pageType: NavigatorIndex.PageType(rawValue: node.item.pageType),
-            children: node.children.map(RenderIndex.Node.fromNavigatorTreeNode)
+            isDeprecated: isDeprecated,
+            children: node.children.map {
+                RenderIndex.Node.fromNavigatorTreeNode($0, in: navigatorIndex, with: builder)
+            }
         )
     }
 }

--- a/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderIndex.spec.json
+++ b/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderIndex.spec.json
@@ -82,6 +82,10 @@
                     "path": {
                         "type": "string"
                     },
+                    "deprecated": {
+                        "type": "boolean",
+                        "default": "false"
+                    },
                     "external": {
                         "type": "boolean",
                         "default": "false"

--- a/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderIndex.spec.json
+++ b/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderIndex.spec.json
@@ -82,7 +82,7 @@
                     "path": {
                         "type": "string"
                     },
-                    "isExternal": {
+                    "external": {
                         "type": "boolean",
                         "default": "false"
                     },

--- a/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderIndex.spec.json
+++ b/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderIndex.spec.json
@@ -90,6 +90,10 @@
                         "type": "boolean",
                         "default": "false"
                     },
+                    "beta": {
+                        "type": "boolean",
+                        "default": "false"
+                    },
                     "children": {
                         "type": "array",
                         "items": {

--- a/Tests/SwiftDocCTests/Indexing/RenderIndexTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/RenderIndexTests.swift
@@ -247,6 +247,33 @@ final class RenderIndexTests: XCTestCase {
         )
     }
     
+    func testRenderIndexGenerationWithExternalNode() throws {
+        let renderIndexWithExternalNode = try RenderIndex.fromString(#"""
+            {
+              "interfaceLanguages": {
+                "swift": [
+                  {
+                    "path": "\/documentation\/framework\/foo-swift.struct",
+                    "title": "Foo",
+                    "type": "struct",
+                    "external": true
+                  }
+                ]
+              },
+              "schemaVersion": {
+                "major": 0,
+                "minor": 1,
+                "patch": 0
+              }
+            }
+            """#
+        )
+        // Let's check that the "external" key is correctly parsed into the isExternal field of RenderIndex.Node.
+        XCTAssertTrue(renderIndexWithExternalNode.interfaceLanguages["swift"]![0].isExternal)
+        // Let's make sure it gets emitted properly by testing if we can roundtrip to JSON.
+        try assertRoundTripCoding(renderIndexWithExternalNode)
+    }
+    
     func generatedRenderIndex(for testBundleName: String, with bundleIdentifier: String) throws -> RenderIndex {
         let (bundle, context) = try testBundleAndContext(named: testBundleName)
         let renderContext = RenderContext(documentationContext: context, bundle: bundle)

--- a/Tests/SwiftDocCTests/Indexing/RenderIndexTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/RenderIndexTests.swift
@@ -267,6 +267,15 @@ final class RenderIndexTests: XCTestCase {
         }
     }
     
+    func testRenderIndexGenerationWithBetaNode() throws {
+        try testRenderIndexGenerationFromJSON(
+            makeRenderIndexJSONSingleNode(withOptionalProperty: "beta")
+        ) { renderIndex in
+            // Let's check that the "deprecated" key is correctly parsed into the isDeprecated field of RenderIndex.Node.
+            XCTAssertTrue(try XCTUnwrap(renderIndex.interfaceLanguages["swift"])[0].isBeta)
+        }
+    }
+    
     func makeRenderIndexJSONSingleNode(withOptionalProperty property: String) -> String {
         return """
     {

--- a/Tests/SwiftDocCTests/Test Resources/Deprecated.symbols.json
+++ b/Tests/SwiftDocCTests/Test Resources/Deprecated.symbols.json
@@ -1,0 +1,121 @@
+{
+    "metadata": {
+        "formatVersion": {
+            "major": 0,
+            "minor": 5,
+            "patch": 3
+        },
+        "generator": "Apple Swift version 5.7 (swiftlang-5.7.0.101.10 clang-1400.0.10.4.2)"
+    },
+    "module": {
+        "name": "MyLibrary",
+        "platform": {
+            "architecture": "x86_64",
+            "operatingSystem": {
+                "minimumVersion": {
+                    "major": 10,
+                    "minor": 10,
+                    "patch": 0
+                },
+                "name": "macosx"
+            },
+            "vendor": "apple"
+        }
+    },
+    "relationships": [],
+    "symbols": [
+        {
+            "accessLevel": "public",
+            "availability": [
+                {
+                    "deprecated": {
+                        "major": 10,
+                        "minor": 15
+                    },
+                    "domain": "macOS",
+                    "introduced": {
+                        "major": 10,
+                        "minor": 10
+                    }
+                }
+            ],
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "foo"
+                },
+                {
+                    "kind": "text",
+                    "spelling": "() -> "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "preciseIdentifier": "s:Si",
+                    "spelling": "Int"
+                }
+            ],
+            "functionSignature": {
+                "returns": [
+                    {
+                        "kind": "typeIdentifier",
+                        "preciseIdentifier": "s:Si",
+                        "spelling": "Int"
+                    }
+                ]
+            },
+            "identifier": {
+                "interfaceLanguage": "swift",
+                "precise": "s:9MyLibrary3fooSiyF"
+            },
+            "kind": {
+                "displayName": "Function",
+                "identifier": "swift.func"
+            },
+            "location": {
+                "position": {
+                    "character": 12,
+                    "line": 2
+                },
+                "uri": "file:///MyLibrary/Sources/MyLibrary/MyLibrary.swift"
+            },
+            "names": {
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "foo"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "() -> "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "preciseIdentifier": "s:Si",
+                        "spelling": "Int"
+                    }
+                ],
+                "title": "foo()"
+            },
+            "pathComponents": [
+                "foo()"
+            ]
+        }
+    ]
+}
+

--- a/Tests/SwiftDocCTests/Test Resources/TestBundle-RenderIndex.json
+++ b/Tests/SwiftDocCTests/Test Resources/TestBundle-RenderIndex.json
@@ -13,7 +13,8 @@
       {
         "path" : "\/documentation\/fillintroduced\/iosonlydeprecated()",
         "title" : "func iOSOnlyDeprecated()",
-        "type" : "func"
+        "type" : "func",
+        "deprecated" : true
       },
       {
         "path" : "\/documentation\/fillintroduced\/iosonlyintroduced()",
@@ -23,7 +24,8 @@
       {
         "path" : "\/documentation\/fillintroduced\/maccatalystonlydeprecated()",
         "title" : "func macCatalystOnlyDeprecated()",
-        "type" : "func"
+        "type" : "func",
+        "deprecated" : true
       },
       {
         "path" : "\/documentation\/fillintroduced\/maccatalystonlyintroduced()",
@@ -33,7 +35,8 @@
       {
         "path" : "\/documentation\/fillintroduced\/macosonlydeprecated()",
         "title" : "func macOSOnlyDeprecated()",
-        "type" : "func"
+        "type" : "func",
+        "deprecated" : true
       },
       {
         "path" : "\/documentation\/fillintroduced\/macosonlyintroduced()",


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://89564513

Summary

Introduce/change 3 boolean node properties in RenderIndex JSON:
- Change `isExternal` to `external`
- Add `deprecated`. Data for this is generated for render index nodes associated with a symbol. The node is marked as deprecated if we have an explicit deprecated platform version for the associated symbol
- Add `beta` to the RenderIndex JSON OpenAPI spec but doesn't actually generate anything for it.

Dependencies

None

Testing

Build documentation for a project with an explicitly deprecated symbol, and check that the RenderIndex JSON contains a `"deprecated" : true` property for the relevant node.

Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

[X]  Added tests
[X]  Ran the ./bin/test script and it succeeded
[X]  Updated documentation if necessary