### PR TITLE
Use navigator title for non-Swift languages

### DIFF
--- a/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex+Ext.swift
+++ b/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex+Ext.swift
@@ -78,12 +78,18 @@ extension RenderNode {
     
     /// Returns a navigator title preferring the fragments inside the metadata, if applicable.
     func navigatorTitle() -> String? {
-        let pageType = navigatorPageType()
-        guard ![.framework, .class, .structure, .enumeration, .protocol, .typeAlias, .associatedType].contains(pageType) else { return metadata.title }
-        guard let fragments = metadata.fragments else { return metadata.title }
-        return fragments.map { token in
-            return token.text
-        }.joined()
+        let fragments: [DeclarationRenderSection.Token]?
+        
+        // FIXME: Use `metadata.navigatorTitle` for all Swift symbols (SR-15947).
+        if identifier.sourceLanguage == .swift || (metadata.navigatorTitle ?? []).isEmpty {
+            let pageType = navigatorPageType()
+            guard ![.framework, .class, .structure, .enumeration, .protocol, .typeAlias, .associatedType].contains(pageType) else { return metadata.title }
+            fragments = metadata.fragments
+        } else {
+            fragments = metadata.navigatorTitle
+        }
+        
+        return fragments?.map(\.text).joined() ?? metadata.title
     }
     
     /// Returns the NavigatorIndex.PageType indicating the type of the page.

--- a/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
@@ -1287,32 +1287,7 @@ Root
     }
     
     func testNavigatorTitle() throws {
-        
-        func buildJSON(title: String, symbolKind: String, fragments: String) -> String {
-            return """
-        {
-          "abstract": [],
-          "hierarchy": { "paths": [] },
-          "identifier": { "interfaceLanguage": "swift", "url": "doc://org.swift.docc.example/documentation/test-item" },
-          "kind": "symbol",
-          "metadata": {
-            "modules": [ { "name": "MyKit" } ],
-            "roleHeading": "My Heading",
-            "title": "\(title)",
-            "symbolKind": "\(symbolKind)",
-            "fragments": \(fragments)
-          },
-          "primaryContentSections": [],
-          "references": {},
-          "schemaVersion": { "major": 1, "minor": 0, "patch": 0 },
-          "sections": [],
-          "seeAlsoSections": [],
-          "topicSections": []
-        }
-        """
-        }
-        
-        var json = buildJSON(title: "Failure", symbolKind: "associatedtype", fragments: """
+        var json = buildRenderJSON(title: "Failure", symbolKind: "associatedtype", fragments: """
             [
                 {
                     "text": "associatedtype",
@@ -1341,7 +1316,7 @@ Root
         var renderNode = try RenderNode.decode(fromJSON: Data(json.utf8))
         XCTAssertEqual(renderNode.navigatorTitle(), "Failure")
         
-        json = buildJSON(title: "Subscriber", symbolKind: "protocol", fragments: """
+        json = buildRenderJSON(title: "Subscriber", symbolKind: "protocol", fragments: """
             [
                 {
                     "text": "protocol",
@@ -1361,7 +1336,7 @@ Root
         renderNode = try RenderNode.decode(fromJSON: Data(json.utf8))
         XCTAssertEqual(renderNode.navigatorTitle(), "Subscriber")
         
-        json = buildJSON(title: "receive(subscription:)", symbolKind: "method", fragments: """
+        json = buildRenderJSON(title: "receive(subscription:)", symbolKind: "method", fragments: """
         [
             {
                 "kind": "keyword",
@@ -1402,7 +1377,7 @@ Root
         renderNode = try RenderNode.decode(fromJSON: Data(json.utf8))
         XCTAssertEqual(renderNode.navigatorTitle(), "func receive(subscription: Subscription)")
         
-        json = buildJSON(title: "init(_:)", symbolKind: "structctr", fragments: """
+        json = buildRenderJSON(title: "init(_:)", symbolKind: "structctr", fragments: """
         [
             {
                 "kind": "identifier",
@@ -1417,6 +1392,28 @@ Root
         )
         renderNode = try RenderNode.decode(fromJSON: Data(json.utf8))
         XCTAssertEqual(renderNode.navigatorTitle(), "init(Double)")
+    }
+    
+    func testNavigatorTitleForEmptyMetadataNavigatorTitle() throws {
+        let json = buildRenderJSON(
+            title: "init(_:)",
+            symbolKind: "not-struct",
+            fragments: """
+            [
+              {
+                "kind": "identifier",
+                "text": "Fragment Value"
+              }
+            ]
+            """,
+            language: "occ"
+        )
+        
+        let renderNode = try RenderNode.decode(fromJSON: Data(json.utf8))
+        XCTAssertEqual(
+            renderNode.navigatorTitle(),
+            "Fragment Value"
+        )
     }
     
     func testSavesNodePresentationDisambiguator() {
@@ -1507,4 +1504,33 @@ fileprivate func testTree(named name: String) throws -> String {
     let fileURL = Bundle.module.url(
         forResource: name, withExtension: "txt", subdirectory: "Test Resources")!
     return try String(contentsOf: fileURL).trimmingCharacters(in: .newlines)
+}
+
+fileprivate func buildRenderJSON(
+    title: String,
+    symbolKind: String,
+    fragments: String,
+    language: String = "swift"
+) -> String {
+    return """
+{
+  "abstract": [],
+  "hierarchy": { "paths": [] },
+  "identifier": { "interfaceLanguage": "\(language)", "url": "doc://org.swift.docc.example/documentation/test-item" },
+  "kind": "symbol",
+  "metadata": {
+    "modules": [ { "name": "MyKit" } ],
+    "roleHeading": "My Heading",
+    "title": "\(title)",
+    "symbolKind": "\(symbolKind)",
+    "fragments": \(fragments)
+  },
+  "primaryContentSections": [],
+  "references": {},
+  "schemaVersion": { "major": 1, "minor": 0, "patch": 0 },
+  "sections": [],
+  "seeAlsoSections": [],
+  "topicSections": []
+}
+"""
 }

--- a/Tests/SwiftDocCTests/Indexing/RenderIndexTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/RenderIndexTests.swift
@@ -89,7 +89,7 @@ final class RenderIndexTests: XCTestCase {
                               }
                             ],
                             "path": "\/documentation\/mixedlanguageframework\/bar\/mystringfunction(_:)",
-                            "title": "typedef enum Foo : NSString {\n    ...\n} Foo;",
+                            "title": "myStringFunction:error: (navigator title)",
                             "type": "method"
                           }
                         ],
@@ -123,22 +123,22 @@ final class RenderIndexTests: XCTestCase {
                           },
                           {
                             "path": "\/documentation\/mixedlanguageframework\/foo-swift.struct\/first",
-                            "title": "static var first: Foo",
+                            "title": "first",
                             "type": "case"
                           },
                           {
                             "path": "\/documentation\/mixedlanguageframework\/foo-swift.struct\/fourth",
-                            "title": "static var fourth: Foo",
+                            "title": "fourth",
                             "type": "case"
                           },
                           {
                             "path": "\/documentation\/mixedlanguageframework\/foo-swift.struct\/second",
-                            "title": "static var second: Foo",
+                            "title": "second",
                             "type": "case"
                           },
                           {
                             "path": "\/documentation\/mixedlanguageframework\/foo-swift.struct\/third",
-                            "title": "static var third: Foo",
+                            "title": "third",
                             "type": "case"
                           }
                         ],

--- a/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFramework.docc/symbol-graphs/clang/MixedLanguageFramework.symbols.json
+++ b/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFramework.docc/symbol-graphs/clang/MixedLanguageFramework.symbols.json
@@ -350,6 +350,12 @@
       },
       "names" : {
         "title" : "myStringFunction:error:",
+        "navigator" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "myStringFunction:error: (navigator title)"
+          }
+        ],
         "subHeading" : [
           {
             "kind" : "keyword",
@@ -630,7 +636,13 @@
         "uri" : "MixedLanguageFramework.h"
       },
       "names" : {
-        "title" : "first"
+        "title" : "first",
+        "navigator" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "first"
+          }
+        ],
       },
       "pathComponents" : [
         "Foo",
@@ -678,7 +690,13 @@
         "uri" : "MixedLanguageFramework.h"
       },
       "names" : {
-        "title" : "fourth"
+        "title" : "fourth",
+        "navigator" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "fourth"
+          }
+        ],
       },
       "pathComponents" : [
         "Foo",
@@ -726,7 +744,13 @@
         "uri" : "MixedLanguageFramework.h"
       },
       "names" : {
-        "title" : "second"
+        "title" : "second",
+        "navigator" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "second"
+          }
+        ],
       },
       "pathComponents" : [
         "Foo",
@@ -774,7 +798,13 @@
         "uri" : "MixedLanguageFramework.h"
       },
       "names" : {
-        "title" : "third"
+        "title" : "third",
+        "navigator" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "third"
+          }
+        ],
       },
       "pathComponents" : [
         "Foo",

--- a/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
@@ -2021,7 +2021,7 @@ class ConvertActionTests: XCTestCase {
             "Classes",
             "Bar",
             "Type Methods",
-            "typedef enum Foo : NSString {\n    ...\n} Foo;",
+            "myStringFunction:error: (navigator title)",
             "Custom",
             "Foo",
             "Variables",
@@ -2030,16 +2030,16 @@ class ConvertActionTests: XCTestCase {
             "Enumerations",
             "Foo",
             "Enumeration Cases",
-            "static var first: Foo",
-            "static var fourth: Foo",
-            "static var second: Foo",
-            "static var third: Foo",
+            "first",
+            "fourth",
+            "second",
+            "third",
         ]
         
         XCTAssertEqual(
             objectiveCNavigatorEntries,
             expectedObjectiveNavigatorEntries,
-            "Swift navigator contained unexpected content."
+            "Objective-C navigator contained unexpected content."
         )
     }
     

--- a/Tests/SwiftDocCUtilitiesTests/Test Bundles/MixedLanguageFramework.docc/symbol-graphs/clang/MixedLanguageFramework.symbols.json
+++ b/Tests/SwiftDocCUtilitiesTests/Test Bundles/MixedLanguageFramework.docc/symbol-graphs/clang/MixedLanguageFramework.symbols.json
@@ -350,6 +350,12 @@
       },
       "names" : {
         "title" : "myStringFunction:error:",
+        "navigator" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "myStringFunction:error: (navigator title)"
+          }
+        ],
         "subHeading" : [
           {
             "kind" : "keyword",
@@ -630,7 +636,13 @@
         "uri" : "MixedLanguageFramework.h"
       },
       "names" : {
-        "title" : "first"
+        "title" : "first",
+        "navigator" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "first"
+          }
+        ],
       },
       "pathComponents" : [
         "Foo",
@@ -678,7 +690,13 @@
         "uri" : "MixedLanguageFramework.h"
       },
       "names" : {
-        "title" : "fourth"
+        "title" : "fourth",
+        "navigator" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "fourth"
+          }
+        ],
       },
       "pathComponents" : [
         "Foo",
@@ -726,7 +744,13 @@
         "uri" : "MixedLanguageFramework.h"
       },
       "names" : {
-        "title" : "second"
+        "title" : "second",
+        "navigator" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "second"
+          }
+        ],
       },
       "pathComponents" : [
         "Foo",
@@ -774,7 +798,13 @@
         "uri" : "MixedLanguageFramework.h"
       },
       "names" : {
-        "title" : "third"
+        "title" : "third",
+        "navigator" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "third"
+          }
+        ],
       },
       "pathComponents" : [
         "Foo",


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://89418043

## Summary

For non-Swift languages, make the navigator index generator use `metadata.navigatorTitle`. I filed a separate [issue](https://bugs.swift.org/browse/SR-15947) to track doing this for Swift symbols as well.

## Dependencies

None.

## Testing

When building documentation with an Objective-C symbol graph file that contains symbols with a `names.navigator` entry, verify that the navigator index title reflects the data provided by the symbol graph.

## Checklist

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
