### PR TITLE
update cmark-gfm

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,7 +15,7 @@
         "repositoryURL": "https://github.com/apple/swift-cmark.git",
         "state": {
           "branch": "gfm",
-          "revision": "2190baadafe6e83e50f8f97c2909eb48fd3eae66",
+          "revision": "5bd1108552a4f54d421d3d39f696952495a4b0cf",
           "version": null
         }
       },


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://89864410

## Summary

This updates the Package.resolved to point to the updated version of swift-cmark/gfm, which has been updated to fix GHSA-mc3g-88wq-6f4x.

## Dependencies

https://github.com/apple/swift-cmark/pull/36 (merged)

## Testing

Ensure existing functionality.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ n/a ] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ n/a ] Updated documentation if necessary
