### PR TITLE
Remove unneeded print statements

### DIFF
--- a/Sources/SwiftDocCUtilities/Action/Actions/CoverageAction.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/CoverageAction.swift
@@ -29,7 +29,8 @@ public struct CoverageAction: Action {
     public mutating func perform(logHandle: LogHandle) throws -> ActionResult {
         switch documentationCoverageOptions.level {
         case .brief, .detailed:
-            Swift.print("   --- Experimental coverage output enabled. ---")
+            var logHandle = logHandle
+            print("   --- Experimental coverage output enabled. ---", to: &logHandle)
 
             let summaryString = try CoverageDataEntry.generateSummary(
                 ofDataAt: workingDirectory.appendingPathComponent(
@@ -38,7 +39,7 @@ public struct CoverageAction: Action {
                 shouldGenerateBrief: true,
                 shouldGenerateDetailed: (documentationCoverageOptions.level == .detailed)
             )
-            print(summaryString)
+            print(summaryString, to: &logHandle)
         case .none:
             break
         }

--- a/Tests/SwiftDocCTests/DocumentationService/ConvertService/ConvertServiceTests.swift
+++ b/Tests/SwiftDocCTests/DocumentationService/ConvertService/ConvertServiceTests.swift
@@ -835,11 +835,6 @@ class ConvertServiceTests: XCTestCase {
             assert: { renderNodes, referenceStore in
                 let referenceStore = try XCTUnwrap(referenceStore)
                 let paths = Set(referenceStore.topics.keys.map(\.path))
-                
-                Set(referenceStore.topics.keys.map(\.path)).forEach { s in
-                    print("path: \(s)")
-                }
-                
                 XCTAssertTrue(paths.contains("/documentation/SideKit/SideClass/Element"))
                 XCTAssertFalse(paths.contains("/documentation/SideKit/SideClass/Element/Protocol-Implementations"))
             }

--- a/Tests/SwiftDocCTests/Model/DocumentationMarkupTests.swift
+++ b/Tests/SwiftDocCTests/Model/DocumentationMarkupTests.swift
@@ -155,7 +155,6 @@ class DocumentationMarkupTests: XCTestCase {
             Text " Abstract."
             """
             let model = DocumentationMarkup(markup: Document(parsing: source, options: .parseBlockDirectives))
-            print(model.abstractSection!.content.map({ $0.detachedFromParent.debugDescription() }).joined(separator: "\n"))
             XCTAssertEqual(expected, model.abstractSection?.content.map({ $0.detachedFromParent.debugDescription() }).joined(separator: "\n"))
         }
 


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://87784021

## Summary

The test `LogHandleTests.testFlushesStandardOutput()` fails when run outside of Xcode because `stdout` is written to by other tests and types. This was breaking the assumption that `stdout` would be empty when it was written to by the test. This PR removes several print statements from the tests that have no effect on the tests, and changes the `CoverageAction` type to write to a provided log handle rather than print directly to `stdout`. 

## Dependencies

None.

## Testing

Steps:
1. Download the latest [5.6 toolchain snapshot from swift.org](https://www.swift.org/download/#swift-56-development-main).
2. Install the toolchain and `cd </path/to/swift-docc>`
3. Run `xcrun --toolchain org.swift.<toolchain ID> swift test` (i.e. `xcrun --toolchain org.swift.56202203021a  swift test`)
    - You can get the [bundle ID of a toolchain on macOS](https://www.swift.org/getting-started/#on-macos) with the command `/usr/libexec/PlistBuddy -c "Print CFBundleIdentifier:" /Library/Developer/Toolchains/<toolchain>/Info.plist`
4. Verify that no test failures are reported. 
5. Verify that the output is formatted as expected when run with the `--experimental-documentation-coverage` flag (i.e. `swift run docc convert --experimental-documentation-coverage --level=brief /path/to/docs.docc`)

## Checklist

- [x] ~Added~ Updated tests
- [x] Ran the `./bin/test` script and it succeeded
-  ~Updated documentation if necessary~
