### PR TITLE
Make ResolvedTopicReference eagerly initialized.

### DIFF
--- a/Sources/SwiftDocC/Model/Identifier.swift
+++ b/Sources/SwiftDocC/Model/Identifier.swift
@@ -396,22 +396,11 @@ public struct ResolvedTopicReference: Hashable, Codable, Equatable, CustomString
         let sourceLanguages: Set<SourceLanguage>
         let identifierPathAndFragment: String
         
-        lazy var url: URL = {
-            var components = URLComponents()
-            components.scheme = ResolvedTopicReference.urlScheme
-            components.host = bundleIdentifier
-            components.path = path
-            components.fragment = fragment
-            return components.url!
-        }()
+        let url: URL
         
-        lazy var pathComponents: [String] = {
-            return url.pathComponents
-        }()
+        let pathComponents: [String]
         
-        lazy var absoluteString: String = {
-            return url.absoluteString
-        }()
+        let absoluteString: String
         
         init(
             bundleIdentifier: String,
@@ -424,6 +413,15 @@ public struct ResolvedTopicReference: Hashable, Codable, Equatable, CustomString
             self.fragment = fragment
             self.sourceLanguages = sourceLanguages
             self.identifierPathAndFragment = "\(bundleIdentifier)\(path)\(fragment ?? "")"
+            
+            var components = URLComponents()
+            components.scheme = ResolvedTopicReference.urlScheme
+            components.host = bundleIdentifier
+            components.path = path
+            components.fragment = fragment
+            self.url = components.url!
+            self.pathComponents = self.url.pathComponents
+            self.absoluteString = self.url.absoluteString
         }
     }
 }

--- a/Tests/SwiftDocCTests/Infrastructure/ResolvedTopicReferenceTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/ResolvedTopicReferenceTests.swift
@@ -61,4 +61,21 @@ class ResolvedTopicReferenceTests: XCTestCase {
             XCTAssertEqual(appended.path, resolvedOriginal.appendingPath("---").path)
         }
     }
+    
+    func testStorageIsConcurrentlyAccessible() throws {
+        let topicReference = ResolvedTopicReference(
+            bundleIdentifier: "com.apple.example",
+            path: "/documentation/path/sub-path",
+            fragment: nil,
+            sourceLanguage: .swift
+        )
+        
+        // TSan should not report a data race for these three accesses.
+        // TODO: Run TSan in Swift-CI (rdar://90157829).
+        DispatchQueue.concurrentPerform(iterations: 5) { _ in
+            _ = topicReference.url
+            _ = topicReference.pathComponents
+            _ = topicReference.absoluteString
+        }
+    }
 }


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://89155442

## Summary

Makes `ResolvedTopicReference.Storage` eagerly initialised. There is a race condition, because `lazy var` is not thread safe.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran the `./bin/test` script and it succeeded
- [X] Updated documentation if necessary