### PR TITLE
Filter topics languages in articles

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/Variants/VariantCollection+Coding.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Variants/VariantCollection+Coding.swift
@@ -39,7 +39,7 @@ extension KeyedEncodingContainer {
         )
     }
     
-    /// Encodes the given variant collection.
+    /// Encodes the given variant collection for its non-empty values.
     mutating func encodeVariantCollectionIfNotEmpty<Value>(
         _ variantCollection: VariantCollection<Value>,
         forKey key: Key,
@@ -47,7 +47,11 @@ extension KeyedEncodingContainer {
     ) throws where Value: Collection {
         try encodeIfNotEmpty(variantCollection.defaultValue, forKey: key)
         
-        variantCollection.addVariantsToEncoder(
+        variantCollection.mapValues { value in
+            // Encode `nil` if the value is empty, so that when the patch is applied, it effectively
+            // removes the default value.
+            value.isEmpty ? nil : value
+        }.addVariantsToEncoder(
             encoder,
             
             // Add the key to the encoder's coding path, since the coding path refers to the value's parent.

--- a/Sources/SwiftDocC/Model/Rendering/Variants/VariantCollection+Variant.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Variants/VariantCollection+Variant.swift
@@ -1,0 +1,42 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+
+public extension VariantCollection {
+    /// A variant for a render node value.
+    struct Variant<Value: Codable> {
+        /// The traits associated with the override.
+        public var traits: [RenderNode.Variant.Trait]
+        
+        /// The patch to apply as part of the override.
+        public var patch: [VariantPatchOperation<Value>]
+        
+        /// Creates an override value for the given traits.
+        ///
+        /// - Parameters:
+        ///   - traits: The traits associated with this override value.
+        ///   - patch: The patch to apply as part of the override.
+        public init(traits: [RenderNode.Variant.Trait], patch: [VariantPatchOperation<Value>]) {
+            self.traits = traits
+            self.patch = patch
+        }
+        
+        /// Returns a new variant collection containing the traits of this variant collection with the values transformed by the given closure.
+        public func mapPatch<TransformedValue>(
+            _ transform: (Value) -> TransformedValue
+        ) -> VariantCollection<TransformedValue>.Variant<TransformedValue> {
+            VariantCollection<TransformedValue>.Variant<TransformedValue>(
+                traits: traits,
+                patch: patch.map { patchOperation in patchOperation.map(transform) }
+            )
+        }
+    }
+}

--- a/Sources/SwiftDocC/Model/Rendering/Variants/VariantCollection.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Variants/VariantCollection.swift
@@ -91,25 +91,16 @@ public struct VariantCollection<Value: Codable>: Codable {
         
         encoder.userInfoVariantOverrides?.add(contentsOf: overrides)
     }
-}
-
-public extension VariantCollection {
-    /// A variant for a render node value.
-    struct Variant<Value: Codable> {
-        /// The traits associated with the override.
-        public var traits: [RenderNode.Variant.Trait]
-        
-        /// The patch to apply as part of the override.
-        public var patch: [VariantPatchOperation<Value>]
-        
-        /// Creates an override value for the given traits.
-        ///
-        /// - Parameters:
-        ///   - traits: The traits associated with this override value.
-        ///   - patch: The patch to apply as part of the override.
-        public init(traits: [RenderNode.Variant.Trait], patch: [VariantPatchOperation<Value>]) {
-            self.traits = traits
-            self.patch = patch
-        }
+    
+    /// Returns a variant collection containing the results of calling the given transformation with each value of this variant collection.
+    public func mapValues<TransformedValue>(
+        _ transform: (Value) -> TransformedValue
+    ) -> VariantCollection<TransformedValue> {
+        VariantCollection<TransformedValue>(
+            defaultValue: transform(defaultValue),
+            variants: variants.map { variant in
+                variant.mapPatch(transform)
+            }
+        )
     }
 }

--- a/Sources/SwiftDocC/Model/Rendering/Variants/VariantPatchOperation.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Variants/VariantPatchOperation.swift
@@ -17,6 +17,9 @@ public enum VariantPatchOperation<Value: Codable> {
     /// - Parameter value: The value to use in the replacement.
     case replace(value: Value)
     
+    /// An addition operation.
+    ///
+    /// - Parameter value: The value to use in the addition.
     case add(value: Value)
     
     /// A removal operation.
@@ -29,6 +32,24 @@ public enum VariantPatchOperation<Value: Codable> {
             return .replace
         case .add(_):
             return .add
+        case .remove:
+            return .remove
+        }
+    }
+    
+    /// Returns a new patch operation with its value transformed using the given closure.
+    ///
+    /// If the patch operation doesn't have a value—for example, if it's a removal operation—the operation is returned unmodified.
+    func map<TransformedValue>(
+        _ transform: (Value) -> TransformedValue
+    ) -> VariantPatchOperation<TransformedValue> {
+        switch self {
+        case .replace(let value):
+            return VariantPatchOperation<TransformedValue>.replace(value: transform(value))
+            
+        case .add(let value):
+            return VariantPatchOperation<TransformedValue>.add(value: transform(value))
+            
         case .remove:
             return .remove
         }

--- a/Sources/SwiftDocC/Semantics/Article/Article.swift
+++ b/Sources/SwiftDocC/Semantics/Article/Article.swift
@@ -75,7 +75,7 @@ public final class Article: Semantic, MarkupConvertible, Abstracted, Redirected,
     private(set) public var abstractSection: AbstractSection?
     
     /// The Topic curation section of the article.
-    private(set) public var topics: TopicsSection?
+    internal(set) public var topics: TopicsSection?
     
     /// The See Also section of the article.
     private(set) public var seeAlso: SeeAlsoSection?

--- a/Tests/SwiftDocCTests/Indexing/RenderIndexTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/RenderIndexTests.swift
@@ -122,6 +122,22 @@ final class RenderIndexTests: XCTestCase {
                         "type": "article"
                       },
                       {
+                        "title": "APICollection",
+                        "path": "/documentation/mixedlanguageframework/apicollection",
+                        "type": "symbol",
+                        "children": [
+                            {
+                              "title": "Objective-C–only APIs",
+                              "type": "groupMarker"
+                            },
+                            {
+                              "title": "_MixedLanguageFrameworkVersionNumber",
+                              "path": "/documentation/mixedlanguageframework/_mixedlanguageframeworkversionnumber",
+                              "type": "var"
+                            }
+                        ]
+                      },
+                      {
                         "title": "Classes",
                         "type": "groupMarker"
                       },
@@ -261,6 +277,33 @@ final class RenderIndexTests: XCTestCase {
                         "title": "Article",
                         "path": "/documentation/mixedlanguageframework/article",
                         "type": "article"
+                      },
+                      {
+                        "path": "/documentation/mixedlanguageframework/apicollection",
+                        "title": "APICollection",
+                        "type": "symbol",
+                        "children": [
+                          {
+                            "title": "Swift-only APIs",
+                            "type": "groupMarker"
+                          },
+                          {
+                            "path": "/documentation/mixedlanguageframework/swiftonlystruct",
+                            "title": "SwiftOnlyStruct",
+                            "type": "struct",
+                            "children": [
+                              {
+                                "title": "Instance Methods",
+                                "type": "groupMarker"
+                              },
+                              {
+                                "title": "func tada()",
+                                "path": "/documentation/mixedlanguageframework/swiftonlystruct/tada()",
+                                "type": "method"
+                              }
+                            ]
+                          }
+                        ]
                       },
                       {
                         "title": "Classes",

--- a/Tests/SwiftDocCTests/Infrastructure/AutomaticCurationTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/AutomaticCurationTests.swift
@@ -379,7 +379,9 @@ class AutomaticCurationTests: XCTestCase {
                 
                 "Structures",
                 "/documentation/MixedLanguageFramework/Foo-swift.struct",
-                "/documentation/MixedLanguageFramework/SwiftOnlyStruct",
+                
+                // SwiftOnlyStruct is manually curated.
+                // "/documentation/MixedLanguageFramework/SwiftOnlyStruct",
             ]
         )
         
@@ -398,7 +400,10 @@ class AutomaticCurationTests: XCTestCase {
                 "/documentation/MixedLanguageFramework/Bar",
                 
                 "Variables",
-                "/documentation/MixedLanguageFramework/_MixedLanguageFrameworkVersionNumber",
+                
+                // _MixedLanguageFrameworkVersionNumber is manually curated.
+                // "/documentation/MixedLanguageFramework/_MixedLanguageFrameworkVersionNumber",
+                
                 "/documentation/MixedLanguageFramework/_MixedLanguageFrameworkVersionString",
                 
                 // 'MixedLanguageFramework/Foo-occ.typealias' is manually curated in a task group titled "Custom" under 'MixedLanguageFramework/Bar/myStringFunction:error:'

--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeMultiLanguageTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeMultiLanguageTests.swift
@@ -468,6 +468,10 @@ class SemaToRenderNodeMixedLanguageTests: ExperimentalObjectiveCTestCase {
             topicSectionIdentifiers: [
                 "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/SwiftOnlyStruct"
             ],
+            seeAlsoSectionIdentifiers: [
+                "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/SwiftOnlyStruct",
+                "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/Article",
+            ],
             referenceTitles: [
                 "Article",
                 "MixedLanguageFramework",
@@ -495,6 +499,9 @@ class SemaToRenderNodeMixedLanguageTests: ExperimentalObjectiveCTestCase {
             topicSectionIdentifiers: [
                 "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/_MixedLanguageFrameworkVersionNumber"
             ],
+            seeAlsoSectionIdentifiers: [
+                "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/Article",
+            ],
             referenceTitles: [
                 "Article",
                 "MixedLanguageFramework",
@@ -520,6 +527,7 @@ class SemaToRenderNodeMixedLanguageTests: ExperimentalObjectiveCTestCase {
         declarationTokens expectedDeclarationTokens: [String]?,
         discussionSection expectedDiscussionSection: [String]?,
         topicSectionIdentifiers expectedTopicSectionIdentifiers: [String],
+        seeAlsoSectionIdentifiers expectedSeeAlsoSectionIdentifiers: [String]? = nil,
         referenceTitles expectedReferenceTitles: [String],
         referenceFragments expectedReferenceFragments: [String],
         failureMessage failureMessageForField: (_ field: String) -> String,
@@ -592,6 +600,16 @@ class SemaToRenderNodeMixedLanguageTests: ExperimentalObjectiveCTestCase {
             file: file,
             line: line
         )
+        
+        if let expectedSeeAlsoSectionIdentifiers = expectedSeeAlsoSectionIdentifiers {
+            XCTAssertEqual(
+                renderNode.seeAlsoSections.flatMap(\.identifiers),
+                expectedSeeAlsoSectionIdentifiers,
+                failureMessageForField("see also sections identifiers"),
+                file: file,
+                line: line
+            )
+        }
         
         XCTAssertEqual(
             renderNode.references.map(\.value).compactMap { reference in

--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeMultiLanguageTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeMultiLanguageTests.swift
@@ -125,6 +125,7 @@ class SemaToRenderNodeMixedLanguageTests: ExperimentalObjectiveCTestCase {
                 "c:objc(cs)Bar",
                 "c:objc(cs)Bar(cm)myStringFunction:error:",
                 "Article",
+                "APICollection",
                 "MixedLanguageFramework Tutorials",
                 "Tutorial Article",
                 "Tutorial",
@@ -153,10 +154,12 @@ class SemaToRenderNodeMixedLanguageTests: ExperimentalObjectiveCTestCase {
                 "doc://org.swift.MixedLanguageFramework/tutorials/MixedLanguageFramework/TutorialArticle",
                 "doc://org.swift.MixedLanguageFramework/tutorials/MixedLanguageFramework/Tutorial",
                 "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/Article",
+                "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/APICollection",
                 "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/Bar",
                 "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/Foo-swift.struct",
             ],
             referenceTitles: [
+                "APICollection",
                 "Article",
                 "Bar",
                 "Foo",
@@ -197,11 +200,13 @@ class SemaToRenderNodeMixedLanguageTests: ExperimentalObjectiveCTestCase {
                 "doc://org.swift.MixedLanguageFramework/tutorials/MixedLanguageFramework/TutorialArticle",
                 "doc://org.swift.MixedLanguageFramework/tutorials/MixedLanguageFramework/Tutorial",
                 "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/Article",
+                "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/APICollection",
                 "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/Bar",
                 "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/_MixedLanguageFrameworkVersionString",
                 "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/Foo-swift.struct",
             ],
             referenceTitles: [
+                "APICollection",
                 "Article",
                 "Bar",
                 "Foo",
@@ -440,7 +445,67 @@ class SemaToRenderNodeMixedLanguageTests: ExperimentalObjectiveCTestCase {
                 "typedef enum Foo : NSString {\n    ...\n} Foo;",
             ],
             failureMessage: { fieldName in
-                "Swift variant of 'MyArticle' article has unexpected content for '\(fieldName)'."
+                "Objective-C variant of 'MyArticle' article has unexpected content for '\(fieldName)'."
+            }
+        )
+    }
+    
+    func testAPICollectionInMixedLanguageFramework() throws {
+        enableFeatureFlag(\.isExperimentalObjectiveCSupportEnabled)
+        
+        let outputConsumer = try mixedLanguageFrameworkConsumer()
+        
+        let articleRenderNode = try outputConsumer.renderNode(withTitle: "APICollection")
+        
+        assertExpectedContent(
+            articleRenderNode,
+            sourceLanguage: "swift",
+            title: "APICollection",
+            navigatorTitle: nil,
+            abstract: "This is an API collection.",
+            declarationTokens: nil,
+            discussionSection: nil,
+            topicSectionIdentifiers: [
+                "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/SwiftOnlyStruct"
+            ],
+            referenceTitles: [
+                "Article",
+                "MixedLanguageFramework",
+                "SwiftOnlyStruct",
+                "_MixedLanguageFrameworkVersionNumber",
+            ],
+            referenceFragments: [
+                "struct SwiftOnlyStruct",
+            ],
+            failureMessage: { fieldName in
+                "Swift variant of 'APICollection' article has unexpected content for '\(fieldName)'."
+            }
+        )
+        
+        let objectiveCVariantNode = try renderNodeApplyingObjectiveCVariantOverrides(to: articleRenderNode)
+        
+        assertExpectedContent(
+            objectiveCVariantNode,
+            sourceLanguage: "occ",
+            title: "APICollection",
+            navigatorTitle: nil,
+            abstract: "This is an API collection.",
+            declarationTokens: nil,
+            discussionSection: nil,
+            topicSectionIdentifiers: [
+                "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/_MixedLanguageFrameworkVersionNumber"
+            ],
+            referenceTitles: [
+                "Article",
+                "MixedLanguageFramework",
+                "SwiftOnlyStruct",
+                "_MixedLanguageFrameworkVersionNumber",
+            ],
+            referenceFragments: [
+                "struct SwiftOnlyStruct",
+            ],
+            failureMessage: { fieldName in
+                "Objective-C variant of 'MyArticle' article has unexpected content for '\(fieldName)'."
             }
         )
     }

--- a/Tests/SwiftDocCTests/Rendering/Variants/VariantCollection+VariantTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/Variants/VariantCollection+VariantTests.swift
@@ -1,0 +1,44 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+import XCTest
+@testable import SwiftDocC
+
+class VariantCollection_VariantTests: XCTestCase {
+    let testVariant = VariantCollection<String>.Variant<String>(
+        traits: [.interfaceLanguage("a")],
+        patch: [
+            .replace(value: "replace"),
+            .add(value: "add"),
+            .remove,
+        ]
+    )
+    
+    func testMapPatch() throws {
+        XCTAssertEqual(
+            testVariant.mapPatch { "\($0) transformed" }.patch.map(\.value),
+            ["replace transformed", "add transformed", nil]
+        )
+    }
+}
+
+private extension VariantPatchOperation {
+    var value: Value? {
+        switch self {
+        case let .replace(value):
+            return value
+        case let .add(value):
+            return value
+        case .remove:
+            return nil
+        }
+    }
+}

--- a/Tests/SwiftDocCTests/Rendering/Variants/VariantCollectionTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/Variants/VariantCollectionTests.swift
@@ -74,4 +74,23 @@ class VariantCollectionTests: XCTestCase {
             XCTAssertEqual(value.value as! String, expectedValue)
         }
     }
+    
+    func testMapValues() {
+        let testCollection = testCollection.mapValues { value -> String? in
+            if value == "default value" {
+               return "default value transformed"
+            }
+            
+            return nil
+        }
+        
+        XCTAssertEqual(testCollection.defaultValue, "default value transformed")
+        
+        guard case .replace(let value)? = testCollection.variants.first?.patch.first else {
+            XCTFail()
+            return
+        }
+        
+        XCTAssertNil(value)
+    }
 }

--- a/Tests/SwiftDocCTests/Rendering/Variants/VariantPatchOperationTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/Variants/VariantPatchOperationTests.swift
@@ -66,4 +66,29 @@ class VariantPatchOperationTests: XCTestCase {
             XCTAssertEqual(stringVariant.applyingPatchTo("A"), expectedValue)
         }
     }
+    
+    func testMap() throws {
+        let transform: (String) -> String = { "\($0) transformed" }
+        let replace = VariantPatchOperation<String>.replace(value: "replace")
+        guard case .replace(let value) = replace.map(transform) else {
+            XCTFail("Expected replace operation")
+            return
+        }
+        
+        XCTAssertEqual(value, "replace transformed")
+        
+        let add = VariantPatchOperation<String>.add(value: "add")
+        guard case .add(let value) = add.map(transform) else {
+            XCTFail("Expected add operation")
+            return
+        }
+        
+        XCTAssertEqual(value, "add transformed")
+        
+        let remove = VariantPatchOperation<String>.remove.map(transform)
+        guard case .remove = remove else {
+            XCTFail("Expected remove operation")
+            return
+        }
+    }
 }

--- a/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFramework.docc/APICollection.md
+++ b/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFramework.docc/APICollection.md
@@ -1,0 +1,15 @@
+# APICollection
+
+This is an API collection.
+
+## Topics
+
+### Swift-only APIs
+
+- ``SwiftOnlyStruct``
+
+### Objective-C–only APIs
+
+- <doc:_MixedLanguageFrameworkVersionNumber>
+
+<!-- Copyright (c) 2022 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFramework.docc/APICollection.md
+++ b/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFramework.docc/APICollection.md
@@ -12,4 +12,8 @@ This is an API collection.
 
 - <doc:_MixedLanguageFrameworkVersionNumber>
 
+## See Also
+
+- ``SwiftOnlyStruct``
+
 <!-- Copyright (c) 2022 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFramework.docc/MixedLanguageFramework.md
+++ b/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFramework.docc/MixedLanguageFramework.md
@@ -21,5 +21,6 @@ This framework is available to both Swift and Objective-C clients.
 ### Articles
 
 - <doc:Article>
+- <doc:APICollection>
 
 <!-- Copyright (c) 2022 Apple Inc and the Swift Project authors. All Rights Reserved. -->


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://90159299

## Summary

As a follow-up to #96, fixes an issue where variants of multi-language articles display APIs that are not available in the language variant. This fix makes DocC only display the APIs available in the language of the currently-selected language. For example, this fix makes DocC omit a Swift-only API from the Objective-C variant of an article that curates it.

I've broken up the changes in three commits:
1. The first commit adds `map` APIs to the `VariantCollection` family of types, to make it easier to update values in variant collections. This functionality is required for the next commit.
2. The actual fix which encodes topics sections on a per-variant basis, and fixes an issue where non-default variants of empty topic sections are encoded as `[]` instead of not at all.
3. Resolves the same issue, but for manually curated See Also sections.

Note: I noticed that automatically curated See Also sections for both articles and symbols don't get the filtering treatment. I will fix this in a follow-up PR.

## Dependencies

None.

## Testing

When building documentation for an article that curates symbols, verify that the render JSON topics and sections for each language variant only contain APIs that are available in that language. Also, verify the same behavior for automatically curated See Also sections.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
