### PR TITLE
Filter topics languages for automatically-curated See Alsos

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -661,15 +661,18 @@ public struct RenderNodeTranslator: SemanticVisitor {
                 // Automatic groups are named after the child's kind, e.g.
                 // "Methods", "Variables", etc.
                 let alreadyCurated = Set(node.topicSections.flatMap { $0.identifiers })
-                let groups = try! AutomaticCuration.topics(for: documentationNode, withTrait: nil, context: context)
-                    .compactMap({ group -> AutomaticCuration.TaskGroup? in
-                        // Remove references that have been already curated.
-                        let newReferences = group.references.filter { !alreadyCurated.contains($0.absoluteString) }
-                        // Remove groups that have no uncurated references
-                        guard !newReferences.isEmpty else { return nil }
-                        
-                        return (title: group.title, references: newReferences)
-                    })
+                let groups = try! AutomaticCuration.topics(
+                    for: documentationNode,
+                    withTrait: trait,
+                    context: context
+                ).compactMap { group -> AutomaticCuration.TaskGroup? in
+                    // Remove references that have been already curated.
+                    let newReferences = group.references.filter { !alreadyCurated.contains($0.absoluteString) }
+                    // Remove groups that have no uncurated references
+                    guard !newReferences.isEmpty else { return nil }
+                    
+                    return (title: group.title, references: newReferences)
+                }
                 
                 // Collect all child topic references.
                 contentCompiler.collectedTopicReferences.append(contentsOf: groups.flatMap(\.references))
@@ -719,6 +722,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
             // Automatic See Also section
             if let seeAlso = try! AutomaticCuration.seeAlso(
                 for: documentationNode,
+                withTrait: trait,
                 context: context,
                 bundle: bundle,
                 renderContext: renderContext,
@@ -1309,6 +1313,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
             // Curate the current node's siblings as further See Also groups.
             if let seeAlso = try! AutomaticCuration.seeAlso(
                 for: documentationNode,
+                withTrait: trait,
                 context: context,
                 bundle: bundle,
                 renderContext: renderContext,

--- a/Tests/SwiftDocCTests/Indexing/RenderIndexTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/RenderIndexTests.swift
@@ -78,6 +78,47 @@ final class RenderIndexTests: XCTestCase {
                         "type": "var"
                       },
                       {
+                        "title": "Some Swift-only APIs, some Objective-C–only APIs, some mixed",
+                        "type": "groupMarker"
+                      },
+                      {
+                        "path": "\/documentation\/mixedlanguageframework\/_mixedlanguageframeworkversionstring",
+                        "title": "_MixedLanguageFrameworkVersionString",
+                        "type": "var"
+                      },
+                      {
+                        "path": "/documentation/mixedlanguageframework/bar",
+                        "title": "Bar",
+                        "type": "class",
+                        "children": [
+                          {
+                            "title": "Type Methods",
+                            "type": "groupMarker"
+                          },
+                          {
+                            "path": "/documentation/mixedlanguageframework/bar/mystringfunction(_:)",
+                            "title": "myStringFunction:error: (navigator title)",
+                            "type": "method",
+                            "children": [
+                              {
+                                "title": "Custom",
+                                "type": "groupMarker"
+                              },
+                              {
+                                "title": "Foo",
+                                "path": "/documentation/mixedlanguageframework/foo-occ.typealias",
+                                "type": "typealias"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "title": "Article",
+                        "path": "/documentation/mixedlanguageframework/article",
+                        "type": "article"
+                      },
+                      {
                         "title": "Tutorials",
                         "type": "groupMarker"
                       },
@@ -142,33 +183,6 @@ final class RenderIndexTests: XCTestCase {
                         "type": "groupMarker"
                       },
                       {
-                        "children": [
-                          {
-                            "title": "Type Methods",
-                            "type": "groupMarker"
-                          },
-                          {
-                            "children": [
-                              {
-                                "title": "Custom",
-                                "type": "groupMarker"
-                              },
-                              {
-                                "path": "\/documentation\/mixedlanguageframework\/foo-occ.typealias",
-                                "title": "Foo",
-                                "type": "typealias"
-                              }
-                            ],
-                            "path": "\/documentation\/mixedlanguageframework\/bar\/mystringfunction(_:)",
-                            "title": "myStringFunction:error: (navigator title)",
-                            "type": "method"
-                          }
-                        ],
-                        "path": "\/documentation\/mixedlanguageframework\/bar",
-                        "title": "Bar",
-                        "type": "class"
-                      },
-                      {
                         "path": "/documentation/mixedlanguageframework/mixedlanguageclassconformingtoprotocol",
                         "title": "MixedLanguageClassConformingToProtocol",
                         "type": "class",
@@ -223,15 +237,6 @@ final class RenderIndexTests: XCTestCase {
                             "type": "method"
                           }
                         ]
-                      },
-                      {
-                        "title": "Variables",
-                        "type": "groupMarker"
-                      },
-                      {
-                        "path": "\/documentation\/mixedlanguageframework\/_mixedlanguageframeworkversionstring",
-                        "title": "_MixedLanguageFrameworkVersionString",
-                        "type": "var"
                       },
                       {
                         "title": "Enumerations",
@@ -289,6 +294,36 @@ final class RenderIndexTests: XCTestCase {
                         "path": "\/documentation\/mixedlanguageframework\/swiftonlystruct",
                         "title": "SwiftOnlyStruct",
                         "type": "struct"
+                      },
+                      {
+                        "title": "Some Swift-only APIs, some Objective-C–only APIs, some mixed",
+                        "type": "groupMarker"
+                      },
+                      {
+                        "title": "SwiftOnlyClass",
+                        "path": "/documentation/mixedlanguageframework/swiftonlyclass",
+                        "type": "class"
+                      },
+                      {
+                        "path": "/documentation/mixedlanguageframework/bar",
+                        "title": "Bar",
+                        "type": "class",
+                        "children": [
+                          {
+                            "title": "Type Methods",
+                            "type": "groupMarker"
+                          },
+                          {
+                            "title": "class func myStringFunction(String) throws -> String",
+                            "path": "/documentation/mixedlanguageframework/bar/mystringfunction(_:)",
+                            "type": "method"
+                          }
+                        ]
+                      },
+                      {
+                        "title": "Article",
+                        "path": "/documentation/mixedlanguageframework/article",
+                        "type": "article"
                       },
                       {
                         "title": "Tutorials",
@@ -364,22 +399,6 @@ final class RenderIndexTests: XCTestCase {
                       {
                         "title": "Classes",
                         "type": "groupMarker"
-                      },
-                      {
-                        "children": [
-                          {
-                            "title": "Type Methods",
-                            "type": "groupMarker"
-                          },
-                          {
-                            "path": "\/documentation\/mixedlanguageframework\/bar\/mystringfunction(_:)",
-                            "title": "class func myStringFunction(String) throws -> String",
-                            "type": "method"
-                          }
-                        ],
-                        "path": "\/documentation\/mixedlanguageframework\/bar",
-                        "title": "Bar",
-                        "type": "class"
                       },
                       {
                         "path": "/documentation/mixedlanguageframework/mixedlanguageclassconformingtoprotocol",

--- a/Tests/SwiftDocCTests/Infrastructure/AutomaticCurationTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/AutomaticCurationTests.swift
@@ -377,14 +377,15 @@ class AutomaticCurationTests: XCTestCase {
                 "Classes",
                 "/documentation/MixedLanguageFramework/Bar",
                 "/documentation/MixedLanguageFramework/MixedLanguageClassConformingToProtocol",
-                
+                "/documentation/MixedLanguageFramework/SwiftOnlyClass",
+
                 "Protocols",
                 "/documentation/MixedLanguageFramework/MixedLanguageProtocol",
                 
                 "Structures",
                 "/documentation/MixedLanguageFramework/Foo-swift.struct",
                 
-                // SwiftOnlyStruct is manually curated.
+                // SwiftOnlyStruct is manually curated in APICollection.md.
                 // "/documentation/MixedLanguageFramework/SwiftOnlyStruct",
             ]
         )
@@ -409,7 +410,7 @@ class AutomaticCurationTests: XCTestCase {
                 
                 "Variables",
                 
-                // _MixedLanguageFrameworkVersionNumber is manually curated.
+                // _MixedLanguageFrameworkVersionNumber is manually curated in APICollection.md.
                 // "/documentation/MixedLanguageFramework/_MixedLanguageFrameworkVersionNumber",
                 
                 "/documentation/MixedLanguageFramework/_MixedLanguageFrameworkVersionString",

--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeMultiLanguageTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeMultiLanguageTests.swift
@@ -24,6 +24,9 @@ class SemaToRenderNodeMixedLanguageTests: ExperimentalObjectiveCTestCase {
                 // Swift-only struct - ``SwiftOnlyStruct``:
                 "s:22MixedLanguageFramework15SwiftOnlyStructV",
                 
+                // Swift-only class - ``SwiftOnlyClass``:
+                "s:22MixedLanguageFramework15SwiftOnlyClassV",
+                
                 // Member of Swift-only struct - ``SwiftOnlyStruct/tada()``:
                 "s:22MixedLanguageFramework15SwiftOnlyStructV4tadayyF",
                 
@@ -85,6 +88,9 @@ class SemaToRenderNodeMixedLanguageTests: ExperimentalObjectiveCTestCase {
             [
                 // Swift-only struct - ``SwiftOnlyStruct``:
                 "s:22MixedLanguageFramework15SwiftOnlyStructV",
+                
+                // Swift-only class - ``SwiftOnlyClass``:
+                "s:22MixedLanguageFramework15SwiftOnlyClassV",
                 
                 // Member of Swift-only struct - ``SwiftOnlyStruct/tada()``:
                 "s:22MixedLanguageFramework15SwiftOnlyStructV4tadayyF",
@@ -158,12 +164,14 @@ class SemaToRenderNodeMixedLanguageTests: ExperimentalObjectiveCTestCase {
             discussionSection: nil,
             topicSectionIdentifiers: [
                 "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/SwiftOnlyStruct",
+                "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/SwiftOnlyClass",
+                "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/Bar",
+                "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/Article",
                 "doc://org.swift.MixedLanguageFramework/tutorials/TutorialOverview",
                 "doc://org.swift.MixedLanguageFramework/tutorials/MixedLanguageFramework/TutorialArticle",
                 "doc://org.swift.MixedLanguageFramework/tutorials/MixedLanguageFramework/Tutorial",
                 "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/Article",
                 "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/APICollection",
-                "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/Bar",
                 "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/MixedLanguageClassConformingToProtocol",
                 "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/MixedLanguageProtocol",
                 "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/Foo-swift.struct",
@@ -177,6 +185,7 @@ class SemaToRenderNodeMixedLanguageTests: ExperimentalObjectiveCTestCase {
                 "MixedLanguageFramework",
                 "MixedLanguageFramework Tutorials",
                 "MixedLanguageProtocol",
+                "SwiftOnlyClass",
                 "SwiftOnlyStruct",
                 "Tutorial",
                 "Tutorial Article",
@@ -186,6 +195,7 @@ class SemaToRenderNodeMixedLanguageTests: ExperimentalObjectiveCTestCase {
             referenceFragments: [
                 "class Bar",
                 "class MixedLanguageClassConformingToProtocol",
+                "class SwiftOnlyClass",
                 "protocol MixedLanguageProtocol",
                 "struct Foo",
                 "struct SwiftOnlyStruct",
@@ -210,15 +220,16 @@ class SemaToRenderNodeMixedLanguageTests: ExperimentalObjectiveCTestCase {
             discussionSection: nil,
             topicSectionIdentifiers: [
                 "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/_MixedLanguageFrameworkVersionNumber",
+                "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/_MixedLanguageFrameworkVersionString",
+                "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/Bar",
+                "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/Article",
                 "doc://org.swift.MixedLanguageFramework/tutorials/TutorialOverview",
                 "doc://org.swift.MixedLanguageFramework/tutorials/MixedLanguageFramework/TutorialArticle",
                 "doc://org.swift.MixedLanguageFramework/tutorials/MixedLanguageFramework/Tutorial",
                 "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/Article",
                 "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/APICollection",
-                "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/Bar",
                 "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/MixedLanguageClassConformingToProtocol",
                 "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/MixedLanguageProtocol",
-                "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/_MixedLanguageFrameworkVersionString",
                 "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/Foo-swift.struct",
             ],
             referenceTitles: [
@@ -230,6 +241,7 @@ class SemaToRenderNodeMixedLanguageTests: ExperimentalObjectiveCTestCase {
                 "MixedLanguageFramework",
                 "MixedLanguageFramework Tutorials",
                 "MixedLanguageProtocol",
+                "SwiftOnlyClass",
                 "SwiftOnlyStruct",
                 "Tutorial",
                 "Tutorial Article",
@@ -240,6 +252,7 @@ class SemaToRenderNodeMixedLanguageTests: ExperimentalObjectiveCTestCase {
                 "@interface Bar : NSObject",
                 "MixedLanguageClassConformingToProtocol",
                 "MixedLanguageProtocol",
+                "class SwiftOnlyClass",
                 "struct Foo",
                 "struct SwiftOnlyStruct",
             ],
@@ -597,6 +610,76 @@ class SemaToRenderNodeMixedLanguageTests: ExperimentalObjectiveCTestCase {
             [
                 "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/MixedLanguageClassConformingToProtocol/init()",
                 // Not the "MixedLanguageProtocol Implementations" page, because it only contains Swift-only symbols.
+            ]
+        )
+    }
+
+    func testAutomaticSeeAlsoOnlyShowsAPIsAvailableInParentsLanguageForSymbol() throws {
+        let outputConsumer = try mixedLanguageFrameworkConsumer()
+        
+        // Swift-only symbol.
+        XCTAssertEqual(
+            try outputConsumer.renderNode(withTitle: "SwiftOnlyClass")
+                .seeAlsoSections
+                .flatMap(\.identifiers),
+            [
+                "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/Bar",
+                "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/Article",
+            ]
+        )
+        
+        // Objective-C–only symbol.
+        XCTAssertEqual(
+            try outputConsumer.renderNode(withTitle: "_MixedLanguageFrameworkVersionString")
+                .seeAlsoSections
+                .flatMap(\.identifiers),
+            [
+                "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/Bar",
+                "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/Article",
+            ]
+        )
+        
+        // Swift variant of mixed-language symbol.
+        XCTAssertEqual(
+            try outputConsumer.renderNode(withTitle: "Bar")
+                .seeAlsoSections
+                .flatMap(\.identifiers),
+            [
+                "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/SwiftOnlyClass",
+                "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/Article",
+            ]
+        )
+        
+        // Objective-C variant of mixed-language symbol.
+        XCTAssertEqual(
+            try renderNodeApplyingObjectiveCVariantOverrides(to: outputConsumer.renderNode(withTitle: "Bar"))
+                .seeAlsoSections
+                .flatMap(\.identifiers),
+            [
+                "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/_MixedLanguageFrameworkVersionString",
+                "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/Article",
+            ]
+        )
+        
+        // Swift variant of mixed-language article.
+        XCTAssertEqual(
+            try outputConsumer.renderNode(withTitle: "Article")
+                .seeAlsoSections
+                .flatMap(\.identifiers),
+            [
+                "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/SwiftOnlyClass",
+                "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/Bar",
+            ]
+        )
+        
+        // Objective-C variant of mixed-language article.
+        XCTAssertEqual(
+            try renderNodeApplyingObjectiveCVariantOverrides(to: outputConsumer.renderNode(withTitle: "Article"))
+                .seeAlsoSections
+                .flatMap(\.identifiers),
+            [
+                "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/_MixedLanguageFrameworkVersionString",
+                "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/Bar",
             ]
         )
     }

--- a/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFramework.docc/MixedLanguageFramework.md
+++ b/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFramework.docc/MixedLanguageFramework.md
@@ -12,6 +12,13 @@ This framework is available to both Swift and Objective-C clients.
 
 - <doc:_MixedLanguageFrameworkVersionNumber>
 
+### Some Swift-only APIs, some Objective-C–only APIs, some mixed
+
+- ``SwiftOnlyClass``
+- <doc:_MixedLanguageFrameworkVersionString>
+- ``Bar``
+- <doc:Article>
+
 ### Tutorials
 
 - <doc:TutorialOverview>

--- a/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFramework.docc/symbol-graphs/swift/MixedLanguageFramework.symbols.json
+++ b/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFramework.docc/symbol-graphs/swift/MixedLanguageFramework.symbols.json
@@ -366,6 +366,81 @@
         },
         {
             "kind": {
+                "identifier": "swift.class",
+                "displayName": "Class"
+            },
+            "identifier": {
+                "precise": "s:22MixedLanguageFramework15SwiftOnlyClassV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "SwiftOnlyClass"
+            ],
+            "names": {
+                "title": "SwiftOnlyClass",
+                "navigator": [
+                    {
+                        "kind": "identifier",
+                        "spelling": "SwiftOnlyClass"
+                    }
+                ],
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "class"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "SwiftOnlyClass"
+                    }
+                ]
+            },
+            "docComment": {
+                "lines": [
+                    {
+                        "range": {
+                            "start": {
+                                "line": 20,
+                                "character": 4
+                            },
+                            "end": {
+                                "line": 20,
+                                "character": 51
+                            }
+                        },
+                        "text": "This is a class that is only exposed to Swift."
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "class"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "SwiftOnlyClass"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file://path/to/MixedLanguageFramework/MixedLanguageFramework/SwiftFile.swift",
+                "position": {
+                    "line": 20,
+                    "character": 14
+                }
+            }
+        },
+        {
+            "kind": {
                 "identifier": "swift.method",
                 "displayName": "Instance Method"
             },


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://90168171

## Summary

As a follow-up to #103, filters out topics in automatically-generated See Also sections that are not available in the parent's current language.

## Dependencies

None.

## Testing

Build documentation for a mixed-language framework and verify that automatically-generated See Also sections only contain topics that are available in the current language of the parent page.

## Checklist

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
