### PR TITLE
Make generated collections multi-language

### DIFF
--- a/Tests/SwiftDocCTests/Indexing/RenderIndexTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/RenderIndexTests.swift
@@ -169,6 +169,62 @@ final class RenderIndexTests: XCTestCase {
                         "type": "class"
                       },
                       {
+                        "path": "/documentation/mixedlanguageframework/mixedlanguageclassconformingtoprotocol",
+                        "title": "MixedLanguageClassConformingToProtocol",
+                        "type": "class",
+                        "children": [
+                          {
+                            "title": "Instance Methods",
+                            "type": "groupMarker"
+                          },
+                          {
+                            "title": "init",
+                            "path": "/documentation/mixedlanguageframework/mixedlanguageclassconformingtoprotocol/init()",
+                            "type": "method"
+                          },
+                          {
+                            "title": "Default Implementations",
+                            "type": "groupMarker"
+                          },
+                          {
+                            "path": "/documentation/mixedlanguageframework/mixedlanguageclassconformingtoprotocol/mixedlanguageprotocol-implementations",
+                            "title": "MixedLanguageProtocol Implementations",
+                            "type": "symbol",
+                            "children": [
+                              {
+                                "title": "Instance Methods",
+                                "type": "groupMarker"
+                              },
+                              {
+                                "title": "mixedLanguageMethod",
+                                "path": "/documentation/mixedlanguageframework/mixedlanguageclassconformingtoprotocol/mixedlanguagemethod()",
+                                "type": "method"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "title": "Protocols",
+                        "type": "groupMarker"
+                      },
+                      {
+                        "path": "/documentation/mixedlanguageframework/mixedlanguageprotocol",
+                        "title": "MixedLanguageProtocol",
+                        "type": "protocol",
+                        "children": [
+                          {
+                            "title": "Instance Methods",
+                            "type": "groupMarker"
+                          },
+                          {
+                            "title": "mixedLanguageMethod",
+                            "path": "/documentation/mixedlanguageframework/mixedlanguageprotocol/mixedlanguagemethod()",
+                            "type": "method"
+                          }
+                        ]
+                      },
+                      {
                         "title": "Variables",
                         "type": "groupMarker"
                       },
@@ -324,6 +380,62 @@ final class RenderIndexTests: XCTestCase {
                         "path": "\/documentation\/mixedlanguageframework\/bar",
                         "title": "Bar",
                         "type": "class"
+                      },
+                      {
+                        "path": "/documentation/mixedlanguageframework/mixedlanguageclassconformingtoprotocol",
+                        "title": "MixedLanguageClassConformingToProtocol",
+                        "type": "class",
+                        "children": [
+                          {
+                            "title": "Initializers",
+                            "type": "groupMarker"
+                          },
+                          {
+                            "title": "init()",
+                            "path": "/documentation/mixedlanguageframework/mixedlanguageclassconformingtoprotocol/init()",
+                            "type": "init"
+                          },
+                          {
+                            "title": "Default Implementations",
+                            "type": "groupMarker"
+                          },
+                          {
+                            "path": "/documentation/mixedlanguageframework/mixedlanguageclassconformingtoprotocol/mixedlanguageprotocol-implementations",
+                            "title": "MixedLanguageProtocol Implementations",
+                            "type": "symbol",
+                            "children": [
+                              {
+                                "title": "Instance Methods",
+                                "type": "groupMarker"
+                              },
+                              {
+                                "title": "func mixedLanguageMethod()",
+                                "path": "/documentation/mixedlanguageframework/mixedlanguageclassconformingtoprotocol/mixedlanguagemethod()",
+                                "type": "method"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "title": "Protocols",
+                        "type": "groupMarker"
+                      },
+                      {
+                        "path": "/documentation/mixedlanguageframework/mixedlanguageprotocol",
+                        "title": "MixedLanguageProtocol",
+                        "type": "protocol",
+                        "children": [
+                          {
+                            "title": "Instance Methods",
+                            "type": "groupMarker"
+                          },
+                          {
+                            "title": "func mixedLanguageMethod()",
+                            "path": "/documentation/mixedlanguageframework/mixedlanguageprotocol/mixedlanguagemethod()",
+                            "type": "method"
+                          }
+                        ]
                       },
                       {
                         "title": "Structures",

--- a/Tests/SwiftDocCTests/Infrastructure/AutomaticCurationTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/AutomaticCurationTests.swift
@@ -376,6 +376,10 @@ class AutomaticCurationTests: XCTestCase {
             [
                 "Classes",
                 "/documentation/MixedLanguageFramework/Bar",
+                "/documentation/MixedLanguageFramework/MixedLanguageClassConformingToProtocol",
+                
+                "Protocols",
+                "/documentation/MixedLanguageFramework/MixedLanguageProtocol",
                 
                 "Structures",
                 "/documentation/MixedLanguageFramework/Foo-swift.struct",
@@ -398,6 +402,10 @@ class AutomaticCurationTests: XCTestCase {
             [
                 "Classes",
                 "/documentation/MixedLanguageFramework/Bar",
+                "/documentation/MixedLanguageFramework/MixedLanguageClassConformingToProtocol",
+                
+                "Protocols",
+                "/documentation/MixedLanguageFramework/MixedLanguageProtocol",
                 
                 "Variables",
                 

--- a/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFramework.docc/symbol-graphs/clang/MixedLanguageFramework.symbols.json
+++ b/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFramework.docc/symbol-graphs/clang/MixedLanguageFramework.symbols.json
@@ -111,13 +111,6 @@
         "displayName" : "Class",
         "identifier" : "class"
       },
-      "location" : {
-        "position" : {
-          "character" : 11,
-          "line" : 31
-        },
-        "uri" : "MixedLanguageFramework.h"
-      },
       "names" : {
         "title" : "Bar",
         "subHeading" : [
@@ -341,13 +334,6 @@
         "displayName" : "Class Method",
         "identifier" : "type.method"
       },
-      "location" : {
-        "position" : {
-          "character" : 0,
-          "line" : 37
-        },
-        "uri" : "MixedLanguageFramework.h"
-      },
       "names" : {
         "title" : "myStringFunction:error:",
         "navigator" : [
@@ -458,13 +444,6 @@
         "displayName" : "Enumeration",
         "identifier" : "enum"
       },
-      "location" : {
-        "position" : {
-          "character" : 8,
-          "line" : 18
-        },
-        "uri" : "MixedLanguageFramework.h"
-      },
       "names" : {
         "title" : "Foo"
       },
@@ -537,13 +516,6 @@
       "kind" : {
         "displayName" : "Typedef",
         "identifier" : "typealias"
-      },
-      "location" : {
-        "position" : {
-          "character" : 8,
-          "line" : 18
-        },
-        "uri" : "MixedLanguageFramework.h"
       },
       "names" : {
         "title" : "Foo",
@@ -628,13 +600,6 @@
         "displayName" : "Case",
         "identifier" : "enum.case"
       },
-      "location" : {
-        "position" : {
-          "character" : 4,
-          "line" : 21
-        },
-        "uri" : "MixedLanguageFramework.h"
-      },
       "names" : {
         "title" : "first",
         "navigator" : [
@@ -681,13 +646,6 @@
       "kind" : {
         "displayName" : "Case",
         "identifier" : "enum.case"
-      },
-      "location" : {
-        "position" : {
-          "character" : 4,
-          "line" : 27
-        },
-        "uri" : "MixedLanguageFramework.h"
       },
       "names" : {
         "title" : "fourth",
@@ -736,13 +694,6 @@
         "displayName" : "Case",
         "identifier" : "enum.case"
       },
-      "location" : {
-        "position" : {
-          "character" : 4,
-          "line" : 23
-        },
-        "uri" : "MixedLanguageFramework.h"
-      },
       "names" : {
         "title" : "second",
         "navigator" : [
@@ -789,13 +740,6 @@
       "kind" : {
         "displayName" : "Case",
         "identifier" : "enum.case"
-      },
-      "location" : {
-        "position" : {
-          "character" : 4,
-          "line" : 25
-        },
-        "uri" : "MixedLanguageFramework.h"
       },
       "names" : {
         "title" : "third",
@@ -844,13 +788,6 @@
         "displayName" : "Global Variable",
         "identifier" : "var"
       },
-      "location" : {
-        "position" : {
-          "character" : 25,
-          "line" : 10
-        },
-        "uri" : "MixedLanguageFramework.h"
-      },
       "names" : {
         "title" : "_MixedLanguageFrameworkVersionNumber"
       },
@@ -890,13 +827,6 @@
       "kind" : {
         "displayName" : "Global Variable",
         "identifier" : "var"
-      },
-      "location" : {
-        "position" : {
-          "character" : 38,
-          "line" : 13
-        },
-        "uri" : "MixedLanguageFramework.h"
       },
       "names" : {
         "title" : "_MixedLanguageFrameworkVersionString"

--- a/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFramework.docc/symbol-graphs/clang/MixedLanguageFramework.symbols.json
+++ b/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFramework.docc/symbol-graphs/clang/MixedLanguageFramework.symbols.json
@@ -58,6 +58,29 @@
       "source" : "c:objc(cs)Bar(cm)myStringFunction:error:",
       "target" : "c:objc(cs)Bar",
       "targetFallback" : null
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:@CM@TestFramework@objc(cs)MixedLanguageClassConformingToProtocol(im)mixedLanguageMethod",
+      "target": "c:objc(cs)MixedLanguageClassConformingToProtocol",
+      "targetFallback": null
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:@M@TestFramework@objc(pl)MixedLanguageProtocol(im)mixedLanguageMethod",
+      "target": "c:@M@TestFramework@objc(pl)MixedLanguageProtocol",
+      "targetFallback": null
+    },
+    {
+      "kind": "conformsTo",
+      "source": "c:@M@TestFramework@objc(cs)MixedLanguageClassConformingToProtocol",
+      "target": "c:@M@TestFramework@objc(pl)MixedLanguageProtocol"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:@M@TestFramework@objc(cs)MixedLanguageClassConformingToProtocol(im)init",
+      "target": "c:@M@TestFramework@objc(cs)MixedLanguageClassConformingToProtocol",
+      "targetFallback": null
     }
   ],
   "symbols" : [
@@ -833,6 +856,288 @@
       },
       "pathComponents" : [
         "_MixedLanguageFrameworkVersionString"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "keyword",
+          "spelling": "@interface"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "MixedLanguageClassConformingToProtocol"
+        },
+        {
+          "kind": "text",
+          "spelling": " : "
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:objc(cs)NSObject",
+          "spelling": "NSObject"
+        }
+      ],
+      "identifier": {
+        "interfaceLanguage": "occ",
+        "precise": "c:@M@TestFramework@objc(cs)MixedLanguageClassConformingToProtocol"
+      },
+      "kind": {
+        "displayName": "Class",
+        "identifier": "class"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "MixedLanguageClassConformingToProtocol"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "MixedLanguageClassConformingToProtocol"
+          }
+        ],
+        "title": "MixedLanguageClassConformingToProtocol"
+      },
+      "pathComponents": [
+        "MixedLanguageClassConformingToProtocol"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "text",
+          "spelling": "- ("
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:v",
+          "spelling": "void"
+        },
+        {
+          "kind": "text",
+          "spelling": ")"
+        },
+        {
+          "kind": "identifier",
+          "spelling": "mixedLanguageMethod"
+        }
+      ],
+      "functionSignature": {
+        "parameters": [],
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:v",
+            "spelling": "void"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "occ",
+        "precise": "c:@CM@TestFramework@objc(cs)MixedLanguageClassConformingToProtocol(im)mixedLanguageMethod"
+      },
+      "kind": {
+        "displayName": "Instance Method",
+        "identifier": "method"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "mixedLanguageMethod"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "text",
+            "spelling": "- "
+          },
+          {
+            "kind": "identifier",
+            "spelling": "mixedLanguageMethod"
+          }
+        ],
+        "title": "mixedLanguageMethod"
+      },
+      "pathComponents": [
+        "MixedLanguageClassConformingToProtocol",
+        "mixedLanguageMethod"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "keyword",
+          "spelling": "@protocol"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "MixedLanguageProtocol"
+        }
+      ],
+      "identifier": {
+        "interfaceLanguage": "occ",
+        "precise": "c:@M@TestFramework@objc(pl)MixedLanguageProtocol"
+      },
+      "kind": {
+        "displayName": "Protocol",
+        "identifier": "protocol"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "MixedLanguageProtocol"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "MixedLanguageProtocol"
+          }
+        ],
+        "title": "MixedLanguageProtocol"
+      },
+      "pathComponents": [
+        "MixedLanguageProtocol"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "text",
+          "spelling": "- ("
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:v",
+          "spelling": "void"
+        },
+        {
+          "kind": "text",
+          "spelling": ")"
+        },
+        {
+          "kind": "identifier",
+          "spelling": "mixedLanguageMethod"
+        }
+      ],
+      "functionSignature": {
+        "parameters": [],
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:v",
+            "spelling": "void"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "occ",
+        "precise": "c:@M@TestFramework@objc(pl)MixedLanguageProtocol(im)mixedLanguageMethod"
+      },
+      "kind": {
+        "displayName": "Instance Method",
+        "identifier": "method"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "mixedLanguageMethod"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "text",
+            "spelling": "- "
+          },
+          {
+            "kind": "identifier",
+            "spelling": "mixedLanguageMethod"
+          }
+        ],
+        "title": "mixedLanguageMethod"
+      },
+      "pathComponents": [
+        "MixedLanguageProtocol",
+        "mixedLanguageMethod"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "text",
+          "spelling": "- ("
+        },
+        {
+          "kind": "keyword",
+          "spelling": "id"
+        },
+        {
+          "kind": "text",
+          "spelling": ")"
+        },
+        {
+          "kind": "identifier",
+          "spelling": "init"
+        }
+      ],
+      "functionSignature": {
+        "parameters": [],
+        "returns": [
+          {
+            "kind": "keyword",
+            "spelling": "id"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "occ",
+        "precise": "c:@M@TestFramework@objc(cs)MixedLanguageClassConformingToProtocol(im)init"
+      },
+      "kind": {
+        "displayName": "Instance Method",
+        "identifier": "method"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "init"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "text",
+            "spelling": "- "
+          },
+          {
+            "kind": "identifier",
+            "spelling": "init"
+          }
+        ],
+        "title": "init"
+      },
+      "pathComponents": [
+        "MixedLanguageClassConformingToProtocol",
+        "init"
       ]
     }
   ]

--- a/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFramework.docc/symbol-graphs/swift/MixedLanguageFramework.symbols.json
+++ b/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFramework.docc/symbol-graphs/swift/MixedLanguageFramework.symbols.json
@@ -884,7 +884,306 @@
                 }
             ],
             "accessLevel": "public"
-        }
+        },
+        {
+            "kind": {
+                "identifier": "swift.method",
+                "displayName": "Instance Method"
+            },
+            "identifier": {
+                "precise": "c:@M@TestFramework@objc(pl)MixedLanguageProtocol(im)mixedLanguageMethod",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "MixedLanguageProtocol",
+                "mixedLanguageMethod()"
+            ],
+            "names": {
+                "title": "mixedLanguageMethod()",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "mixedLanguageMethod"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "functionSignature": {
+                "returns": [
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "attribute",
+                    "spelling": "@objc"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "mixedLanguageMethod"
+                },
+                {
+                    "kind": "text",
+                    "spelling": "()"
+                }
+            ],
+            "accessLevel": "public"
+        },
+        {
+            "kind": {
+                "identifier": "swift.method",
+                "displayName": "Instance Method"
+            },
+            "identifier": {
+                "precise": "c:@CM@TestFramework@objc(cs)MixedLanguageClassConformingToProtocol(im)mixedLanguageMethod",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "MixedLanguageClassConformingToProtocol",
+                "mixedLanguageMethod()"
+            ],
+            "names": {
+                "title": "mixedLanguageMethod()",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "mixedLanguageMethod"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "functionSignature": {
+                "returns": [
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "TestFramework"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "mixedLanguageMethod"
+                },
+                {
+                    "kind": "text",
+                    "spelling": "()"
+                }
+            ],
+            "accessLevel": "public"
+        },
+        {
+            "kind": {
+                "identifier": "swift.protocol",
+                "displayName": "Protocol"
+            },
+            "identifier": {
+                "precise": "c:@M@TestFramework@objc(pl)MixedLanguageProtocol",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "MixedLanguageProtocol"
+            ],
+            "names": {
+                "title": "MixedLanguageProtocol",
+                "navigator": [
+                    {
+                        "kind": "identifier",
+                        "spelling": "MixedLanguageProtocol"
+                    }
+                ],
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "protocol"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "MixedLanguageProtocol"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "attribute",
+                    "spelling": "@objc"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "protocol"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "MixedLanguageProtocol"
+                }
+            ],
+            "accessLevel": "public"
+        },
+        {
+            "kind": {
+                "identifier": "swift.class",
+                "displayName": "Class"
+            },
+            "identifier": {
+                "precise": "c:@M@TestFramework@objc(cs)MixedLanguageClassConformingToProtocol",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "MixedLanguageClassConformingToProtocol"
+            ],
+            "names": {
+                "title": "MixedLanguageClassConformingToProtocol",
+                "navigator": [
+                    {
+                        "kind": "identifier",
+                        "spelling": "MixedLanguageClassConformingToProtocol"
+                    }
+                ],
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "class"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "MixedLanguageClassConformingToProtocol"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "attribute",
+                    "spelling": "@objc"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "class"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "MixedLanguageClassConformingToProtocol"
+                }
+            ],
+            "accessLevel": "public"
+        },
+        {
+          "kind": {
+            "identifier": "swift.init",
+            "displayName": "Initializer"
+          },
+          "identifier": {
+            "precise": "c:@M@TestFramework@objc(cs)MixedLanguageClassConformingToProtocol(im)init",
+            "interfaceLanguage": "swift"
+          },
+          "pathComponents": [
+            "MixedLanguageClassConformingToProtocol",
+            "init()"
+          ],
+          "names": {
+            "title": "init()",
+            "subHeading": [
+              {
+                "kind": "keyword",
+                "spelling": "init"
+              },
+              {
+                "kind": "text",
+                "spelling": "()"
+              }
+            ]
+          },
+          "declarationFragments": [
+            {
+              "kind": "keyword",
+              "spelling": "override"
+            },
+            {
+              "kind": "text",
+              "spelling": " "
+            },
+            {
+              "kind": "keyword",
+              "spelling": "init"
+            },
+            {
+              "kind": "text",
+              "spelling": "()"
+            }
+          ],
+          "accessLevel": "public"
+        },
     ],
     "relationships": [
         {
@@ -999,6 +1298,25 @@
             "kind": "memberOf",
             "source": "c:@E@Foo@second",
             "target": "c:@E@Foo"
+        },
+        {
+            "kind": "conformsTo",
+            "source": "c:@M@TestFramework@objc(cs)MixedLanguageClassConformingToProtocol",
+            "target": "c:@M@TestFramework@objc(pl)MixedLanguageProtocol"
+        },
+        {
+            "kind": "memberOf",
+            "source": "c:@CM@TestFramework@objc(cs)MixedLanguageClassConformingToProtocol(im)mixedLanguageMethod",
+            "target": "c:@M@TestFramework@objc(cs)MixedLanguageClassConformingToProtocol",
+            "sourceOrigin": {
+                "identifier": "c:@M@TestFramework@objc(pl)MixedLanguageProtocol(im)mixedLanguageMethod",
+                "displayName": "MixedLanguageProtocol.mixedLanguageMethod()"
+            }
+        },
+        {
+            "kind": "memberOf",
+            "source": "c:@M@TestFramework@objc(cs)MixedLanguageClassConformingToProtocol(im)init",
+            "target": "c:@M@TestFramework@objc(cs)MixedLanguageClassConformingToProtocol"
         }
     ]
 }


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://89779283

## Summary

Automatically curates generated API collections ("Default Implementations" collections) in the language variants the symbol is available in. For API collections that only contain APIs available in a single language, curates the API collection in that language variant of the symbol.

Note: the first commit just removes the `location` field from the fixture clang symbol graph to work around [this](https://bugs.swift.org/browse/SR-15982) SymbolKit bug. This allows to manipulate the symbol graph for testing purposes in the next commit.

## Dependencies

None.

## Testing

Build documentation for a class that conforms to a protocol with default implementations. Verify that the default generated implementations API collection is curated in Swift and Objective-C when the protocol has APIs exposed to both languages. Verify that the API collection is curated in Swift only when the protocol's APIs are all Swift-only.

## Checklist

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
