### PR TITLE
Don't show snippet symbol graph modules as top-level preview sites

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -1936,8 +1936,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
         // Keep track of the root modules registered from symbol graph files, we'll need them to automatically
         // curate articles.
         rootModules = topicGraph.nodes.values.compactMap { node in
-            guard node.kind == .module,
-                  !onlyHasSnippetRelatedChildren(for: node.reference) else {
+            guard node.kind == .module else {
                 return nil
             }
             return node.reference
@@ -2009,6 +2008,15 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
         topicGraphGlobalAnalysis()
         
         preResolveModuleNames()
+
+        // Symbol Graph modules whose children are all snippets should not
+        // be presented as a top-level preview page.
+        // First, a package might have a similar but different name to its
+        // primary library. Second, snippets are not automatically curated as
+        // other symbols might be.
+        rootModules.removeAll {
+              onlyHasSnippetRelatedChildren(for: $0)
+        }
     }
     
     /// Given a list of topics that have been automatically curated, checks if a topic has been additionally manually curated

--- a/Tests/SwiftDocCTests/Semantics/SnippetTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/SnippetTests.swift
@@ -58,4 +58,10 @@ class SnippetTests: XCTestCase {
         XCTAssertNotNil(snippet)
         XCTAssertTrue(problems.isEmpty)
     }
+
+    func testNoTopLevelPageForSnippetModule() throws {
+        let (_, context) = try testBundleAndContext(named: "TestBundle")
+        XCTAssertEqual(3, context.rootModules.count)
+        XCTAssertFalse(context.rootModules.contains { $0.path == "/documentation/Test" })
+    }
 }


### PR DESCRIPTION
Move the check for a symbol being "snippet-only" to later in the
bundle loading process so that symbol edges are established fully.

rdar://90506525