### PR TITLE
Publish SwiftDocC's framework documentation to GitHub pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,21 +58,11 @@ This archive contains _render JSON_ files, which fully describe the contents
 of a documentation page and can be processed by a renderer such as
 [Swift-DocC-Render](https://github.com/apple/swift-docc-render).
 
-For more in-depth technical information about Swift-DocC, you
-can build and preview the project's technical documentation 
-from the command line with
+For more in-depth technical information about Swift-DocC, please the
+project's technical documentation:
 
-```sh
-bin/preview-docs
-```
-
-> **Note:** The `preview-docs` script expects the `DOCC_HTML_DIR` environment
-> variable to be set with the path to a Swift-DocC renderer. See the
-> [Using `docc` to build and preview documentation](#using-docc-to-build-and-preview-documentation)
-> section below for details.
-
-Alternatively, you can open the package in Xcode 13 and select the "Build Documentation"
-button in the Product menu to view the documentation in Xcode's documentation window.
+- [`SwiftDocC` framework documentation](https://apple.github.io/swift-docc/documentation/swiftdocc/)
+- [`SwiftDocCUtilities` framework documentation](https://apple.github.io/swift-docc/documentation/swiftdoccutilities/)
 
 ### Related Projects
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ This archive contains _render JSON_ files, which fully describe the contents
 of a documentation page and can be processed by a renderer such as
 [Swift-DocC-Render](https://github.com/apple/swift-docc-render).
 
-For more in-depth technical information about Swift-DocC, please the
+For more in-depth technical information about Swift-DocC, please refer to the
 project's technical documentation:
 
 - [`SwiftDocC` framework documentation](https://apple.github.io/swift-docc/documentation/swiftdocc/)

--- a/Sources/SwiftDocCUtilities/SwiftDocCUtilities.docc/SwiftDocCUtilities.md
+++ b/Sources/SwiftDocCUtilities/SwiftDocCUtilities.docc/SwiftDocCUtilities.md
@@ -4,7 +4,7 @@ Build custom documentation workflows by leveraging the DocC compiler pipeline.
 
 ## Overview
 
-SwiftDocCUtilities provides a default, command-line workflow for DocC, powered by Swift [Argument Parser](https://github.com/apple/swift-argument-parser). `docc` commands, such as `convert` and `preview`, are conformant ``Action`` types that use DocC to perform documentation tasks.
+SwiftDocCUtilities provides a default, command-line workflow for DocC, powered by Swift [Argument Parser](https://apple.github.io/swift-argument-parser/documentation/argumentparser/). `docc` commands, such as `convert` and `preview`, are conformant ``Action`` types that use DocC to perform documentation tasks.
 
 Use SwiftDocCUtilities to build a custom, command-line interface and extend it with additional commands. To add a new sub-command called `example`, create an conformant ``Action`` type, `ExampleAction`, that performs the desired work, and add it as a sub-command. Optionally, you can also reuse any of the provided actions like ``ConvertAction``.
 

--- a/bin/update-gh-pages-documentation-site
+++ b/bin/update-gh-pages-documentation-site
@@ -1,0 +1,86 @@
+#!/bin/bash
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2022 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+#
+# Updates the GitHub Pages documentation site thats published from the 'docs' 
+# subdirectory in the 'gh-pages' branch of this repository.
+#
+# This script should be run by someone with commit access to the 'gh-pages' branch
+# at a regular frequency so that the documentation content on the GitHub Pages site
+# is up-to-date with the content in this repo.
+#
+
+set -eu
+
+# A `realpath` alternative using the default C implementation.
+filepath() {
+  [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
+}
+
+SWIFT_DOCC_ROOT="$(dirname $(dirname $(filepath $0)))"
+
+DOCC_BUILD_DIR="$SWIFT_DOCC_ROOT"/.build/docc-gh-pages-build
+DOCC_UTILITIES_OUTPUT_DIR="$DOCC_BUILD_DIR"/docc-utilities-docs
+
+mkdir -p "$DOCC_UTILITIES_OUTPUT_DIR"
+
+# Set current directory to the repository root
+cd "$SWIFT_DOCC_ROOT"
+
+# Use git worktree to checkout the gh-pages branch of this repository in a gh-pages sub-directory
+git fetch
+git worktree add --checkout gh-pages origin/gh-pages
+
+# Pretty print DocC JSON output so that it can be consistently diffed between commits
+export DOCC_JSON_PRETTYPRINT="YES"
+
+# Generate documentation for the 'SwiftDocC' target and output it
+# to the /docs subdirectory in the gh-pages worktree directory.
+swift package \
+    --allow-writing-to-directory "$SWIFT_DOCC_ROOT/gh-pages/docs" \
+    generate-documentation \
+    --target SwiftDocC \
+    --disable-indexing \
+    --transform-for-static-hosting \
+    --hosting-base-path swift-docc \
+    --output-path "$SWIFT_DOCC_ROOT/gh-pages/docs"
+
+# Generate documentation for the 'SwiftDocCUtilities' target and output it
+# to a temporary output directory in the .build directory.
+swift package \
+    --allow-writing-to-directory "$DOCC_BUILD_DIR" \
+    generate-documentation \
+    --target SwiftDocCUtilities \
+    --disable-indexing \
+    --transform-for-static-hosting \
+    --hosting-base-path swift-docc \
+    --output-path "$DOCC_UTILITIES_OUTPUT_DIR"
+
+# Merge the SwiftDocCUtilities docs into the primary SwiftDocC docs
+cp -R "$DOCC_UTILITIES_OUTPUT_DIR"/* "$SWIFT_DOCC_ROOT/gh-pages/docs/"
+
+# Save the current commit we've just built documentation from in a variable
+CURRENT_COMMIT_HASH=`git rev-parse --short HEAD`
+
+# Commit and push our changes to the gh-pages branch
+cd gh-pages
+git add docs
+
+if [ -n "$(git status --porcelain)" ]; then
+    echo "Documentation changes found. Commiting the changes to the 'gh-pages' branch and pushing to origin."
+    git commit -m "Update GitHub Pages documentation site to $CURRENT_COMMIT_HASH"
+    git push origin HEAD:gh-pages
+else
+  # No changes found, nothing to commit.
+  echo "No documentation changes found."
+fi
+
+# Delete the git worktree we created
+cd ..
+git worktree remove gh-pages


### PR DESCRIPTION
## Summary

This sets the foundation for deploying Swift-DocC's technical documentation to GitHub pages.

After merging this PR, we should be able to prepare a `gh-pages` branch on the main `swift-docc` repo with no content on it, run the `bin/update-gh-pages-documentation-site` script and have docs available.

## Testing

I've used the included `bin/update-gh-pages-documentation-site` script to deploy to GitHub pages on my fork. Verify the output looks correct here:

- https://ethan-kusters.github.io/swift-docc/documentation/swiftdocc/
- https://ethan-kusters.github.io/swift-docc/documentation/swiftdoccutilities/

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] ~~Added tests~~ NFC
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
