### PR TITLE
Accept more Objective-C symbol graph identifiers

### DIFF
--- a/Sources/SwiftDocC/Semantics/Symbol/DocumentationDataVariants+SymbolGraphSymbol.swift
+++ b/Sources/SwiftDocC/Semantics/Symbol/DocumentationDataVariants+SymbolGraphSymbol.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -23,7 +23,7 @@ extension DocumentationDataVariants {
                     guard selector.platform == platformName else { return nil }
                     
                     return (
-                        DocumentationDataVariantsTrait(interfaceLanguage: selector.interfaceLanguage),
+                        DocumentationDataVariantsTrait(for: selector),
                         transform(value)
                     )
                 }
@@ -44,7 +44,7 @@ extension DocumentationDataVariants {
                     else { return nil }
                     
                     return (
-                        DocumentationDataVariantsTrait(interfaceLanguage: selector.interfaceLanguage),
+                        DocumentationDataVariantsTrait(for: selector),
                         value
                     )
                 }

--- a/Sources/SwiftDocC/Semantics/Symbol/DocumentationDataVariants.swift
+++ b/Sources/SwiftDocC/Semantics/Symbol/DocumentationDataVariants.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -9,6 +9,7 @@
 */
 
 import Foundation
+import SymbolKit
 
 /// A model type that encapsulates variants of documentation node data.
 ///
@@ -140,5 +141,15 @@ public struct DocumentationDataVariantsTrait: Hashable {
     /// - Parameter interfaceLanguage: The language in which a documentation node is relevant.
     public init(interfaceLanguage: String? = nil) {
         self.interfaceLanguage = interfaceLanguage
+    }
+
+    /// Creates a new trait given a symbol graph selector.
+    ///
+    /// - Parameter selector: The symbol graph selector to use when creating the trait.
+    public init(for selector: UnifiedSymbolGraph.Selector) {
+        self.init(
+            interfaceLanguage: SourceLanguage(knownLanguageIdentifier: selector.interfaceLanguage)?.id
+                ?? selector.interfaceLanguage
+        )
     }
 }

--- a/Sources/SwiftDocC/Semantics/Symbol/Symbol.swift
+++ b/Sources/SwiftDocC/Semantics/Symbol/Symbol.swift
@@ -303,7 +303,7 @@ extension Symbol {
     /// depending on variances in their implementation across platforms (e.g. use `NSPoint` vs `CGPoint` parameter in a method).
     /// This method finds matching symbols between graphs and merges their declarations in case there are differences.
     func mergeDeclaration(mergingDeclaration: SymbolGraph.Symbol.DeclarationFragments, identifier: String, symbolAvailability: SymbolGraph.Symbol.Availability?, selector: UnifiedSymbolGraph.Selector) throws {
-        let trait = DocumentationDataVariantsTrait(interfaceLanguage: selector.interfaceLanguage)
+        let trait = DocumentationDataVariantsTrait(for: selector)
         let platformName = selector.platform
 
         if let platformName = platformName,

--- a/Tests/SwiftDocCTests/Model/SourceLanguageTests.swift
+++ b/Tests/SwiftDocCTests/Model/SourceLanguageTests.swift
@@ -1,0 +1,19 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+@testable import SwiftDocC
+import XCTest
+
+class SourceLanguageTests: XCTestCase {
+    func testUsesIDAliasesWhenQueryingFirstKnownLanguage() {
+        XCTAssertEqual(SourceLanguage(knownLanguageIdentifier: "objective-c"), .objectiveC)
+        XCTAssertEqual(SourceLanguage(knownLanguageIdentifier: "c"), .objectiveC)
+    }
+}

--- a/Tests/SwiftDocCTests/Semantics/DocumentationDataVariantsTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/DocumentationDataVariantsTests.swift
@@ -10,6 +10,7 @@
 
 import Foundation
 import XCTest
+import SymbolKit
 @testable import SwiftDocC
 
 class DocumentationDataVariantsTests: XCTestCase {
@@ -83,5 +84,17 @@ class DocumentationDataVariantsTests: XCTestCase {
         XCTAssertEqual(variants.firstValue, "Swift")
         variants[objectiveCTrait] = "Objective-C"
         XCTAssertEqual(variants.firstValue, "Swift") // Swift is still treated as the default value.
+    }
+
+    func testInitializesUsingSelectorLanguage() {
+        XCTAssertEqual(
+            DocumentationDataVariantsTrait(
+                for: UnifiedSymbolGraph.Selector(
+                    interfaceLanguage: "MyLanguage",
+                    platform: nil
+                )
+            ).interfaceLanguage,
+            "MyLanguage"
+        )
     }
 }


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://90361614

## Summary

Accept "objective-c" and "c" as interface language identifiers in symbol
graph files emitted by clang.

## Dependencies

None.

## Testing

Build documentation with symbol graph files that use the `objective-c` and `c` interface language identifiers.

## Checklist

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
