### PR TITLE
Include platform availability info in indexing records

### DIFF
--- a/Sources/SwiftDocC/Indexing/IndexingRecord.swift
+++ b/Sources/SwiftDocC/Indexing/IndexingRecord.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -90,13 +90,19 @@ public struct IndexingRecord: Equatable {
      */
     public let rawIndexableTextContent: String
     
-    init(kind: Kind, location: Location, title: String, summary: String, headings: [String], rawIndexableTextContent: String) {
+    /// The availability information for a platform.
+    public typealias PlatformAvailability = AvailabilityRenderItem
+    /// Information about the platforms for which the summarized element is available.
+    public let platforms: [PlatformAvailability]?
+
+    init(kind: Kind, location: Location, title: String, summary: String, headings: [String], rawIndexableTextContent: String, platforms: [PlatformAvailability]? = nil) {
         self.kind = kind
         self.location = location
         self.title = title
         self.summary = summary
         self.headings = headings
         self.rawIndexableTextContent = rawIndexableTextContent
+        self.platforms = platforms
     }
 }
 

--- a/Sources/SwiftDocC/Indexing/RenderNode+Indexable.swift
+++ b/Sources/SwiftDocC/Indexing/RenderNode+Indexable.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -65,7 +65,7 @@ extension RenderNode: Indexable {
 
         let summary = summaryParagraph?.rawIndexableTextContent(references: references) ?? ""
         
-        return IndexingRecord(kind: kind, location: .topLevelPage(identifier), title: title, summary: summary, headings: self.headings, rawIndexableTextContent: self.rawIndexableTextContent)
+        return IndexingRecord(kind: kind, location: .topLevelPage(identifier), title: title, summary: summary, headings: self.headings, rawIndexableTextContent: self.rawIndexableTextContent, platforms: metadata.platforms)
     }
     
     public func indexingRecords(onPage page: ResolvedTopicReference) throws -> [IndexingRecord] {

--- a/Sources/SwiftDocC/SwiftDocC.docc/Resources/IndexingRecords.spec.json
+++ b/Sources/SwiftDocC/SwiftDocC.docc/Resources/IndexingRecords.spec.json
@@ -53,6 +53,12 @@
                     },
                     "rawIndexableTextContent": {
                         "type": "string"
+                    },
+                    "platforms": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/PlatformAvailability"
+                        }
                     }
                 }
             },
@@ -105,6 +111,44 @@
                     },
                     "interfaceLanguage": {
                         "type": "string"
+                    }
+                }
+            },
+            "PlatformAvailability": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "deprecated": {
+                        "type": "boolean",
+                        "format": "true"
+                    },
+                    "unavailable": {
+                        "type": "boolean",
+                        "format": "true"
+                    },
+                    "introducedAt": {
+                        "type": "string",
+                        "format": "version"
+                    },
+                    "deprecatedAt": {
+                        "type": "string",
+                        "format": "version"
+                    },
+                    "message": {
+                        "type": "string"
+                    },
+                    "renamed": {
+                        "type": "string"
+                    },
+                    "current": {
+                        "type": "string",
+                        "format": "version"
+                    },
+                    "beta": {
+                        "type": "boolean",
+                        "format": "true"
                     }
                 }
             }

--- a/Sources/SwiftDocC/SwiftDocC.docc/Resources/IndexingRecords.spec.json
+++ b/Sources/SwiftDocC/SwiftDocC.docc/Resources/IndexingRecords.spec.json
@@ -2,7 +2,7 @@
     "openapi": "3.0.0",
     "info": {
         "description": "Specification of the DocC indexing-records.json digest file.",
-        "version": "0.1.0",
+        "version": "0.2.0",
         "title": "Indexing Records"
     },
     "paths": { },


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://71214411

## Summary

This updates the indexing records and their OpenAPI spec to add optional platform availability information to each record.

Doing so enabled consumers of the indexing-records.json digest file to implement for example filtering based on platform availability. Note that the platform information is a type of metadata about the indexing record and not indexable content. 

## Dependencies

n/a

## Testing

For a documentation catalog with symbol graphs files with availability information:

1. Convert the documentation passing `--emit-index`
2. Inspect the indexing-records.json file inside the output documentation archive. 
Any symbol that has platform availability in its page should also contain this information in its indexing record.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] ~Added~ Updated tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
