### PR TITLE
remove placeholder abstract from DocumentationNode

### DIFF
--- a/Sources/SwiftDocC/Model/DocumentationNode.swift
+++ b/Sources/SwiftDocC/Model/DocumentationNode.swift
@@ -252,11 +252,7 @@ public struct DocumentationNode {
             relationshipsVariants: DocumentationDataVariants(
                 defaultVariantValue: RelationshipsSection()
             ),
-            abstractSectionVariants: DocumentationDataVariants(
-                defaultVariantValue: AbstractSection(
-                    paragraph: .init([Text("Placeholder Abstract")])
-                )
-            ),
+            abstractSectionVariants: .empty,
             discussionVariants: .empty,
             topicsVariants: .empty,
             seeAlsoVariants: .empty,


### PR DESCRIPTION
Bug/issue #: [SR-16072](https://bugs.swift.org/browse/SR-16072)

## Summary

This PR removes the placeholder abstract from `DocumentationNode`. Since the `DocumentationNode` is always overwritten with symbol information the placeholder is unnecessary.

## Dependencies

None.

## Testing

This is just a type change. Functionality remains unchanged. The build & test script both succeeded. There were no additional tests added for this reason as well.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [N/A] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [N/A] Updated documentation if necessary
