### PR TITLE
Use "c" rather than "occ" in kind disambiguation suffixes

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolReference.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolReference.swift
@@ -66,7 +66,13 @@ public struct SymbolReference {
         var name = symbol.pathComponents.joinedSymbolPathComponents
 
         if shouldAddKind {
-            name = name.appending("-\(symbol.identifier.interfaceLanguage).\(symbol.kind.identifier.identifier)")
+            let interfaceLanguage = symbol.identifier.interfaceLanguage
+            
+            let languageIdentifier = SourceLanguage(
+                knownLanguageIdentifier: interfaceLanguage
+            )?.linkDisambiguationID ?? interfaceLanguage
+            
+            name = name.appending("-\(languageIdentifier).\(symbol.kind.identifier.identifier)")
         }
         if shouldAddHash {
             name = name.appendingHashedIdentifier(identifier)

--- a/Sources/SwiftDocC/Model/SourceLanguage.swift
+++ b/Sources/SwiftDocC/Model/SourceLanguage.swift
@@ -16,16 +16,20 @@ public struct SourceLanguage: Hashable, Codable {
     public var id: String
     /// Aliases for the language's identifier.
     public var idAliases: [String] = []
-    
+    /// The identifier to use for link disambiguation purposes.
+    public var linkDisambiguationID: String
+
     /// Creates a new language with a given name and identifier.
     /// - Parameters:
     ///   - name: The display name of the programming language.
     ///   - id: A globally unique identifier for the language.
     ///   - idAliases: Aliases for the language's identifier.
-    public init(name: String, id: String, idAliases: [String] = []) {
+    ///   - linkDisambiguationID: The identifier to use for link disambiguation purposes.
+    public init(name: String, id: String, idAliases: [String] = [], linkDisambiguationID: String? = nil) {
         self.name = name
         self.id = id
         self.idAliases = idAliases
+        self.linkDisambiguationID = linkDisambiguationID ?? id
     }
     
     /// Finds the programming language that matches a given query identifier.
@@ -63,6 +67,7 @@ public struct SourceLanguage: Hashable, Codable {
         default:
             self.name = id
             self.id = id
+            self.linkDisambiguationID = id
         }
     }
 
@@ -74,7 +79,10 @@ public struct SourceLanguage: Hashable, Codable {
             self = knownLanguage
         } else {
             self.name = name
-            self.id = name.lowercased()
+            
+            let id = name.lowercased()
+            self.id = id
+            self.linkDisambiguationID = id
         }
     }
     
@@ -126,7 +134,8 @@ public struct SourceLanguage: Hashable, Codable {
         idAliases: [
             "objective-c",
             "c", // FIXME: DocC should display C as its own language (SR-16050).
-        ]
+        ],
+        linkDisambiguationID: "c"
     )
 
     /// The JavaScript programming language or another language that conforms to the ECMAScript specification.

--- a/Tests/SwiftDocCTests/Indexing/RenderIndexTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/RenderIndexTests.swift
@@ -106,7 +106,7 @@ final class RenderIndexTests: XCTestCase {
                               },
                               {
                                 "title": "Foo",
-                                "path": "/documentation/mixedlanguageframework/foo-occ.typealias",
+                                "path": "/documentation/mixedlanguageframework/foo-c.typealias",
                                 "type": "typealias"
                               }
                             ]

--- a/Tests/SwiftDocCTests/Infrastructure/AutomaticCurationTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/AutomaticCurationTests.swift
@@ -413,7 +413,7 @@ class AutomaticCurationTests: XCTestCase {
                 
                 "/documentation/MixedLanguageFramework/_MixedLanguageFrameworkVersionString",
                 
-                // 'MixedLanguageFramework/Foo-occ.typealias' is manually curated in a task group titled "Custom" under 'MixedLanguageFramework/Bar/myStringFunction:error:'
+                // 'MixedLanguageFramework/Foo-c.typealias' is manually curated in a task group titled "Custom" under 'MixedLanguageFramework/Bar/myStringFunction:error:'
                 
                 "Enumerations",
                 "/documentation/MixedLanguageFramework/Foo-swift.struct",

--- a/Tests/SwiftDocCTests/LinkTargets/LinkDestinationSummaryTests.swift
+++ b/Tests/SwiftDocCTests/LinkTargets/LinkDestinationSummaryTests.swift
@@ -363,7 +363,7 @@ class ExternalLinkableTests: XCTestCase {
                 [],
                 """
                 Expected no task groups for the Swift documentation because the symbol \
-                it curates (``Foo-occ.typealias``) is available in Objective-C only.
+                it curates (``Foo-c.typealias``) is available in Objective-C only.
                 """
             )
             
@@ -417,7 +417,7 @@ class ExternalLinkableTests: XCTestCase {
                             summary.referenceURL
                                 .deletingLastPathComponent() // myStringFunction:error:
                                 .deletingLastPathComponent() // Bar
-                                .appendingPathComponent("Foo-occ.typealias").absoluteString,
+                                .appendingPathComponent("Foo-c.typealias").absoluteString,
                         ]
                     )
                 ]

--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeMultiLanguageTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeMultiLanguageTests.swift
@@ -41,7 +41,7 @@ class SemaToRenderNodeMixedLanguageTests: XCTestCase {
                 // Objective-C only variable - ``_MixedLanguageFrameworkVersionString``:
                 "c:@MixedLanguageFrameworkVersionString",
                 
-                // Objective-C only typealias - ``Foo-occ.typealias``
+                // Objective-C only typealias - ``Foo-c.typealias``
                 "c:MixedLanguageFramework.h@T@Foo",
             ]
             
@@ -129,7 +129,7 @@ class SemaToRenderNodeMixedLanguageTests: XCTestCase {
                 // Objective-C only variable - ``_MixedLanguageFrameworkVersionString``:
                 "c:@MixedLanguageFrameworkVersionString",
                 
-                // Objective-C only typealias - ``Foo-occ.typealias``
+                // Objective-C only typealias - ``Foo-c.typealias``
                 "c:MixedLanguageFramework.h@T@Foo",
             ]
         )
@@ -161,6 +161,34 @@ class SemaToRenderNodeMixedLanguageTests: XCTestCase {
                 "MixedLanguageFramework Tutorials",
                 "Tutorial Article",
                 "Tutorial",
+            ]
+        )
+
+        XCTAssertEqual(
+            Set(
+                outputConsumer.renderNodes(withInterfaceLanguages: ["swift", "occ"])
+                    .map { $0.identifier.path }
+            ),
+            [
+                "/tutorials/TutorialOverview",
+                "/documentation/MixedLanguageFramework",
+                "/documentation/MixedLanguageFramework/Bar",
+                "/tutorials/MixedLanguageFramework/Tutorial",
+                "/documentation/MixedLanguageFramework/Article",
+                "/tutorials/MixedLanguageFramework/TutorialArticle",
+                "/documentation/MixedLanguageFramework/APICollection",
+                "/documentation/MixedLanguageFramework/Foo-swift.struct",
+                "/documentation/MixedLanguageFramework/MixedLanguageProtocol",
+                "/documentation/MixedLanguageFramework/Foo-swift.struct/first",
+                "/documentation/MixedLanguageFramework/Foo-swift.struct/second",
+                "/documentation/MixedLanguageFramework/Foo-swift.struct/third",
+                "/documentation/MixedLanguageFramework/Foo-swift.struct/fourth",
+                "/documentation/MixedLanguageFramework/Bar/myStringFunction(_:)",
+                "/documentation/MixedLanguageFramework/MixedLanguageClassConformingToProtocol",
+                "/documentation/MixedLanguageFramework/MixedLanguageProtocol/mixedLanguageMethod()",
+                "/documentation/MixedLanguageFramework/MixedLanguageClassConformingToProtocol/init()",
+                "/documentation/MixedLanguageFramework/MixedLanguageClassConformingToProtocol/mixedLanguageMethod()",
+                "/documentation/MixedLanguageFramework/MixedLanguageClassConformingToProtocol/MixedLanguageProtocol-Implementations",
             ]
         )
     }

--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeMultiLanguageTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeMultiLanguageTests.swift
@@ -184,6 +184,7 @@ class SemaToRenderNodeMixedLanguageTests: XCTestCase {
                 "/documentation/MixedLanguageFramework/Foo-swift.struct/third",
                 "/documentation/MixedLanguageFramework/Foo-swift.struct/fourth",
                 "/documentation/MixedLanguageFramework/Bar/myStringFunction(_:)",
+                "/documentation/MixedLanguageFramework/ArticleCuratedInASingleLanguagePage",
                 "/documentation/MixedLanguageFramework/MixedLanguageClassConformingToProtocol",
                 "/documentation/MixedLanguageFramework/MixedLanguageProtocol/mixedLanguageMethod()",
                 "/documentation/MixedLanguageFramework/MixedLanguageClassConformingToProtocol/init()",

--- a/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFramework.docc/symbol-graphs/clang/MixedLanguageFramework.symbols.json
+++ b/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFramework.docc/symbol-graphs/clang/MixedLanguageFramework.symbols.json
@@ -345,7 +345,7 @@
                 "line" : 43
               }
             },
-            "text" : "- ``Foo-occ.typealias``"
+            "text" : "- ``Foo-c.typealias``"
           }
         ]
       },

--- a/Tests/SwiftDocCUtilitiesTests/Test Bundles/MixedLanguageFramework.docc/symbol-graphs/clang/MixedLanguageFramework.symbols.json
+++ b/Tests/SwiftDocCUtilitiesTests/Test Bundles/MixedLanguageFramework.docc/symbol-graphs/clang/MixedLanguageFramework.symbols.json
@@ -329,7 +329,7 @@
                 "line" : 43
               }
             },
-            "text" : "- ``Foo-occ.typealias``"
+            "text" : "- ``Foo-c.typealias``"
           }
         ]
       },


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://90143115

## Summary

For kind-based disambiguation suffixes of links to Objective-C APIs, use the "c" identifier rather than "occ". The "c" identifier is used to represent all C-family languages.

## Dependencies

None.

## Testing

When compiling documentation for a framework that contains link collisions in Objective-C APIs (e.g., a struct called `foo` and a type alias called `Foo`), verify that DocC resolves links to these APIs that a disambiguation suffix that use the `c` identifier (e.g., ` ``Foo-c.typealias`` ` rather than ` ``Foo-occ.typealias`` `)

## Checklist

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
