### PR TITLE
[Test] Disable testWatchRecoversAfterConversionErrors

### DIFF
--- a/Tests/SwiftDocCUtilitiesTests/PreviewActionIntegrationTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/PreviewActionIntegrationTests.swift
@@ -74,148 +74,150 @@ class PreviewActionIntegrationTests: XCTestCase {
     /// Test the fix for <rdar://problem/48615392>.
     func testWatchRecoversAfterConversionErrors() throws {
         #if os(macOS)
-        // Source files.
-        let source = createMinimalDocsBundle()
-        let (sourceURL, outputURL, templateURL) = try createPreviewSetup(source: source)
+        throw XCTSkip("This test is flaky rdar://90866510")
         
-        let logStorage = LogHandle.LogStorage()
-        var logHandle = LogHandle.memory(logStorage)
-
-        let convertActionTempDirectory = try createTemporaryDirectory()
-        let createConvertAction = {
-            try ConvertAction(
-                documentationBundleURL: sourceURL,
-                outOfProcessResolver: nil,
-                analyze: false,
-                targetDirectory: outputURL,
-                htmlTemplateDirectory: templateURL,
-                emitDigest: false,
-                currentPlatforms: nil,
-                fileManager: FileManager.default,
-                temporaryDirectory: convertActionTempDirectory)
-        }
-        
-        guard let preview = try? PreviewAction(
-                tlsCertificateKey: nil,
-                tlsCertificateChain: nil,
-                serverUsername: nil,
-                serverPassword: nil,
-                port: 8000, // We ignore this value when we set the `bindServerToSocketPath` property below.
-                createConvertAction: createConvertAction) else {
-            XCTFail("Could not create preview action from parameters")
-            return
-        }
-
-        let socketURL = try createTemporaryDirectory().appendingPathComponent("sock")
-        preview.bindServerToSocketPath = socketURL.path
-        
-        // The technology output file URL
-        let convertedOverviewURL = outputURL
-            .appendingPathComponent("data")
-            .appendingPathComponent("tutorials")
-            .appendingPathComponent("Overview.json")
-
-        // Start watching the source and get the initial (successful) state.
-        do {
-            let logOutputExpectation = asyncLogExpectation(log: logStorage, description: "Did produce log output") { $0.contains("=======")  }
-
-            // Start the preview and keep it running for the asserts that follow inside this test.
-            DispatchQueue.global().async {
-                var action = preview as Action
-                do {
-                    let result = try action.perform(logHandle: logHandle)
-                            
-                    guard !result.problems.containsErrors else {
-                        throw ErrorsEncountered()
-                    }
-                
-                    if !result.problems.isEmpty {
-                        print(result.problems.localizedDescription, to: &logHandle)
-                    }
-                } catch {
-                    XCTFail(error.localizedDescription)
-                }
-            }
-
-            wait(for: [logOutputExpectation], timeout: 20.0)
-
-            // Check the log output to confirm that expected informational
-            // text is printed
-            let logOutput = logStorage.text
-            
-            // rdar://71318888
-            let expectedLogIntroductoryOutput = """
-                Input: \(sourceURL.path)
-                Template: \(templateURL.path)
-                """
-            XCTAssertTrue(logOutput.hasPrefix(expectedLogIntroductoryOutput), """
-                Missing expected input and template information in log/print output
-                """)
-            
-            if let previewInfoStart = logOutput.range(of: "=====\n")?.upperBound,
-                let previewInfoEnd = logOutput[previewInfoStart...].range(of: "\n=====")?.lowerBound {
-                XCTAssertEqual(logOutput[previewInfoStart..<previewInfoEnd], """
-                Starting Local Preview Server
-                \t Address: http://localhost:8000/documentation/mykit
-                \t          http://localhost:8000/tutorials/overview
-                """)
-            } else {
-                XCTFail("Missing preview information in log/print output")
-            }
-            
-            XCTAssertTrue(FileManager.default.fileExists(atPath: convertedOverviewURL.path, isDirectory: nil))
-        }
-        
-        // Verify conversion result.
-        let json1 = try json(contentsOf: convertedOverviewURL)
-        guard let sections = json1["sections"] as? [[String: Any]],
-            let intro = sections.first( where: { $0["kind"] as? String == "hero" }),
-            let initialIntroTitle = intro["title"] as? String else {
-            XCTFail("Couldn't parse converted markdown")
-            return
-        }
-        
-        XCTAssertEqual(initialIntroTitle, "Technology X")
-
-        let invalidJSONSymbolGraphURL = sourceURL.appendingPathComponent("invalid-incomplete-data.symbols.json")
-        
-        // Start watching the source and detect failed conversion.
-        do {
-            let outputExpectation = asyncLogExpectation(log: logStorage, description: "Did produce output") { $0.contains("Compilation failed") }
-
-            // this is invalid JSON and will result in an error
-            try "{".write(to: invalidJSONSymbolGraphURL, atomically: true, encoding: .utf8)
-
-            // Wait for watch to produce output.
-            wait(for: [outputExpectation], timeout: 20.0)
-        }
-        
-        // Start watching the source and detect recovery and successful conversion after a failure.
-        do {
-            let outputExpectation = asyncLogExpectation(log: logStorage, description: "Did finish conversion") { $0.contains("Done") }
-
-            try FileManager.default.removeItem(at: invalidJSONSymbolGraphURL)
-
-            // Wait for watch to produce output.
-            wait(for: [outputExpectation], timeout: 20.0)
-            
-            // Check conversion result.
-            let finalJSON = try json(contentsOf: convertedOverviewURL)
-            guard let sections = finalJSON["sections"] as? [[String: Any]],
-                let intro = sections.first( where: { $0["kind"] as? String == "hero" }),
-                let finalIntroTitle = intro["title"] as? String else {
-                XCTFail("Couldn't parse converted markdown")
-                return
-            }
-            XCTAssertEqual(finalIntroTitle, "Technology X")
-        }
-
-        // Make sure to stop the preview process so it doesn't stay alive on the machine running the tests.
-        try preview.stop()
-        
-        try FileManager.default.removeItem(at: sourceURL)
-        try FileManager.default.removeItem(at: outputURL)
-        try FileManager.default.removeItem(at: templateURL)
+//        // Source files.
+//        let source = createMinimalDocsBundle()
+//        let (sourceURL, outputURL, templateURL) = try createPreviewSetup(source: source)
+//
+//        let logStorage = LogHandle.LogStorage()
+//        var logHandle = LogHandle.memory(logStorage)
+//
+//        let convertActionTempDirectory = try createTemporaryDirectory()
+//        let createConvertAction = {
+//            try ConvertAction(
+//                documentationBundleURL: sourceURL,
+//                outOfProcessResolver: nil,
+//                analyze: false,
+//                targetDirectory: outputURL,
+//                htmlTemplateDirectory: templateURL,
+//                emitDigest: false,
+//                currentPlatforms: nil,
+//                fileManager: FileManager.default,
+//                temporaryDirectory: convertActionTempDirectory)
+//        }
+//
+//        guard let preview = try? PreviewAction(
+//                tlsCertificateKey: nil,
+//                tlsCertificateChain: nil,
+//                serverUsername: nil,
+//                serverPassword: nil,
+//                port: 8000, // We ignore this value when we set the `bindServerToSocketPath` property below.
+//                createConvertAction: createConvertAction) else {
+//            XCTFail("Could not create preview action from parameters")
+//            return
+//        }
+//
+//        let socketURL = try createTemporaryDirectory().appendingPathComponent("sock")
+//        preview.bindServerToSocketPath = socketURL.path
+//
+//        // The technology output file URL
+//        let convertedOverviewURL = outputURL
+//            .appendingPathComponent("data")
+//            .appendingPathComponent("tutorials")
+//            .appendingPathComponent("Overview.json")
+//
+//        // Start watching the source and get the initial (successful) state.
+//        do {
+//            let logOutputExpectation = asyncLogExpectation(log: logStorage, description: "Did produce log output") { $0.contains("=======")  }
+//
+//            // Start the preview and keep it running for the asserts that follow inside this test.
+//            DispatchQueue.global().async {
+//                var action = preview as Action
+//                do {
+//                    let result = try action.perform(logHandle: logHandle)
+//
+//                    guard !result.problems.containsErrors else {
+//                        throw ErrorsEncountered()
+//                    }
+//
+//                    if !result.problems.isEmpty {
+//                        print(result.problems.localizedDescription, to: &logHandle)
+//                    }
+//                } catch {
+//                    XCTFail(error.localizedDescription)
+//                }
+//            }
+//
+//            wait(for: [logOutputExpectation], timeout: 20.0)
+//
+//            // Check the log output to confirm that expected informational
+//            // text is printed
+//            let logOutput = logStorage.text
+//
+//            // rdar://71318888
+//            let expectedLogIntroductoryOutput = """
+//                Input: \(sourceURL.path)
+//                Template: \(templateURL.path)
+//                """
+//            XCTAssertTrue(logOutput.hasPrefix(expectedLogIntroductoryOutput), """
+//                Missing expected input and template information in log/print output
+//                """)
+//
+//            if let previewInfoStart = logOutput.range(of: "=====\n")?.upperBound,
+//                let previewInfoEnd = logOutput[previewInfoStart...].range(of: "\n=====")?.lowerBound {
+//                XCTAssertEqual(logOutput[previewInfoStart..<previewInfoEnd], """
+//                Starting Local Preview Server
+//                \t Address: http://localhost:8000/documentation/mykit
+//                \t          http://localhost:8000/tutorials/overview
+//                """)
+//            } else {
+//                XCTFail("Missing preview information in log/print output")
+//            }
+//
+//            XCTAssertTrue(FileManager.default.fileExists(atPath: convertedOverviewURL.path, isDirectory: nil))
+//        }
+//
+//        // Verify conversion result.
+//        let json1 = try json(contentsOf: convertedOverviewURL)
+//        guard let sections = json1["sections"] as? [[String: Any]],
+//            let intro = sections.first( where: { $0["kind"] as? String == "hero" }),
+//            let initialIntroTitle = intro["title"] as? String else {
+//            XCTFail("Couldn't parse converted markdown")
+//            return
+//        }
+//
+//        XCTAssertEqual(initialIntroTitle, "Technology X")
+//
+//        let invalidJSONSymbolGraphURL = sourceURL.appendingPathComponent("invalid-incomplete-data.symbols.json")
+//
+//        // Start watching the source and detect failed conversion.
+//        do {
+//            let outputExpectation = asyncLogExpectation(log: logStorage, description: "Did produce output") { $0.contains("Compilation failed") }
+//
+//            // this is invalid JSON and will result in an error
+//            try "{".write(to: invalidJSONSymbolGraphURL, atomically: true, encoding: .utf8)
+//
+//            // Wait for watch to produce output.
+//            wait(for: [outputExpectation], timeout: 20.0)
+//        }
+//
+//        // Start watching the source and detect recovery and successful conversion after a failure.
+//        do {
+//            let outputExpectation = asyncLogExpectation(log: logStorage, description: "Did finish conversion") { $0.contains("Done") }
+//
+//            try FileManager.default.removeItem(at: invalidJSONSymbolGraphURL)
+//
+//            // Wait for watch to produce output.
+//            wait(for: [outputExpectation], timeout: 20.0)
+//
+//            // Check conversion result.
+//            let finalJSON = try json(contentsOf: convertedOverviewURL)
+//            guard let sections = finalJSON["sections"] as? [[String: Any]],
+//                let intro = sections.first( where: { $0["kind"] as? String == "hero" }),
+//                let finalIntroTitle = intro["title"] as? String else {
+//                XCTFail("Couldn't parse converted markdown")
+//                return
+//            }
+//            XCTAssertEqual(finalIntroTitle, "Technology X")
+//        }
+//
+//        // Make sure to stop the preview process so it doesn't stay alive on the machine running the tests.
+//        try preview.stop()
+//
+//        try FileManager.default.removeItem(at: sourceURL)
+//        try FileManager.default.removeItem(at: outputURL)
+//        try FileManager.default.removeItem(at: templateURL)
         #endif
     }
     


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://91013719

## Summary

Disables `SwiftDocCUtilitiesTests.PreviewActionIntegrationTests.testWatchRecoversAfterConversionErrors()`.
