### PR TITLE
[Snippets] Filter (snippet-only) modules from the preview list

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -2398,11 +2398,10 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
 
     /// Returns whether a documentation node only has snippet or snippet group children.
     func onlyHasSnippetRelatedChildren(for reference: ResolvedTopicReference) -> Bool {
-        let children = children(of: reference)
-        guard !children.isEmpty else {
+        guard topicGraph.nodeWithReference(reference)?.kind == .module else {
             return false
         }
-        return children
+        return children(of: reference)
             .compactMap { $0.kind }
             .allSatisfy({ $0 == .snippet || $0 == .snippetGroup })
     }

--- a/Tests/SwiftDocCTests/Test Bundles/TestBundle.docc/Test-snippets.symbols.json
+++ b/Tests/SwiftDocCTests/Test Bundles/TestBundle.docc/Test-snippets.symbols.json
@@ -1,1 +1,52 @@
-{"metadata":{"generator":"SwiftPM","formatVersion":{"major":0,"minor":1,"patch":0}},"relationships":[{"kind":"memberOf","source":"$snippet__Test.FirstGroup.MySnippet","target":"$snippet__Test.FirstGroup","targetFallback":null}],"symbols":[{"accessLevel":"public","kind":{"displayName":"Snippet Group","identifier":"snippetGroup"},"pathComponents":["FirstGroup"],"identifier":{"precise":"$snippet__Test.FirstGroup","interfaceLanguage":"swift"},"names":{"title":"FirstGroup"},"docComment":{"lines":[{"text":""}]}},{"docComment":{"lines":[{"text":"Does a foo. "}]},"snippet":{"chunks":[{"code":"func foo() {\n  print(\"Hello, world!\")\n}","language":"swift"}]},"identifier":{"precise":"$snippet__Test.FirstGroup.MySnippet","interfaceLanguage":"swift"},"kind":{"displayName":"Snippet","identifier":"snippet"},"accessLevel":"public","pathComponents":["Test","FirstGroup","MySnippet"],"names":{"title":"MySnippet"}}],"module":{"name":"Test","platform":{}}}
+{
+  "metadata": {
+    "generator": "SwiftPM",
+    "formatVersion": {
+      "major": 0,
+      "minor": 1,
+      "patch": 0
+    }
+  },
+  "relationships": [
+  ],
+  "symbols": [
+    {
+      "docComment": {
+        "lines": [
+          {
+            "text": "Does a foo. "
+          }
+        ]
+      },
+      "snippet": {
+        "chunks": [
+          {
+            "code": "func foo() {\n  print(\"Hello, world!\")\n}",
+            "language": "swift"
+          }
+        ]
+      },
+      "identifier": {
+        "precise": "$snippet__Test.MySnippet",
+        "interfaceLanguage": "swift"
+      },
+      "kind": {
+        "displayName": "Snippet",
+        "identifier": "snippet"
+      },
+      "accessLevel": "public",
+      "pathComponents": [
+        "Test",
+        "Snippets",
+        "MySnippet"
+      ],
+      "names": {
+        "title": "MySnippet"
+      }
+    }
+  ],
+  "module": {
+    "name": "Test",
+    "platform": {}
+  }
+}


### PR DESCRIPTION
The logic here was incorrect. Now that snippet groups will be removed,
it's possible for snippet-only modules to appear empty in terms of the
topic graph.