### PR TITLE
Add support for RenderIndex JSON in `docc preview`

### DIFF
--- a/Sources/SwiftDocCUtilities/PreviewServer/RequestHandler/FileRequestHandler.swift
+++ b/Sources/SwiftDocCUtilities/PreviewServer/RequestHandler/FileRequestHandler.swift
@@ -67,6 +67,7 @@ struct FileRequestHandler: RequestHandlerFactory {
     /// a list of file and content types allowed in those locations.
     static let assets: [AssetFileMetadata] = [
         AssetFileMetadata(folderPath: "/data/", mimetype: { _ in "application/json" }),
+        AssetFileMetadata(folderPath: "/index/", mimetype: { _ in "application/json" }),
         AssetFileMetadata(folderPath: "/css/", mimetype: { _ in "text/css" }),
         AssetFileMetadata(folderPath: "/js/", mimetype: { _ in "text/javascript" }),
         AssetFileMetadata(folderPath: "/fonts/", mimetype: { name in

--- a/Tests/SwiftDocCUtilitiesTests/PreviewServer/RequestHandler/FileRequestHandlerTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/PreviewServer/RequestHandler/FileRequestHandlerTests.swift
@@ -63,7 +63,10 @@ class FileRequestHandlerTests: XCTestCase {
             ]),
             Folder(name: "downloads", content: [
                 TextFile(name: "project.zip", utf8Content: "zip"),
-            ])
+            ]),
+            Folder(name: "index", content: [
+                TextFile(name: "index.json", utf8Content: "data"),
+            ]),
         ])
 
         try verifyAsset(root: tempFolderURL, path: "/data/test.json", body: "data", type: "application/json")
@@ -84,6 +87,9 @@ class FileRequestHandlerTests: XCTestCase {
         try verifyAsset(root: tempFolderURL, path: "/videos/video.mov", body: "mov", type: "video/quicktime")
         try verifyAsset(root: tempFolderURL, path: "/videos/video.avi", body: "avi", type: "video/x-msvideo")
         try verifyAsset(root: tempFolderURL, path: "/downloads/project.zip", body: "zip", type: "application/zip")
+        
+        // RenderIndex navigator index json
+        try verifyAsset(root: tempFolderURL, path: "/index/index.json", body: "data", type: "application/json")
     }
     
     func testFileHandlerAssetsMissing() throws {


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://90377550

## Summary

Updates the `docc preview` CLI tool to support previewing DocC archives that include a RenderIndex JSON.

## Testing

1. Clone a recent copy of Swift-DocC-Render:

   ```shell
   git clone https://github.com/apple/swift-docc-render-artifact.git
   ```
  
2. Enable the Swift-DocC-Render navigator feature flag:

   1. Open the [`theme-settings.json`](https://github.com/apple/swift-docc-render-artifact/blob/38aca7c/dist/theme-settings.json#L61) file:
    
      ```shell
      open /path/to/swift-docc-render-artifact/dist/theme-settings.json
      ```
    
   2. Set `features.navigator.enable` to `true`.
   
      ```json
      "features": {
        "docs": {
          "navigator": {
            "enable": true
          }
      }
      ```
  
3. Preview DocC's documentation with your copy of Swift-DocC-Render:

   1. Navigate to this repo:
  
      ```shell
      cd /path/to/swift-docc-repo-checked-out-at-this-branch
      ```
    
   2. `swift build`
  
   3. Set custom renderer path:
  
      ```shell
      export DOCC_HTML_DIR=/path/to/swift-docc-render-artifact/dist
      ```
  
   4. Set custom `docc` path:
  
      ```shell
      export DOCC_EXEC=/path/to/swift-docc-repo/.build/debug/docc
      ```
  
   5. Launch the preview server:
  
      ```shell
      swift package --disable-sandbox preview-documentation --target DocC
      ```
  
4. Confirm the navigator sidebar is rendered as expected 

    <img width="450" alt="Screen Shot 2022-03-30 at 6 08 00 PM" src="https://user-images.githubusercontent.com/6750147/160955984-4f455ed6-dcb8-4b0c-b91a-22039ffafb55.png">


## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
