### PR TITLE
Fix navigator tree curation of multi-language nodes

### DIFF
--- a/Tests/SwiftDocCTests/Indexing/RenderIndexTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/RenderIndexTests.swift
@@ -60,8 +60,10 @@ final class RenderIndexTests: XCTestCase {
     }
     
     func testRenderIndexGenerationForMixedLanguageFramework() throws {
+        let renderIndex = try generatedRenderIndex(for: "MixedLanguageFramework", with: "org.swift.MixedLanguageFramework")
+
         XCTAssertEqual(
-            try generatedRenderIndex(for: "MixedLanguageFramework", with: "org.swift.MixedLanguageFramework"),
+            renderIndex,
             try RenderIndex.fromString(#"""
                 {
                   "interfaceLanguages": {
@@ -280,6 +282,15 @@ final class RenderIndexTests: XCTestCase {
                       {
                         "children": [
                           {
+                            "title": "Multi-language pages",
+                            "type": "groupMarker"
+                          },
+                          {
+                            "path": "\/documentation\/mixedlanguageframework\/articlecuratedinasinglelanguagepage",
+                            "title": "Article curated in a single-language page",
+                            "type": "article"
+                          },
+                          {
                             "title": "Instance Methods",
                             "type": "groupMarker"
                           },
@@ -381,6 +392,15 @@ final class RenderIndexTests: XCTestCase {
                             "title": "SwiftOnlyStruct",
                             "type": "struct",
                             "children": [
+                              {
+                                "title": "Multi-language pages",
+                                "type": "groupMarker"
+                              },
+                              {
+                                "path": "\/documentation\/mixedlanguageframework\/articlecuratedinasinglelanguagepage",
+                                "title": "Article curated in a single-language page",
+                                "type": "article"
+                              },
                               {
                                 "title": "Instance Methods",
                                 "type": "groupMarker"
@@ -507,7 +527,11 @@ final class RenderIndexTests: XCTestCase {
                   }
                 }
                 """#
-            )
+            ),
+            """
+            Generated render index does not match expected index. Actual index was: \
+            \(String(data: (try? JSONEncoder().encode(renderIndex)) ?? Data(), encoding: .utf8) ?? "")
+            """
         )
     }
     

--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeMultiLanguageTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeMultiLanguageTests.swift
@@ -156,6 +156,7 @@ class SemaToRenderNodeMixedLanguageTests: XCTestCase {
                 
                 "MixedLanguageProtocol Implementations",
                 "Article",
+                "Article curated in a single-language page",
                 "APICollection",
                 "MixedLanguageFramework Tutorials",
                 "Tutorial Article",

--- a/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFramework.docc/ArticleCuratedInASingleLanguagePage.md
+++ b/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFramework.docc/ArticleCuratedInASingleLanguagePage.md
@@ -1,0 +1,6 @@
+# Article curated in a single-language page
+
+This article is curated in a Swift-only page. Therefore, it should not appear in the Objective-C tree of the 
+navigator index.
+
+<!-- Copyright (c) 2022 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFramework.docc/SwiftOnlyStruct.md
+++ b/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFramework.docc/SwiftOnlyStruct.md
@@ -1,0 +1,11 @@
+# ``MixedLanguageFramework/SwiftOnlyStruct``
+
+This is the abstract for `SwiftOnlyStruct`, which is only available in Swift.
+
+## Topics
+
+### Multi-language pages
+
+- <doc:ArticleCuratedInASingleLanguagePage>
+
+<!-- Copyright (c) 2022 Apple Inc and the Swift Project authors. All Rights Reserved. -->


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://90703852

## Summary

When a Swift+Objective-C page is curated in a Swift-only page, there is nowhere to place the Objective-C version of the page in the Objective-C navigator tree. Rather than arbitrarily curating the Objective-C page right under the "Objective-C" language node, do not curate at all. If the documentation author wants the Objective-C node to be displayed in the Objective-C navigator tree, they can curate the page in a page that is available in Objective-C.

## Dependencies

None.

## Testing

Build documentation for a mixed-language framework that contains an article curated only in a Swift-only node. When building an navigator index, verify that the article doesn't appear in the Objective-C navigator tree.

## Checklist

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
