### PR TITLE
Escape unicode characters in the path values of linkable entities

### DIFF
--- a/Sources/SwiftDocC/LinkTargets/LinkDestinationSummary.swift
+++ b/Sources/SwiftDocC/LinkTargets/LinkDestinationSummary.swift
@@ -81,7 +81,11 @@ public struct LinkDestinationSummary: Codable, Equatable {
     public let language: SourceLanguage
     
     /// The relative path to this element.
-    public let path: String
+    ///
+    /// > Note: For elements representing on-page elements, this value will include a fragment component.
+    public var path: String {
+        return referenceURL.withoutHostAndPortAndScheme().absoluteString
+    }
     
     /// The resolved topic reference URL to this element.
     public var referenceURL: URL
@@ -215,7 +219,7 @@ public extension DocumentationNode {
 
         let platforms = renderNode.metadata.platforms
         
-        let landmarkSummaries = ((semantic as? Tutorial)?.landmarks ?? (semantic as? TutorialArticle)?.landmarks ?? []).compactMap {
+        let landmarkSummaries = ((semantic as? Tutorial)?.landmarks ?? (semantic as? TutorialArticle)?.landmarks ?? []).map {
             LinkDestinationSummary(landmark: $0, basePath: presentationURL.path, page: self, platforms: platforms, compiler: &compiler)
         }
         
@@ -267,7 +271,6 @@ extension LinkDestinationSummary {
             self.init(
                 kind: documentationNode.kind,
                 language: documentationNode.sourceLanguage,
-                path: path,
                 referenceURL: referenceURL,
                 title: ReferenceResolver.title(forNode: documentationNode),
                 abstract: (documentationNode.semantic as? Abstracted)?.renderedAbstract(using: &compiler),
@@ -335,7 +338,6 @@ extension LinkDestinationSummary {
         self.init(
             kind: kind,
             language: language,
-            path: path,
             referenceURL: referenceURL,
             title: title,
             abstract: abstract,
@@ -359,17 +361,8 @@ extension LinkDestinationSummary {
     ///   - basePath: The bundle-relative path of the page that contain this section.
     ///   - page: The topic reference of the page that contain this section.
     ///   - compiler: The content compiler that's used to render the section's abstract.
-    init?(landmark: Landmark, basePath: String, page: DocumentationNode, platforms: [PlatformAvailability]?, compiler: inout RenderContentCompiler) {
+    init(landmark: Landmark, basePath: String, page: DocumentationNode, platforms: [PlatformAvailability]?, compiler: inout RenderContentCompiler) {
         let anchor = urlReadableFragment(landmark.title)
-        
-        guard let path: String = {
-            var components = URLComponents()
-            components.path = basePath
-            components.fragment = anchor // use an in-page anchor for the landmark's path
-            return components.url?.absoluteString
-        }() else {
-            return nil
-        }
         
         let abstract: Abstract?
         if let abstracted = landmark as? Abstracted {
@@ -383,7 +376,6 @@ extension LinkDestinationSummary {
         self.init(
             kind: .onPageLandmark,
             language: page.sourceLanguage,
-            path: path,
             referenceURL: page.reference.withFragment(anchor).url,
             title: landmark.title,
             abstract: abstract,
@@ -433,7 +425,6 @@ extension LinkDestinationSummary {
             throw DecodingError.dataCorruptedError(forKey: .kind, in: container, debugDescription: "Unknown DocumentationNode.Kind identifier: '\(kindID)'.")
         }
         kind = foundKind
-        path = try container.decode(String.self, forKey: .path)
         referenceURL = try container.decode(URL.self, forKey: .referenceURL)
         title = try container.decode(String.self, forKey: .title)
         abstract = try container.decodeIfPresent(Abstract.self, forKey: .abstract)

--- a/Sources/SwiftDocC/LinkTargets/LinkDestinationSummary.swift
+++ b/Sources/SwiftDocC/LinkTargets/LinkDestinationSummary.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -215,7 +215,7 @@ public extension DocumentationNode {
 
         let platforms = renderNode.metadata.platforms
         
-        let landmarkSummaries = ((semantic as? Tutorial)?.landmarks ?? (semantic as? TutorialArticle)?.landmarks ?? []).map {
+        let landmarkSummaries = ((semantic as? Tutorial)?.landmarks ?? (semantic as? TutorialArticle)?.landmarks ?? []).compactMap {
             LinkDestinationSummary(landmark: $0, basePath: presentationURL.path, page: self, platforms: platforms, compiler: &compiler)
         }
         
@@ -359,8 +359,17 @@ extension LinkDestinationSummary {
     ///   - basePath: The bundle-relative path of the page that contain this section.
     ///   - page: The topic reference of the page that contain this section.
     ///   - compiler: The content compiler that's used to render the section's abstract.
-    init(landmark: Landmark, basePath: String, page: DocumentationNode, platforms: [PlatformAvailability]?, compiler: inout RenderContentCompiler) {
+    init?(landmark: Landmark, basePath: String, page: DocumentationNode, platforms: [PlatformAvailability]?, compiler: inout RenderContentCompiler) {
         let anchor = urlReadableFragment(landmark.title)
+        
+        guard let path: String = {
+            var components = URLComponents()
+            components.path = basePath
+            components.fragment = anchor // use an in-page anchor for the landmark's path
+            return components.url?.absoluteString
+        }() else {
+            return nil
+        }
         
         let abstract: Abstract?
         if let abstracted = landmark as? Abstracted {
@@ -374,7 +383,7 @@ extension LinkDestinationSummary {
         self.init(
             kind: .onPageLandmark,
             language: page.sourceLanguage,
-            path: basePath + "#\(anchor)", // use an in-page anchor for the landmark's path
+            path: path,
             referenceURL: page.reference.withFragment(anchor).url,
             title: landmark.title,
             abstract: abstract,

--- a/Sources/SwiftDocC/LinkTargets/LinkDestinationSummary.swift
+++ b/Sources/SwiftDocC/LinkTargets/LinkDestinationSummary.swift
@@ -81,7 +81,15 @@ public struct LinkDestinationSummary: Codable, Equatable {
     public let language: SourceLanguage
     
     /// The relative path to this element.
-    public let path: String
+    ///
+    /// > Note: For elements representing on-page elements, this value will include a fragment component.
+    @available(*, deprecated, message: "Use 'relativePresentationURL' instead.")
+    public var path: String {
+        return relativePresentationURL.absoluteString
+    }
+    
+    /// The relative presentation URL for this element.
+    public let relativePresentationURL: URL
     
     /// The resolved topic reference URL to this element.
     public var referenceURL: URL
@@ -164,7 +172,13 @@ public struct LinkDestinationSummary: Codable, Equatable {
         public let language: VariantValue<SourceLanguage>
         
         /// The relative path of the variant or `nil` if the relative is the same as the summarized element.
-        public let path: VariantValue<String>
+        @available(*, deprecated, message: "Use 'relativePresentationURL' instead.")
+        public var path: VariantValue<String> {
+            return relativePresentationURL?.absoluteString
+        }
+        
+        /// The relative presentation URL of the variant or `nil` if the relative is the same as the summarized element.
+        public let relativePresentationURL: VariantValue<URL>
         
         /// The title of the variant or `nil` if the title is the same as the summarized element.
         public let title: VariantValue<String?>
@@ -209,14 +223,14 @@ public extension DocumentationNode {
             return []
         }
         let urlGenerator = PresentationURLGenerator(context: context, baseURL: bundle.baseURL)
-        let presentationURL = urlGenerator.presentationURLForReference(reference)
+        let relativePresentationURL = urlGenerator.presentationURLForReference(reference).withoutHostAndPortAndScheme()
         
         var compiler = RenderContentCompiler(context: context, bundle: bundle, identifier: reference)
 
         let platforms = renderNode.metadata.platforms
         
         let landmarkSummaries = ((semantic as? Tutorial)?.landmarks ?? (semantic as? TutorialArticle)?.landmarks ?? []).compactMap {
-            LinkDestinationSummary(landmark: $0, basePath: presentationURL.path, page: self, platforms: platforms, compiler: &compiler)
+            LinkDestinationSummary(landmark: $0, relativeParentPresentationURL: relativePresentationURL, page: self, platforms: platforms, compiler: &compiler)
         }
         
         var taskGroupVariants: [[RenderNode.Variant.Trait]: [LinkDestinationSummary.TaskGroup]] = [:]
@@ -230,7 +244,7 @@ public extension DocumentationNode {
                 taskGroupVariants[variant.traits] = variant.applyingPatchTo(renderNode.topicSections).map { group in .init(title: group.title, identifiers: group.identifiers) }
             }
         }
-        return [LinkDestinationSummary(documentationNode: self, path: presentationURL.path, taskGroups: taskGroups, taskGroupVariants: taskGroupVariants, platforms: platforms, compiler: &compiler)] + landmarkSummaries
+        return [LinkDestinationSummary(documentationNode: self, relativePresentationURL: relativePresentationURL, taskGroups: taskGroups, taskGroupVariants: taskGroupVariants, platforms: platforms, compiler: &compiler)] + landmarkSummaries
     }
 }
 
@@ -255,10 +269,10 @@ extension LinkDestinationSummary {
     ///
     /// - Parameters:
     ///   - documentationNode: The render node to summarize.
-    ///   - path: The bundle-relative path to this page.
+    ///   - relativePresentationURL: The relative presentation URL for this page.
     ///   - taskGroups: The task groups that lists the children of this page.
     ///   - compiler: The content compiler that's used to render the node's abstract.
-    init(documentationNode: DocumentationNode, path: String, taskGroups: [TaskGroup], taskGroupVariants: [[RenderNode.Variant.Trait]: [TaskGroup]], platforms: [PlatformAvailability]?, compiler: inout RenderContentCompiler) {
+    init(documentationNode: DocumentationNode, relativePresentationURL: URL, taskGroups: [TaskGroup], taskGroupVariants: [[RenderNode.Variant.Trait]: [TaskGroup]], platforms: [PlatformAvailability]?, compiler: inout RenderContentCompiler) {
         let redirects = (documentationNode.semantic as? Redirected)?.redirects?.map { $0.oldPath }
         let referenceURL = documentationNode.reference.url
         
@@ -267,7 +281,7 @@ extension LinkDestinationSummary {
             self.init(
                 kind: documentationNode.kind,
                 language: documentationNode.sourceLanguage,
-                path: path,
+                relativePresentationURL: relativePresentationURL,
                 referenceURL: referenceURL,
                 title: ReferenceResolver.title(forNode: documentationNode),
                 abstract: (documentationNode.semantic as? Abstracted)?.renderedAbstract(using: &compiler),
@@ -323,7 +337,7 @@ extension LinkDestinationSummary {
                 traits: variantTraits,
                 kind: nilIfEqual(main: kind, variant: symbol.kindVariants[trait].map { DocumentationNode.kind(forKind: $0.identifier) }),
                 language: nilIfEqual(main: language, variant: SourceLanguage(knownLanguageIdentifier: interfaceLanguage)),
-                path: nil, // The symbol variant uses the same relative path
+                relativePresentationURL: nil, // The symbol variant uses the same relative path
                 title: nilIfEqual(main: title, variant: symbol.titleVariants[trait]),
                 abstract: nilIfEqual(main: abstract, variant: abstractVariant),
                 taskGroups: nilIfEqual(main: taskGroups, variant: taskGroupVariants[variantTraits]),
@@ -335,7 +349,7 @@ extension LinkDestinationSummary {
         self.init(
             kind: kind,
             language: language,
-            path: path,
+            relativePresentationURL: relativePresentationURL,
             referenceURL: referenceURL,
             title: title,
             abstract: abstract,
@@ -356,17 +370,16 @@ extension LinkDestinationSummary {
     ///
     /// - Parameters:
     ///   - landmark: The landmark to summarize.
-    ///   - basePath: The bundle-relative path of the page that contain this section.
+    ///   - relativeParentPresentationURL: The bundle-relative path of the page that contain this section.
     ///   - page: The topic reference of the page that contain this section.
     ///   - compiler: The content compiler that's used to render the section's abstract.
-    init?(landmark: Landmark, basePath: String, page: DocumentationNode, platforms: [PlatformAvailability]?, compiler: inout RenderContentCompiler) {
+    init?(landmark: Landmark, relativeParentPresentationURL: URL, page: DocumentationNode, platforms: [PlatformAvailability]?, compiler: inout RenderContentCompiler) {
         let anchor = urlReadableFragment(landmark.title)
         
-        guard let path: String = {
-            var components = URLComponents()
-            components.path = basePath
-            components.fragment = anchor // use an in-page anchor for the landmark's path
-            return components.url?.absoluteString
+        guard let relativePresentationURL: URL = {
+            var components = URLComponents(url: relativeParentPresentationURL, resolvingAgainstBaseURL: false)
+            components?.fragment = anchor // use an in-page anchor for the landmark's path
+            return components?.url
         }() else {
             return nil
         }
@@ -383,7 +396,7 @@ extension LinkDestinationSummary {
         self.init(
             kind: .onPageLandmark,
             language: page.sourceLanguage,
-            path: path,
+            relativePresentationURL: relativePresentationURL,
             referenceURL: page.reference.withFragment(anchor).url,
             title: landmark.title,
             abstract: abstract,
@@ -403,14 +416,15 @@ extension LinkDestinationSummary {
 // Add Codable methods—which include an initializer—in an extension so that it doesn't override the member-wise initializer.
 extension LinkDestinationSummary {
     enum CodingKeys: String, CodingKey {
-        case kind, path, referenceURL, title, abstract, language, taskGroups, usr, availableLanguages, platforms, redirects, variants
+        case kind, referenceURL, title, abstract, language, taskGroups, usr, availableLanguages, platforms, redirects, variants
+        case relativePresentationURL = "path"
         case declarationFragments = "fragments"
     }
     
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(kind.id, forKey: .kind)
-        try container.encode(path, forKey: .path)
+        try container.encode(relativePresentationURL, forKey: .relativePresentationURL)
         try container.encode(referenceURL, forKey: .referenceURL)
         try container.encode(title, forKey: .title)
         try container.encodeIfPresent(abstract, forKey: .abstract)
@@ -433,7 +447,7 @@ extension LinkDestinationSummary {
             throw DecodingError.dataCorruptedError(forKey: .kind, in: container, debugDescription: "Unknown DocumentationNode.Kind identifier: '\(kindID)'.")
         }
         kind = foundKind
-        path = try container.decode(String.self, forKey: .path)
+        relativePresentationURL = try container.decode(URL.self, forKey: .relativePresentationURL)
         referenceURL = try container.decode(URL.self, forKey: .referenceURL)
         title = try container.decode(String.self, forKey: .title)
         abstract = try container.decodeIfPresent(Abstract.self, forKey: .abstract)
@@ -462,14 +476,16 @@ extension LinkDestinationSummary {
 
 extension LinkDestinationSummary.Variant {
     enum CodingKeys: String, CodingKey {
-        case traits, kind, path, title, abstract, language, usr, declarationFragments = "fragments", taskGroups
+        case traits, kind, title, abstract, language, usr, taskGroups
+        case relativePresentationURL = "path"
+        case declarationFragments = "fragments"
     }
     
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(traits, forKey: .traits)
         try container.encodeIfPresent(kind?.id, forKey: .kind)
-        try container.encodeIfPresent(path, forKey: .path)
+        try container.encodeIfPresent(relativePresentationURL, forKey: .relativePresentationURL)
         try container.encodeIfPresent(title, forKey: .title)
         try container.encodeIfPresent(abstract, forKey: .abstract)
         try container.encodeIfPresent(language, forKey: .language)
@@ -508,7 +524,7 @@ extension LinkDestinationSummary.Variant {
         } else {
             language = nil
         }
-        path = try container.decodeIfPresent(String.self, forKey: .path)
+        relativePresentationURL = try container.decodeIfPresent(URL.self, forKey: .relativePresentationURL)
         title = try container.decodeIfPresent(String?.self, forKey: .title)
         abstract = try container.decodeIfPresent(LinkDestinationSummary.Abstract?.self, forKey: .abstract)
         usr = try container.decodeIfPresent(String?.self, forKey: .title)

--- a/Tests/SwiftDocCTests/LinkTargets/LinkDestinationSummaryTests.swift
+++ b/Tests/SwiftDocCTests/LinkTargets/LinkDestinationSummaryTests.swift
@@ -110,7 +110,7 @@ class ExternalLinkableTests: XCTestCase {
         let summaries = node.externallyLinkableElementSummaries(context: context, renderNode: renderNode)
         let pageSummary = summaries[0]
         XCTAssertEqual(pageSummary.title, "Basic Augmented Reality App 💻")
-        XCTAssertEqual(pageSummary.path, "/tutorials/TestBundle/Tutorial")
+        XCTAssertEqual(pageSummary.path, "/tutorials/testbundle/tutorial")
         XCTAssertEqual(pageSummary.referenceURL.absoluteString, "doc://com.test.example/tutorials/TestBundle/Tutorial")
         XCTAssertEqual(pageSummary.language, .swift)
         XCTAssertEqual(pageSummary.kind, .tutorial)
@@ -128,7 +128,7 @@ class ExternalLinkableTests: XCTestCase {
 
         let sectionSummary = summaries[1]
         XCTAssertEqual(sectionSummary.title, "Create a New AR Project 💻")
-        XCTAssertEqual(sectionSummary.path, "/tutorials/TestBundle/Tutorial#Create-a-New-AR-Project-%F0%9F%92%BB")
+        XCTAssertEqual(sectionSummary.path, "/tutorials/testbundle/tutorial#Create-a-New-AR-Project-%F0%9F%92%BB")
         XCTAssertEqual(sectionSummary.referenceURL.absoluteString, "doc://com.test.example/tutorials/TestBundle/Tutorial#Create-a-New-AR-Project-%F0%9F%92%BB")
         XCTAssertEqual(sectionSummary.language, .swift)
         XCTAssertEqual(sectionSummary.kind, .onPageLandmark)
@@ -162,7 +162,7 @@ class ExternalLinkableTests: XCTestCase {
             let summary = node.externallyLinkableElementSummaries(context: context, renderNode: renderNode)[0]
             
             XCTAssertEqual(summary.title, "MyClass")
-            XCTAssertEqual(summary.path, "/documentation/MyKit/MyClass")
+            XCTAssertEqual(summary.path, "/documentation/mykit/myclass")
             XCTAssertEqual(summary.referenceURL.absoluteString, "doc://org.swift.docc.example/documentation/MyKit/MyClass")
             XCTAssertEqual(summary.language, .swift)
             XCTAssertEqual(summary.kind, .class)
@@ -200,7 +200,7 @@ class ExternalLinkableTests: XCTestCase {
             let summary = node.externallyLinkableElementSummaries(context: context, renderNode: renderNode)[0]
             
             XCTAssertEqual(summary.title, "MyProtocol")
-            XCTAssertEqual(summary.path, "/documentation/MyKit/MyProtocol")
+            XCTAssertEqual(summary.path, "/documentation/mykit/myprotocol")
             XCTAssertEqual(summary.referenceURL.absoluteString, "doc://org.swift.docc.example/documentation/MyKit/MyProtocol")
             XCTAssertEqual(summary.language, .swift)
             XCTAssertEqual(summary.kind, .protocol)
@@ -235,7 +235,7 @@ class ExternalLinkableTests: XCTestCase {
             let summary = node.externallyLinkableElementSummaries(context: context, renderNode: renderNode)[0]
             
             XCTAssertEqual(summary.title, "myFunction()")
-            XCTAssertEqual(summary.path, "/documentation/MyKit/MyClass/myFunction()")
+            XCTAssertEqual(summary.path, "/documentation/mykit/myclass/myfunction()")
             XCTAssertEqual(summary.referenceURL.absoluteString, "doc://org.swift.docc.example/documentation/MyKit/MyClass/myFunction()")
             XCTAssertEqual(summary.language, .swift)
             XCTAssertEqual(summary.kind, .instanceMethod)
@@ -254,7 +254,7 @@ class ExternalLinkableTests: XCTestCase {
             let summary = node.externallyLinkableElementSummaries(context: context, renderNode: renderNode)[0]
             
             XCTAssertEqual(summary.title, "globalFunction(_:considering:)")
-            XCTAssertEqual(summary.path, "/documentation/MyKit/globalFunction(_:considering:)")
+            XCTAssertEqual(summary.path, "/documentation/mykit/globalfunction(_:considering:)")
             XCTAssertEqual(summary.referenceURL.absoluteString, "doc://org.swift.docc.example/documentation/MyKit/globalFunction(_:considering:)")
             XCTAssertEqual(summary.language, .swift)
             XCTAssertEqual(summary.kind, .function)
@@ -291,7 +291,7 @@ class ExternalLinkableTests: XCTestCase {
             let summary = node.externallyLinkableElementSummaries(context: context, renderNode: renderNode)[0]
             
             XCTAssertEqual(summary.title, "Bar")
-            XCTAssertEqual(summary.path, "/documentation/MixedLanguageFramework/Bar")
+            XCTAssertEqual(summary.path, "/documentation/mixedlanguageframework/bar")
             XCTAssertEqual(summary.referenceURL.absoluteString, "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/Bar")
             XCTAssertEqual(summary.language, .swift)
             XCTAssertEqual(summary.kind, .class)
@@ -344,7 +344,7 @@ class ExternalLinkableTests: XCTestCase {
             let summary = node.externallyLinkableElementSummaries(context: context, renderNode: renderNode)[0]
             
             XCTAssertEqual(summary.title, "myStringFunction(_:)")
-            XCTAssertEqual(summary.path, "/documentation/MixedLanguageFramework/Bar/myStringFunction(_:)")
+            XCTAssertEqual(summary.path, "/documentation/mixedlanguageframework/bar/mystringfunction(_:)")
             XCTAssertEqual(summary.referenceURL.absoluteString, "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/Bar/myStringFunction(_:)")
             XCTAssertEqual(summary.language, .swift)
             XCTAssertEqual(summary.kind, .typeMethod)
@@ -423,7 +423,7 @@ class ExternalLinkableTests: XCTestCase {
           "title": "ClassName",
           "referenceURL": "doc://org.swift.docc.example/documentation/MyKit/ClassName",
           "language": "swift",
-          "path": "a legacy path value that is ignored",
+          "path": "documentation/MyKit/ClassName",
           "availableLanguages": [
             "swift"
           ],
@@ -466,7 +466,7 @@ class ExternalLinkableTests: XCTestCase {
         XCTAssertEqual(decoded.kind, .class)
         XCTAssertEqual(decoded.title, "ClassName")
         XCTAssertEqual(decoded.abstract?.plainText, "A brief explanation of my class.")
-        XCTAssertEqual(decoded.path, "/documentation/MyKit/ClassName")
+        XCTAssertEqual(decoded.path, "documentation/MyKit/ClassName")
         XCTAssertEqual(decoded.declarationFragments, [
             .init(text: "class", kind: .keyword, identifier: nil),
             .init(text: " ", kind: .text, identifier: nil),

--- a/Tests/SwiftDocCTests/LinkTargets/LinkDestinationSummaryTests.swift
+++ b/Tests/SwiftDocCTests/LinkTargets/LinkDestinationSummaryTests.swift
@@ -111,6 +111,7 @@ class ExternalLinkableTests: XCTestCase {
         let pageSummary = summaries[0]
         XCTAssertEqual(pageSummary.title, "Basic Augmented Reality App 💻")
         XCTAssertEqual(pageSummary.path, "/tutorials/testbundle/tutorial")
+        XCTAssertEqual(pageSummary.relativePresentationURL.absoluteString, "/tutorials/testbundle/tutorial")
         XCTAssertEqual(pageSummary.referenceURL.absoluteString, "doc://com.test.example/tutorials/TestBundle/Tutorial")
         XCTAssertEqual(pageSummary.language, .swift)
         XCTAssertEqual(pageSummary.kind, .tutorial)
@@ -129,6 +130,7 @@ class ExternalLinkableTests: XCTestCase {
         let sectionSummary = summaries[1]
         XCTAssertEqual(sectionSummary.title, "Create a New AR Project 💻")
         XCTAssertEqual(sectionSummary.path, "/tutorials/testbundle/tutorial#Create-a-New-AR-Project-%F0%9F%92%BB")
+        XCTAssertEqual(sectionSummary.relativePresentationURL.absoluteString, "/tutorials/testbundle/tutorial#Create-a-New-AR-Project-%F0%9F%92%BB")
         XCTAssertEqual(sectionSummary.referenceURL.absoluteString, "doc://com.test.example/tutorials/TestBundle/Tutorial#Create-a-New-AR-Project-%F0%9F%92%BB")
         XCTAssertEqual(sectionSummary.language, .swift)
         XCTAssertEqual(sectionSummary.kind, .onPageLandmark)
@@ -163,6 +165,7 @@ class ExternalLinkableTests: XCTestCase {
             
             XCTAssertEqual(summary.title, "MyClass")
             XCTAssertEqual(summary.path, "/documentation/mykit/myclass")
+            XCTAssertEqual(summary.relativePresentationURL.absoluteString, "/documentation/mykit/myclass")
             XCTAssertEqual(summary.referenceURL.absoluteString, "doc://org.swift.docc.example/documentation/MyKit/MyClass")
             XCTAssertEqual(summary.language, .swift)
             XCTAssertEqual(summary.kind, .class)
@@ -201,6 +204,7 @@ class ExternalLinkableTests: XCTestCase {
             
             XCTAssertEqual(summary.title, "MyProtocol")
             XCTAssertEqual(summary.path, "/documentation/mykit/myprotocol")
+            XCTAssertEqual(summary.relativePresentationURL.absoluteString, "/documentation/mykit/myprotocol")
             XCTAssertEqual(summary.referenceURL.absoluteString, "doc://org.swift.docc.example/documentation/MyKit/MyProtocol")
             XCTAssertEqual(summary.language, .swift)
             XCTAssertEqual(summary.kind, .protocol)
@@ -236,6 +240,7 @@ class ExternalLinkableTests: XCTestCase {
             
             XCTAssertEqual(summary.title, "myFunction()")
             XCTAssertEqual(summary.path, "/documentation/mykit/myclass/myfunction()")
+            XCTAssertEqual(summary.relativePresentationURL.absoluteString, "/documentation/mykit/myclass/myfunction()")
             XCTAssertEqual(summary.referenceURL.absoluteString, "doc://org.swift.docc.example/documentation/MyKit/MyClass/myFunction()")
             XCTAssertEqual(summary.language, .swift)
             XCTAssertEqual(summary.kind, .instanceMethod)
@@ -255,6 +260,7 @@ class ExternalLinkableTests: XCTestCase {
             
             XCTAssertEqual(summary.title, "globalFunction(_:considering:)")
             XCTAssertEqual(summary.path, "/documentation/mykit/globalfunction(_:considering:)")
+            XCTAssertEqual(summary.relativePresentationURL.absoluteString, "/documentation/mykit/globalfunction(_:considering:)")
             XCTAssertEqual(summary.referenceURL.absoluteString, "doc://org.swift.docc.example/documentation/MyKit/globalFunction(_:considering:)")
             XCTAssertEqual(summary.language, .swift)
             XCTAssertEqual(summary.kind, .function)
@@ -292,6 +298,7 @@ class ExternalLinkableTests: XCTestCase {
             
             XCTAssertEqual(summary.title, "Bar")
             XCTAssertEqual(summary.path, "/documentation/mixedlanguageframework/bar")
+            XCTAssertEqual(summary.relativePresentationURL.absoluteString, "/documentation/mixedlanguageframework/bar")
             XCTAssertEqual(summary.referenceURL.absoluteString, "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/Bar")
             XCTAssertEqual(summary.language, .swift)
             XCTAssertEqual(summary.kind, .class)
@@ -345,6 +352,7 @@ class ExternalLinkableTests: XCTestCase {
             
             XCTAssertEqual(summary.title, "myStringFunction(_:)")
             XCTAssertEqual(summary.path, "/documentation/mixedlanguageframework/bar/mystringfunction(_:)")
+            XCTAssertEqual(summary.relativePresentationURL.absoluteString, "/documentation/mixedlanguageframework/bar/mystringfunction(_:)")
             XCTAssertEqual(summary.referenceURL.absoluteString, "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/Bar/myStringFunction(_:)")
             XCTAssertEqual(summary.language, .swift)
             XCTAssertEqual(summary.kind, .typeMethod)
@@ -467,6 +475,7 @@ class ExternalLinkableTests: XCTestCase {
         XCTAssertEqual(decoded.title, "ClassName")
         XCTAssertEqual(decoded.abstract?.plainText, "A brief explanation of my class.")
         XCTAssertEqual(decoded.path, "documentation/MyKit/ClassName")
+        XCTAssertEqual(decoded.relativePresentationURL.absoluteString, "documentation/MyKit/ClassName")
         XCTAssertEqual(decoded.declarationFragments, [
             .init(text: "class", kind: .keyword, identifier: nil),
             .init(text: " ", kind: .text, identifier: nil),

--- a/Tests/SwiftDocCTests/LinkTargets/LinkDestinationSummaryTests.swift
+++ b/Tests/SwiftDocCTests/LinkTargets/LinkDestinationSummaryTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -44,11 +44,11 @@ class ExternalLinkableTests: XCTestCase {
             TextFile(name: "Tutorial.tutorial", utf8Content: """
                 @Tutorial(time: 20, projectFiles: project.zip) {
                    @XcodeRequirement(title: "Xcode 10.2 Beta 3", destination: "https://www.example.com/download")
-                   @Intro(title: "Basic Augmented Reality App", background: image.jpg) {
+                   @Intro(title: "Basic Augmented Reality App 💻", background: image.jpg) {
                       @Video(source: video.mov)
                    }
                    
-                   @Section(title: "Create a New AR Project") {
+                   @Section(title: "Create a New AR Project 💻") {
                       @ContentAndMedia(layout: vertical) {
                          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
                          ut labore et dolore magna aliqua. Phasellus faucibus scelerisque eleifend donec pretium.
@@ -109,14 +109,14 @@ class ExternalLinkableTests: XCTestCase {
         
         let summaries = node.externallyLinkableElementSummaries(context: context, renderNode: renderNode)
         let pageSummary = summaries[0]
-        XCTAssertEqual(pageSummary.title, "Basic Augmented Reality App")
+        XCTAssertEqual(pageSummary.title, "Basic Augmented Reality App 💻")
         XCTAssertEqual(pageSummary.path, "/tutorials/testbundle/tutorial")
         XCTAssertEqual(pageSummary.referenceURL.absoluteString, "doc://com.test.example/tutorials/TestBundle/Tutorial")
         XCTAssertEqual(pageSummary.language, .swift)
         XCTAssertEqual(pageSummary.kind, .tutorial)
         XCTAssertEqual(pageSummary.taskGroups, [
             .init(title: nil,
-                  identifiers: ["doc://com.test.example/tutorials/TestBundle/Tutorial#Create-a-New-AR-Project"]
+                  identifiers: ["doc://com.test.example/tutorials/TestBundle/Tutorial#Create-a-New-AR-Project-%F0%9F%92%BB"]
             ),
         ])
         XCTAssertEqual(pageSummary.availableLanguages, [.swift])
@@ -127,9 +127,9 @@ class ExternalLinkableTests: XCTestCase {
         XCTAssertNil(pageSummary.abstract, "There is no text to use as an abstract for the tutorial page")
 
         let sectionSummary = summaries[1]
-        XCTAssertEqual(sectionSummary.title, "Create a New AR Project")
-        XCTAssertEqual(sectionSummary.path, "/tutorials/testbundle/tutorial#Create-a-New-AR-Project")
-        XCTAssertEqual(sectionSummary.referenceURL.absoluteString, "doc://com.test.example/tutorials/TestBundle/Tutorial#Create-a-New-AR-Project")
+        XCTAssertEqual(sectionSummary.title, "Create a New AR Project 💻")
+        XCTAssertEqual(sectionSummary.path, "/tutorials/testbundle/tutorial#Create-a-New-AR-Project-%F0%9F%92%BB")
+        XCTAssertEqual(sectionSummary.referenceURL.absoluteString, "doc://com.test.example/tutorials/TestBundle/Tutorial#Create-a-New-AR-Project-%F0%9F%92%BB")
         XCTAssertEqual(sectionSummary.language, .swift)
         XCTAssertEqual(sectionSummary.kind, .onPageLandmark)
         XCTAssertEqual(sectionSummary.taskGroups, [])

--- a/Tests/SwiftDocCTests/LinkTargets/LinkDestinationSummaryTests.swift
+++ b/Tests/SwiftDocCTests/LinkTargets/LinkDestinationSummaryTests.swift
@@ -110,7 +110,7 @@ class ExternalLinkableTests: XCTestCase {
         let summaries = node.externallyLinkableElementSummaries(context: context, renderNode: renderNode)
         let pageSummary = summaries[0]
         XCTAssertEqual(pageSummary.title, "Basic Augmented Reality App 💻")
-        XCTAssertEqual(pageSummary.path, "/tutorials/testbundle/tutorial")
+        XCTAssertEqual(pageSummary.path, "/tutorials/TestBundle/Tutorial")
         XCTAssertEqual(pageSummary.referenceURL.absoluteString, "doc://com.test.example/tutorials/TestBundle/Tutorial")
         XCTAssertEqual(pageSummary.language, .swift)
         XCTAssertEqual(pageSummary.kind, .tutorial)
@@ -128,7 +128,7 @@ class ExternalLinkableTests: XCTestCase {
 
         let sectionSummary = summaries[1]
         XCTAssertEqual(sectionSummary.title, "Create a New AR Project 💻")
-        XCTAssertEqual(sectionSummary.path, "/tutorials/testbundle/tutorial#Create-a-New-AR-Project-%F0%9F%92%BB")
+        XCTAssertEqual(sectionSummary.path, "/tutorials/TestBundle/Tutorial#Create-a-New-AR-Project-%F0%9F%92%BB")
         XCTAssertEqual(sectionSummary.referenceURL.absoluteString, "doc://com.test.example/tutorials/TestBundle/Tutorial#Create-a-New-AR-Project-%F0%9F%92%BB")
         XCTAssertEqual(sectionSummary.language, .swift)
         XCTAssertEqual(sectionSummary.kind, .onPageLandmark)
@@ -162,7 +162,7 @@ class ExternalLinkableTests: XCTestCase {
             let summary = node.externallyLinkableElementSummaries(context: context, renderNode: renderNode)[0]
             
             XCTAssertEqual(summary.title, "MyClass")
-            XCTAssertEqual(summary.path, "/documentation/mykit/myclass")
+            XCTAssertEqual(summary.path, "/documentation/MyKit/MyClass")
             XCTAssertEqual(summary.referenceURL.absoluteString, "doc://org.swift.docc.example/documentation/MyKit/MyClass")
             XCTAssertEqual(summary.language, .swift)
             XCTAssertEqual(summary.kind, .class)
@@ -200,7 +200,7 @@ class ExternalLinkableTests: XCTestCase {
             let summary = node.externallyLinkableElementSummaries(context: context, renderNode: renderNode)[0]
             
             XCTAssertEqual(summary.title, "MyProtocol")
-            XCTAssertEqual(summary.path, "/documentation/mykit/myprotocol")
+            XCTAssertEqual(summary.path, "/documentation/MyKit/MyProtocol")
             XCTAssertEqual(summary.referenceURL.absoluteString, "doc://org.swift.docc.example/documentation/MyKit/MyProtocol")
             XCTAssertEqual(summary.language, .swift)
             XCTAssertEqual(summary.kind, .protocol)
@@ -235,7 +235,7 @@ class ExternalLinkableTests: XCTestCase {
             let summary = node.externallyLinkableElementSummaries(context: context, renderNode: renderNode)[0]
             
             XCTAssertEqual(summary.title, "myFunction()")
-            XCTAssertEqual(summary.path, "/documentation/mykit/myclass/myfunction()")
+            XCTAssertEqual(summary.path, "/documentation/MyKit/MyClass/myFunction()")
             XCTAssertEqual(summary.referenceURL.absoluteString, "doc://org.swift.docc.example/documentation/MyKit/MyClass/myFunction()")
             XCTAssertEqual(summary.language, .swift)
             XCTAssertEqual(summary.kind, .instanceMethod)
@@ -254,7 +254,7 @@ class ExternalLinkableTests: XCTestCase {
             let summary = node.externallyLinkableElementSummaries(context: context, renderNode: renderNode)[0]
             
             XCTAssertEqual(summary.title, "globalFunction(_:considering:)")
-            XCTAssertEqual(summary.path, "/documentation/mykit/globalfunction(_:considering:)")
+            XCTAssertEqual(summary.path, "/documentation/MyKit/globalFunction(_:considering:)")
             XCTAssertEqual(summary.referenceURL.absoluteString, "doc://org.swift.docc.example/documentation/MyKit/globalFunction(_:considering:)")
             XCTAssertEqual(summary.language, .swift)
             XCTAssertEqual(summary.kind, .function)
@@ -291,7 +291,7 @@ class ExternalLinkableTests: XCTestCase {
             let summary = node.externallyLinkableElementSummaries(context: context, renderNode: renderNode)[0]
             
             XCTAssertEqual(summary.title, "Bar")
-            XCTAssertEqual(summary.path, "/documentation/mixedlanguageframework/bar")
+            XCTAssertEqual(summary.path, "/documentation/MixedLanguageFramework/Bar")
             XCTAssertEqual(summary.referenceURL.absoluteString, "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/Bar")
             XCTAssertEqual(summary.language, .swift)
             XCTAssertEqual(summary.kind, .class)
@@ -344,7 +344,7 @@ class ExternalLinkableTests: XCTestCase {
             let summary = node.externallyLinkableElementSummaries(context: context, renderNode: renderNode)[0]
             
             XCTAssertEqual(summary.title, "myStringFunction(_:)")
-            XCTAssertEqual(summary.path, "/documentation/mixedlanguageframework/bar/mystringfunction(_:)")
+            XCTAssertEqual(summary.path, "/documentation/MixedLanguageFramework/Bar/myStringFunction(_:)")
             XCTAssertEqual(summary.referenceURL.absoluteString, "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/Bar/myStringFunction(_:)")
             XCTAssertEqual(summary.language, .swift)
             XCTAssertEqual(summary.kind, .typeMethod)
@@ -423,7 +423,7 @@ class ExternalLinkableTests: XCTestCase {
           "title": "ClassName",
           "referenceURL": "doc://org.swift.docc.example/documentation/MyKit/ClassName",
           "language": "swift",
-          "path": "documentation/MyKit/ClassName",
+          "path": "a legacy path value that is ignored",
           "availableLanguages": [
             "swift"
           ],
@@ -466,7 +466,7 @@ class ExternalLinkableTests: XCTestCase {
         XCTAssertEqual(decoded.kind, .class)
         XCTAssertEqual(decoded.title, "ClassName")
         XCTAssertEqual(decoded.abstract?.plainText, "A brief explanation of my class.")
-        XCTAssertEqual(decoded.path, "documentation/MyKit/ClassName")
+        XCTAssertEqual(decoded.path, "/documentation/MyKit/ClassName")
         XCTAssertEqual(decoded.declarationFragments, [
             .init(text: "class", kind: .keyword, identifier: nil),
             .init(text: " ", kind: .text, identifier: nil),

--- a/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
@@ -1095,7 +1095,7 @@ class ConvertActionTests: XCTestCase {
                 return [
                     LinkDestinationSummary(
                         kind: .module,
-                        path: "/documentation/testbed",
+                        relativePresentationURL: URL(string: "/documentation/testbed")!,
                         referenceURL: reference.url,
                         title: "TestBed",
                         language: .swift,
@@ -1114,7 +1114,7 @@ class ConvertActionTests: XCTestCase {
                 return [
                     LinkDestinationSummary(
                         kind: .structure,
-                        path: "/documentation/testbed/a",
+                        relativePresentationURL: URL(string: "/documentation/testbed/a")!,
                         referenceURL: reference.url,
                         title: "A",
                         language: .swift,
@@ -1130,7 +1130,7 @@ class ConvertActionTests: XCTestCase {
                 return [
                     LinkDestinationSummary(
                         kind: .article,
-                        path: "/documentation/testbundle/article",
+                        relativePresentationURL: URL(string: "/documentation/testbundle/article")!,
                         referenceURL: reference.url,
                         title: "This is an article",
                         language: .swift,
@@ -1296,7 +1296,7 @@ class ConvertActionTests: XCTestCase {
                 return [
                     LinkDestinationSummary(
                         kind: .tutorialArticle,
-                        path: "/tutorials/testbundle/article",
+                        relativePresentationURL: URL(string: "/tutorials/testbundle/article")!,
                         referenceURL: reference.url,
                         title: "Making an Augmented Reality App",
                         language: .swift,
@@ -1308,7 +1308,7 @@ class ConvertActionTests: XCTestCase {
                     ),
                     LinkDestinationSummary(
                         kind: .onPageLandmark,
-                        path: "/tutorials/testbundle/article#Section-Name",
+                        relativePresentationURL: URL(string: "/tutorials/testbundle/article#Section-Name")!,
                         referenceURL: reference.withFragment("Section-Name").url,
                         title: "Section Name",
                         language: .swift,
@@ -1323,7 +1323,7 @@ class ConvertActionTests: XCTestCase {
                 return [
                     LinkDestinationSummary(
                         kind: .technology,
-                        path: "/tutorials/technologyx",
+                        relativePresentationURL: URL(string: "/tutorials/technologyx")!,
                         referenceURL: reference.url,
                         title: "Technology X",
                         language: .swift,
@@ -2385,7 +2385,7 @@ private extension LinkDestinationSummary {
     // A convenience initializer for test data.
     init(
         kind: DocumentationNode.Kind,
-        path: String,
+        relativePresentationURL: URL,
         referenceURL: URL,
         title: String,
         language: SourceLanguage,
@@ -2399,7 +2399,7 @@ private extension LinkDestinationSummary {
         self.init(
             kind: kind,
             language: language,
-            path: path,
+            relativePresentationURL: relativePresentationURL,
             referenceURL: referenceURL,
             title: title,
             abstract: abstract.map { [.text($0)] },

--- a/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
@@ -1095,6 +1095,7 @@ class ConvertActionTests: XCTestCase {
                 return [
                     LinkDestinationSummary(
                         kind: .module,
+                        path: "/documentation/testbed",
                         referenceURL: reference.url,
                         title: "TestBed",
                         language: .swift,
@@ -1113,6 +1114,7 @@ class ConvertActionTests: XCTestCase {
                 return [
                     LinkDestinationSummary(
                         kind: .structure,
+                        path: "/documentation/testbed/a",
                         referenceURL: reference.url,
                         title: "A",
                         language: .swift,
@@ -1128,6 +1130,7 @@ class ConvertActionTests: XCTestCase {
                 return [
                     LinkDestinationSummary(
                         kind: .article,
+                        path: "/documentation/testbundle/article",
                         referenceURL: reference.url,
                         title: "This is an article",
                         language: .swift,
@@ -1293,6 +1296,7 @@ class ConvertActionTests: XCTestCase {
                 return [
                     LinkDestinationSummary(
                         kind: .tutorialArticle,
+                        path: "/tutorials/testbundle/article",
                         referenceURL: reference.url,
                         title: "Making an Augmented Reality App",
                         language: .swift,
@@ -1304,6 +1308,7 @@ class ConvertActionTests: XCTestCase {
                     ),
                     LinkDestinationSummary(
                         kind: .onPageLandmark,
+                        path: "/tutorials/testbundle/article#Section-Name",
                         referenceURL: reference.withFragment("Section-Name").url,
                         title: "Section Name",
                         language: .swift,
@@ -1318,6 +1323,7 @@ class ConvertActionTests: XCTestCase {
                 return [
                     LinkDestinationSummary(
                         kind: .technology,
+                        path: "/tutorials/technologyx",
                         referenceURL: reference.url,
                         title: "Technology X",
                         language: .swift,
@@ -2379,6 +2385,7 @@ private extension LinkDestinationSummary {
     // A convenience initializer for test data.
     init(
         kind: DocumentationNode.Kind,
+        path: String,
         referenceURL: URL,
         title: String,
         language: SourceLanguage,
@@ -2392,6 +2399,7 @@ private extension LinkDestinationSummary {
         self.init(
             kind: kind,
             language: language,
+            path: path,
             referenceURL: referenceURL,
             title: title,
             abstract: abstract.map { [.text($0)] },

--- a/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
@@ -1095,7 +1095,6 @@ class ConvertActionTests: XCTestCase {
                 return [
                     LinkDestinationSummary(
                         kind: .module,
-                        path: "/documentation/testbed",
                         referenceURL: reference.url,
                         title: "TestBed",
                         language: .swift,
@@ -1114,7 +1113,6 @@ class ConvertActionTests: XCTestCase {
                 return [
                     LinkDestinationSummary(
                         kind: .structure,
-                        path: "/documentation/testbed/a",
                         referenceURL: reference.url,
                         title: "A",
                         language: .swift,
@@ -1130,7 +1128,6 @@ class ConvertActionTests: XCTestCase {
                 return [
                     LinkDestinationSummary(
                         kind: .article,
-                        path: "/documentation/testbundle/article",
                         referenceURL: reference.url,
                         title: "This is an article",
                         language: .swift,
@@ -1296,7 +1293,6 @@ class ConvertActionTests: XCTestCase {
                 return [
                     LinkDestinationSummary(
                         kind: .tutorialArticle,
-                        path: "/tutorials/testbundle/article",
                         referenceURL: reference.url,
                         title: "Making an Augmented Reality App",
                         language: .swift,
@@ -1308,7 +1304,6 @@ class ConvertActionTests: XCTestCase {
                     ),
                     LinkDestinationSummary(
                         kind: .onPageLandmark,
-                        path: "/tutorials/testbundle/article#Section-Name",
                         referenceURL: reference.withFragment("Section-Name").url,
                         title: "Section Name",
                         language: .swift,
@@ -1323,7 +1318,6 @@ class ConvertActionTests: XCTestCase {
                 return [
                     LinkDestinationSummary(
                         kind: .technology,
-                        path: "/tutorials/technologyx",
                         referenceURL: reference.url,
                         title: "Technology X",
                         language: .swift,
@@ -2385,7 +2379,6 @@ private extension LinkDestinationSummary {
     // A convenience initializer for test data.
     init(
         kind: DocumentationNode.Kind,
-        path: String,
         referenceURL: URL,
         title: String,
         language: SourceLanguage,
@@ -2399,7 +2392,6 @@ private extension LinkDestinationSummary {
         self.init(
             kind: kind,
             language: language,
-            path: path,
             referenceURL: referenceURL,
             title: title,
             abstract: abstract.map { [.text($0)] },


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://91106310

## Summary

This changes how linkable entities are created for landmarks so that the `path` property is encoded like a URL.

## Dependencies

n/a

## Testing

1. In a documentation catalog with tutorial content, add unicode characters to one or more of the tutorial's section's titles.
2. Convert the documentation catalog passing the `--emit-digest` flag
3. Inspect the linkable-entities.json content. 
The entities with unicode characters in their sections should encode the `path` values the same as that portion of the `referenceURL` values.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
