### PR TITLE
Avoid dropping source language information for external content

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/External Data/OutOfProcessReferenceResolver.swift
+++ b/Sources/SwiftDocC/Infrastructure/External Data/OutOfProcessReferenceResolver.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -175,8 +175,8 @@ public class OutOfProcessReferenceResolver: ExternalReferenceResolver, FallbackR
         return DocumentationNode(
             reference: reference,
             kind: resolvedInformation.kind,
-            sourceLanguage: .init(name: resolvedInformation.language.name, id: resolvedInformation.language.id),
-            availableSourceLanguages: Set(resolvedInformation.availableLanguages.map { .init(name: $0.name, id: $0.id) }),
+            sourceLanguage: resolvedInformation.language,
+            availableSourceLanguages: sourceLanguages(for: resolvedInformation),
             name: name,
             markup: Document(parsing: resolvedInformation.abstract, options: []),
             semantic: maybeSymbol,

--- a/Sources/SwiftDocC/Infrastructure/External Data/OutOfProcessReferenceResolver.swift
+++ b/Sources/SwiftDocC/Infrastructure/External Data/OutOfProcessReferenceResolver.swift
@@ -396,7 +396,7 @@ public class OutOfProcessReferenceResolver: ExternalReferenceResolver, FallbackR
         }
         
         // Fall back to the `language` property if `availableLanguages` is empty.
-        return [SourceLanguage(name: resolvedInformation.language.name, id: resolvedInformation.language.id)]
+        return [resolvedInformation.language]
     }
 }
 

--- a/Tests/SwiftDocCUtilitiesTests/OutOfProcessReferenceResolverTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/OutOfProcessReferenceResolverTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -64,6 +64,7 @@ class OutOfProcessReferenceResolverTests: XCTestCase {
             availableLanguages: [
                 .swift,
                 .init(name: "Language Name 2", id: "com.test.another-language.id"),
+                .objectiveC,
             ],
             platforms: [
                 .init(name: "fooOS", introduced: "1.2.3", isBeta: false),
@@ -113,24 +114,20 @@ class OutOfProcessReferenceResolverTests: XCTestCase {
         
         XCTAssertEqual(node.name, .symbol(declaration: .init([.plain(testMetadata.title)])))
         
-        XCTAssertEqual(node.sourceLanguage.name, testMetadata.language.name)
-        XCTAssertEqual(node.sourceLanguage.id, testMetadata.language.id)
+        XCTAssertEqual(node.sourceLanguage, testMetadata.language)
 
-        XCTAssertEqual(node.availableSourceLanguages.count, 2)
+        XCTAssertEqual(node.availableSourceLanguages.count, 3)
 
         let availableSourceLanguages = node.availableSourceLanguages
             .sorted(by: { lhs, rhs in lhs.id < rhs.id })
         let expectedLanguages = testMetadata.availableLanguages
             .sorted(by: { lhs, rhs in lhs.id < rhs.id })
         
-        XCTAssertEqual(availableSourceLanguages[0].name, expectedLanguages[0].name)
-        XCTAssertEqual(availableSourceLanguages[0].id, expectedLanguages[0].id)
-
-        XCTAssertEqual(availableSourceLanguages[1].name, expectedLanguages[1].name)
-        XCTAssertEqual(availableSourceLanguages[1].id, expectedLanguages[1].id)
-
-        XCTAssertEqual(node.platformNames?.sorted(), ["barOS", "fooOS"])
+        XCTAssertEqual(availableSourceLanguages[0], expectedLanguages[0])
+        XCTAssertEqual(availableSourceLanguages[1], expectedLanguages[1])
+        XCTAssertEqual(availableSourceLanguages[2], expectedLanguages[2])
         
+        XCTAssertEqual(node.platformNames?.sorted(), ["barOS", "fooOS"])
         
         XCTAssertEqual(symbol.subHeading, [.init(kind: .text, spelling: "declaration fragment", preciseIdentifier: nil)])
         
@@ -226,6 +223,7 @@ class OutOfProcessReferenceResolverTests: XCTestCase {
             availableLanguages: [
                 .swift,
                 .init(name: "Language Name 2", id: "com.test.another-language.id"),
+                .objectiveC,
             ],
             platforms: [
                 .init(name: "fooOS", introduced: "1.2.3", isBeta: false),
@@ -272,20 +270,17 @@ class OutOfProcessReferenceResolverTests: XCTestCase {
         
         XCTAssertEqual(symbolNode.name, .symbol(declaration: .init([.plain(testMetadata.title)])))
         
-        XCTAssertEqual(symbolNode.sourceLanguage.name, testMetadata.language.name)
-        XCTAssertEqual(symbolNode.sourceLanguage.id, testMetadata.language.id)
+        XCTAssertEqual(symbolNode.sourceLanguage, testMetadata.language)
 
-        XCTAssertEqual(symbolNode.availableSourceLanguages.count, 2)
+        XCTAssertEqual(symbolNode.availableSourceLanguages.count, 3)
 
         let availableSourceLanguages = symbolNode.availableSourceLanguages.sorted(by: { lhs, rhs in lhs.id < rhs.id })
         let expectedLanguages = testMetadata.availableLanguages.sorted(by: { lhs, rhs in lhs.id < rhs.id })
         
-        XCTAssertEqual(availableSourceLanguages[0].name, expectedLanguages[0].name)
-        XCTAssertEqual(availableSourceLanguages[0].id, expectedLanguages[0].id)
-
-        XCTAssertEqual(availableSourceLanguages[1].name, expectedLanguages[1].name)
-        XCTAssertEqual(availableSourceLanguages[1].id, expectedLanguages[1].id)
-
+        XCTAssertEqual(availableSourceLanguages[0], expectedLanguages[0])
+        XCTAssertEqual(availableSourceLanguages[1], expectedLanguages[1])
+        XCTAssertEqual(availableSourceLanguages[2], expectedLanguages[2])
+        
         XCTAssertEqual(symbolNode.platformNames?.sorted(), ["barOS", "fooOS"])
         
         XCTAssertEqual(symbol.subHeading, [.init(kind: .text, spelling: "declaration fragment", preciseIdentifier: nil)])

--- a/bin/test-data-external-resolver
+++ b/bin/test-data-external-resolver
@@ -23,11 +23,18 @@ RESPONSE='{
     "availableLanguages" : [
       {
         "id" : "swift",
-        "name" : "Language Name"
+        "name" : "Language Name",
+        "idAliases" : [],
+        "linkDisambiguationID": "swift"
       },
       {
         "id" : "occ",
-        "name" : "Variant Language Name"
+        "name" : "Variant Language Name",
+        "idAliases" : [
+          "objective-c",
+          "c"
+        ],
+        "linkDisambiguationID" : "c"
       }
     ],
     "declarationFragments" : [
@@ -43,7 +50,10 @@ RESPONSE='{
     },
     "language" : {
       "id" : "swift",
-      "name" : "Language Name"
+      "name" : "Language Name",
+      "idAliases" : [],
+      "linkDisambiguationID": "swift"
+      
     },
     "platforms" : [
       {
@@ -70,7 +80,12 @@ RESPONSE='{
         },
         "language" : {
           "id" : "occ",
-          "name" : "Variant Language Name"
+          "name" : "Variant Language Name",
+          "idAliases" : [
+            "objective-c",
+            "c"
+          ],
+          "linkDisambiguationID" : "c"
         },
         "title" : "Resolved Variant Title",
         "traits" : [


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://91179282

## Summary

This preserved the all the source language information that's passed from an external resolver.

## Dependencies

n/a

## Testing

1. Setup docc to run with the test-data-external-resolver

```
export DOCC_LINK_RESOLVER_EXECUTABLE=/path/to/swift-docc/bin/test-data-external-resolver
```

2. Add a couple of external links to some documentation. For example, add this content to a topic section for an existing page:
```
### External references

- <doc://com.test.bundle/first-test> 
- <doc://com.test.bundle/second-test>
```

3. Convert the documentation catalog with the external references.

The external references should resolve.
There shouldn't be any errors raised about invalid JSON from the external link resolver script.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] ~Added~ Updated tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
