### PR TITLE
Consider entire output size when benchmarking

### DIFF
--- a/Sources/SwiftDocC/Benchmark/Metrics/OutputSize.swift
+++ b/Sources/SwiftDocC/Benchmark/Metrics/OutputSize.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -11,32 +11,63 @@
 import Foundation
 
 extension Benchmark {
-    /// A disk size metric for a given directory.
+    /// Measures the total output size of a DocC archive.
+    public struct ArchiveOutputSize: BenchmarkMetric {
+        public static let identifier = "total-archive-output-size"
+        public static let displayName = "Total DocC archive size (bytes)"
+        public var result: MetricValue?
+        
+        public init(archiveDirectory: URL) {
+            self.result = MetricValue(directory: archiveDirectory)
+        }
+    }
+    
+    /// Measures the output size of the data subdirectory in a DocC archive.
+    public struct DataDirectoryOutputSize: BenchmarkMetric {
+        public static let identifier = "data-subdirectory-output-size"
+        public static let displayName = "Data subdirectory size (bytes)"
+        public var result: MetricValue?
+        
+        public init(dataDirectory: URL) {
+            self.result = MetricValue(directory: dataDirectory)
+        }
+    }
+    
+    /// Measures the output size of the index subdirectory in a DocC archive.
+    public struct IndexDirectoryOutputSize: BenchmarkMetric {
+        public static let identifier = "index-subdirectory-output-size"
+        public static let displayName = "Index subdirectory size (bytes)"
+        public var result: MetricValue?
+        
+        public init(indexDirectory: URL) {
+            self.result = MetricValue(directory: indexDirectory)
+        }
+    }
+}
+
+extension MetricValue {
+    /// Creates a disk size metric for a given directory.
     ///
-    /// - Note: This metric measures the real amount of bytes saved to disk
+    /// This metric measures the real amount of bytes saved to disk
     /// in the given directory and not the disk space reserved for storing the
     /// corresponding files. This behavior helps produce real deltas between
     /// multiple benchmarks.
-    public class OutputSize: BenchmarkMetric {
-        public static let identifier = "output-size"
-        public static let displayName = "Compiled output size (bytes)"
-        
-        public var result: MetricValue? = nil
-        
-        /// Logs the recursive file size of the given directory contents.
-        public init(dataURL: URL) {
-            guard let enumerator = FileManager.default.enumerator(
-                at: dataURL,
-                includingPropertiesForKeys: [.totalFileAllocatedSizeKey, .fileAllocatedSizeKey],
-                options: .skipsHiddenFiles,
-                errorHandler: nil) else { return }
-            
-            var bytes: Int64 = 0
-            for case let url as URL in enumerator {
-                bytes += Int64((try? url.resourceValues(forKeys: [.fileSizeKey]))?.fileSize ?? 0)
-            }
-            
-            result = .integer(bytes)
+    init?(directory: URL) {
+        guard let enumerator = FileManager.default.enumerator(
+            at: directory,
+            includingPropertiesForKeys: [.totalFileAllocatedSizeKey, .fileAllocatedSizeKey],
+            options: .skipsHiddenFiles,
+            errorHandler: nil
+        ) else {
+            return nil
         }
+        
+        var bytes: Int64 = 0
+        for case let url as URL in enumerator {
+            bytes += Int64((try? url.resourceValues(forKeys: [.fileSizeKey]))?.fileSize ?? 0)
+        }
+        
+        
+        self = .integer(bytes)
     }
 }

--- a/Sources/SwiftDocC/Benchmark/Metrics/OutputSize.swift
+++ b/Sources/SwiftDocC/Benchmark/Metrics/OutputSize.swift
@@ -67,7 +67,6 @@ extension MetricValue {
             bytes += Int64((try? url.resourceValues(forKeys: [.fileSizeKey]))?.fileSize ?? 0)
         }
         
-        
         self = .integer(bytes)
     }
 }

--- a/Sources/SwiftDocC/Infrastructure/NodeURLGenerator.swift
+++ b/Sources/SwiftDocC/Infrastructure/NodeURLGenerator.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -42,6 +42,7 @@ public struct NodeURLGenerator {
         public static let tutorialsFolderName = "tutorials"
         public static let documentationFolderName = "documentation"
         public static let dataFolderName = "data"
+        public static let indexFolderName = "index"
         
         public static let tutorialsFolder = "/\(tutorialsFolderName)"
         public static let documentationFolder = "/\(documentationFolderName)"

--- a/Sources/SwiftDocCUtilities/Action/Actions/Convert/ConvertAction.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Convert/ConvertAction.swift
@@ -395,7 +395,7 @@ public struct ConvertAction: Action, RecreatingContext {
         }
 
         // Log the output size.
-        benchmark(add: Benchmark.OutputSize(dataURL: targetDirectory.appendingPathComponent(NodeURLGenerator.Path.dataFolderName)))
+        benchmark(add: Benchmark.OutputSize(dataURL: targetDirectory))
         
         if Benchmark.main.isEnabled {
             // Write the benchmark files directly in the target directory.

--- a/Sources/SwiftDocCUtilities/Action/Actions/Convert/ConvertAction.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Convert/ConvertAction.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -395,7 +395,23 @@ public struct ConvertAction: Action, RecreatingContext {
         }
 
         // Log the output size.
-        benchmark(add: Benchmark.OutputSize(dataURL: targetDirectory))
+        benchmark(add: Benchmark.ArchiveOutputSize(archiveDirectory: targetDirectory))
+        benchmark(
+            add: Benchmark.DataDirectoryOutputSize(
+                dataDirectory: targetDirectory.appendingPathComponent(
+                    NodeURLGenerator.Path.dataFolderName,
+                    isDirectory: true
+                )
+            )
+        )
+        benchmark(
+            add: Benchmark.IndexDirectoryOutputSize(
+                indexDirectory: targetDirectory.appendingPathComponent(
+                    NodeURLGenerator.Path.indexFolderName,
+                    isDirectory: true
+                )
+            )
+        )
         
         if Benchmark.main.isEnabled {
             // Write the benchmark files directly in the target directory.

--- a/Tests/SwiftDocCTests/Benchmark/OutputSizeTests.swift
+++ b/Tests/SwiftDocCTests/Benchmark/OutputSizeTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -22,7 +22,7 @@ class OutputSizeTests: XCTestCase {
         
         // Benchmark the directory size
         let testBenchmark = Benchmark()
-        benchmark(add: Benchmark.OutputSize(dataURL: writeURL), benchmarkLog: testBenchmark)
+        benchmark(add: Benchmark.DataDirectoryOutputSize(dataDirectory: writeURL), benchmarkLog: testBenchmark)
         
         XCTAssertEqual(testBenchmark.metrics.count, 1)
         guard testBenchmark.metrics.count == 1 else { return }

--- a/bin/benchmark-diff.swift
+++ b/bin/benchmark-diff.swift
@@ -89,18 +89,17 @@ enum BenchmarkDiff {
         formatter.locale = Locale.current
         
         after.sorted { (lhs, rhs) in
-            // Sort by kind of data and then by name
-            if lhs.name.contains("(msec)") && !rhs.name.contains("(msec)") {
-                return true
-            } else if lhs.name.contains("memory footprint") && !rhs.name.contains("memory footprint") {
-                // Special-case the "Peak memory footprint" metric so that it appears above
-                // the data size metrics.
-                return true
-            } else if lhs.name.contains("(bytes)") && !rhs.name.contains("(bytes)") {
-                return true
-            } else {
-                return lhs.name < rhs.name
+            // Sort by metric type and then by name
+            let metricTypeIndicators = ["(msec)", "memory footprint", "(bytes)"]
+            for indicator in metricTypeIndicators {
+                if lhs.name.contains(indicator) && !rhs.name.contains(indicator) {
+                    return true
+                } else if !lhs.name.contains(indicator) && rhs.name.contains(indicator) { 
+                    return false
+                }
             }
+            
+            return lhs.name < rhs.name
         }
         .enumerated()
         .forEach { (index, metric) in

--- a/bin/benchmark-diff.swift
+++ b/bin/benchmark-diff.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -88,7 +88,18 @@ enum BenchmarkDiff {
         formatter.numberStyle = .decimal
         formatter.locale = Locale.current
         
-        after.sorted(by: { $0.name < $1.name }).enumerated().forEach { (index, metric) in
+        after.sorted { (lhs, rhs) in
+            // Sort by kind of data and then by name
+            if lhs.name.contains("(bytes)") && !rhs.name.contains("(bytes)") {
+                return true
+            } else if lhs.name.contains("(msec)") && !rhs.name.contains("(msec)") {
+                return true
+            } else {
+                return lhs.name < rhs.name
+            }
+        }
+        .enumerated()
+        .forEach { (index, metric) in
             guard var beforeValue = before.first(where: { $0.id == metric.id })?.value
                 else { return }
             

--- a/bin/benchmark-diff.swift
+++ b/bin/benchmark-diff.swift
@@ -90,9 +90,13 @@ enum BenchmarkDiff {
         
         after.sorted { (lhs, rhs) in
             // Sort by kind of data and then by name
-            if lhs.name.contains("(bytes)") && !rhs.name.contains("(bytes)") {
+            if lhs.name.contains("(msec)") && !rhs.name.contains("(msec)") {
                 return true
-            } else if lhs.name.contains("(msec)") && !rhs.name.contains("(msec)") {
+            } else if lhs.name.contains("memory footprint") && !rhs.name.contains("memory footprint") {
+                // Special-case the "Peak memory footprint" metric so that it appears above
+                // the data size metrics.
+                return true
+            } else if lhs.name.contains("(bytes)") && !rhs.name.contains("(bytes)") {
                 return true
             } else {
                 return lhs.name < rhs.name


### PR DESCRIPTION


Bug/issue #, if applicable: 

## Summary

With the introduction of RenderIndex JSON and the prevalence of `--transform-for-static-hosting` it no longer makes sense to only consider the `data` directory when looking for regressions in DocC Archive output size.

I ran into this when attempting to benchmark #121 and noticing that the output size didn't change despite introducing many new files to the archive.

## Testing

Run the benchmark script and confirm that the output size considers the HTML template and Index.json file.

I'll provide benchmarks here vs the main branch shortly.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
