### PR TITLE
Enable library evolution for SwiftDocC library via a conditional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ DerivedData
 docc-dist-build
 .docc-build
 .swiftpm
+.enable-library-evolution

--- a/Package.swift
+++ b/Package.swift
@@ -11,6 +11,8 @@
 
 import PackageDescription
 import class Foundation.ProcessInfo
+import class Foundation.FileManager
+import struct Foundation.URL
 
 let package = Package(
     name: "SwiftDocC",
@@ -41,7 +43,9 @@ let package = Package(
                 "SymbolKit",
                 "CLMDB",
                 .product(name: "Crypto", package: "swift-crypto"),
-            ]),
+            ],
+            swiftSettings: swiftSettingsForEnablingLibraryEvolution()
+        ),
         .testTarget(
             name: "SwiftDocCTests",
             dependencies: [
@@ -112,6 +116,26 @@ let package = Package(
         
     ]
 )
+
+func swiftSettingsForEnablingLibraryEvolution() -> [SwiftSetting]? {
+    let manifestLocation = URL(fileURLWithPath: #filePath)
+
+    let enableLibraryEvolutionFileLocation = manifestLocation
+        .deletingLastPathComponent()
+        .appendingPathComponent(".enable-library-evolution")
+
+    // If there is a `.enable-library-evolution` file as a sibling of this package manifest
+    // build libraries with library evolution enabled. Note that for SwiftDocC's dependencies
+    // to be built with library evolution as well, they need to be local checkouts, as a
+    // workaround to SR-11207.
+    if FileManager.default.fileExists(atPath: enableLibraryEvolutionFileLocation.path) {
+        return [
+            .unsafeFlags(["-enable-library-evolution"])
+        ]
+    } else {
+        return []
+    }
+}
 
 // If the `SWIFTCI_USE_LOCAL_DEPS` environment variable is set,
 // we're building in the Swift.org CI system alongside other projects in the Swift toolchain and


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://89033233

## Summary

Adds support for building the `SwiftDocC` library with library evolution enabled. This is disabled by default, and to enable the behavior, add an `.enable-library-evolution` file at the root of your checkout. Note that `SwiftDocC`'s dependencies need to be built with library evolution as well (see dependency PRs below). They also need to be checked out locally as a workaround to [SR-11207](https://bugs.swift.org/browse/SR-11207).

Test PR to verify that this doesn't break toolchain builds: https://github.com/apple/swift/pull/42182

## Dependencies

SymbolKit: https://github.com/apple/swift-docc-symbolkit/pull/22
Swift-Markdown: https://github.com/apple/swift-markdown/pull/34

## Testing

Set up local checkouts of Swift-DocC, SymbolKit, and Swift-Markdown with `.enable-library-evolution` files at their root, and set up Swift-DocC to use the local dependencies. Verify that when building Swift-DocC, library evolution is enabled by inspecting build logs. Verify that the compiler doesn't emit warnings about dependencies not being built with library evolution enabled.

## Checklist

- ~[ ] Added tests~ N/A
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
