### PR TITLE
Update copyright year in DocC docs

### DIFF
--- a/Sources/DocCDocumentation/DocCDocumentation.docc/footer.html
+++ b/Sources/DocCDocumentation/DocCDocumentation.docc/footer.html
@@ -1,7 +1,7 @@
 <!--
   This source file is part of the Swift.org open source project
 
-  Copyright (c) 2021 Apple Inc. and the Swift project authors
+  Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
   Licensed under Apache License v2.0 with Runtime Library Exception
 
   See https://swift.org/LICENSE.txt for license information
@@ -11,7 +11,7 @@
 <footer id="footer" role="contentinfo" hidden>
   <div class="container">
     <div>
-      <p class="copyright">Copyright © 2021 Apple Inc. All rights reserved.</p>
+      <p class="copyright">Copyright © 2022 Apple Inc. All rights reserved.</p>
       <p class="trademark">Swift and the Swift logo are trademarks of Apple Inc.</p>
       <p class="privacy">
         <a href="//www.apple.com/privacy/privacy-policy/">Privacy Policy</a>

--- a/Sources/SwiftDocC/SwiftDocC.docc/footer.html
+++ b/Sources/SwiftDocC/SwiftDocC.docc/footer.html
@@ -1,7 +1,7 @@
 <!--
   This source file is part of the Swift.org open source project
 
-  Copyright (c) 2021 Apple Inc. and the Swift project authors
+  Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
   Licensed under Apache License v2.0 with Runtime Library Exception
 
   See https://swift.org/LICENSE.txt for license information
@@ -11,7 +11,7 @@
 <footer id="footer" role="contentinfo" hidden>
   <div class="container">
     <div>
-      <p class="copyright">Copyright © 2021 Apple Inc. All rights reserved.</p>
+      <p class="copyright">Copyright © 2022 Apple Inc. All rights reserved.</p>
       <p class="trademark">Swift and the Swift logo are trademarks of Apple Inc.</p>
       <p class="privacy">
         <a href="//www.apple.com/privacy/privacy-policy/">Privacy Policy</a>

--- a/Sources/SwiftDocCUtilities/SwiftDocCUtilities.docc/footer.html
+++ b/Sources/SwiftDocCUtilities/SwiftDocCUtilities.docc/footer.html
@@ -1,7 +1,7 @@
 <!--
   This source file is part of the Swift.org open source project
 
-  Copyright (c) 2021 Apple Inc. and the Swift project authors
+  Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
   Licensed under Apache License v2.0 with Runtime Library Exception
 
   See https://swift.org/LICENSE.txt for license information
@@ -11,7 +11,7 @@
 <footer id="footer" role="contentinfo" hidden>
   <div class="container">
     <div>
-      <p class="copyright">Copyright © 2021 Apple Inc. All rights reserved.</p>
+      <p class="copyright">Copyright © 2022 Apple Inc. All rights reserved.</p>
       <p class="trademark">Swift and the Swift logo are trademarks of Apple Inc.</p>
       <p class="privacy">
         <a href="//www.apple.com/privacy/privacy-policy/">Privacy Policy</a>


### PR DESCRIPTION
Bug/issue #, if applicable: N/A

## Summary

Updates the copyright year in the DocC documentation footers.

## Dependencies

None.

## Testing

When building documentation for DocC, verify that the footer contains '2022' as the copyright year.

## Checklist

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
