### PR TITLE
[5.7] use new `ivar` and `macro` symbol kinds

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -39,10 +39,10 @@
       },
       {
         "package": "SymbolKit",
-        "repositoryURL": "https://github.com/apple/swift-docc-symbolkit",
+        "repositoryURL": "https://github.com/QuietMisdreavus/swift-docc-symbolkit",
         "state": {
-          "branch": "main",
-          "revision": "ed8ce5502e563090ab1400b4dd7d703b01eceabb",
+          "branch": "5.7/objc-kinds",
+          "revision": "579f0af2f11de450b600c398bf120fde52d562fd",
           "version": null
         }
       },

--- a/Package.swift
+++ b/Package.swift
@@ -124,7 +124,8 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(name: "swift-markdown", url: "https://github.com/apple/swift-markdown.git", .branch("main")),
         .package(name: "CLMDB", url: "https://github.com/apple/swift-lmdb.git", .branch("main")),
         .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "1.0.1")),
-        .package(name: "SymbolKit", url: "https://github.com/apple/swift-docc-symbolkit", .branch("main")),
+//        .package(name: "SymbolKit", url: "https://github.com/apple/swift-docc-symbolkit", .branch("main")),
+        .package(name: "SymbolKit", url: "https://github.com/QuietMisdreavus/swift-docc-symbolkit", .branch("5.7/objc-kinds")),
         .package(url: "https://github.com/apple/swift-crypto.git", .upToNextMinor(from: "1.1.2")),
     ]
     

--- a/Sources/SwiftDocC/Infrastructure/Topic Graph/AutomaticCuration.swift
+++ b/Sources/SwiftDocC/Infrastructure/Topic Graph/AutomaticCuration.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -190,6 +190,8 @@ extension AutomaticCuration {
             case .`func`: return "Functions"
             case .`operator`: return "Operators"
             case .`init`: return "Initializers"
+            case .ivar: return "Instance Variables"
+            case .macro: return "Macros"
             case .`method`: return "Instance Methods"
             case .`property`: return "Instance Properties"
             case .`protocol`: return "Protocols"

--- a/Sources/SwiftDocC/Model/DocumentationNode.swift
+++ b/Sources/SwiftDocC/Model/DocumentationNode.swift
@@ -443,6 +443,8 @@ public struct DocumentationNode {
         case .`func`: return .function
         case .`operator`: return .operator
         case .`init`: return .initializer
+        case .ivar: return .instanceVariable
+        case .macro: return .macro
         case .`method`: return .instanceMethod
         case .`property`: return .instanceProperty
         case .`protocol`: return .protocol


### PR DESCRIPTION
This PR cherry-picks https://github.com/apple/swift-docc/pull/126 onto `release/5.7`.

Like the linked PR, this PR requires https://github.com/apple/swift-docc-symbolkit/pull/27 to be merged before this can be merged.

Explanation: In preparation of allowing SymbolKit (and by proxy, Swift-DocC) to accept symbol graphs from Clang, this PR adds two new symbol kinds to the KindIdentifier enum: ivar (for Objective-C instance variables) and macro (for C preprocessor macros).

Scope: A low-impact change that shouldn't affect any existing uses of SymbolKit/Swift-DocC, and enables new ones.

Radar: rdar://91166981

Risk: Low. New KindIdentifier cases will not cause any existing workflows that use SymbolKit to change or be affected.

Testing: A new automated test has been added to SymbolKit to ensure that symbol kinds can be parsed as themselves when serialized out and re-read. All existing automated tests still pass.