### PR TITLE
Pass extra `bin/test` arguments through to `swift test`

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -20,7 +20,7 @@ filepath() {
 DOCC_ROOT="$(dirname $(dirname $(filepath $0)))"
 
 # Build SwiftDocC.
-swift test --parallel --package-path "$DOCC_ROOT"
+swift test --parallel --package-path "$DOCC_ROOT" $@
 
 # Run source code checks for the codebase.
 LC_ALL=C "$DOCC_ROOT"/bin/check-source


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://91267402

## Summary

This allows invocations to pass any valid flags to `swift test` through the test script. To enable testing with the address sanitizer, for example, pass the same flags to the test script.

    ./bin/test --sanitize address

## Dependencies

None

## Testing

Verify that invoking `bin/test` as usual works as expected, and that passing valid flags for `swift test` to `bin/test` work as expected. 

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- ~Added tests~
- [x] Ran the `./bin/test` script and it succeeded
- ~Updated documentation if necessary~
