### PR TITLE
Fix missing space character in DocC docs

### DIFF
--- a/Sources/DocCDocumentation/DocCDocumentation.docc/Reference Syntax/Tutorials Syntax/Shared Directives/Intro.md
+++ b/Sources/DocCDocumentation/DocCDocumentation.docc/Reference Syntax/Tutorials Syntax/Shared Directives/Intro.md
@@ -7,7 +7,7 @@ Displays an introduction section at the top of a table of contents or tutorial p
 
 ## Overview
 
-You can display an introduction at the top of every table of contents by using the ``Tutorials`` directive and at the top of every tutorial page by using the``Tutorial`` directive. It's the first thing a reader sees on these pages, so it needs to draw them into the content that follows.
+You can display an introduction at the top of every table of contents by using the ``Tutorials`` directive and at the top of every tutorial page by using the ``Tutorial`` directive. It's the first thing a reader sees on these pages, so it needs to draw them into the content that follows.
 
 Example of an introduction section on a table of contents page:
 


### PR DESCRIPTION
Bug/issue #, if applicable: N/A

## Summary

Fix a missing space character in the DocC docs.

## Dependencies

None.

## Testing

Build DocC documentation and verify that missing space is no longer present.

## Checklist

- ~[ ] Added tests~ N/A
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
