### PR TITLE
Fix Render Node OpenAPI spec for variants key

### DIFF
--- a/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderNode.spec.json
+++ b/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderNode.spec.json
@@ -1759,8 +1759,7 @@
                     "schemaVersion",
                     "hierarchy",
                     "metadata",
-                    "sections",
-                    "variants"
+                    "sections"
                 ],
                 "type": "object",
                 "properties": {


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://88356862

## Summary

Remove the `variants` key of render node from the `required` array, since the `variants` key is optional in the Swift model.

## Dependencies

None.

## Testing

N/A

## Checklist

- ~[ ] Added tests~ N/A
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
