### PR TITLE
Allow null for TypeDetails keys in OpenAPI spec

### DIFF
--- a/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderNode.spec.json
+++ b/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderNode.spec.json
@@ -2815,11 +2815,13 @@
                 "type": "object",
                 "properties": {
                     "baseType": {
-                        "type": "string"
+                        "type": "string",
+                        "nullable": true
                     },
                     "arrayMode": {
                         "type": "boolean",
-                        "format": "true"
+                        "format": "true",
+                        "nullable": true
                     }
                 }
             },


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://88357075

## Summary

Allow null values for the TypeDetails keys. This reflects the properties
being optional in the Swift model.

## Dependencies

None.

## Testing

N/A

## Checklist

- ~[ ] Added tests~ N/A
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
