### PR TITLE
[5.7] use `default` branches for unknown symbol kinds

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Topic Graph/AutomaticCuration.swift
+++ b/Sources/SwiftDocC/Infrastructure/Topic Graph/AutomaticCuration.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -203,7 +203,7 @@ extension AutomaticCuration {
             case .`typealias`: return "Type Aliases"
             case .`var`: return "Variables"
             case .module: return "Modules"
-            case .unknown: return "Symbols"
+            default: return "Symbols"
         }
     }
 

--- a/Sources/SwiftDocC/Model/DocumentationNode.swift
+++ b/Sources/SwiftDocC/Model/DocumentationNode.swift
@@ -457,7 +457,7 @@ public struct DocumentationNode {
         case .`var`: return .globalVariable
 
         case .module: return .module
-        case .unknown: return .unknown
+        default: return .unknown
         }
     }
 


### PR DESCRIPTION
This is a cherry-pick of https://github.com/apple/swift-docc/pull/132 onto `release/5.7`.

**Explanation**: In preparation for updating the way symbol kinds are stored in the symbol graph, this PR changes the way swift-docc matches on that type to use a `default` branch instead of an explicit `case .unknown`.

**Scope**: No effect on user experience.

**Radar**: None, though this is a prerequisite for landing rdar://84276085

**Risk**: Low. This should offer no change to the behavior or test outcomes of Swift-DocC.

**Testing**: Ensure that the behavior of Swift-DocC does not change compared to beforehand.