### PR TITLE
[5.7] Register references resolved by fallback resolvers

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -1383,11 +1383,15 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
             referencesIndex.removeAll()
             referencesIndex.reserveCapacity(knownIdentifiers.count)
             for reference in knownIdentifiers {
-                referencesIndex[reference.absoluteString] = reference
+                registerReference(reference)
             }
 
             return (moduleReferences: Set(moduleReferences.values), urlHierarchy: symbolsURLHierarchy)
         }
+    }
+    
+    private func registerReference(_ resolvedReference: ResolvedTopicReference) {
+        referencesIndex[resolvedReference.absoluteString] = resolvedReference
     }
 
     private func shouldContinueRegistration() throws {
@@ -2607,6 +2611,11 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
                     
                     if case .success(let resolvedReference) = reference {
                         cacheReference(resolvedReference, withKey: ResolvedTopicReference.cacheIdentifier(unresolvedReference, fromSymbolLink: isCurrentlyResolvingSymbolLink, in: parent))
+                        
+                        // Register the resolved reference in the context so that it can be looked up via its absolute
+                        // path. We only do this for in-bundle content, and since we've just resolved an in-bundle link,
+                        // we register the reference.
+                        registerReference(resolvedReference)
                         return .success(resolvedReference)
                     }
                 }

--- a/Tests/SwiftDocCTests/Test Resources/one-symbol-top-level.symbols.json
+++ b/Tests/SwiftDocCTests/Test Resources/one-symbol-top-level.symbols.json
@@ -1,0 +1,213 @@
+{
+    "metadata": {
+        "formatVersion": {
+            "major": 0,
+            "minor": 5,
+            "patch": 3
+        },
+        "generator": "Apple Swift version 5.7 (swiftlang-5.7.0.101.10 clang-1400.0.10.4.2)"
+    },
+    "module": {
+        "name": "MyKit",
+        "platform": {
+            "architecture": "x86_64",
+            "vendor": "apple",
+            "operatingSystem": {
+                "name": "macosx",
+                "minimumVersion": {
+                    "major": 10,
+                    "minor": 10,
+                    "patch": 0
+                }
+            }
+        }
+    },
+    "symbols": [
+        {
+            "kind": {
+                "identifier": "swift.struct",
+                "displayName": "Structure"
+            },
+            "identifier": {
+                "precise": "s:32MyKit3FooV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "Foo"
+            ],
+            "names": {
+                "title": "Foo"
+            },
+            "docComment": {
+                "lines": [
+                    {
+                        "range": {
+                            "start": {
+                                "line": 0,
+                                "character": 4
+                            },
+                            "end": {
+                                "line": 0,
+                                "character": 15
+                            }
+                        },
+                        "text": "Foo"
+                    },
+                    {
+                        "range": {
+                            "start": {
+                                "line": 1,
+                                "character": 3
+                            },
+                            "end": {
+                                "line": 1,
+                                "character": 3
+                            }
+                        },
+                        "text": ""
+                    },
+                    {
+                        "range": {
+                            "start": {
+                                "line": 2,
+                                "character": 4
+                            },
+                            "end": {
+                                "line": 2,
+                                "character": 39
+                            }
+                        },
+                        "text": "All of these links should resolve:"
+                    },
+                    {
+                        "range": {
+                            "start": {
+                                "line": 3,
+                                "character": 3
+                            },
+                            "end": {
+                                "line": 3,
+                                "character": 3
+                            }
+                        },
+                        "text": ""
+                    },
+                    {
+                        "range": {
+                            "start": {
+                                "line": 4,
+                                "character": 4
+                            },
+                            "end": {
+                                "line": 4,
+                                "character": 13
+                            }
+                        },
+                        "text": "``bar()``"
+                    },
+                    {
+                        "range": {
+                            "start": {
+                                "line": 5,
+                                "character": 3
+                            },
+                            "end": {
+                                "line": 5,
+                                "character": 3
+                            }
+                        },
+                        "text": ""
+                    },
+                    {
+                        "range": {
+                            "start": {
+                                "line": 6,
+                                "character": 4
+                            },
+                            "end": {
+                                "line": 6,
+                                "character": 17
+                            }
+                        },
+                        "text": "``Foo/bar()``"
+                    },
+                    {
+                        "range": {
+                            "start": {
+                                "line": 7,
+                                "character": 3
+                            },
+                            "end": {
+                                "line": 7,
+                                "character": 3
+                            }
+                        },
+                        "text": ""
+                    },
+                    {
+                        "range": {
+                            "start": {
+                                "line": 8,
+                                "character": 4
+                            },
+                            "end": {
+                                "line": 8,
+                                "character": 22
+                            }
+                        },
+                        "text": "``Foo/otherBar()``"
+                    },
+                    {
+                        "range": {
+                            "start": {
+                                "line": 9,
+                                "character": 3
+                            },
+                            "end": {
+                                "line": 9,
+                                "character": 3
+                            }
+                        },
+                        "text": ""
+                    },
+                    {
+                        "range": {
+                            "start": {
+                                "line": 10,
+                                "character": 4
+                            },
+                            "end": {
+                                "line": 10,
+                                "character": 50
+                            }
+                        },
+                        "text": "``MyKit/Foo/bar()``"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "struct"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "Foo"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///tmp/Downloads/MyKit/MyKit.swift",
+                "position": {
+                    "line": 11,
+                    "character": 14
+                }
+            }
+        }
+    ],
+    "relationships": []
+}


### PR DESCRIPTION
- **Rationale:** Resolves an issue when using `ConvertService` where link resolution fails in doc comments of top-level symbols.
- **Risk:** Low
- **Risk Detail:** This only affects `ConvertService`-based compilation.
- **Reward:** High
- **Reward Details:** This aligns the `docc`-based and `ConvertService`-based compilations.
- **Original PR:** #135
- **Issue:** rdar://91545038
- **Code Reviewed By:** @d-ronnqvist 
- **Testing Details:** Existing tests continue to pass. A test that confirms that links can be resolved in top-level symbol documentation has been added.