### PR TITLE
[5.7] Disable flaky testResolvingTopicLinkProcess test

### DIFF
--- a/Tests/SwiftDocCUtilitiesTests/OutOfProcessReferenceResolverTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/OutOfProcessReferenceResolverTests.swift
@@ -143,6 +143,8 @@ class OutOfProcessReferenceResolverTests: XCTestCase {
     
     func testResolvingTopicLinkProcess() throws {
         #if os(macOS)
+        throw XCTSkip("This test is flaky (rdar://91678333)")
+        
         try assertResolvesTopicLink(makeResolver: { testMetadata in
             let temporaryFolder = try createTemporaryDirectory()
             let executableLocation = temporaryFolder.appendingPathComponent("link-resolver-executable")


### PR DESCRIPTION
- **Rationale:** Skips a flaky test.
- **Risk:** Low.
- **Risk Detail:** No user-facing changes.
- **Reward:** High
- **Reward Details:** Reduces spurious test failures
- **Original PR:** #140
- **Issue:** N/A
- **Code Reviewed By:** @daniel-grumberg
- **Testing Details:** Test has been skipped.