### PR TITLE
[5.7] Allow `readOnly` attribute in `TypedProperty` OpenAPI spec

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/Symbol/PropertiesRenderSection.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Symbol/PropertiesRenderSection.swift
@@ -69,6 +69,8 @@ public struct RenderProperty: Codable, TextIndexing, Equatable {
     public var required: Bool? = false
     /// If true, the property is deprecated.
     public var deprecated: Bool? = false
+    /// If true, the property can only be accessed and not modified.
+    public var readOnly: Bool? = false
     /// A version of the platform that first introduced the property, if known.
     public var introducedVersion: String?
 }

--- a/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderNode.spec.json
+++ b/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderNode.spec.json
@@ -2800,6 +2800,9 @@
                     "mimeType": {
                         "type": "string"
                     },
+                    "readOnly": {
+                        "type": "boolean"
+                    },
                     "required": {
                         "type": "boolean"
                     },

--- a/Tests/SwiftDocCTests/Rendering/RESTSymbolsTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/RESTSymbolsTests.swift
@@ -244,11 +244,13 @@ class RESTSymbolsTests: XCTestCase {
         XCTAssertEqual(properties.items.count, 2)
         guard properties.items.count == 2 else { return }
         
-        // The first property is not deprecated but required
+        // The first property is not deprecated/readonly but required
         XCTAssertNil(properties.items[0].deprecated)
+        XCTAssertNil(properties.items[0].readOnly)
         XCTAssertEqual(properties.items[0].required, true)
-        // The second property is deprecated but not required
+        // The second property is deprecated/readonly but not required
         XCTAssertEqual(properties.items[1].deprecated, true)
+        XCTAssertEqual(properties.items[1].readOnly, true)
         XCTAssertNil(properties.items[1].required)
         
         guard let attributes = properties.items[0].attributes else {

--- a/Tests/SwiftDocCTests/Rendering/Rendering Fixtures/rest-object.json
+++ b/Tests/SwiftDocCTests/Rendering/Rendering Fixtures/rest-object.json
@@ -136,6 +136,7 @@
         {
             "name" : "status",
             "deprecated" : true,
+            "readOnly" : true,
             "type" : [
                 {
                     "kind" : "identifier",


### PR DESCRIPTION
- **Rationale:** Adds support for a new, additive boolean property in the Render JSON specification.
- **Risk:** Low
- **Risk Detail:** Minor, additive change to Swift model and JSON spec
- **Reward:** High
- **Reward Details:** Allows additional clarifying data to be represented for REST object properties
- **Original PR:** https://github.com/apple/swift-docc/pull/134
- **Issue:** rdar://91505904
- **Code Reviewed By:** @franklinsch 
- **Testing Details:** Updated unit tests