### PR TITLE
Add fallback title for externally resolved symbols

### DIFF
--- a/Sources/SwiftDocC/Semantics/ReferenceResolver.swift
+++ b/Sources/SwiftDocC/Semantics/ReferenceResolver.swift
@@ -363,8 +363,8 @@ struct ReferenceResolver: SemanticVisitor {
         switch node.name {
         case .conceptual(let documentTitle):
             return documentTitle
-        case .symbol(_):
-            return node.symbol?.names.title ?? ""
+        case .symbol(let declaration):
+            return node.symbol?.names.title ?? declaration.tokens.map { $0.description }.joined(separator: " ")
         }
     }
     

--- a/Tests/SwiftDocCUtilitiesTests/OutOfProcessReferenceResolverTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/OutOfProcessReferenceResolverTests.swift
@@ -109,6 +109,8 @@ class OutOfProcessReferenceResolverTests: XCTestCase {
         XCTAssertEqual(node.kind.id, testMetadata.kind.id)
         XCTAssertEqual(node.kind.isSymbol, testMetadata.kind.isSymbol)
         
+        XCTAssertEqual(ReferenceResolver.title(forNode: node), "Resolved Title")
+        
         let symbol = try XCTUnwrap(node.semantic as? Symbol)
         XCTAssertEqual(symbol.title, "Resolved Title")
         
@@ -264,6 +266,8 @@ class OutOfProcessReferenceResolverTests: XCTestCase {
         XCTAssertEqual(symbolNode.kind.name, testMetadata.kind.name)
         XCTAssertEqual(symbolNode.kind.id, testMetadata.kind.id)
         XCTAssertEqual(symbolNode.kind.isSymbol, testMetadata.kind.isSymbol)
+        
+        XCTAssertEqual(ReferenceResolver.title(forNode: symbolNode), "Resolved Title")
         
         let symbol = try XCTUnwrap(symbolNode.semantic as? Symbol)
         XCTAssertEqual(symbol.kind.identifier, .class,


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

This adds a fallback value for `ReferenceResolver.title(forNode:)` for externally resolved symbols.

Documentation nodes for external symbols are created with a `.symbol()` style node `Name`, a minimal `Symbol` semantic, but without a `SymbolGraph.Symbol?`. 
See [`OutOfProcessReferenceResolver.entity(with:)`](https://github.com/apple/swift-docc/blob/main/Sources/SwiftDocC/Infrastructure/External%20Data/OutOfProcessReferenceResolver.swift#L158-L184)

Because the node has a symbol name but no SymbolGraph symbol, getting the title via `ReferenceResolver.title(forNode:)` result in `""`. 

If the external content originated from DocC, then its title—which is used to create the externally resolved node's name—is based on the SymbolGraph symbol's name, since the local documentation node for a symbol has a SymbolGraph symbol value. 
See [`LinkDestinationSummary.init`](https://github.com/apple/swift-docc/blob/main/Sources/SwiftDocC/LinkTargets/LinkDestinationSummary.swift#L286)

## Dependencies

n/a

## Testing

_Describe how a reviewer can test the functionality of your PR. Provide test content to test with if
applicable._

Steps:
1. _Provide setup instructions._
2. _Explain in detail how the functionality can be tested._

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
