### PR TITLE
[5.7] Add fallback title for externally resolved symbols 

### DIFF
--- a/Sources/SwiftDocC/Semantics/ReferenceResolver.swift
+++ b/Sources/SwiftDocC/Semantics/ReferenceResolver.swift
@@ -363,8 +363,8 @@ struct ReferenceResolver: SemanticVisitor {
         switch node.name {
         case .conceptual(let documentTitle):
             return documentTitle
-        case .symbol(_):
-            return node.symbol?.names.title ?? ""
+        case .symbol(let declaration):
+            return node.symbol?.names.title ?? declaration.tokens.map { $0.description }.joined(separator: " ")
         }
     }
     

--- a/Tests/SwiftDocCUtilitiesTests/OutOfProcessReferenceResolverTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/OutOfProcessReferenceResolverTests.swift
@@ -109,6 +109,8 @@ class OutOfProcessReferenceResolverTests: XCTestCase {
         XCTAssertEqual(node.kind.id, testMetadata.kind.id)
         XCTAssertEqual(node.kind.isSymbol, testMetadata.kind.isSymbol)
         
+        XCTAssertEqual(ReferenceResolver.title(forNode: node), "Resolved Title")
+        
         let symbol = try XCTUnwrap(node.semantic as? Symbol)
         XCTAssertEqual(symbol.title, "Resolved Title")
         
@@ -264,6 +266,8 @@ class OutOfProcessReferenceResolverTests: XCTestCase {
         XCTAssertEqual(symbolNode.kind.name, testMetadata.kind.name)
         XCTAssertEqual(symbolNode.kind.id, testMetadata.kind.id)
         XCTAssertEqual(symbolNode.kind.isSymbol, testMetadata.kind.isSymbol)
+        
+        XCTAssertEqual(ReferenceResolver.title(forNode: symbolNode), "Resolved Title")
         
         let symbol = try XCTUnwrap(symbolNode.semantic as? Symbol)
         XCTAssertEqual(symbol.kind.identifier, .class,


### PR DESCRIPTION
- **Rationale:** Adds logic for providing a fallback title for externally resolved symbols.
- **Risk:** Low
- **Risk Detail:** Minor, additive change that's only applicable to externally resoled symbols.
- **Reward:** Low
- **Reward Details:** Node's that represent externally resolved symbols won't resolve to having empty titles.
- **Original PR:** https://github.com/apple/swift-docc/pull/145
- **Issue:** rdar://91714948
- **Code Reviewed By:** @ethan-kusters 
- **Testing Details:** Updated unit tests to assert that nodes representing externally resolved symbols don't have empty titles.