### PR TITLE
Remove confusing error when no docs are produced

### DIFF
--- a/Sources/SwiftDocCUtilities/Action/Actions/Convert/ConvertAction.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Convert/ConvertAction.swift
@@ -377,12 +377,19 @@ public struct ConvertAction: Action, RecreatingContext {
         }
 
         // Process Static Hosting as needed.
-        if transformForStaticHosting, let templateDirectory = htmlTemplateDirectory {
+        if transformForStaticHosting,
+           let templateDirectory = htmlTemplateDirectory,
+           // If this conversion didn't actually produce documentation, then we expect
+           // the creation of this data provider to file because there will be no 'data' subdirectory
+           // in the documentation output. (r91790147)
+           let dataProvider = try? LocalFileSystemDataProvider(
+               rootURL: temporaryFolder.appendingPathComponent(NodeURLGenerator.Path.dataFolderName)
+           )
+        {
             if indexHTMLData == nil {
                 indexHTMLData = try StaticHostableTransformer.transformHTMLTemplate(htmlTemplate: templateDirectory, hostingBasePath: hostingBasePath)
             }
             
-            let dataProvider = try LocalFileSystemDataProvider(rootURL: temporaryFolder.appendingPathComponent(NodeURLGenerator.Path.dataFolderName))
             let transformer = StaticHostableTransformer(dataProvider: dataProvider, fileManager: fileManager, outputURL: temporaryFolder, indexHTMLData: indexHTMLData!)
             try transformer.transform()
         }

--- a/Sources/SwiftDocCUtilities/Action/Actions/Convert/ConvertAction.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Convert/ConvertAction.swift
@@ -380,7 +380,7 @@ public struct ConvertAction: Action, RecreatingContext {
         if transformForStaticHosting,
            let templateDirectory = htmlTemplateDirectory,
            // If this conversion didn't actually produce documentation, then we expect
-           // the creation of this data provider to file because there will be no 'data' subdirectory
+           // the creation of this data provider to fail because there will be no 'data' subdirectory
            // in the documentation output. (r91790147)
            let dataProvider = try? LocalFileSystemDataProvider(
                rootURL: temporaryFolder.appendingPathComponent(NodeURLGenerator.Path.dataFolderName)


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://91790147

## Summary

Removes a confusing error that started being emitted when `docc convert` failed to actually produce documentation for an otherwise valid DocC catalog.

This regression was introduced by the enablement of transform for static hosting by default (https://github.com/apple/swift-docc/pull/121) since that command relies on a `data` subdirectory existing in the produced documentation archive.

## Notes

This started causing failures in the SwiftCI integration tests because we were building a DocC catalog that didn't produce documentation there. Those integration tests are being updated to be more complete with https://github.com/apple/swift-integration-tests/pull/101 but this will fix the actual cause of the regression there.

Steps:
1. Run `docc convert` on a DocC catalog that contains only an info.plist
2. Confirm that `docc` exits with a zero exist status.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
