### PR TITLE
[5.7] Remove confusing error when no docs are produced

### DIFF
--- a/Sources/SwiftDocCUtilities/Action/Actions/Convert/ConvertAction.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Convert/ConvertAction.swift
@@ -377,12 +377,19 @@ public struct ConvertAction: Action, RecreatingContext {
         }
 
         // Process Static Hosting as needed.
-        if transformForStaticHosting, let templateDirectory = htmlTemplateDirectory {
+        if transformForStaticHosting,
+           let templateDirectory = htmlTemplateDirectory,
+           // If this conversion didn't actually produce documentation, then we expect
+           // the creation of this data provider to fail because there will be no 'data' subdirectory
+           // in the documentation output. (r91790147)
+           let dataProvider = try? LocalFileSystemDataProvider(
+               rootURL: temporaryFolder.appendingPathComponent(NodeURLGenerator.Path.dataFolderName)
+           )
+        {
             if indexHTMLData == nil {
                 indexHTMLData = try StaticHostableTransformer.transformHTMLTemplate(htmlTemplate: templateDirectory, hostingBasePath: hostingBasePath)
             }
             
-            let dataProvider = try LocalFileSystemDataProvider(rootURL: temporaryFolder.appendingPathComponent(NodeURLGenerator.Path.dataFolderName))
             let transformer = StaticHostableTransformer(dataProvider: dataProvider, fileManager: fileManager, outputURL: temporaryFolder, indexHTMLData: indexHTMLData!)
             try transformer.transform()
         }


### PR DESCRIPTION
- **Rationale:** Addressed a regression where `docc convert` would throw an error upon failing to actually produce documentation for an otherwise valid DocC catalog.
- **Risk:** Low
- **Risk Detail:** Minor, targeted change that is covered by a test.
- **Reward:** High
- **Reward Details:** Resolves a regression and avoids potential breakage with DocC's integration into other clients. Unblocks the enablement of `transform-for-static-hosting` by default for the 5.7 release.
- **Original PR:** https://github.com/apple/swift-docc/pull/148
- **Issue:** rdar://91790147
- **Code Reviewed By:** @d-ronnqvist and @talzag 
- **Testing Details:** Added unit tests to ensure that the default behavior of `docc convert` on the command-line does not throw an error in this scenario.