### PR TITLE
Fix ResolvedTopicReference memory leak

### DIFF
--- a/Sources/SwiftDocC/Utility/Weak.swift
+++ b/Sources/SwiftDocC/Utility/Weak.swift
@@ -1,0 +1,14 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+/// A wrapper that provides weak ownership of a value.
+struct Weak<T: AnyObject> {
+    weak var value: T?
+}


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://92131596

## Summary

The caching mechanism in `ResolvedTopicReference` never releases references to the `ResolvedTopicReference`s it holds.

This has likely always been a problem since the introduction of the cache, but is now appearing as a memory leak when profiling SwiftDocC because we recently added copy-on-write functionality to `ResolvedTopicReference` with #47 .

It’s important to release unused `ResolvedTopicReference`s because we can create potentially tens of thousands of them when compiling large documentation catalogs or loading large navigator indexes.

## Testing

Profile DocC after converting a documentation catalog and confirm that there are no references to unused `ResolvedTopicReference`s.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
