### PR TITLE
[5.7] use new ivar/macro symbol kinds

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -50,7 +50,7 @@
         "package": "CLMDB",
         "repositoryURL": "https://github.com/apple/swift-lmdb.git",
         "state": {
-          "branch": "main",
+          "branch": "release/5.7",
           "revision": "6ea45a7ebf6d8f72bd299dfcc3299e284bbb92ee",
           "version": null
         }
@@ -59,7 +59,7 @@
         "package": "swift-markdown",
         "repositoryURL": "https://github.com/apple/swift-markdown.git",
         "state": {
-          "branch": "main",
+          "branch": "release/5.7",
           "revision": "caafc56d3794a08c2203fe417b3aff81e2ab2fc1",
           "version": null
         }

--- a/Package.resolved
+++ b/Package.resolved
@@ -41,8 +41,8 @@
         "package": "SymbolKit",
         "repositoryURL": "https://github.com/apple/swift-docc-symbolkit",
         "state": {
-          "branch": "main",
-          "revision": "ed8ce5502e563090ab1400b4dd7d703b01eceabb",
+          "branch": "release/5.7",
+          "revision": "3866a31493efce07a57e8344b8b1318c6ae1b3c8",
           "version": null
         }
       },

--- a/Package.swift
+++ b/Package.swift
@@ -124,7 +124,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(name: "swift-markdown", url: "https://github.com/apple/swift-markdown.git", .branch("main")),
         .package(name: "CLMDB", url: "https://github.com/apple/swift-lmdb.git", .branch("main")),
         .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "1.0.1")),
-        .package(name: "SymbolKit", url: "https://github.com/apple/swift-docc-symbolkit", .branch("main")),
+        .package(name: "SymbolKit", url: "https://github.com/apple/swift-docc-symbolkit", .branch("release/5.7")),
         .package(url: "https://github.com/apple/swift-crypto.git", .upToNextMinor(from: "1.1.2")),
     ]
     

--- a/Package.swift
+++ b/Package.swift
@@ -121,8 +121,8 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     package.dependencies += [
         .package(url: "https://github.com/apple/swift-nio.git", .upToNextMinor(from: "2.31.2")),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", .upToNextMinor(from: "2.15.0")),
-        .package(name: "swift-markdown", url: "https://github.com/apple/swift-markdown.git", .branch("main")),
-        .package(name: "CLMDB", url: "https://github.com/apple/swift-lmdb.git", .branch("main")),
+        .package(name: "swift-markdown", url: "https://github.com/apple/swift-markdown.git", .branch("release/5.7")),
+        .package(name: "CLMDB", url: "https://github.com/apple/swift-lmdb.git", .branch("release/5.7")),
         .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "1.0.1")),
         .package(name: "SymbolKit", url: "https://github.com/apple/swift-docc-symbolkit", .branch("release/5.7")),
         .package(url: "https://github.com/apple/swift-crypto.git", .upToNextMinor(from: "1.1.2")),

--- a/Sources/SwiftDocC/Infrastructure/Topic Graph/AutomaticCuration.swift
+++ b/Sources/SwiftDocC/Infrastructure/Topic Graph/AutomaticCuration.swift
@@ -219,11 +219,13 @@ extension AutomaticCuration {
         .`var`,
         .`func`,
         .`operator`,
+        .`macro`,
 
         .`associatedtype`,
         .`case`,
         .`init`,
         .`deinit`,
+        .`ivar`,
         .`property`,
         .`method`,
         .`subscript`,

--- a/Sources/SwiftDocC/Infrastructure/Topic Graph/AutomaticCuration.swift
+++ b/Sources/SwiftDocC/Infrastructure/Topic Graph/AutomaticCuration.swift
@@ -190,6 +190,8 @@ extension AutomaticCuration {
             case .`func`: return "Functions"
             case .`operator`: return "Operators"
             case .`init`: return "Initializers"
+            case .ivar: return "Instance Variables"
+            case .macro: return "Macros"
             case .`method`: return "Instance Methods"
             case .`property`: return "Instance Properties"
             case .`protocol`: return "Protocols"

--- a/Sources/SwiftDocC/Model/DocumentationNode.swift
+++ b/Sources/SwiftDocC/Model/DocumentationNode.swift
@@ -443,6 +443,8 @@ public struct DocumentationNode {
         case .`func`: return .function
         case .`operator`: return .operator
         case .`init`: return .initializer
+        case .ivar: return .instanceVariable
+        case .macro: return .macro
         case .`method`: return .instanceMethod
         case .`property`: return .instanceProperty
         case .`protocol`: return .protocol

--- a/Tests/SwiftDocCTests/Test Resources/Whatsit-Objective-C.symbols.json
+++ b/Tests/SwiftDocCTests/Test Resources/Whatsit-Objective-C.symbols.json
@@ -1,0 +1,193 @@
+{
+  "metadata" : {
+    "formatVersion" : {
+      "major" : 0,
+      "minor" : 5,
+      "patch" : 0
+    },
+    "generator" : "clang"
+  },
+  "module" : {
+    "name" : "Whatsit",
+    "platform" : {
+      "architecture" : "x86_64",
+      "operatingSystem" : {
+        "minimumVersion" : {
+          "major" : 11,
+          "minor" : 0,
+          "patch" : 0
+        },
+        "name" : "macos"
+      },
+      "vendor" : "apple"
+    }
+  },
+  "relationships" : [
+    {
+      "kind" : "memberOf",
+      "source" : "c:objc(cs)Whatsit@Ivar",
+      "target" : "c:objc(cs)Whatsit",
+      "targetFallback" : null
+    }
+  ],
+  "symbols" : [
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "keyword",
+          "spelling" : "#define"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " "
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "IS_COOL"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "("
+        },
+        {
+          "kind" : "internalParam",
+          "spelling" : "X"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ")"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:PlayingCard.h@154@macro@IS_COOL"
+      },
+      "kind" : {
+        "displayName" : "Macro",
+        "identifier" : "macro"
+      },
+      "location" : {
+        "position" : {
+          "character" : 8,
+          "line" : 11
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "IS_COOL"
+          }
+        ],
+        "title" : "IS_COOL"
+      },
+      "pathComponents" : [
+        "IS_COOL"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "keyword",
+          "spelling" : "@interface"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " "
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "Whatsit"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:objc(cs)Whatsit"
+      },
+      "kind" : {
+        "displayName" : "Class",
+        "identifier" : "class"
+      },
+      "location" : {
+        "position" : {
+          "character" : 11,
+          "line" : 64
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "Whatsit"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "Whatsit"
+          }
+        ],
+        "title" : "Whatsit"
+      },
+      "pathComponents" : [
+        "Whatsit"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "preciseIdentifier" : "c:C",
+          "spelling" : "char"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " "
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "Ivar"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "occ",
+        "precise" : "c:objc(cs)Whatsit@Ivar"
+      },
+      "kind" : {
+        "displayName" : "Instance Variable",
+        "identifier" : "ivar"
+      },
+      "location" : {
+        "position" : {
+          "character" : 9,
+          "line" : 65
+        },
+        "uri" : "PlayingCard.h"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "Ivar"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "Ivar"
+          }
+        ],
+        "title" : "Ivar"
+      },
+      "pathComponents" : [
+        "Whatsit",
+        "Ivar"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This is a cherry-pick of https://github.com/apple/swift-docc/pull/152 onto `release/5.7`.

**Explanation**: A change in SymbolKit (https://github.com/apple/swift-docc-symbolkit/pull/31) is adding new symbol kinds: ivar and macro. This change updates DocC to handle these new symbols and curate them within rendered documentation.

**Scope**: Adds new behavior to load and curate new symbol types. Existing documentation should render with no change in behavior.

**Radar**: rdar://92124246

**Risk**: Low. This is a small enhancement without changing existing behavior for loading and curating symbols.

**Testing**: A new automated test has been added to ensure that the new symbol kinds can be loaded and organized into the documentation hierarchy correctly.