### PR TITLE
Update cmark-gfm and swift-markdown to latest versions

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
         "package": "cmark-gfm",
         "repositoryURL": "https://github.com/apple/swift-cmark.git",
         "state": {
-          "branch": "gfm",
-          "revision": "5bd1108552a4f54d421d3d39f696952495a4b0cf",
+          "branch": "release/5.7-gfm",
+          "revision": "792c1c3326327515ce9bf64c44196b7f4daab9a6",
           "version": null
         }
       },
@@ -60,7 +60,7 @@
         "repositoryURL": "https://github.com/apple/swift-markdown.git",
         "state": {
           "branch": "release/5.7",
-          "revision": "caafc56d3794a08c2203fe417b3aff81e2ab2fc1",
+          "revision": "fae172a60b3ed107bd4dc1e732abfec537661150",
           "version": null
         }
       },


### PR DESCRIPTION
## Summary

Updates cmark-gfm and swift-markdown to their latest versions on the `release/5.7` branch.

This is effectively a non-functional change since SwiftCI ignores the Package.resolved file when building a toolchain but it’s important to keep these up-to-date for local development of Swift-DocC.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] ~~Added tests~~ NFC
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
