### PR TITLE
Avoid using the module's customized display name when creating availability render items

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -417,6 +417,8 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
                 case .symbol(let declaration):
                     displayName = declaration.tokens.map { $0.description }.joined()
                 }
+                // A module node should always have a symbol.
+                // Remove the fallback value and force unwrap `node.symbol` on the main branch: https://github.com/apple/swift-docc/issues/249
                 moduleNameCache[reference] = (displayName, node.symbol?.names.title ?? reference.lastPathComponent)
             }
         }

--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -384,7 +384,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
     }
     
     /// A cache of plain string module names, keyed by the module node reference.
-    private var moduleNameCache: [ResolvedTopicReference: String] = [:]
+    private var moduleNameCache: [ResolvedTopicReference: (displayName: String, symbolName: String)] = [:]
     
     /// Find the known plain string module name for a given module reference.
     ///
@@ -392,7 +392,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
     ///
     /// - Parameter moduleReference: The module reference to find the module name for.
     /// - Returns: The plain string name for the referenced module.
-    func moduleName(forModuleReference moduleReference: ResolvedTopicReference) -> String {
+    func moduleName(forModuleReference moduleReference: ResolvedTopicReference) -> (displayName: String, symbolName: String) {
         if let name = moduleNameCache[moduleReference]  {
             return name
         }
@@ -410,12 +410,14 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
     func preResolveModuleNames() {
         for reference in rootModules {
             if let node = try? entity(with: reference) {
+                let displayName: String
                 switch node.name {
                 case .conceptual(let title):
-                    moduleNameCache[reference] = title
+                    displayName = title
                 case .symbol(let declaration):
-                    moduleNameCache[reference] = declaration.tokens.map { $0.description }.joined()
+                    displayName = declaration.tokens.map { $0.description }.joined()
                 }
+                moduleNameCache[reference] = (displayName, node.symbol?.names.title ?? reference.lastPathComponent)
             }
         }
     }

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -1008,7 +1008,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
         let moduleName = context.moduleName(forModuleReference: symbol.moduleReference)
         
         node.metadata.modulesVariants = VariantCollection(defaultValue:
-            [RenderMetadata.Module(name: moduleName, relatedModules: symbol.bystanderModuleNames)]
+            [RenderMetadata.Module(name: moduleName.displayName, relatedModules: symbol.bystanderModuleNames)]
         )
         
         node.metadata.extendedModuleVariants = VariantCollection<String?>(defaultValue: symbol.extendedModule)
@@ -1031,7 +1031,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
                 .filter({ !($0.unconditionallyUnavailable == true) })
                 .sorted(by: AvailabilityRenderOrder.compare)
         } ?? .init(defaultValue:
-            defaultAvailability(for: bundle, moduleName: moduleName, currentPlatforms: context.externalMetadata.currentPlatforms)?
+            defaultAvailability(for: bundle, moduleName: moduleName.symbolName, currentPlatforms: context.externalMetadata.currentPlatforms)?
                 .filter({ !($0.unconditionallyUnavailable == true) })
                 .sorted(by: AvailabilityRenderOrder.compare)
         )

--- a/Tests/SwiftDocCTests/Rendering/DefaultAvailabilityTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/DefaultAvailabilityTests.swift
@@ -40,6 +40,8 @@ class DefaultAvailabilityTests: XCTestCase {
             let myKitDocExtensionFile = url.appendingPathComponent("documentation", isDirectory: true).appendingPathComponent("mykit.md")
             var myKitDocExtension = try String(contentsOf: myKitDocExtensionFile)
             
+            // Customize the display name of the MyKit module to verify that the default availability uses the Info.plist
+            // information that's specified using the module's symbol name.
             let firstNewLineIndex = try XCTUnwrap(myKitDocExtension.firstIndex(of: "\n"))
             myKitDocExtension.insert(contentsOf: """
                 

--- a/Tests/SwiftDocCTests/Rendering/DefaultAvailabilityTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/DefaultAvailabilityTests.swift
@@ -33,11 +33,24 @@ class DefaultAvailabilityTests: XCTestCase {
     // Test whether the default availability is loaded from Info.plist and applied during render time
     func testBundleWithDefaultAvailability() throws {
         // Copy an Info.plist with default availability
-        let (url, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], codeListings: [:]) { (url) in
+        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], codeListings: [:]) { (url) in
             try? FileManager.default.removeItem(at: url.appendingPathComponent("Info.plist"))
             try? FileManager.default.copyItem(at: self.infoPlistAvailabilityURL, to: url.appendingPathComponent("Info.plist"))
+            
+            let myKitDocExtensionFile = url.appendingPathComponent("documentation", isDirectory: true).appendingPathComponent("mykit.md")
+            var myKitDocExtension = try String(contentsOf: myKitDocExtensionFile)
+            
+            let firstNewLineIndex = try XCTUnwrap(myKitDocExtension.firstIndex(of: "\n"))
+            myKitDocExtension.insert(contentsOf: """
+                
+                @Metadata {
+                  @DisplayName("MyKit custom display name")
+                }
+                
+                """, at: myKitDocExtension.index(after: firstNewLineIndex))
+            
+            try myKitDocExtension.write(to: myKitDocExtensionFile, atomically: true, encoding: .utf8)
         }
-        defer { try? FileManager.default.removeItem(at: url) }
         
         // Verify the bundle has loaded the default availability
         XCTAssertEqual(bundle.info.defaultAvailability?.modules["MyKit"]?.map({ "\($0.platformName.displayName) \($0.platformVersion)" }).sorted(), expectedDefaultAvailability)


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://92197472

## Summary

This fixes a small issue where availability render items was created based on the module's display name instead of the module's symbol name. This resulted in missed default availability items not being rendered after customizing the module's display name.

## Dependencies

n/a

## Testing

With a documentation catalog with default availability specified in the Into.plist (using the `CDAppleDefaultAvailability` key)
- Customize the module's display name with a `@DisplayName` directive in the module's documentation extension file.
- Build documentation for the project and navigate to the module page.

The default availability should be rendered on the module page.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] ~Added~ Updated tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
