### PR TITLE
Add more benchmark duration metrics

### DIFF
--- a/Sources/SwiftDocC/Benchmark/Metrics/Duration.swift
+++ b/Sources/SwiftDocC/Benchmark/Metrics/Duration.swift
@@ -54,7 +54,7 @@ extension Benchmark {
         /// - Parameter duration: The duration value in milliseconds to be logged.
         public init(id: String, duration: TimeInterval) {
             self.id = id
-            result = .integer(Int64(duration))
+            result = .integer(Int64(duration * 1000.0))
         }
     }
 }

--- a/Sources/SwiftDocC/Infrastructure/DocumentationConverter.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationConverter.swift
@@ -215,7 +215,7 @@ public struct DocumentationConverter: DocumentationConverterProtocol {
         // If cancelled, return early before we emit diagnostics.
         guard !isConversionCancelled() else { return ([], []) }
         
-        processingDurationMetric = benchmark(begin: Benchmark.Duration(id: "convert-processing"))
+        processingDurationMetric = benchmark(begin: Benchmark.Duration(id: "documentation-processing"))
         
         let bundles = try sorted(bundles: dataProvider.bundles(options: bundleDiscoveryOptions))
         guard !bundles.isEmpty else {

--- a/Sources/SwiftDocCUtilities/Action/Actions/Convert/ConvertAction.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Convert/ConvertAction.swift
@@ -392,11 +392,6 @@ public struct ConvertAction: Action, RecreatingContext {
                rootURL: temporaryFolder.appendingPathComponent(NodeURLGenerator.Path.dataFolderName)
            )
         {
-            let staticHostingTransformMetric = benchmark(begin: Benchmark.Duration(id: "static-hosting-transform"))
-            defer {
-                benchmark(end: staticHostingTransformMetric)
-            }
-            
             if indexHTMLData == nil {
                 indexHTMLData = try StaticHostableTransformer.transformHTMLTemplate(htmlTemplate: templateDirectory, hostingBasePath: hostingBasePath)
             }


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://92584930

## Summary

This adds a few more benchmark duration metrics to measure the tasks that happen after `DocumentationConverter.convert(outputConsumer:)`.

## Dependencies

n/a

This is done separately from https://github.com/apple/swift-docc/pull/159 so that it can be cherry-picked into the 5.7 branch. The other benchmark tool improvements are only intended for the main branch and forward.

## Testing

Run the benchmark.swift file with convert flags that include `--index`. 
There benchmark output should list the new duration metrics.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- ~Added tests~
- [x] Ran the `./bin/test` script and it succeeded
- ~Updated documentation if necessary~
