### PR TITLE
[5.7-04252022] Add more benchmark duration metrics (#165)

### DIFF
--- a/Sources/SwiftDocC/Benchmark/Metrics/Duration.swift
+++ b/Sources/SwiftDocC/Benchmark/Metrics/Duration.swift
@@ -54,7 +54,7 @@ extension Benchmark {
         /// - Parameter duration: The duration value in milliseconds to be logged.
         public init(id: String, duration: TimeInterval) {
             self.id = id
-            result = .integer(Int64(duration))
+            result = .integer(Int64(duration * 1000.0))
         }
     }
 }

--- a/Sources/SwiftDocC/Infrastructure/DocumentationConverter.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationConverter.swift
@@ -92,7 +92,7 @@ public struct DocumentationConverter: DocumentationConverterProtocol {
     /// `true` if the conversion is cancelled.
     private var isCancelled: Synchronized<Bool>? = nil
 
-    private var durationMetric: Benchmark.Duration?
+    private var processingDurationMetric: Benchmark.Duration?
 
     /// Creates a documentation converter given a documentation bundle's URL.
     ///
@@ -174,8 +174,6 @@ public struct DocumentationConverter: DocumentationConverterProtocol {
         // Do additional context setup.
         setupContext?(&context)
 
-        durationMetric = benchmark(begin: Benchmark.Duration(id: "convert-action"))
-
         /*
            Asynchronously cancel registration if necessary.
            We spawn a timer that periodically checks `isCancelled` and if necessary
@@ -216,6 +214,8 @@ public struct DocumentationConverter: DocumentationConverterProtocol {
         
         // If cancelled, return early before we emit diagnostics.
         guard !isConversionCancelled() else { return ([], []) }
+        
+        processingDurationMetric = benchmark(begin: Benchmark.Duration(id: "documentation-processing"))
         
         let bundles = try sorted(bundles: dataProvider.bundles(options: bundleDiscoveryOptions))
         guard !bundles.isEmpty else {
@@ -372,8 +372,8 @@ public struct DocumentationConverter: DocumentationConverterProtocol {
             )
         )
         
-        // Log the duration of the convert action.
-        benchmark(end: durationMetric)
+        // Log the duration of the processing (after the bundle content finished registering).
+        benchmark(end: processingDurationMetric)
         // Log the finalized topic graph checksum.
         benchmark(add: Benchmark.TopicGraphHash(context: context))
         // Log the finalized list of topic anchor sections.

--- a/Sources/SwiftDocCUtilities/Action/Actions/Convert/ConvertAction.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Convert/ConvertAction.swift
@@ -283,6 +283,7 @@ public struct ConvertAction: Action, RecreatingContext {
     /// Converts each eligible file from the source documentation bundle,
     /// saves the results in the given output alongside the template files.
     mutating public func perform(logHandle: LogHandle) throws -> ActionResult {
+        let totalTimeMetric = benchmark(begin: Benchmark.Duration(id: "convert-total-time"))
         
         // While running this method keep the `isPerforming` flag up.
         isPerforming.sync({ $0 = true })
@@ -370,6 +371,11 @@ public struct ConvertAction: Action, RecreatingContext {
         
         // If we're building a navigation index, finalize the process and collect encountered problems.
         if let indexer = indexer {
+            let finalizeNavigationIndexMetric = benchmark(begin: Benchmark.Duration(id: "finalize-navigation-index"))
+            defer {
+                benchmark(end: finalizeNavigationIndexMetric)
+            }
+            
             // Always emit a JSON representation of the index but only emit the LMDB
             // index if the user has explicitly opted in with the `--emit-lmdb-index` flag.
             let indexerProblems = indexer.finalize(emitJSON: true, emitLMDB: buildLMDBIndex)
@@ -393,6 +399,10 @@ public struct ConvertAction: Action, RecreatingContext {
             let transformer = StaticHostableTransformer(dataProvider: dataProvider, fileManager: fileManager, outputURL: temporaryFolder, indexHTMLData: indexHTMLData!)
             try transformer.transform()
         }
+        
+        // Stop the "total time" metric here. The moveOutput time isn't very interesting to include in the benchmark.
+        // New tasks and computations should be added above this line so that they're included in the benchmark.
+        benchmark(end: totalTimeMetric)
         
         // We should generally only replace the current build output if we didn't encounter errors
         // during conversion. However, if the `emitDigest` flag is true,


### PR DESCRIPTION
- **Rationale:** This adds additional benchmark metrics for the total convert time. Having these on the 5.7-04252022 branch makes it more straight forward to asses the performance improvements of #166 if we want to cherry-pick that into the 5.7-04252022 branch as well. If we don't, then we can skip this cherry-pick. 
- **Risk:** Low
- **Risk Detail:** This is a targeted change that only apply when benchmark metrics is gathered.
- **Reward:** Low
- **Reward Details:** Having these metrics on the release/5.7-04252022 branch makes it easier to asses the performance improvements of cherry-picking the #166 changes into the release/5.7-04252022 branch
- **Original PR:** https://github.com/apple/swift-docc/pull/165
- **Issue:** rdar://92584930
- **Code Reviewed By:** @ethan-kusters 
- **Testing Details:** Ethan and I manually tested these new benchmark metrics by running `docc` with benchmarking enabled and verifying that these metrics are reported with their expected values.