### PR TITLE
Do not emit variants for pages in article-only catalogs

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -1881,7 +1881,10 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
         let reference = ResolvedTopicReference(
             bundleIdentifier: bundle.identifier,
             path: path,
-            sourceLanguages: availableSourceLanguages ?? [.swift]
+            sourceLanguages: availableSourceLanguages
+                // FIXME: Pages in article-only catalogs should not be inferred as "Swift" as a fallback
+                // (github.com/apple/swift-docc/issues/240).
+                ?? [.swift]
         )
         
         let title = article.topicGraphNode.title

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -601,7 +601,14 @@ public struct RenderNodeTranslator: SemanticVisitor {
         collectedTopicReferences.append(contentsOf: hierarchyTranslator.collectedTopicReferences)
         node.hierarchy = hierarchy
         
-        node.variants = variants(for: documentationNode)
+        // Emit variants only if we're not compiling an article-only catalog to prevent renderers from
+        // advertising the page as "Swift", which is the language DocC assigns to pages in article only pages.
+        // (github.com/apple/swift-docc/issues/240).
+        if let topLevelModule = context.soleRootModuleReference,
+           try! context.entity(with: topLevelModule).kind.isSymbol
+        {
+            node.variants = variants(for: documentationNode)
+        }
         
         if let abstract = article.abstractSection,
             let abstractContent = visitMarkup(abstract.content) as? [RenderInlineContent] {

--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeArticleOnlyCatalogTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeArticleOnlyCatalogTests.swift
@@ -1,0 +1,20 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+@testable import SwiftDocC
+
+class SemaToRenderNodeArticleOnlyCatalogTests: XCTestCase {
+    func testDoesNotEmitVariantsForPagesInArticleOnlyCatalog() throws {
+        for renderNode in try renderNodeConsumer(for: "BundleWithTechnologyRoot").allRenderNodes() {
+            XCTAssertNil(renderNode.variants)
+        }
+    }
+}

--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeMultiLanguageTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeMultiLanguageTests.swift
@@ -476,7 +476,7 @@ class SemaToRenderNodeMixedLanguageTests: XCTestCase {
     }
     
     func testObjectiveCOnlySymbolCuratedInSwiftOnlySymbolIsNotFilteredOut() throws {
-         let outputConsumer = try mixedLanguageFrameworkConsumer(bundleName: "MixedLanguageFrameworkSingleLanguageCuration")
+         let outputConsumer = try renderNodeConsumer(for: "MixedLanguageFrameworkSingleLanguageCuration")
          let fooRenderNode = try outputConsumer.renderNode(
              withIdentifier: "s:22MixedLanguageFramework15SwiftOnlyStruct1V"
          )

--- a/Tests/SwiftDocCTests/TestRenderNodeOutputConsumer.swift
+++ b/Tests/SwiftDocCTests/TestRenderNodeOutputConsumer.swift
@@ -1,0 +1,111 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+@testable import SwiftDocC
+import XCTest
+
+class TestRenderNodeOutputConsumer: ConvertOutputConsumer {
+    var renderNodes = Synchronized<[RenderNode]>([])
+    
+    func consume(renderNode: RenderNode) throws {
+        renderNodes.sync { renderNodes in
+            renderNodes.append(renderNode)
+        }
+    }
+    
+    func consume(problems: [Problem]) throws { }
+    func consume(assetsInBundle bundle: DocumentationBundle) throws { }
+    func consume(linkableElementSummaries: [LinkDestinationSummary]) throws { }
+    func consume(indexingRecords: [IndexingRecord]) throws { }
+    func consume(assets: [RenderReferenceType: [RenderReference]]) throws { }
+    func consume(benchmarks: Benchmark) throws { }
+    func consume(documentationCoverageInfo: [CoverageDataEntry]) throws { }
+    func consume(renderReferenceStore: RenderReferenceStore) throws { }
+    func consume(buildMetadata: BuildMetadata) throws { }
+}
+
+extension TestRenderNodeOutputConsumer {
+    func allRenderNodes() -> [RenderNode] {
+        renderNodes.sync { $0 }
+    }
+    
+    func renderNodes(withInterfaceLanguages interfaceLanguages: Set<String>?) -> [RenderNode] {
+        renderNodes.sync { renderNodes in
+            renderNodes.filter { renderNode in
+                guard let interfaceLanguages = interfaceLanguages else {
+                    // If there are no interface languages set, return the nodes with no variants.
+                    return renderNode.variants == nil
+                }
+                
+                guard let variants = renderNode.variants else {
+                    return false
+                }
+                
+                let actualInterfaceLanguages: [String] = variants.flatMap { variant in
+                    variant.traits.compactMap { trait in
+                        guard case .interfaceLanguage(let interfaceLanguage) = trait else {
+                            return nil
+                        }
+                        return interfaceLanguage
+                    }
+                }
+                
+                return Set(actualInterfaceLanguages) == interfaceLanguages
+            }
+        }
+    }
+    
+    func renderNode(withIdentifier identifier: String) throws -> RenderNode {
+        try renderNode(where: { renderNode in renderNode.metadata.externalID == identifier })
+    }
+    
+    func renderNode(withTitle title: String) throws -> RenderNode {
+        try renderNode(where: { renderNode in renderNode.metadata.title == title })
+    }
+    
+    func renderNode(where predicate: (RenderNode) -> Bool) throws -> RenderNode {
+        let renderNode = renderNodes.sync { renderNodes in
+            renderNodes.first { renderNode in
+                predicate(renderNode)
+            }
+        }
+        
+        return try XCTUnwrap(renderNode)
+    }
+}
+
+extension XCTestCase {
+    func renderNodeConsumer(
+        for bundleName: String,
+        configureBundle: ((URL) throws -> Void)? = nil
+    ) throws -> TestRenderNodeOutputConsumer {
+        let (bundleURL, _, context) = try testBundleAndContext(
+            copying: bundleName,
+            configureBundle: configureBundle
+        )
+        
+        var converter = DocumentationConverter(
+            documentationBundleURL: bundleURL,
+            emitDigest: false,
+            documentationCoverageOptions: .noCoverage,
+            currentPlatforms: nil,
+            workspace: context.dataProvider as! DocumentationWorkspace,
+            context: context,
+            dataProvider: try LocalFileSystemDataProvider(rootURL: bundleURL),
+            bundleDiscoveryOptions: BundleDiscoveryOptions()
+        )
+        
+        let outputConsumer = TestRenderNodeOutputConsumer()
+        let (_, _) = try converter.convert(outputConsumer: outputConsumer)
+        
+        return outputConsumer
+    }
+}


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://92758192

## Summary

Don't emit variants for article-only catalogs

For article-only catalogs, i.e., catalogs that use `@TechnologyRoot`, don't emit the variants array in the render node, so that renderers don't display the page's language, since it doesn't have a language.

A longer-term fix here would be to not consider articles in article-only catalogs to be "Swift", and implement logic in RenderNodeTranslator to not emit variants information for language-less pages (#240).

> Note: The first commit just moves a test utility so that it can be used in a test introduced by the second commit.

## Dependencies

None.

## Testing

Build documentation for an article-only catalog, and verify that the "Language: Swift" label doesn't appear for any of its pages.

## Checklist

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
