### PR TITLE
[5.7]changes to have diagnostics only for known directives (#154)

### DIFF
--- a/Sources/SwiftDocC/Model/DocumentationNode.swift
+++ b/Sources/SwiftDocC/Model/DocumentationNode.swift
@@ -380,10 +380,14 @@ public struct DocumentationNode {
                 let location = symbol.mixins.getValueIfPresent(
                     for: SymbolGraph.Symbol.Location.self
                 )?.url()
-                
+
                 for comment in docCommentDirectives {
                     let range = docCommentMarkup.child(at: comment.indexInParent)?.range
                     
+                    guard BlockDirective.allKnownDirectiveNames.contains(comment.name) else {
+                        continue
+                    }
+
                     var diagnostic = Diagnostic(
                         source: location,
                         severity: .warning,

--- a/Sources/SwiftDocC/Utility/MarkupExtensions/BlockDirectiveExtensions.swift
+++ b/Sources/SwiftDocC/Utility/MarkupExtensions/BlockDirectiveExtensions.swift
@@ -17,4 +17,39 @@ extension BlockDirective {
         Tutorial.directiveName,
         TutorialArticle.directiveName,
     ]
+
+    /// Names of known directives
+    static let allKnownDirectiveNames: [String] = [
+        Assessments.directiveName,
+        Chapter.directiveName,
+        Choice.directiveName,
+        Code.directiveName,
+        Comment.directiveName,
+        ContentAndMedia.directiveName,
+        DeprecationSummary.directiveName,
+        DisplayName.directiveName,
+        DocumentationExtension.directiveName,
+        ImageMedia.directiveName,
+        Intro.directiveName,
+        Justification.directiveName,
+        Metadata.directiveName,
+        MultipleChoice.directiveName,
+        Redirect.directiveName,
+        Resources.directiveName,
+        Snippet.directiveName,
+        Stack.directiveName,
+        Step.directiveName,
+        Steps.directiveName,
+        Technology.directiveName,
+        TechnologyRoot.directiveName,
+        TechnologyRoot.directiveName,
+        Tile.directiveName,
+        Tutorial.directiveName,
+        TutorialArticle.directiveName,
+        TutorialReference.directiveName,
+        TutorialSection.directiveName,
+        VideoMedia.directiveName,
+        Volume.directiveName,
+        XcodeRequirement.directiveName
+    ]
 }

--- a/Tests/SwiftDocCTests/Semantics/SymbolTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/SymbolTests.swift
@@ -499,7 +499,7 @@ class SymbolTests: XCTestCase {
         XCTAssertEqual(problems.first?.diagnostic.range?.lowerBound.column, 1)
     }
     
-    func testWarningWhenDocCommentContainsDirectiveInSubclass() throws {
+    func testNoWarningWhenDocCommentContainsDoxygen() throws {
         let tempURL = try createTemporaryDirectory()
         
         let bundleURL = try Folder(name: "Inheritance.docc", content: [
@@ -511,13 +511,7 @@ class SymbolTests: XCTestCase {
         
         let (_, _, context) = try loadBundle(from: bundleURL)
         let problems = context.diagnosticEngine.problems
-        XCTAssertEqual(problems.count, 3)
-        XCTAssertFalse(problems.containsErrors)
-        let initProblems = problems.filter { $0.diagnostic.range?.lowerBound.line == 7 }
-        XCTAssertEqual(initProblems.count, 1, "There should only be one error from the doc comments for 'ParentClass/init()'")
-        // Problems in the `index` doc comments
-        let indexProblems = problems.filter { $0.diagnostic.range?.lowerBound.line == 12 }
-        XCTAssertEqual(indexProblems.count, 2, "There should be two errors from the doc comments for 'index()'. One from 'ParentClass' and one synthesized from 'ChildClass'.")
+        XCTAssertEqual(problems.count, 0)
     }
 
     func testUnresolvedReferenceWarnignsInDocumentationExtension() throws {
@@ -656,7 +650,7 @@ class SymbolTests: XCTestCase {
             start: .init(line: 0, character: 0),
             end: .init(line: 0, character: 0)
         )
-        let line = SymbolGraph.LineList.Line(text: "@this is a directive", range: range)
+        let line = SymbolGraph.LineList.Line(text: "@Image this is a known directive", range: range)
         let docComment = SymbolGraph.LineList([line])
         let symbol = SymbolGraph.Symbol(
             identifier: identifer,


### PR DESCRIPTION
Rationale: Fixes the issue where diagnostic were added for Doxygen at-commands like @param and @returns, limiting diagnostics to know directives 
Risk: Low
Risk Detail: Minor, targeted change that is covered by a test.
Reward: Medium
Reward Details: This avoid confusing the Doxygen at-commands like @param and @return with DocC-style directives which throws a warning. Limiting this diagnostic so it only throws when it detects a specific directive that is not supported. 
Original PR: https://github.com/apple/swift-docc/pull/154
Issue: rdar://90953916 
Code Reviewed By: @ethan-kusters, @d-ronnqvist 
Testing Details: Added unit tests to ensure that the affected links now resolve, existing tests are pass.