### PR TITLE
[5.7] Avoid using the module's customized display name when creating availability render items (#161)

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -384,7 +384,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
     }
     
     /// A cache of plain string module names, keyed by the module node reference.
-    private var moduleNameCache: [ResolvedTopicReference: String] = [:]
+    private var moduleNameCache: [ResolvedTopicReference: (displayName: String, symbolName: String)] = [:]
     
     /// Find the known plain string module name for a given module reference.
     ///
@@ -392,7 +392,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
     ///
     /// - Parameter moduleReference: The module reference to find the module name for.
     /// - Returns: The plain string name for the referenced module.
-    func moduleName(forModuleReference moduleReference: ResolvedTopicReference) -> String {
+    func moduleName(forModuleReference moduleReference: ResolvedTopicReference) -> (displayName: String, symbolName: String) {
         if let name = moduleNameCache[moduleReference]  {
             return name
         }
@@ -410,12 +410,16 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
     func preResolveModuleNames() {
         for reference in rootModules {
             if let node = try? entity(with: reference) {
+                let displayName: String
                 switch node.name {
                 case .conceptual(let title):
-                    moduleNameCache[reference] = title
+                    displayName = title
                 case .symbol(let declaration):
-                    moduleNameCache[reference] = declaration.tokens.map { $0.description }.joined()
+                    displayName = declaration.tokens.map { $0.description }.joined()
                 }
+                // A module node should always have a symbol.
+                // Remove the fallback value and force unwrap `node.symbol` on the main branch: https://github.com/apple/swift-docc/issues/249
+                moduleNameCache[reference] = (displayName, node.symbol?.names.title ?? reference.lastPathComponent)
             }
         }
     }

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -1008,7 +1008,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
         let moduleName = context.moduleName(forModuleReference: symbol.moduleReference)
         
         node.metadata.modulesVariants = VariantCollection(defaultValue:
-            [RenderMetadata.Module(name: moduleName, relatedModules: symbol.bystanderModuleNames)]
+            [RenderMetadata.Module(name: moduleName.displayName, relatedModules: symbol.bystanderModuleNames)]
         )
         
         node.metadata.extendedModuleVariants = VariantCollection<String?>(defaultValue: symbol.extendedModule)
@@ -1031,7 +1031,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
                 .filter({ !($0.unconditionallyUnavailable == true) })
                 .sorted(by: AvailabilityRenderOrder.compare)
         } ?? .init(defaultValue:
-            defaultAvailability(for: bundle, moduleName: moduleName, currentPlatforms: context.externalMetadata.currentPlatforms)?
+            defaultAvailability(for: bundle, moduleName: moduleName.symbolName, currentPlatforms: context.externalMetadata.currentPlatforms)?
                 .filter({ !($0.unconditionallyUnavailable == true) })
                 .sorted(by: AvailabilityRenderOrder.compare)
         )


### PR DESCRIPTION
- **Rationale:** This fixes a small issue where default availability items wasn't being rendered after customizing the module's display name.
- **Risk:** Low
- **Risk Detail:** This is a targeted change that only apply when the developer has customized the module's display name provided default availability for that module.
- **Reward:** Low
- **Reward Details:** The bug only happens when two relatively niche features are used together.
- **Original PR:** #161
- **Issue:** rdar://92197472
- **Code Reviewed By:** @ethan-kusters 
- **Testing Details:** Updated existing tests to verify that customizing the display name doesn't impact the availability items
