### PR TITLE
Emit symbol URL to link to declaration in repo

### DIFF
--- a/Sources/SwiftDocC/Converter/DocumentationContextConverter.swift
+++ b/Sources/SwiftDocC/Converter/DocumentationContextConverter.swift
@@ -37,6 +37,9 @@ public class DocumentationContextConverter {
     /// Whether the documentation converter should include access level information for symbols.
     let shouldEmitSymbolAccessLevels: Bool
     
+    /// The remote source control repository where the documented module's source is hosted.
+    let sourceRepository: SourceRepository?
+    
     /// Creates a new node converter for the given bundle and context.
     ///
     /// The converter uses bundle and context to resolve references to other documentation and describe the documentation hierarchy.
@@ -51,18 +54,21 @@ public class DocumentationContextConverter {
     ///     Before passing `true` please confirm that your use case doesn't include public
     ///     distribution of any created render nodes as there are filesystem privacy and security
     ///     concerns with distributing this data.
+    ///   - sourceRepository: The source repository where the documentation's sources are hosted.
     public init(
         bundle: DocumentationBundle,
         context: DocumentationContext,
         renderContext: RenderContext,
         emitSymbolSourceFileURIs: Bool = false,
-        emitSymbolAccessLevels: Bool = false
+        emitSymbolAccessLevels: Bool = false,
+        sourceRepository: SourceRepository? = nil
     ) {
         self.bundle = bundle
         self.context = context
         self.renderContext = renderContext
         self.shouldEmitSymbolSourceFileURIs = emitSymbolSourceFileURIs
         self.shouldEmitSymbolAccessLevels = emitSymbolAccessLevels
+        self.sourceRepository = sourceRepository
     }
     
     /// Converts a documentation node to a render node.
@@ -84,7 +90,8 @@ public class DocumentationContextConverter {
             source: source,
             renderContext: renderContext,
             emitSymbolSourceFileURIs: shouldEmitSymbolSourceFileURIs,
-            emitSymbolAccessLevels: shouldEmitSymbolAccessLevels
+            emitSymbolAccessLevels: shouldEmitSymbolAccessLevels,
+            sourceRepository: sourceRepository
         )
         return translator.visit(node.semantic) as? RenderNode
     }

--- a/Sources/SwiftDocC/Infrastructure/DocumentationConverter.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationConverter.swift
@@ -89,6 +89,9 @@ public struct DocumentationConverter: DocumentationConverterProtocol {
     /// Whether the documentation converter should include access level information for symbols.
     var shouldEmitSymbolAccessLevels: Bool
     
+    /// The source repository where the documentation's sources are hosted.
+    var sourceRepository: SourceRepository?
+    
     /// `true` if the conversion is cancelled.
     private var isCancelled: Synchronized<Bool>? = nil
 
@@ -128,6 +131,7 @@ public struct DocumentationConverter: DocumentationConverterProtocol {
         bundleDiscoveryOptions: BundleDiscoveryOptions,
         emitSymbolSourceFileURIs: Bool = false,
         emitSymbolAccessLevels: Bool = false,
+        sourceRepository: SourceRepository? = nil,
         isCancelled: Synchronized<Bool>? = nil,
         diagnosticEngine: DiagnosticEngine = .init()
     ) {
@@ -142,6 +146,7 @@ public struct DocumentationConverter: DocumentationConverterProtocol {
         self.bundleDiscoveryOptions = bundleDiscoveryOptions
         self.shouldEmitSymbolSourceFileURIs = emitSymbolSourceFileURIs
         self.shouldEmitSymbolAccessLevels = emitSymbolAccessLevels
+        self.sourceRepository = sourceRepository
         self.isCancelled = isCancelled
         self.diagnosticEngine = diagnosticEngine
         
@@ -247,7 +252,8 @@ public struct DocumentationConverter: DocumentationConverterProtocol {
             context: context,
             renderContext: renderContext,
             emitSymbolSourceFileURIs: shouldEmitSymbolSourceFileURIs,
-            emitSymbolAccessLevels: shouldEmitSymbolAccessLevels
+            emitSymbolAccessLevels: shouldEmitSymbolAccessLevels,
+            sourceRepository: sourceRepository
         )
         
         var indexingRecords = [IndexingRecord]()

--- a/Sources/SwiftDocC/Model/Rendering/RenderNode/RenderMetadata.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNode/RenderMetadata.swift
@@ -144,6 +144,15 @@ public struct RenderMetadata: VariantContainer {
     /// The variants for the source file URI of a page.
     public var sourceFileURIVariants: VariantCollection<String?> = .init(defaultValue: nil)
     
+    /// The remote location where the source declaration of the topic can be viewed.
+    public var remoteSource: RemoteSource? {
+        get { getVariantDefaultValue(keyPath: \.remoteSourceVariants) }
+        set { setVariantDefaultValue(newValue, keyPath: \.remoteSourceVariants) }
+    }
+    
+    /// The variants for the topic's remote source.
+    public var remoteSourceVariants: VariantCollection<RemoteSource?> = .init(defaultValue: nil)
+    
     /// Any tags assigned to the node.
     public var tags: [RenderNode.Tag]?
 }
@@ -162,6 +171,21 @@ extension RenderMetadata: Codable {
         /// Possible dependencies to the module, we allow for those in the render JSON model
         /// but have no authoring support at the moment.
         public let relatedModules: [String]?
+    }
+    
+    /// Describes the location of the topic's source code, hosted remotely by a source service.
+    public struct RemoteSource: Codable, Equatable {
+        /// The name of the file where the topic is declared.
+        public var fileName: String
+        
+        /// The location of the topic's source code, hosted by a source service.
+        public var url: URL
+        
+        /// Creates a topic's source given its source code's file name and URL.
+        public init(fileName: String, url: URL) {
+            self.fileName = fileName
+            self.url = url
+        }
     }
 
     public struct CodingKeys: CodingKey, Hashable {
@@ -196,6 +220,7 @@ extension RenderMetadata: Codable {
         public static let fragments = CodingKeys(stringValue: "fragments")
         public static let navigatorTitle = CodingKeys(stringValue: "navigatorTitle")
         public static let sourceFileURI = CodingKeys(stringValue: "sourceFileURI")
+        public static let remoteSource = CodingKeys(stringValue: "remoteSource")
         public static let tags = CodingKeys(stringValue: "tags")
     }
     
@@ -221,6 +246,7 @@ extension RenderMetadata: Codable {
         fragmentsVariants = try container.decodeVariantCollectionIfPresent(ofValueType: [DeclarationRenderSection.Token]?.self, forKey: .fragments)
         navigatorTitleVariants = try container.decodeVariantCollectionIfPresent(ofValueType: [DeclarationRenderSection.Token]?.self, forKey: .navigatorTitle)
         sourceFileURIVariants = try container.decodeVariantCollectionIfPresent(ofValueType: String?.self, forKey: .sourceFileURI)
+        remoteSourceVariants = try container.decodeVariantCollectionIfPresent(ofValueType: RemoteSource?.self, forKey: .remoteSource)
         tags = try container.decodeIfPresent([RenderNode.Tag].self, forKey: .tags)
         
         let extraKeys = Set(container.allKeys).subtracting(
@@ -242,6 +268,7 @@ extension RenderMetadata: Codable {
                 .fragments,
                 .navigatorTitle,
                 .sourceFileURI,
+                .remoteSource,
                 .tags
             ]
         )
@@ -272,6 +299,7 @@ extension RenderMetadata: Codable {
         try container.encodeVariantCollection(fragmentsVariants, forKey: .fragments, encoder: encoder)
         try container.encodeVariantCollection(navigatorTitleVariants, forKey: .navigatorTitle, encoder: encoder)
         try container.encodeVariantCollection(sourceFileURIVariants, forKey: .sourceFileURI, encoder: encoder)
+        try container.encodeVariantCollection(remoteSourceVariants, forKey: .remoteSource, encoder: encoder)
         if let tags = self.tags, !tags.isEmpty {
             try container.encodeIfPresent(tags, forKey: .tags)
         }

--- a/Sources/SwiftDocC/SourceRepository/SourceRepository.swift
+++ b/Sources/SwiftDocC/SourceRepository/SourceRepository.swift
@@ -1,0 +1,92 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+
+/// A remote repository that hosts source code.
+public struct SourceRepository {
+    /// The path at which the repository is cloned locally.
+    public var checkoutPath: String
+    
+    /// The base URL where the service hosts the repository's contents.
+    public var sourceServiceBaseURL: URL
+    
+    /// A function that formats a line number to be included in a URL.
+    public var formatLineNumber: (Int) -> String
+    
+    /// Creates a source code repository.
+    /// - Parameters:
+    ///   - checkoutPath: The path at which the repository is checked out locally and from which its symbol graphs were generated.
+    ///   - sourceServiceBaseURL: The base URL where the service hosts the repository's contents.
+    ///   - formatLineNumber: A function that formats a line number to be included in a URL.
+    public init(
+        checkoutPath: String,
+        sourceServiceBaseURL: URL,
+        formatLineNumber: @escaping (Int) -> String
+    ) {
+        self.checkoutPath = checkoutPath
+        self.sourceServiceBaseURL = sourceServiceBaseURL
+        self.formatLineNumber = formatLineNumber
+    }
+    
+    /// Formats a local source file URL to a URL hosted by the remote source code service.
+    /// - Parameters:
+    ///   - sourceFileURL: The location of the source file on disk.
+    ///   - lineNumber: A line number in the source file, 1-indexed.
+    /// - Returns: The URL of the file hosted by the remote source code service if it could be constructed, otherwise, `nil`.
+    public func format(sourceFileURL: URL, lineNumber: Int? = nil) -> URL? {
+        guard sourceFileURL.path.hasPrefix(checkoutPath) else {
+            return nil
+        }
+        
+        let path = sourceFileURL.path.dropFirst(checkoutPath.count).removingLeadingSlash
+        return sourceServiceBaseURL
+            .appendingPathComponent(path)
+            .withFragment(lineNumber.map(formatLineNumber))
+    }
+}
+
+public extension SourceRepository {
+    /// Creates a source repository hosted by the GitHub service.
+    /// - Parameters:
+    ///   - checkoutPath: The path of the local checkout.
+    ///   - sourceServiceBaseURL: The base URL where the service hosts the repository's contents.
+    static func github(checkoutPath: String, sourceServiceBaseURL: URL) -> SourceRepository {
+        SourceRepository(
+            checkoutPath: checkoutPath,
+            sourceServiceBaseURL: sourceServiceBaseURL,
+            formatLineNumber: { line in "L\(line)" }
+        )
+    }
+    
+    /// Creates a source repository hosted by the GitLab service.
+    /// - Parameters:
+    ///   - checkoutPath: The path of the local checkout.
+    ///   - sourceServiceBaseURL: The base URL where the service hosts the repository's contents.
+    static func gitlab(checkoutPath: String, sourceServiceBaseURL: URL) -> SourceRepository {
+        SourceRepository(
+            checkoutPath: checkoutPath,
+            sourceServiceBaseURL: sourceServiceBaseURL,
+            formatLineNumber: { line in "L\(line)" }
+        )
+    }
+    
+    /// Creates a source repository hosted by the BitBucket service.
+    /// - Parameters:
+    ///   - checkoutPath: The path of the local checkout.
+    ///   - sourceServiceBaseURL: The base URL where the service hosts the repository's contents.
+    static func bitbucket(checkoutPath: String, sourceServiceBaseURL: URL) -> SourceRepository {
+        SourceRepository(
+            checkoutPath: checkoutPath,
+            sourceServiceBaseURL: sourceServiceBaseURL,
+            formatLineNumber: { line in "lines-\(line)" }
+        )
+    }
+}

--- a/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderNode.spec.json
+++ b/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderNode.spec.json
@@ -2048,6 +2048,21 @@
                     "sourceFileURI": {
                         "type": "string"
                     },
+                    "remoteSource": {
+                        "type": "object",
+                        "required": [
+                            "fileName",
+                            "url"
+                        ],
+                        "properties": {
+                            "fileName": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            }
+                        }
+                    },
                     "tags": {
                         "type": "array",
                         "items": {

--- a/Sources/SwiftDocC/Utility/FoundationExtensions/String+Path.swift
+++ b/Sources/SwiftDocC/Utility/FoundationExtensions/String+Path.swift
@@ -10,16 +10,21 @@
 
 import Foundation
 
-extension String {
+extension StringProtocol {
     /// A copy of the string prefixed with a slash ("/") if the string doesn't already start with a leading slash.
     var prependingLeadingSlash: String {
-        guard !hasPrefix("/") else { return self }
+        guard !hasPrefix("/") else { return String(self) }
         return "/".appending(self)
     }
     
     /// A copy of the string without a leading slash ("/") or the original string if it doesn't start with a leading slash.
     var removingLeadingSlash: String {
-        guard hasPrefix("/") else { return self }
+        guard hasPrefix("/") else { return String(self) }
         return String(dropFirst())
+    }
+    
+    var removingTrailingSlash: String {
+        guard hasSuffix("/") else { return String(self) }
+        return String(dropLast())
     }
 }

--- a/Sources/SwiftDocCUtilities/Action/Actions/Convert/ConvertAction.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Convert/ConvertAction.swift
@@ -42,6 +42,7 @@ public struct ConvertAction: Action, RecreatingContext {
     let transformForStaticHosting: Bool
     let hostingBasePath: String?
     
+    let sourceRepository: SourceRepository?
     
     private(set) var context: DocumentationContext {
         didSet {
@@ -100,7 +101,8 @@ public struct ConvertAction: Action, RecreatingContext {
         inheritDocs: Bool = false,
         experimentalEnableCustomTemplates: Bool = false,
         transformForStaticHosting: Bool = false,
-        hostingBasePath: String? = nil
+        hostingBasePath: String? = nil,
+        sourceRepository: SourceRepository? = nil
     ) throws
     {
         self.rootURL = documentationBundleURL
@@ -117,6 +119,7 @@ public struct ConvertAction: Action, RecreatingContext {
         self.documentationCoverageOptions = documentationCoverageOptions
         self.transformForStaticHosting = transformForStaticHosting
         self.hostingBasePath = hostingBasePath
+        self.sourceRepository = sourceRepository
         
         let filterLevel: DiagnosticSeverity
         if analyze {
@@ -180,6 +183,7 @@ public struct ConvertAction: Action, RecreatingContext {
             context: self.context,
             dataProvider: dataProvider,
             bundleDiscoveryOptions: bundleDiscoveryOptions,
+            sourceRepository: sourceRepository,
             isCancelled: isCancelled,
             diagnosticEngine: self.diagnosticEngine
         )
@@ -208,6 +212,7 @@ public struct ConvertAction: Action, RecreatingContext {
         experimentalEnableCustomTemplates: Bool = false,
         transformForStaticHosting: Bool,
         hostingBasePath: String?,
+        sourceRepository: SourceRepository? = nil,
         temporaryDirectory: URL
     ) throws {
         // Note: This public initializer exists separately from the above internal one
@@ -239,7 +244,8 @@ public struct ConvertAction: Action, RecreatingContext {
             inheritDocs: inheritDocs,
             experimentalEnableCustomTemplates: experimentalEnableCustomTemplates,
             transformForStaticHosting: transformForStaticHosting,
-            hostingBasePath: hostingBasePath
+            hostingBasePath: hostingBasePath,
+            sourceRepository: sourceRepository
         )
     }
 

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/ActionExtensions/ConvertAction+CommandInitialization.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/ActionExtensions/ConvertAction+CommandInitialization.swift
@@ -80,7 +80,8 @@ extension ConvertAction {
             inheritDocs: convert.enableInheritedDocs,
             experimentalEnableCustomTemplates: convert.experimentalEnableCustomTemplates,
             transformForStaticHosting: convert.transformForStaticHosting,
-            hostingBasePath: convert.hostingBasePath
+            hostingBasePath: convert.hostingBasePath,
+            sourceRepository: SourceRepository(from: convert.sourceRepositoryArguments)
         )
     }
 }

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/Options/Source Repository/SourceRepositoryArguments.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/Options/Source Repository/SourceRepositoryArguments.swift
@@ -1,0 +1,99 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import ArgumentParser
+import Foundation
+import SwiftDocC
+
+/// Command-line arguments for specifying the catalog's source repository information.
+public struct SourceRepositoryArguments: ParsableArguments {
+    public init() {}
+    
+    /// The root path on disk of the repository's checkout.
+    @Option(
+        help: ArgumentHelp(
+            "The root path on disk of the repository's checkout."
+        )
+    )
+    public var checkoutPath: String?
+    
+    /// The source code service used to host the project's sources.
+    ///
+    /// Required when using `--source-service-base-url`. Supported values are `github`, `gitlab`, and `bitbucket`.
+    @Option(
+        help: ArgumentHelp(
+            "The source code service used to host the project's sources.",
+            discussion: """
+                Required when using '--source-service-base-url'. Supported values are 'github', 'gitlab', and 'bitbucket'.
+                """
+        )
+    )
+    public var sourceService: String?
+    
+    /// The base URL where the source service hosts the project's sources.
+    ///
+    /// Required when using `--source-service`. For example, `https://github.com/my-org/my-repo/blob/main`.
+    @Option(
+        help: ArgumentHelp(
+            "The base URL where the source service hosts the project's sources.",
+            discussion: """
+                Required when using '--source-service'. For example, 'https://github.com/my-org/my-repo/blob/main'.
+                """
+        )
+    )
+    public var sourceServiceBaseURL: String?
+}
+
+extension SourceRepository {
+    init?(from arguments: SourceRepositoryArguments) throws {
+        switch (arguments.sourceService, arguments.sourceServiceBaseURL, arguments.checkoutPath) {
+        case (nil, nil, nil):
+            return nil
+        case (nil, _, _):
+            throw ValidationError(
+                """
+                Missing argument '--source-service', which is required when using '--source-service-base-url' \
+                and '--checkout-path'.
+                """
+            )
+        case (_, nil, _):
+            throw ValidationError(
+                """
+                Missing argument '--source-service-base-url', which is required when using '--source-service' \
+                and '--checkout-path'.
+                """
+            )
+        case (_, _, nil):
+            throw ValidationError(
+                """
+                Missing argument '--checkout-path', which is required when using '--source-service' and \
+                '--source-service-base-url'.
+                """
+            )
+        case let (sourceService?, sourceServiceBaseURL?, checkoutPath?):
+            guard let sourceServiceBaseURL = URL(string: sourceServiceBaseURL) else {
+                throw ValidationError("Invalid URL '\(sourceServiceBaseURL)' for '--source-service-base-url' argument.")
+            }
+            
+            switch sourceService.lowercased() {
+            case "github":
+                self = .github(checkoutPath: checkoutPath, sourceServiceBaseURL: sourceServiceBaseURL)
+            case "gitlab":
+                self = .gitlab(checkoutPath: checkoutPath, sourceServiceBaseURL: sourceServiceBaseURL)
+            case "bitbucket":
+                self = .bitbucket(checkoutPath: checkoutPath, sourceServiceBaseURL: sourceServiceBaseURL)
+            default:
+                throw ValidationError(
+                    "Unsupported source service '\(sourceService)'. Use 'github', 'gitlab', or 'bitbucket'."
+                )
+            }
+        }
+    }
+}

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Convert.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Convert.swift
@@ -137,6 +137,10 @@ extension Docc {
         /// Defaults to false.
         @Flag(help: "Inherit documentation for inherited symbols")
         public var enableInheritedDocs = false
+        
+        /// Arguments for specifying information about the source code repository that hosts the documented project's code.
+        @OptionGroup()
+        public var sourceRepositoryArguments: SourceRepositoryArguments
 
         // MARK: - Info.plist fallbacks
         

--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeSourceRepositoryTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeSourceRepositoryTests.swift
@@ -1,0 +1,46 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+@testable import SwiftDocC
+import SymbolKit
+import XCTest
+
+class SemaToRenderNodeSourceRepositoryTests: XCTestCase {
+    func testDoesNotEmitsSourceRepositoryInformationWhenNoSourceIsGiven() throws {
+        let outputConsumer = try renderNodeConsumer(
+            for: "SourceLocations",
+            configureConverter: { converter in
+                converter.sourceRepository = nil
+            }
+        )
+        
+        XCTAssertNil(try outputConsumer.renderNode(withTitle: "MyStruct").metadata.remoteSource)
+    }
+    
+    func testEmitsSourceRepositoryInformationForSymbolsWhenPresent() throws {
+        let outputConsumer = try renderNodeConsumer(
+            for: "SourceLocations",
+            configureConverter: { converter in
+                converter.sourceRepository = SourceRepository.github(
+                    checkoutPath: "/path/to/checkout",
+                    sourceServiceBaseURL: URL(string: "https://example.com/my-repo")!
+                )
+            }
+        )
+        XCTAssertEqual(
+            try outputConsumer.renderNode(withTitle: "MyStruct").metadata.remoteSource,
+            RenderMetadata.RemoteSource(
+                fileName: "MyStruct.swift",
+                url: URL(string: "https://example.com/my-repo/SourceLocations/MyStruct.swift#L10")!
+            )
+        )
+    }
+}

--- a/Tests/SwiftDocCTests/SourceRepository/SourceRepositoryTests.swift
+++ b/Tests/SwiftDocCTests/SourceRepository/SourceRepositoryTests.swift
@@ -1,0 +1,86 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+@testable import SwiftDocC
+
+class SourceRepositoryTests: XCTestCase {
+    func testFormatReturnsNilIfSourceFilePrefixDoesNotMatchCheckout() {
+        XCTAssertNil(
+            SourceRepository(
+                checkoutPath: "/path/to/checkout",
+                sourceServiceBaseURL: URL(string: "https://example.com/source")!,
+                formatLineNumber: { _ in "" }
+            ).format(sourceFileURL: URL(string: "file:///not/path/to/checkout/file")!),
+            """
+            format(sourceFileURL:lineNumber:) unexpectedly returned non-nil result for source file that isn't in \
+            source repository's local checkout folder.
+            """
+        )
+    }
+    
+    func testFormatReturnsURLIfSourceFilePrefixMatchesCheckout() {
+        XCTAssertEqual(
+            SourceRepository(
+                checkoutPath: "/path/to/checkout",
+                sourceServiceBaseURL: URL(string: "https://example.com/source")!,
+                formatLineNumber: { _ in "" }
+            ).format(sourceFileURL: URL(string: "file:///path/to/checkout/file")!),
+            URL(string: "https://example.com/source/file")!
+        )
+    }
+    
+    func testFormatReturnsURLWithLineNumber() {
+        XCTAssertEqual(
+            SourceRepository(
+                checkoutPath: "/path/to/checkout",
+                sourceServiceBaseURL: URL(string: "https://example.com/source")!,
+                formatLineNumber: { lineNumber in "line-\(lineNumber)" }
+            ).format(sourceFileURL: URL(string: "file:///path/to/checkout/file")!, lineNumber: 5),
+            URL(string: "https://example.com/source/file#line-5")!
+        )
+    }
+    
+    func testGitHubFormatting() {
+        XCTAssertEqual(
+            SourceRepository
+                .github(
+                    checkoutPath: "/path/to/checkout",
+                    sourceServiceBaseURL: URL(string: "https://example.com/source")!
+                )
+                .format(sourceFileURL: URL(string: "file:///path/to/checkout/file")!, lineNumber: 5),
+            URL(string: "https://example.com/source/file#L5")!
+        )
+    }
+    
+    func testGitLabFormatting() {
+        XCTAssertEqual(
+            SourceRepository
+                .gitlab(
+                    checkoutPath: "/path/to/checkout",
+                    sourceServiceBaseURL: URL(string: "https://example.com/source")!
+                )
+                .format(sourceFileURL: URL(string: "file:///path/to/checkout/file")!, lineNumber: 5),
+            URL(string: "https://example.com/source/file#L5")!
+        )
+    }
+    
+    func testBitBucketFormatting() {
+        XCTAssertEqual(
+            SourceRepository
+                .bitbucket(
+                    checkoutPath: "/path/to/checkout",
+                    sourceServiceBaseURL: URL(string: "https://example.com/source")!
+                )
+                .format(sourceFileURL: URL(string: "file:///path/to/checkout/file")!, lineNumber: 5),
+            URL(string: "https://example.com/source/file#lines-5")!
+        )
+    }
+}

--- a/Tests/SwiftDocCTests/Test Bundles/SourceLocations.docc/Info.plist
+++ b/Tests/SwiftDocCTests/Test Bundles/SourceLocations.docc/Info.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleName</key>
+	<string>SourceLocations</string>
+	<key>CFBundleDisplayName</key>
+	<string>SourceLocations</string>
+	<key>CFBundleIdentifier</key>
+	<string>org.swift.SourceLocations</string>
+	<key>CFBundleVersion</key>
+	<string>0.1.0</string>
+</dict>
+</plist>

--- a/Tests/SwiftDocCTests/Test Bundles/SourceLocations.docc/symbol-graph/swift/TestFrameworkWithSourceLocations.symbols.json
+++ b/Tests/SwiftDocCTests/Test Bundles/SourceLocations.docc/symbol-graph/swift/TestFrameworkWithSourceLocations.symbols.json
@@ -1,0 +1,52 @@
+{
+  "metadata": {
+    "formatVersion": {
+      "major": 0,
+      "minor": 5,
+      "patch": 3
+    },
+    "generator": "Apple Swift version 5.7 (swiftlang-5.7.0.116.4 clang-1400.0.25)"
+  },
+  "module": {
+    "name": "SourceLocations",
+    "platform": {
+      "architecture": "x86_64",
+      "vendor": "apple",
+      "operatingSystem": {
+        "name": "macosx",
+        "minimumVersion": {
+          "major": 13,
+          "minor": 0,
+          "patch": 0
+        }
+      }
+    }
+  },
+  "symbols": [
+    {
+      "kind": {
+        "identifier": "swift.struct",
+        "displayName": "Structure"
+      },
+      "identifier": {
+        "precise": "s:32SourceLocations8MyStructV",
+        "interfaceLanguage": "swift"
+      },
+      "pathComponents": [
+        "MyStruct"
+      ],
+      "names": {
+        "title": "MyStruct"
+      },
+      "accessLevel": "public",
+      "location": {
+        "uri": "file:///path/to/checkout/SourceLocations/MyStruct.swift",
+        "position": {
+          "line": 9,
+          "character": 14
+        }
+      }
+    }
+  ],
+  "relationships": []
+}

--- a/Tests/SwiftDocCTests/TestRenderNodeOutputConsumer.swift
+++ b/Tests/SwiftDocCTests/TestRenderNodeOutputConsumer.swift
@@ -85,7 +85,8 @@ extension TestRenderNodeOutputConsumer {
 extension XCTestCase {
     func renderNodeConsumer(
         for bundleName: String,
-        configureBundle: ((URL) throws -> Void)? = nil
+        configureBundle: ((URL) throws -> Void)? = nil,
+        configureConverter: ((inout DocumentationConverter) throws -> Void)? = nil
     ) throws -> TestRenderNodeOutputConsumer {
         let (bundleURL, _, context) = try testBundleAndContext(
             copying: bundleName,
@@ -102,6 +103,8 @@ extension XCTestCase {
             dataProvider: try LocalFileSystemDataProvider(rootURL: bundleURL),
             bundleDiscoveryOptions: BundleDiscoveryOptions()
         )
+        
+        try configureConverter?(&converter)
         
         let outputConsumer = TestRenderNodeOutputConsumer()
         let (_, _) = try converter.convert(outputConsumer: outputConsumer)

--- a/Tests/SwiftDocCUtilitiesTests/ArgumentParsing/ConvertSubcommandSourceRepositoryTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ArgumentParsing/ConvertSubcommandSourceRepositoryTests.swift
@@ -1,0 +1,155 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+@testable import SwiftDocCUtilities
+@testable import SwiftDocC
+import SwiftDocCTestUtilities
+import ArgumentParser
+
+class ConvertSubcommandSourceRepositoryTests: XCTestCase {
+    private let testBundleURL = Bundle.module.url(
+        forResource: "TestBundle",
+        withExtension: "docc",
+        subdirectory: "Test Bundles"
+    )!
+    
+    private let testTemplateURL = Bundle.module.url(
+        forResource: "Test Template",
+        withExtension: nil,
+        subdirectory: "Test Resources"
+    )!
+    
+    func testSourceRepositoryAllArgumentsSpecified() throws {
+        for sourceService in ["github", "gitlab", "bitbucket"] {
+            try assertSourceRepositoryArguments(
+                checkoutPath: "checkout path",
+                sourceService: sourceService,
+                sourceServiceBaseURL: "example.com/path/to/base"
+            ) { action in
+                XCTAssertEqual(action.sourceRepository?.checkoutPath, "checkout path")
+                XCTAssertEqual(action.sourceRepository?.sourceServiceBaseURL, URL(string: "example.com/path/to/base")!)
+            }
+        }
+    }
+    
+    func testDoesNotSetSourceRepositoryIfBothCheckoutPathAndsourceServiceBaseURLArgumentsAreMissing() throws {
+        try assertSourceRepositoryArguments(
+            checkoutPath: nil,
+            sourceService: nil,
+            sourceServiceBaseURL: nil
+        ) { action in
+            XCTAssertNil(action.sourceRepository)
+        }
+    }
+    
+    func testThrowsValidationErrorWhenSourceServiceIsSpecifiedButNotSourceServiceBaseURL() throws {
+        XCTAssertThrowsError(
+            try assertSourceRepositoryArguments(
+                checkoutPath: nil,
+                sourceService: nil,
+                sourceServiceBaseURL: "example.com/path/to/base"
+            )
+        ) { error in
+            XCTAssertEqual(
+                (error as? ValidationError)?.message,
+                """
+                Missing argument '--source-service', which is required when using '--source-service-base-url' \
+                and '--checkout-path'.
+                """
+            )
+        }
+    }
+    
+    func testThrowsValidationErrorWhenSourceServiceBaseURLIsSpecifiedButNotSourceService() throws {
+        XCTAssertThrowsError(
+            try assertSourceRepositoryArguments(
+                checkoutPath: nil,
+                sourceService: "github",
+                sourceServiceBaseURL: nil
+            )
+        ) { error in
+            XCTAssertEqual(
+                (error as? ValidationError)?.message,
+                """
+                Missing argument '--source-service-base-url', which is required when using '--source-service' \
+                and '--checkout-path'.
+                """
+            )
+        }
+    }
+    
+    func testThrowsValidationErrorWhenSourceServiceBaseURLIsInvalid() throws {
+        XCTAssertThrowsError(
+            try assertSourceRepositoryArguments(
+                checkoutPath: "checkout path",
+                sourceService: "github",
+                sourceServiceBaseURL: "not a valid URL"
+            )
+        ) { error in
+            XCTAssertEqual(
+                (error as? ValidationError)?.message,
+                "Invalid URL 'not a valid URL' for '--source-service-base-url' argument."
+            )
+        }
+    }
+    
+    func testThrowsValidationErrorWhenCheckoutPathIsNotSpecified() throws {
+        XCTAssertThrowsError(
+            try assertSourceRepositoryArguments(
+                checkoutPath: nil,
+                sourceService: "github",
+                sourceServiceBaseURL: "example.com/path/to/base"
+            )
+        ) { error in
+            XCTAssertEqual(
+                (error as? ValidationError)?.message,
+                """
+                Missing argument '--checkout-path', which is required when using '--source-service' \
+                and '--source-service-base-url'.
+                """
+            )
+        }
+    }
+    
+    func testThrowsValidationErrorWhenSourceServiceIsInvalid() throws {
+        XCTAssertThrowsError(
+            try assertSourceRepositoryArguments(
+                checkoutPath: "checkout path",
+                sourceService: "not a supported source service",
+                sourceServiceBaseURL: "example.com/foo"
+            )
+        ) { error in
+            XCTAssertEqual(
+                (error as? ValidationError)?.message,
+                "Unsupported source service 'not a supported source service'. Use 'github', 'gitlab', or 'bitbucket'."
+            )
+        }
+    }
+    
+    private func assertSourceRepositoryArguments(
+        checkoutPath: String?,
+        sourceService: String?,
+        sourceServiceBaseURL: String?,
+        assertion: ((ConvertAction) throws -> Void)? = nil
+    ) throws {
+        setenv(TemplateOption.environmentVariableKey, testTemplateURL.path, 1)
+        
+        let convertOptions = try Docc.Convert.parse(
+            [testBundleURL.path]
+                + (checkoutPath.map { ["--checkout-path", $0] } ?? [])
+                + (sourceService.map { ["--source-service", $0] } ?? [])
+                + (sourceServiceBaseURL.map { ["--source-service-base-url", $0] } ?? [])
+        )
+        
+        let result = try ConvertAction(fromConvertCommand: convertOptions)
+        try assertion?(result)
+    }
+}


### PR DESCRIPTION
Bug/issue #, if applicable: #186, rdar://88537303

## Summary

Adds command-line arguments to configure a repo URL so that documentation websites can display a link to the symbol's declaration in the repo.

Example invocation:
```
swift package generate-documentation \
  --source-service github \
  --source-service-base-url https://github.com/<org>/<repo>/blob/main \
  --checkout-path <path to local checkout>
```

## Dependencies

https://github.com/apple/swift-docc-render/pull/366

## Testing

Set the `DOCC_EXEC` environment variable to a local build of DocC from this branch and run with the flags described above. Verify that documentation pages for Swift symbols contains a `.metadata.source` field that links to the symbol's declaration in the git service.

## Checklist

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary

## TODO

- [x] Add documentation
- [x] Add tests