### PR TITLE
Allow writing doc links to subsections using special characters

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -879,7 +879,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
                 // At this point we consider all articles with an H1 containing link "documentation extension" - some links might not resolve in the final documentation hierarchy
                 // and we will emit warnings for those later on when we finalize the bundle discovery phase.
                 if let link = result.value.title?.child(at: 0) as? AnyLink,
-                   let url = link.destination.flatMap(ValidatedURL.init) {
+                   let url = link.destination.flatMap(ValidatedURL.init(parsing:)) {
                     let reference = result.topicGraphNode.reference
                     
                     let symbolPath = NodeURLGenerator.Path.documentation(path: url.components.path).stringValue

--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -879,7 +879,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
                 // At this point we consider all articles with an H1 containing link "documentation extension" - some links might not resolve in the final documentation hierarchy
                 // and we will emit warnings for those later on when we finalize the bundle discovery phase.
                 if let link = result.value.title?.child(at: 0) as? AnyLink,
-                   let url = link.destination.flatMap(ValidatedURL.init(parsing:)) {
+                   let url = link.destination.flatMap(ValidatedURL.init(parsingExact:)) {
                     let reference = result.topicGraphNode.reference
                     
                     let symbolPath = NodeURLGenerator.Path.documentation(path: url.components.path).stringValue

--- a/Sources/SwiftDocC/Infrastructure/DocumentationCurator.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationCurator.swift
@@ -54,7 +54,7 @@ struct DocumentationCurator {
     /// Tries to resolve a link in the current module/context.
     mutating func referenceFromLink(link: Link, resolved: ResolvedTopicReference, source: URL?) -> ResolvedTopicReference? {
         // Try a link to a topic
-        guard let unresolved = link.destination.flatMap(ValidatedURL.init(parsingAndEscapingFragmentIfNeeded:))?
+        guard let unresolved = link.destination.flatMap(ValidatedURL.init(parsingAuthoredLink:))?
             .requiring(scheme: ResolvedTopicReference.urlScheme)
             .map(UnresolvedTopicReference.init(topicURL:)) else {
                 // Emit a warning regarding the invalid link found in a task group.

--- a/Sources/SwiftDocC/Infrastructure/DocumentationCurator.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationCurator.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -54,7 +54,7 @@ struct DocumentationCurator {
     /// Tries to resolve a link in the current module/context.
     mutating func referenceFromLink(link: Link, resolved: ResolvedTopicReference, source: URL?) -> ResolvedTopicReference? {
         // Try a link to a topic
-        guard let unresolved = link.destination.flatMap(ValidatedURL.init)?
+        guard let unresolved = link.destination.flatMap(ValidatedURL.init(parsingAndEscapingFragmentIfNeeded:))?
             .requiring(scheme: ResolvedTopicReference.urlScheme)
             .map(UnresolvedTopicReference.init(topicURL:)) else {
                 // Emit a warning regarding the invalid link found in a task group.

--- a/Sources/SwiftDocC/Infrastructure/Symbol Link Resolution/AbsoluteSymbolLink.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Link Resolution/AbsoluteSymbolLink.swift
@@ -46,7 +46,7 @@ public struct AbsoluteSymbolLink: CustomStringConvertible {
         // Begin by constructing a validated URL from the given string.
         // Normally symbol links would be validated with `init(symbolPath:)` but since this is expected
         // to be an absolute URL we parse it with `init(parsing:)` instead.
-        guard let validatedURL = ValidatedURL(parsing: string)?.requiring(scheme: ResolvedTopicReference.urlScheme) else {
+        guard let validatedURL = ValidatedURL(parsingExact: string)?.requiring(scheme: ResolvedTopicReference.urlScheme) else {
             return nil
         }
         

--- a/Sources/SwiftDocC/Model/DocumentationNode.swift
+++ b/Sources/SwiftDocC/Model/DocumentationNode.swift
@@ -104,7 +104,7 @@ public struct DocumentationNode {
                 // so we can index all anchors found in the bundle for link resolution.
                 if let heading = child as? Heading, heading.level > 1, heading.level < 4 {
                     anchorSections.append(
-                        AnchorSection(reference: reference.withFragment(urlReadableFragment(heading.plainText)), title: heading.plainText)
+                        AnchorSection(reference: reference.withFragment(heading.plainText), title: heading.plainText)
                     )
                 }
             }

--- a/Sources/SwiftDocC/Model/Identifier.swift
+++ b/Sources/SwiftDocC/Model/Identifier.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -291,7 +291,7 @@ public struct ResolvedTopicReference: Hashable, Codable, Equatable, CustomString
         let newReference = ResolvedTopicReference(
             bundleIdentifier: bundleIdentifier,
             urlReadablePath: newPath,
-            urlReadableFragment: reference.fragment,
+            urlReadableFragment: reference.fragment.map(urlReadableFragment),
             sourceLanguages: sourceLanguages
         )
         return newReference
@@ -550,8 +550,11 @@ func urlReadablePath(_ path: String) -> String {
 }
 
 private extension CharacterSet {
-    static let invalidCharacterSet = CharacterSet(charactersIn: "'\"`")
-    static let whitespaceAndDashes = CharacterSet(charactersIn: "-").union(.whitespaces)
+    static let fragmentCharactersToRemove = CharacterSet.punctuationCharacters // Remove punctuation from fragments
+        .union(CharacterSet(charactersIn: "`"))       // Also consider back-ticks as punctuation. They are used as quotes around symbols or other code.
+        .subtracting(CharacterSet(charactersIn: "-")) // Don't remove hyphens. They are used as a whitespace replacement.
+    static let whitespaceAndDashes = CharacterSet.whitespaces
+        .union(CharacterSet(charactersIn: "-–—")) // hyphen, en dash, em dash
 }
 
 /// Creates a more readable version of a fragment by replacing characters that are not allowed in the fragment of a URL with hyphens.
@@ -569,7 +572,7 @@ func urlReadableFragment(_ fragment: String) -> String {
         .joined(separator: "-")
     
     // Remove invalid characters
-    fragment.unicodeScalars.removeAll(where: CharacterSet.invalidCharacterSet.contains)
+    fragment.unicodeScalars.removeAll(where: CharacterSet.fragmentCharactersToRemove.contains)
     
     return fragment
 }

--- a/Sources/SwiftDocC/Model/Rendering/RenderContentCompiler.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderContentCompiler.swift
@@ -113,7 +113,7 @@ struct RenderContentCompiler: MarkupVisitor {
             }
         }
         
-        guard let unresolved = link.destination.flatMap(ValidatedURL.init(parsingAndEscapingFragmentIfNeeded:))
+        guard let unresolved = link.destination.flatMap(ValidatedURL.init(parsingAuthoredLink:))
             .map({ UnresolvedTopicReference(topicURL: $0) }),
             // Try to resolve in the local context
             case let .success(resolved) = context.resolve(.unresolved(unresolved), in: identifier) else {

--- a/Sources/SwiftDocC/Model/Rendering/RenderContentCompiler.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderContentCompiler.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -95,7 +95,7 @@ struct RenderContentCompiler: MarkupVisitor {
             let externalLinkIdentifier = RenderReferenceIdentifier(forExternalLink: destination)
             
             if linkReferences.keys.contains(externalLinkIdentifier.identifier) {
-                // If we've already seen this link, return the existing reference with an overriden title.
+                // If we've already seen this link, return the existing reference with an overridden title.
                 return [RenderInlineContent.reference(identifier: externalLinkIdentifier,
                                                      isActive: true,
                                                      overridingTitle: plainTextLinkTitle.isEmpty ? nil : plainTextLinkTitle,
@@ -113,7 +113,7 @@ struct RenderContentCompiler: MarkupVisitor {
             }
         }
         
-        guard let unresolved = link.destination.flatMap(ValidatedURL.init)
+        guard let unresolved = link.destination.flatMap(ValidatedURL.init(parsingAndEscapingFragmentIfNeeded:))
             .map({ UnresolvedTopicReference(topicURL: $0) }),
             // Try to resolve in the local context
             case let .success(resolved) = context.resolve(.unresolved(unresolved), in: identifier) else {

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -913,7 +913,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
                     case let link as Link:
                         if !allowExternalLinks {
                             // For links require documentation scheme
-                            guard let _ = link.destination.flatMap(ValidatedURL.init)?.requiring(scheme: ResolvedTopicReference.urlScheme) else {
+                            guard let _ = link.destination.flatMap(ValidatedURL.init(parsingAndEscapingFragmentIfNeeded:))?.requiring(scheme: ResolvedTopicReference.urlScheme) else {
                                 return nil
                             }
                         }

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -913,7 +913,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
                     case let link as Link:
                         if !allowExternalLinks {
                             // For links require documentation scheme
-                            guard let _ = link.destination.flatMap(ValidatedURL.init(parsingAndEscapingFragmentIfNeeded:))?.requiring(scheme: ResolvedTopicReference.urlScheme) else {
+                            guard let _ = link.destination.flatMap(ValidatedURL.init(parsingAuthoredLink:))?.requiring(scheme: ResolvedTopicReference.urlScheme) else {
                                 return nil
                             }
                         }

--- a/Sources/SwiftDocC/Semantics/ExternalLinks/ExternalMarkupReferenceWalker.swift
+++ b/Sources/SwiftDocC/Semantics/ExternalLinks/ExternalMarkupReferenceWalker.swift
@@ -37,7 +37,7 @@ struct ExternalMarkupReferenceWalker: MarkupVisitor {
     mutating func visitLink(_ link: Link) {
         // Only process documentation links to external bundles
         guard let destination = link.destination,
-            let url = ValidatedURL(parsing: destination),
+            let url = ValidatedURL(parsingExact: destination),
             url.components.scheme == ResolvedTopicReference.urlScheme,
             let bundleID = url.components.host,
             bundleID != bundle.identifier else {

--- a/Sources/SwiftDocC/Semantics/MarkupReferenceResolver.swift
+++ b/Sources/SwiftDocC/Semantics/MarkupReferenceResolver.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -96,7 +96,7 @@ struct MarkupReferenceResolver: MarkupRewriter {
         guard let destination = link.destination else {
             return link
         }
-        guard let url = ValidatedURL(parsing: destination) else {
+        guard let url = ValidatedURL(parsingAndEscapingFragmentIfNeeded: destination) else {
             problems.append(invalidLinkDestinationProblem(destination: destination, source: source, range: link.range, severity: .warning))
             return link
         }

--- a/Sources/SwiftDocC/Semantics/MarkupReferenceResolver.swift
+++ b/Sources/SwiftDocC/Semantics/MarkupReferenceResolver.swift
@@ -96,7 +96,7 @@ struct MarkupReferenceResolver: MarkupRewriter {
         guard let destination = link.destination else {
             return link
         }
-        guard let url = ValidatedURL(parsingAndEscapingFragmentIfNeeded: destination) else {
+        guard let url = ValidatedURL(parsingAuthoredLink: destination) else {
             problems.append(invalidLinkDestinationProblem(destination: destination, source: source, range: link.range, severity: .warning))
             return link
         }
@@ -122,7 +122,7 @@ struct MarkupReferenceResolver: MarkupRewriter {
         }
 
         // We don't require a scheme here as the link can be a relative one, e.g. ``SwiftUI/View``.
-        let url = ValidatedURL(parsing: unresolvedDestination)?.requiring(scheme: ResolvedTopicReference.urlScheme) ?? ValidatedURL(symbolPath: unresolvedDestination)
+        let url = ValidatedURL(parsingExact: unresolvedDestination)?.requiring(scheme: ResolvedTopicReference.urlScheme) ?? ValidatedURL(symbolPath: unresolvedDestination)
         let unresolved = TopicReference.unresolved(.init(topicURL: url))
         guard let resolvedURL = resolve(reference: unresolved, range: range, severity: .warning, fromSymbolLink: true) else {
             return unresolvedDestination

--- a/Sources/SwiftDocC/Utility/ValidatedURL.swift
+++ b/Sources/SwiftDocC/Utility/ValidatedURL.swift
@@ -37,7 +37,9 @@ public struct ValidatedURL: Hashable, Equatable {
     /// > URL with the "someMethodWithFirstValue" scheme which is a valid link but which won't resolve to the intended symbol.
     /// >
     /// > When working with symbol destinations use ``init(symbolPath:)`` instead.
-    init?(parsing string: String) {
+    /// >
+    /// > When working with authored documentation links use ``init(parsingAuthoredLink:)`` instead.
+    init?(parsingExact string: String) {
         guard let components = URLComponents(string: string) else {
             return nil
         }
@@ -53,9 +55,9 @@ public struct ValidatedURL: Hashable, Equatable {
     ///
     /// Use this to parse author provided documentation links that may contain links to on-page subsections. Escaping the fragment allows authors
     /// to write links to subsections using characters that wouldn't otherwise be allowed in a fragment of a URL.
-    init?(parsingAndEscapingFragmentIfNeeded string: String) {
+    init?(parsingAuthoredLink string: String) {
         // Try to parse the string without escaping anything
-        if let parsed = ValidatedURL(parsing: string) {
+        if let parsed = ValidatedURL(parsingExact: string) {
             self.components = parsed.components
             return
         }

--- a/Sources/SwiftDocC/Utility/ValidatedURL.swift
+++ b/Sources/SwiftDocC/Utility/ValidatedURL.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -41,6 +41,31 @@ public struct ValidatedURL: Hashable, Equatable {
         guard let components = URLComponents(string: string) else {
             return nil
         }
+        self.components = components
+    }
+    
+    /// Creates a new RFC 3986 valid URL by using the given string URL and percent escaping the fragment component if necessary.
+    ///
+    /// Will return `nil` when the given `string` is not a valid URL.
+    /// - Parameter string: Source URL address as string.
+    ///
+    /// If the parsed fragment component contains characters not allowed in the fragment of a URL, those characters will be percent encoded.
+    ///
+    /// Use this to parse author provided documentation links that may contain links to on-page subsections. Escaping the fragment allows authors
+    /// to write links to subsections using characters that wouldn't otherwise be allowed in a fragment of a URL.
+    init?(parsingAndEscapingFragmentIfNeeded string: String) {
+        // Try to parse the string without escaping anything
+        if let parsed = ValidatedURL(parsing: string) {
+            self.components = parsed.components
+            return
+        }
+        
+        // If the string doesn't contain a fragment and the string couldn't be parsed with `ValidatedURL(parsing:)` above, then consider it invalid.
+        guard let fragmentSeparatorIndex = string.firstIndex(of: "#"), var components = URLComponents(string: String(string[..<fragmentSeparatorIndex])) else {
+            return nil
+        }
+        
+        components.percentEncodedFragment = String(string[fragmentSeparatorIndex...].dropFirst()).addingPercentEncoding(withAllowedCharacters: .urlFragmentAllowed)
         self.components = components
     }
     

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -44,7 +44,7 @@ class DocumentationContextTests: XCTestCase {
         try workspace.registerProvider(dataProvider)
         
         // Test resolving
-        let unresolved = UnresolvedTopicReference(topicURL: ValidatedURL(parsing: "doc:/TestTutorial")!)
+        let unresolved = UnresolvedTopicReference(topicURL: ValidatedURL(parsingExact: "doc:/TestTutorial")!)
         let parent = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "", sourceLanguage: .swift)
         
         guard case let .success(resolved) = context.resolve(.unresolved(unresolved), in: parent) else {
@@ -56,7 +56,7 @@ class DocumentationContextTests: XCTestCase {
         XCTAssertEqual("/tutorials/Test-Bundle/TestTutorial", resolved.path)
         
         // Test lowercasing of path
-        let unresolvedUppercase = UnresolvedTopicReference(topicURL: ValidatedURL(parsing: "doc:/TESTTUTORIAL")!)
+        let unresolvedUppercase = UnresolvedTopicReference(topicURL: ValidatedURL(parsingExact: "doc:/TESTTUTORIAL")!)
         guard case .failure = context.resolve(.unresolved(unresolvedUppercase), in: parent) else {
             XCTFail("Did incorrectly resolve \(unresolvedUppercase)")
             return
@@ -2749,7 +2749,7 @@ let expected = """
         
         // Try resolving the new resolvable node
         XCTAssertNoThrow(try context.entity(with: resolvableReference))
-        switch context.resolve(.unresolved(UnresolvedTopicReference(topicURL: ValidatedURL(parsing: "doc:resolvable-article")!)), in: moduleReference) {
+        switch context.resolve(.unresolved(UnresolvedTopicReference(topicURL: ValidatedURL(parsingExact: "doc:resolvable-article")!)), in: moduleReference) {
         case .success: break
         case .failure(_, let errorMessage): XCTFail("Did not resolve resolvable link. Error: \(errorMessage)")
         }
@@ -2902,7 +2902,7 @@ let expected = """
             // Tutorial
             XCTAssertNotNil(context.documentationCache[ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/tutorials/Test-Bundle/Test", sourceLanguage: .swift)])
             
-            let unresolved = TopicReference.unresolved(.init(topicURL: try XCTUnwrap(ValidatedURL(parsing: "doc:Test"))))
+            let unresolved = TopicReference.unresolved(.init(topicURL: try XCTUnwrap(ValidatedURL(parsingExact: "doc:Test"))))
             let expected = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/Test-Bundle/Test", sourceLanguage: .swift)
 
             // Resolve from various locations in the bundle
@@ -2941,7 +2941,7 @@ let expected = """
             // Symbol
             XCTAssertNotNil(context.documentationCache[ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/Minimal_docs/Test", sourceLanguage: .swift)])
             
-            let unresolved = TopicReference.unresolved(.init(topicURL: try XCTUnwrap(ValidatedURL(parsing: "doc:Test"))))
+            let unresolved = TopicReference.unresolved(.init(topicURL: try XCTUnwrap(ValidatedURL(parsingExact: "doc:Test"))))
             let expected = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/Test-Bundle/Test", sourceLanguage: .swift)
             
             let symbolReference = try XCTUnwrap(context.symbolIndex["s:12Minimal_docs4TestV"]?.reference)
@@ -3000,7 +3000,7 @@ let expected = """
 
             // Verify we resolve/not resolve non-symbols when calling directly context.resolve(...)
             // with an explicity preference.
-            let unresolvedSymbolRef1 = UnresolvedTopicReference(topicURL: ValidatedURL(parsing: "Test")!)
+            let unresolvedSymbolRef1 = UnresolvedTopicReference(topicURL: ValidatedURL(parsingExact: "Test")!)
             switch context.resolve(.unresolved(unresolvedSymbolRef1), in: moduleReference, fromSymbolLink: true) {
                 case .failure(_, let errorMessage): XCTFail("Did not resolve a symbol link to the symbol Test. Error: \(errorMessage)")
                 default: break
@@ -3010,7 +3010,7 @@ let expected = """
                 default: break
             }
 
-            let articleRef1 = UnresolvedTopicReference(topicURL: ValidatedURL(parsing: "Article")!)
+            let articleRef1 = UnresolvedTopicReference(topicURL: ValidatedURL(parsingExact: "Article")!)
             switch context.resolve(.unresolved(articleRef1), in: moduleReference, fromSymbolLink: true) {
                 case .success: XCTFail("Did resolve a symbol link to an article")
                 default: break

--- a/Tests/SwiftDocCTests/Infrastructure/ExternalReferenceResolverTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/ExternalReferenceResolverTests.swift
@@ -121,7 +121,7 @@ class ExternalReferenceResolverTests: XCTestCase {
         let dataProvider = PrebuiltLocalFileSystemDataProvider(bundles: [bundle])
         try workspace.registerProvider(dataProvider)
 
-        let unresolved = UnresolvedTopicReference(topicURL: ValidatedURL(parsing: "doc://com.external.testbundle/article")!)
+        let unresolved = UnresolvedTopicReference(topicURL: ValidatedURL(parsingExact: "doc://com.external.testbundle/article")!)
         let parent = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyClass", sourceLanguage: .swift)
 
         guard case let .success(resolved) = context.resolve(.unresolved(unresolved), in: parent) else {
@@ -151,7 +151,7 @@ class ExternalReferenceResolverTests: XCTestCase {
         let context = try DocumentationContext(dataProvider: workspace)
         let bundleIdentifier = bundle.identifier
         
-        let unresolved = UnresolvedTopicReference(topicURL: ValidatedURL(parsing: "doc://\(bundleIdentifier)/ArticleThatDoesNotExistInLocally")!)
+        let unresolved = UnresolvedTopicReference(topicURL: ValidatedURL(parsingExact: "doc://\(bundleIdentifier)/ArticleThatDoesNotExistInLocally")!)
         let parent = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "", sourceLanguage: .swift)
         
         do {
@@ -524,26 +524,26 @@ Document @1:1-1:35
             "doc://com.external.testbundle/resolved" // the successfully resolved reference has a different reference which should also be collected.
         ], "Results for both failed and successfully resolved external references should be collected.")
         
-        XCTAssertNil(context.externallyResolvedLinks[ValidatedURL(parsing: "doc://com.external.other-test-bundle/article")!],
+        XCTAssertNil(context.externallyResolvedLinks[ValidatedURL(parsingExact: "doc://com.external.other-test-bundle/article")!],
                      "External references without a registered external resolver should not be collected.")
         
         // Expected failed externally resolved reference.
         XCTAssertEqual(
-            context.externallyResolvedLinks[ValidatedURL(parsing: "doc://com.external.testbundle/not-resolvable-1")!],
-            TopicReferenceResolutionResult.failure(UnresolvedTopicReference(topicURL: ValidatedURL(parsing: "doc://com.external.testbundle/not-resolvable-1")!), errorMessage: "Unit test: External resolve error.")
+            context.externallyResolvedLinks[ValidatedURL(parsingExact: "doc://com.external.testbundle/not-resolvable-1")!],
+            TopicReferenceResolutionResult.failure(UnresolvedTopicReference(topicURL: ValidatedURL(parsingExact: "doc://com.external.testbundle/not-resolvable-1")!), errorMessage: "Unit test: External resolve error.")
         )
         XCTAssertEqual(
-            context.externallyResolvedLinks[ValidatedURL(parsing: "doc://com.external.testbundle/not-resolvable-2")!],
-            TopicReferenceResolutionResult.failure(UnresolvedTopicReference(topicURL: ValidatedURL(parsing: "doc://com.external.testbundle/not-resolvable-2")!), errorMessage: "Unit test: External resolve error.")
+            context.externallyResolvedLinks[ValidatedURL(parsingExact: "doc://com.external.testbundle/not-resolvable-2")!],
+            TopicReferenceResolutionResult.failure(UnresolvedTopicReference(topicURL: ValidatedURL(parsingExact: "doc://com.external.testbundle/not-resolvable-2")!), errorMessage: "Unit test: External resolve error.")
         )
         
         // Expected successful externally resolved reference.
         XCTAssertEqual(
-            context.externallyResolvedLinks[ValidatedURL(parsing: "doc://com.external.testbundle/resolvable")!],
+            context.externallyResolvedLinks[ValidatedURL(parsingExact: "doc://com.external.testbundle/resolvable")!],
             TopicReferenceResolutionResult.success(ResolvedTopicReference(bundleIdentifier: "com.external.testbundle", path: "/resolved", fragment: nil, sourceLanguage: .swift))
         )
         XCTAssertEqual(
-            context.externallyResolvedLinks[ValidatedURL(parsing: "doc://com.external.testbundle/resolved")!],
+            context.externallyResolvedLinks[ValidatedURL(parsingExact: "doc://com.external.testbundle/resolved")!],
             TopicReferenceResolutionResult.success(ResolvedTopicReference(bundleIdentifier: "com.external.testbundle", path: "/resolved", fragment: nil, sourceLanguage: .swift))
         )
         
@@ -608,7 +608,7 @@ Document @1:1-1:35
         XCTAssertEqual(markdownLink, "doc://com.external.testbundle/externally/resolved/path#67890")
 
         // Verify that the external link was stored in the context.
-        let linkURL = try XCTUnwrap(ValidatedURL(parsing: markdownLink))
+        let linkURL = try XCTUnwrap(ValidatedURL(parsingExact: markdownLink))
         guard case .success(let linkReference) = try XCTUnwrap(context.externallyResolvedLinks[linkURL]) else {
             XCTFail("Unexpected failed external reference.")
             return

--- a/Tests/SwiftDocCTests/Infrastructure/PresentationURLGeneratorTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/PresentationURLGeneratorTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -31,7 +31,7 @@ class PresentationURLGeneratorTests: XCTestCase {
         
         // Fragment
         let fragment = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/path", fragment: "test URL! FRAGMENT", sourceLanguage: .swift)
-        XCTAssertEqual(generator.presentationURLForReference(fragment).absoluteString, "https://host:1024/webPrefix/path#test-URL!-FRAGMENT")
+        XCTAssertEqual(generator.presentationURLForReference(fragment).absoluteString, "https://host:1024/webPrefix/path#test-URL-FRAGMENT")
     }
     
     func testExternalURLs() throws {

--- a/Tests/SwiftDocCTests/Infrastructure/ResolvedTopicReferenceTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/ResolvedTopicReferenceTests.swift
@@ -43,7 +43,7 @@ class ResolvedTopicReferenceTests: XCTestCase {
         do {
             let resolvedOriginal = ResolvedTopicReference(bundleIdentifier: "bundleID", path: "/path/sub-path", fragment: "fragment", sourceLanguage: .swift)
             
-            let unresolved = UnresolvedTopicReference(topicURL: ValidatedURL(parsing: "doc://host-name")!)
+            let unresolved = UnresolvedTopicReference(topicURL: ValidatedURL(parsingExact: "doc://host-name")!)
             XCTAssert(unresolved.path.isEmpty)
             
             let appended = resolvedOriginal.appendingPathOfReference(unresolved)
@@ -54,7 +54,7 @@ class ResolvedTopicReferenceTests: XCTestCase {
         do {
             let resolvedOriginal = ResolvedTopicReference(bundleIdentifier: "bundleID", path: "/path/sub-path", fragment: "fragment", sourceLanguage: .swift)
             
-            let unresolved = UnresolvedTopicReference(topicURL: ValidatedURL(parsing: "doc://host.name/;;;")!)
+            let unresolved = UnresolvedTopicReference(topicURL: ValidatedURL(parsingExact: "doc://host.name/;;;")!)
             XCTAssertFalse(unresolved.path.isEmpty)
             
             let appended = resolvedOriginal.appendingPathOfReference(unresolved)

--- a/Tests/SwiftDocCTests/Model/IdentifierTests.swift
+++ b/Tests/SwiftDocCTests/Model/IdentifierTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -40,6 +40,28 @@ class IdentifierTests: XCTestCase {
         XCTAssertEqual(urlReadableFragment("Test replacing 'complete' sentence"), "Test-replacing-complete-sentence")
         
         XCTAssertEqual(urlReadableFragment("💻"), "💻")
+    }
+    
+    func testURLReadableFragmentTwice() {
+        XCTAssertEqual(urlReadableFragment(urlReadableFragment("")), "")
+
+        XCTAssertEqual(urlReadableFragment(urlReadableFragment(" ä ö ")), "ä-ö")
+        XCTAssertEqual(urlReadableFragment(urlReadableFragment(" asdö  ")), "asdö")
+        
+        XCTAssertEqual(urlReadableFragment(urlReadableFragment(" ASD  ")), "ASD")
+        
+        XCTAssertEqual(urlReadableFragment(urlReadableFragment(" ASD ASD  ")), "ASD-ASD")
+        XCTAssertEqual(urlReadableFragment(urlReadableFragment(" 3äêòNS  ")), "3äêòNS")
+
+        XCTAssertEqual(urlReadableFragment(urlReadableFragment("    Aä    êò  B   CD    ")), "Aä-êò-B-CD")
+
+        XCTAssertEqual(urlReadableFragment(urlReadableFragment(" This is a 'test' ")), "This-is-a-test")
+        XCTAssertEqual(urlReadableFragment(urlReadableFragment(" This is a \"test\" ")), "This-is-a-test")
+        XCTAssertEqual(urlReadableFragment(urlReadableFragment(" This is a `test` ")), "This-is-a-test")
+        
+        XCTAssertEqual(urlReadableFragment(urlReadableFragment("Test replacing 'complete' sentence")), "Test-replacing-complete-sentence")
+        
+        XCTAssertEqual(urlReadableFragment(urlReadableFragment("💻")), "💻")
     }
     
     func testReusingReferences() {

--- a/Tests/SwiftDocCTests/Semantics/TutorialReferenceTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/TutorialReferenceTests.swift
@@ -45,7 +45,7 @@ class TutorialReferenceTests: XCTestCase {
             guard case let .unresolved(unresolved) = tutorialReference.topic else {
                 fatalError()
             }
-            XCTAssertEqual(ValidatedURL(parsing: tutorialLink), unresolved.topicURL)
+            XCTAssertEqual(ValidatedURL(parsingExact: tutorialLink), unresolved.topicURL)
         }
         XCTAssertTrue(problems.isEmpty)
     }

--- a/Tests/SwiftDocCTests/Utility/ValidatedURLTests.swift
+++ b/Tests/SwiftDocCTests/Utility/ValidatedURLTests.swift
@@ -24,7 +24,7 @@ class ValidatedURLTests: XCTestCase {
         
         // Test ValidatedURL.init(String)
         validURLs.forEach { url in
-            let validated = ValidatedURL(parsing: url.absoluteString)
+            let validated = ValidatedURL(parsingExact: url.absoluteString)
             XCTAssertEqual(url.absoluteString, validated?.absoluteString)
         }
 
@@ -42,7 +42,7 @@ class ValidatedURLTests: XCTestCase {
         
         // Test ValidatedURL.init(String)
         invalidURLs.forEach { url in
-            XCTAssertNil(ValidatedURL(parsing: url.absoluteString))
+            XCTAssertNil(ValidatedURL(parsingExact: url.absoluteString))
         }
 
         // Test ValidatedURL.init(URL)
@@ -86,7 +86,7 @@ class ValidatedURLTests: XCTestCase {
         // Test successful fragment parsing
         fragmentDestinations
             .forEach { url in
-                XCTAssertNotNil(ValidatedURL(parsing: url)?.components.fragment)
+                XCTAssertNotNil(ValidatedURL(parsingExact: url)?.components.fragment)
             }
     }
 }

--- a/Tests/SwiftDocCUtilitiesTests/OutOfProcessReferenceResolverTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/OutOfProcessReferenceResolverTests.swift
@@ -93,7 +93,7 @@ class OutOfProcessReferenceResolverTests: XCTestCase {
         
         // Resolve the reference
         let unresolved = TopicReference.unresolved(
-            UnresolvedTopicReference(topicURL: ValidatedURL(parsing: "doc://com.test.bundle/something")!))
+            UnresolvedTopicReference(topicURL: ValidatedURL(parsingExact: "doc://com.test.bundle/something")!))
         guard case .success(let resolvedReference) = resolver.resolve(
                 unresolved, sourceLanguage: .swift)
         else {
@@ -402,7 +402,7 @@ class OutOfProcessReferenceResolverTests: XCTestCase {
     
     func assertForwardsResolverErrors(resolver: OutOfProcessReferenceResolver) throws {
         XCTAssertEqual(resolver.bundleIdentifier, "com.test.bundle")
-        let resolverResult = resolver.resolve(.unresolved(UnresolvedTopicReference(topicURL: ValidatedURL(parsing: "doc://com.test.bundle/something")!)), sourceLanguage: .swift)
+        let resolverResult = resolver.resolve(.unresolved(UnresolvedTopicReference(topicURL: ValidatedURL(parsingExact: "doc://com.test.bundle/something")!)), sourceLanguage: .swift)
         guard case .failure(_, let errorMessage) = resolverResult else {
             XCTFail("Encountered an unexpected type of error.")
             return


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://93458581

## Summary

This makes two changes related to doc links to subsections (doc links with fragments):
- Developers can now write links to subsections using characters that aren't allowed in URL fragments without needing to percent escape those characters in the link.
- Punctuation characters in doc links to subsections are now removed from the resolved topic reference fragment. This means that links to subsections written both with and without punctuation will resolve.

## Dependencies

None.

## Testing

In a DocC catalog with at least one article or documentation extension file:

- Add a few headings that contain punctuation characters
- Write links to those articles as `<doc:article-file-name#Heading-name-with-punctuation>`
The doc links to those subsections should resolve both with and without punctuation

- Add a few headings that contain emoji or other unicode characters
- Write links to those articles as `<doc:article-file-name#emoji-or-other-unicode-character>`
The doc links to those subsections should resolve without needing to percent encode the emoji or unicode characters.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
