### PR TITLE
[5.7] Improve performance of static hosting transformation during conversion

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -60,7 +60,7 @@
         "repositoryURL": "https://github.com/apple/swift-markdown.git",
         "state": {
           "branch": "release/5.7",
-          "revision": "fae172a60b3ed107bd4dc1e732abfec537661150",
+          "revision": "7e704622ef98b3cc9233283b6298ed61806ddb43",
           "version": null
         }
       },

--- a/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
+++ b/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
@@ -159,7 +159,7 @@ public class NavigatorIndex {
         let information = try environment.openDatabase(named: "information", flags: [])
         self.information = information
         
-        let data = try Data(contentsOf: url.appendingPathComponent("availability.index"))
+        let data = try Data(contentsOf: url.appendingPathComponent("availability.index", isDirectory: false))
         let plistDecoder = PropertyListDecoder()
         let availabilityIndex = try plistDecoder.decode(AvailabilityIndex.self, from: data)
         self.availabilityIndex = availabilityIndex
@@ -170,7 +170,7 @@ public class NavigatorIndex {
         self.pathHasher = PathHasher(rawValue: information.get(type: String.self, forKey: NavigatorIndex.pathHasherKey) ?? "") ?? .fnv1
         
         if readNavigatorTree {
-            self.navigatorTree = try NavigatorTree.read(from: url.appendingPathComponent("navigator.index"), bundleIdentifier: self.bundleIdentifier, interfaceLanguages: availabilityIndex.interfaceLanguages, presentationIdentifier: presentationIdentifier)
+            self.navigatorTree = try NavigatorTree.read(from: url.appendingPathComponent("navigator.index", isDirectory: false), bundleIdentifier: self.bundleIdentifier, interfaceLanguages: availabilityIndex.interfaceLanguages, presentationIdentifier: presentationIdentifier)
         } else {
             self.navigatorTree = NavigatorTree()
         }

--- a/Sources/SwiftDocC/Indexing/Navigator/NavigatorTree.swift
+++ b/Sources/SwiftDocC/Indexing/Navigator/NavigatorTree.swift
@@ -287,7 +287,7 @@ public class NavigatorTree {
     
     /// Read a tree by loading the whole data into disk and then process the content.
     fileprivate static func __readAtomically(from path: String, bundleIdentifier: String? = nil, interfaceLanguageMap: [InterfaceLanguage.ID: InterfaceLanguage], presentationIdentifier: String? = nil) throws -> NavigatorTree {
-        let fileUrl = URL(fileURLWithPath: path)
+        let fileUrl = URL(fileURLWithPath: path, isDirectory: false)
         let data = try Data(contentsOf: fileUrl)
         
         var map = [UInt32: Node]()

--- a/Sources/SwiftDocC/Infrastructure/Bundle Assets/DataAssetManager.swift
+++ b/Sources/SwiftDocC/Infrastructure/Bundle Assets/DataAssetManager.swift
@@ -118,13 +118,15 @@ struct DataAssetManager {
         for dataURL in datas {
             let meta = try referenceMetaInformationForDataURL(dataURL, dataProvider: dataProvider, bundle: documentationBundle)
 
+            let referenceURL = URL(fileURLWithPath: meta.reference, isDirectory: false)
+            
             // Store the image with given scale information and display scale.
-            let name = URL(fileURLWithPath: meta.reference).lastPathComponent
+            let name = referenceURL.lastPathComponent
             storage[name, default: DataAsset()]
                 .register(dataURL, with: meta.traits)
             
             if name.contains(".") {
-                let nameNoExtension = URL(fileURLWithPath: name).deletingPathExtension().lastPathComponent
+                let nameNoExtension = referenceURL.deletingPathExtension().lastPathComponent
                 fuzzyKeyIndex[nameNoExtension] = name
             }
         }

--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -2364,6 +2364,14 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
         return try dataProvider.contentsOfURL(resource.url, in: bundle)
     }
     
+    /// Returns true if a resource with the given identifier exists in the registered bundle.
+    public func resourceExists(with identifier: ResourceReference) -> Bool{
+        guard let assetManager = assetManagers[identifier.bundleIdentifier] else {
+            return false
+        }
+        
+        return assetManager.bestKey(forAssetName: identifier.path) != nil
+    }
     
     /**
      Returns an externally resolved node for the given reference.

--- a/Sources/SwiftDocC/Infrastructure/NodeURLGenerator.swift
+++ b/Sources/SwiftDocC/Infrastructure/NodeURLGenerator.swift
@@ -61,19 +61,56 @@ public struct NodeURLGenerator {
             switch self {
             case .documentation(let path):
                 // Format: "/documentation/MyKit/MyClass/myFunction(_:)"
-                return Self.documentationFolderURL.appendingPathComponent(urlReadablePath(path.removingLeadingSlash)).path
+                return Self.documentationFolderURL
+                    .appendingPathComponent(
+                        urlReadablePath(path.removingLeadingSlash),
+                        isDirectory: false
+                    )
+                    .path
             case .documentationCuration(let parentPath, let name):
                 // Format: "/documentation/MyKit/MyClass/MyCollection"
-                return Self.rootURL.appendingPathComponent(urlReadablePath(parentPath.removingLeadingSlash)).appendingPathComponent(urlReadablePath(name)).path
+                return Self.rootURL
+                    .appendingPathComponent(
+                        urlReadablePath(parentPath.removingLeadingSlash),
+                        isDirectory: true
+                    )
+                    .appendingPathComponent(
+                        urlReadablePath(name),
+                        isDirectory: false
+                    )
+                    .path
             case .article(let bundleName, let articleName):
                 // Format: "/documentation/MyBundle/MyArticle"
-                return Self.documentationFolderURL.appendingPathComponent(urlReadablePath(bundleName)).appendingPathComponent(urlReadablePath(articleName)).path
+                return Self.documentationFolderURL
+                    .appendingPathComponent(
+                        urlReadablePath(bundleName),
+                        isDirectory: true
+                    )
+                    .appendingPathComponent(
+                        urlReadablePath(articleName),
+                        isDirectory: false
+                    )
+                    .path
             case .technology(let technologyName):
                 // Format: "/tutorials/MyTechnology"
-                return Self.tutorialsFolderURL.appendingPathComponent(urlReadablePath(technologyName)).path
+                return Self.tutorialsFolderURL
+                    .appendingPathComponent(
+                        urlReadablePath(technologyName),
+                        isDirectory: false
+                    )
+                    .path
             case .tutorial(let bundleName, let tutorialName):
                 // Format: "/tutorials/MyBundle/MyTutorial"
-                return Self.tutorialsFolderURL.appendingPathComponent(urlReadablePath(bundleName)).appendingPathComponent(urlReadablePath(tutorialName)).path
+                return Self.tutorialsFolderURL
+                    .appendingPathComponent(
+                        urlReadablePath(bundleName),
+                        isDirectory: true
+                    )
+                    .appendingPathComponent(
+                        urlReadablePath(tutorialName),
+                        isDirectory: false
+                    )
+                    .path
             }
         }
     }
@@ -127,9 +164,9 @@ public struct NodeURLGenerator {
     public func urlForReference(_ reference: ResolvedTopicReference, fileSafePath safePath: String) -> URL {
         if safePath.isEmpty {
             // Return the root path for the conversion: /documentation.json
-            return baseURL.appendingPathComponent("documentation")
+            return baseURL.appendingPathComponent("documentation", isDirectory: false)
         } else {
-            let url = baseURL.appendingPathComponent(safePath)
+            let url = baseURL.appendingPathComponent(safePath, isDirectory: false)
             return url.withFragment(reference.url.fragment)
         }
     }

--- a/Sources/SwiftDocC/Infrastructure/NodeURLGenerator.swift
+++ b/Sources/SwiftDocC/Infrastructure/NodeURLGenerator.swift
@@ -98,14 +98,37 @@ public struct NodeURLGenerator {
         }
     }
     
+    /// Returns the reference's path in a format that is safe for writing to disk.
+    public static func fileSafeReferencePath(
+        _ reference: ResolvedTopicReference,
+        lowercased: Bool = false
+    ) -> String {
+        guard !reference.path.removingLeadingSlash.isEmpty else {
+            return ""
+        }
+        
+        let safeURL = fileSafeURL(reference.url)
+        let pathRemovingLeadingSlash = safeURL.path.removingLeadingSlash
+        
+        if lowercased {
+            return pathRemovingLeadingSlash.lowercased()
+        } else {
+            return pathRemovingLeadingSlash
+        }
+    }
+    
     /// Returns a URL appropriate for the given reference.
     public func urlForReference(_ reference: ResolvedTopicReference, lowercased: Bool = false) -> URL {
-        if reference.path.removingLeadingSlash.isEmpty {
+        let safePath = Self.fileSafeReferencePath(reference, lowercased: lowercased)
+        return urlForReference(reference, fileSafePath: safePath)
+    }
+    
+    /// Returns a URL appropriate for the given reference and file safe path.
+    public func urlForReference(_ reference: ResolvedTopicReference, fileSafePath safePath: String) -> URL {
+        if safePath.isEmpty {
             // Return the root path for the conversion: /documentation.json
             return baseURL.appendingPathComponent("documentation")
         } else {
-            let safeURL = fileSafeURL(reference.url)
-            let safePath = (lowercased) ? safeURL.path.removingLeadingSlash.lowercased() : safeURL.path.removingLeadingSlash
             let url = baseURL.appendingPathComponent(safePath)
             return url.withFragment(reference.url.fragment)
         }
@@ -118,7 +141,7 @@ public struct NodeURLGenerator {
     /// there might be more complex rules for "safe" paths beyond simply replacing a set of
     /// characters. For example a period is a safe character but when a file path component
     /// starts with a period that might be problematic when hosted on a generic web server.
-    public func fileSafeURL(_ url: URL) -> URL {
+    public static func fileSafeURL(_ url: URL) -> URL {
         // Prepend leading period with a "'" to avoid file names looking like hidden files on web servers
         var isURLModified = false
         let pathComponents = url.pathComponents
@@ -157,5 +180,10 @@ public struct NodeURLGenerator {
         var components = URLComponents(url: url, resolvingAgainstBaseURL: false)!
         components.path = newPath
         return components.url!
+    }
+    
+    @available(*, deprecated, message: "Use the static version of 'NodeURLGenerator.fileSafeURL(_:)' instead")
+    public func fileSafeURL(_ url: URL) -> URL {
+        return Self.fileSafeURL(url)
     }
 }

--- a/Sources/SwiftDocC/Model/Identifier.swift
+++ b/Sources/SwiftDocC/Model/Identifier.swift
@@ -482,7 +482,10 @@ public struct UnresolvedTopicReference: Hashable, CustomStringConvertible {
     ///   - parent: The resolved parent reference of the unresolved reference.
     ///   - unresolvedChild: The other unresolved reference.
     public init(parent: ResolvedTopicReference, unresolvedChild: UnresolvedTopicReference) {
-        var components = URLComponents(url: parent.url.appendingPathComponent(unresolvedChild.path), resolvingAgainstBaseURL: false)!
+        var components = URLComponents(
+            url: parent.url.appendingPathComponent(unresolvedChild.path, isDirectory: false),
+            resolvingAgainstBaseURL: false
+        )!
         components.fragment = unresolvedChild.fragment
         self.init(topicURL: ValidatedURL(components: components))
     }

--- a/Sources/SwiftDocC/Model/Rendering/References/RenderReference.swift
+++ b/Sources/SwiftDocC/Model/Rendering/References/RenderReference.swift
@@ -68,7 +68,7 @@ extension URLReference {
     /// - Parameter path: The path of the file.
     /// - Returns: The destination URL for the given file path.
     func destinationURL(for path: String) -> URL {
-        return Self.baseURL.appendingPathComponent(path)
+        return Self.baseURL.appendingPathComponent(path, isDirectory: false)
     }
 }
 

--- a/Sources/SwiftDocC/Semantics/MarkupReferenceResolver.swift
+++ b/Sources/SwiftDocC/Semantics/MarkupReferenceResolver.swift
@@ -72,7 +72,7 @@ struct MarkupReferenceResolver: MarkupRewriter {
     }
 
     mutating func visitImage(_ image: Image) -> Markup? {
-        if let reference = image.reference(in: bundle), (try? context.resource(with: reference)) == nil {
+        if let reference = image.reference(in: bundle), !context.resourceExists(with: reference) {
             problems.append(unresolvedResourceProblem(resource: reference, source: source, range: image.range, severity: .warning))
         }
 

--- a/Sources/SwiftDocC/Semantics/ReferenceResolver.swift
+++ b/Sources/SwiftDocC/Semantics/ReferenceResolver.swift
@@ -73,7 +73,7 @@ struct ReferenceResolver: SemanticVisitor {
     Returns a ``Problem`` if the resource cannot be found; otherwise `nil`.
     */
     private func resolve(resource: ResourceReference, range: SourceRange?, severity: DiagnosticSeverity) -> Problem? {
-        if (try? context.resource(with: resource)) == nil {
+        if !context.resourceExists(with: resource) {
             return unresolvedResourceProblem(resource: resource, source: source, range: range, severity: severity)
         } else {
             return nil

--- a/Sources/SwiftDocCUtilities/Action/Actions/Convert/ConvertFileWritingConsumer.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Convert/ConvertFileWritingConsumer.swift
@@ -25,13 +25,24 @@ struct ConvertFileWritingConsumer: ConvertOutputConsumer {
         case footer = "custom-footer"
     }
     
-    init(targetFolder: URL, bundleRootFolder: URL?, fileManager: FileManagerProtocol, context: DocumentationContext, indexer: ConvertAction.Indexer?, enableCustomTemplates: Bool = false) {
+    init(
+        targetFolder: URL,
+        bundleRootFolder: URL?,
+        fileManager: FileManagerProtocol,
+        context: DocumentationContext,
+        indexer: ConvertAction.Indexer?,
+        enableCustomTemplates: Bool = false,
+        transformForStaticHostingIndexHTML: URL?
+    ) {
         self.targetFolder = targetFolder
         self.bundleRootFolder = bundleRootFolder
         self.fileManager = fileManager
         self.context = context
         self.renderNodeWriter = JSONEncodingRenderNodeWriter(
-            targetFolder: targetFolder, fileManager: fileManager)
+            targetFolder: targetFolder,
+            fileManager: fileManager,
+            transformForStaticHostingIndexHTML: transformForStaticHostingIndexHTML
+        )
         self.indexer = indexer
         self.enableCustomTemplates = enableCustomTemplates
     }

--- a/Sources/SwiftDocCUtilities/Action/Actions/Convert/ConvertFileWritingConsumer.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Convert/ConvertFileWritingConsumer.swift
@@ -70,7 +70,7 @@ struct ConvertFileWritingConsumer: ConvertOutputConsumer {
                 let assetName = sourceURL.lastPathComponent
                 try fileManager.copyItem(
                     at: sourceURL,
-                    to: destinationFolder.appendingPathComponent(assetName)
+                    to: destinationFolder.appendingPathComponent(assetName, isDirectory: false)
                 )
             }
         }
@@ -178,7 +178,7 @@ struct ConvertFileWritingConsumer: ConvertOutputConsumer {
     // Injects a <template> tag into the index.html <body> using the contents of
     // the given URL for the provided HTML file
     private func injectCustomTemplate(_ templateURL: URL, identifiedBy id: CustomTemplateIdentifier) throws {
-        let index = targetFolder.appendingPathComponent("index.html")
+        let index = targetFolder.appendingPathComponent("index.html", isDirectory: false)
         guard let indexData = fileManager.contents(atPath: index.path),
               let indexContents = String(data: indexData, encoding: .utf8),
               let templateData = fileManager.contents(atPath: templateURL.path),

--- a/Sources/SwiftDocCUtilities/Action/Actions/Convert/Indexer.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Convert/Indexer.swift
@@ -34,7 +34,7 @@ extension ConvertAction {
         ///   - outputURL: The target directory to create the index file.
         ///   - bundleIdentifier: The identifier of the bundle being indexed.
         init(outputURL: URL, bundleIdentifier: String) throws {
-            let indexURL = outputURL.appendingPathComponent("index")
+            let indexURL = outputURL.appendingPathComponent("index", isDirectory: true)
             indexBuilder = Synchronized<NavigatorIndex.Builder>(
                 NavigatorIndex.Builder(renderNodeProvider: nil,
                     outputURL: indexURL,

--- a/Sources/SwiftDocCUtilities/Action/Actions/Convert/JSONEncodingRenderNodeWriter.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Convert/JSONEncodingRenderNodeWriter.swift
@@ -27,7 +27,9 @@ class JSONEncodingRenderNodeWriter {
         }
     }
     
-    private let urlGenerator: NodeURLGenerator
+    private let renderNodeURLGenerator: NodeURLGenerator
+    private let targetFolder: URL
+    private let transformForStaticHostingIndexHTML: URL?
     private let fileManager: FileManagerProtocol
     private let renderReferenceCache = RenderReferenceCache([:])
     
@@ -36,10 +38,12 @@ class JSONEncodingRenderNodeWriter {
     /// - Parameters:
     ///   - targetFolder: The folder to which the writer object writes the files.
     ///   - fileManager: The file manager with which the writer object writes data to files.
-    init(targetFolder: URL, fileManager: FileManagerProtocol) {
-        self.urlGenerator = NodeURLGenerator(
+    init(targetFolder: URL, fileManager: FileManagerProtocol, transformForStaticHostingIndexHTML: URL?) {
+        self.renderNodeURLGenerator = NodeURLGenerator(
             baseURL: targetFolder.appendingPathComponent("data", isDirectory: true)
         )
+        self.targetFolder = targetFolder
+        self.transformForStaticHostingIndexHTML = transformForStaticHostingIndexHTML
         self.fileManager = fileManager
     }
     
@@ -54,33 +58,64 @@ class JSONEncodingRenderNodeWriter {
     /// - Parameter renderNode: The node which the writer object writes to a JSON file.
     /// - Throws: A ``Error/fileExists`` error if a file already exists at the location for this node's JSON file.
     func write(_ renderNode: RenderNode) throws {
+        let fileSafePath = NodeURLGenerator.fileSafeReferencePath(
+            renderNode.identifier,
+            lowercased: true
+        )
+        
         // The path on disk to write the render node JSON file at.
-        let targetFileURL = urlGenerator
+        let renderNodeTargetFileURL = renderNodeURLGenerator
             .urlForReference(
                 renderNode.identifier,
-                // Lowercase the URL on disk so that it matches the casing used for topic references in render nodes.
-                // It's important that the casing matches for case-sensitive file systems.
-                lowercased: true
+                fileSafePath: fileSafePath
             )
             .appendingPathExtension("json")
         
-        let targetFolderURL = targetFileURL.deletingLastPathComponent()
+        let renderNodeTargetFolderURL = renderNodeTargetFileURL.deletingLastPathComponent()
         
         // On Linux sometimes it takes a moment for the directory to be created and that leads to
         // errors when trying to write files concurrently in the same target location.
         // We keep an index in `directoryIndex` and create new sub-directories as needed.
         // When the symbol's directory already exists no code is executed during the lock below
         // besides the set lookup.
-        try directoryIndex.sync {
-            if !$0.contains(targetFileURL) {
-                $0.insert(targetFileURL)
-                try fileManager.createDirectory(at: targetFolderURL, withIntermediateDirectories: true, attributes: nil)
+        try directoryIndex.sync { directoryIndex in
+            let (insertedRenderNodeTargetFolderURL, _) = directoryIndex.insert(renderNodeTargetFolderURL)
+            if insertedRenderNodeTargetFolderURL {
+                try fileManager.createDirectory(
+                    at: renderNodeTargetFolderURL,
+                    withIntermediateDirectories: true,
+                    attributes: nil
+                )
             }
         }
         
         let encoder = RenderJSONEncoder.makeEncoder()
         
         let data = try renderNode.encodeToJSON(with: encoder, renderReferenceCache: renderReferenceCache)
-        try fileManager.createFile(at: targetFileURL, contents: data)
+        try fileManager.createFile(at: renderNodeTargetFileURL, contents: data)
+        
+        guard let indexHTML = transformForStaticHostingIndexHTML else {
+            return
+        }
+        
+        let htmlTargetFolderURL = targetFolder.appendingPathComponent(
+            fileSafePath,
+            isDirectory: true
+        )
+        let htmlTargetFileURL = htmlTargetFolderURL.appendingPathComponent(
+            HTMLTemplate.indexFileName.rawValue,
+            isDirectory: false
+        )
+        
+        // Note that it doesn't make sense to use the above-described `directoryIndex` for this use
+        // case since we expect every 'index.html' file to require the creation of
+        // its own unique parent directory.
+        try fileManager.createDirectory(
+            at: htmlTargetFolderURL,
+            withIntermediateDirectories: true,
+            attributes: nil
+        )
+        
+        try fileManager.copyItem(at: indexHTML, to: htmlTargetFileURL)
     }
 }

--- a/Sources/SwiftDocCUtilities/Action/Actions/Convert/JSONEncodingRenderNodeWriter.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Convert/JSONEncodingRenderNodeWriter.swift
@@ -92,7 +92,7 @@ class JSONEncodingRenderNodeWriter {
         let encoder = RenderJSONEncoder.makeEncoder()
         
         let data = try renderNode.encodeToJSON(with: encoder, renderReferenceCache: renderReferenceCache)
-        try fileManager.createFile(at: renderNodeTargetFileURL, contents: data)
+        try fileManager.createFile(at: renderNodeTargetFileURL, contents: data, options: nil)
         
         guard let indexHTML = transformForStaticHostingIndexHTML else {
             return

--- a/Sources/SwiftDocCUtilities/Action/Actions/CoverageAction.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/CoverageAction.swift
@@ -34,7 +34,9 @@ public struct CoverageAction: Action {
 
             let summaryString = try CoverageDataEntry.generateSummary(
                 ofDataAt: workingDirectory.appendingPathComponent(
-                    ConvertFileWritingConsumer.docCoverageFileName),
+                    ConvertFileWritingConsumer.docCoverageFileName,
+                    isDirectory: false
+                ),
                 fileManager: fileManager,
                 shouldGenerateBrief: true,
                 shouldGenerateDetailed: (documentationCoverageOptions.level == .detailed)

--- a/Sources/SwiftDocCUtilities/Action/Actions/TransformForStaticHostingAction.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/TransformForStaticHostingAction.swift
@@ -89,7 +89,11 @@ struct TransformForStaticHostingAction: Action {
         }
         
         // Transform the indexHTML if needed.
-        let indexHTMLData = try StaticHostableTransformer.transformHTMLTemplate(htmlTemplate: htmlTemplateDirectory, hostingBasePath: hostingBasePath)
+        let indexHTMLData = try StaticHostableTransformer.indexHTMLData(
+            in: htmlTemplateDirectory,
+            with: hostingBasePath,
+            fileManager: FileManager.default
+        )
 
         // Create a StaticHostableTransformer targeted at the archive data folder
         let dataProvider = try LocalFileSystemDataProvider(rootURL: rootURL.appendingPathComponent(NodeURLGenerator.Path.dataFolderName))

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/Options/DirectoryPathOption.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/Options/DirectoryPathOption.swift
@@ -22,7 +22,7 @@ public protocol DirectoryPathOption: ParsableArguments {
 extension DirectoryPathOption {
     /// The provided ``url`` or the "current directory" if the user didn't provide an argument.
     public var urlOrFallback: URL {
-        return url ?? URL(fileURLWithPath: ".")
+        return url ?? URL(fileURLWithPath: ".", isDirectory: true)
     }
 
     public mutating func validate() throws {

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/Options/OutOfProcessLinkResolverOption.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/Options/OutOfProcessLinkResolverOption.swift
@@ -25,7 +25,7 @@ public struct OutOfProcessLinkResolverOption: ParsableArguments {
     /// the environment variable `DOCC_LINK_RESOLVER_EXECUTABLE`.
     var linkResolverExecutableURL: URL? {
         ProcessInfo.processInfo.environment[OutOfProcessLinkResolverOption.environmentVariableKey]
-            .map { URL(fileURLWithPath: $0) }
+            .map { URL(fileURLWithPath: $0, isDirectory: false) }
     }
 
     public mutating func validate() throws {

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Convert.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Convert.swift
@@ -291,7 +291,7 @@ extension Docc {
                         neededFileName = HTMLTemplate.indexFileName.rawValue
                     }
 
-                    let indexTemplate = templateURL.appendingPathComponent(neededFileName)
+                    let indexTemplate = templateURL.appendingPathComponent(neededFileName, isDirectory: false)
                     if !FileManager.default.fileExists(atPath: indexTemplate.path) {
                         throw TemplateOption.invalidHTMLTemplateError(
                             path: templateURL.path,

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Index.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Index.swift
@@ -40,7 +40,7 @@ extension Docc {
 
         /// The path to the directory that all build output should be placed in.
         public var outputURL: URL {
-            documentationBundle.urlOrFallback.appendingPathComponent("index")
+            documentationBundle.urlOrFallback.appendingPathComponent("index", isDirectory: true)
         }
 
         // MARK: - Execution

--- a/Sources/SwiftDocCUtilities/Utility/FileManagerProtocol.swift
+++ b/Sources/SwiftDocCUtilities/Utility/FileManagerProtocol.swift
@@ -61,6 +61,16 @@ protocol FileManagerProtocol {
     ///
     /// - Throws: If the file couldn't be created with the specified contents.
     func createFile(at: URL, contents: Data) throws
+    
+    /// Creates a file with the given contents at the given url with the specified
+    /// writing options.
+    ///
+    /// - Parameters:
+    ///   - at: The location to create the file
+    ///   - contents: The data to write to the file.
+    ///   - options: Options for writing the data. Provide `nil` to use the default
+    ///              writing options of the file manager.
+    func createFile(at location: URL, contents: Data, options writingOptions: NSData.WritingOptions?) throws
 }
 
 extension FileManagerProtocol {
@@ -81,4 +91,11 @@ extension FileManager: FileManagerProtocol {
         try contents.write(to: location, options: .atomic)
     }
     
+    func createFile(at location: URL, contents: Data, options writingOptions: NSData.WritingOptions?) throws {
+        if let writingOptions = writingOptions {
+            try contents.write(to: location, options: writingOptions)
+        } else {
+            try contents.write(to: location)
+        }
+    }
 }

--- a/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
@@ -1446,6 +1446,59 @@ Root
             XCTAssertEqual("e47cfd13c4af", pathHasher.hash("/mykit/myclass/myfunc"))
         }
     }
+    
+    func testNormalizedNavigatorIndexIdentifier() throws {
+        let topicReference = ResolvedTopicReference(
+            bundleIdentifier: "org.swift.example",
+            path: "/documentation/path/sub-path",
+            fragment: nil,
+            sourceLanguage: .swift
+        )
+        
+        XCTAssertEqual(
+            topicReference.normalizedNavigatorIndexIdentifier(forLanguage: 0),
+            NavigatorIndex.Identifier(
+                bundleIdentifier:  "org.swift.example",
+                path: "/documentation/path/sub-path",
+                fragment: nil,
+                languageIdentifier: 0
+            )
+        )
+        
+        let topicReferenceWithCapitalization = ResolvedTopicReference(
+            bundleIdentifier: "org.Swift.Example",
+            path: "/documentation/Path/subPath",
+            fragment: nil,
+            sourceLanguage: .swift
+        )
+        
+        XCTAssertEqual(
+            topicReferenceWithCapitalization.normalizedNavigatorIndexIdentifier(forLanguage: 1),
+            NavigatorIndex.Identifier(
+                bundleIdentifier:  "org.swift.example",
+                path: "/documentation/path/subpath",
+                fragment: nil,
+                languageIdentifier: 1
+            )
+        )
+        
+        let topicReferenceWithFragment = ResolvedTopicReference(
+            bundleIdentifier: "org.Swift.Example",
+            path: "/documentation/Path/subPath",
+            fragment: "FRAGMENT",
+            sourceLanguage: .swift
+        )
+        
+        XCTAssertEqual(
+            topicReferenceWithFragment.normalizedNavigatorIndexIdentifier(forLanguage: 1),
+            NavigatorIndex.Identifier(
+                bundleIdentifier:  "org.swift.example",
+                path: "/documentation/path/subpath",
+                fragment: "FRAGMENT",
+                languageIdentifier: 1
+            )
+        )
+    }
 
     func generatedNavigatorIndex(for testBundleName: String, bundleIdentifier: String) throws -> NavigatorIndex {
         let (bundle, context) = try testBundleAndContext(named: testBundleName)

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -430,6 +430,44 @@ class DocumentationContextTests: XCTestCase {
         XCTAssertThrowsError(try context.resource(with: imageFigure), "Images should be registered (and referred to) by their name, not by their path.")
     }
     
+    func testResourceExists() throws {
+        let (bundle, context) = try testBundleAndContext(named: "TestBundle")
+        
+        let existingImageReference = ResourceReference(
+            bundleIdentifier: bundle.identifier,
+            path: "introposter"
+        )
+        let nonexistentImageReference = ResourceReference(
+            bundleIdentifier: bundle.identifier,
+            path: "nonexistent-image"
+        )
+        XCTAssertTrue(
+            context.resourceExists(with: existingImageReference),
+            "\(existingImageReference.path) expected in \(bundle.displayName)"
+        )
+        XCTAssertFalse(
+            context.resourceExists(with: nonexistentImageReference),
+            "\(nonexistentImageReference.path) does not exist in \(bundle.displayName)"
+        )
+        
+        let correctImageReference = ResourceReference(
+            bundleIdentifier: bundle.identifier,
+            path: "figure1.jpg"
+        )
+        let incorrectImageReference = ResourceReference(
+            bundleIdentifier: bundle.identifier,
+            path: "images/figure1.jpg"
+        )
+        XCTAssertTrue(
+            context.resourceExists(with: correctImageReference),
+            "\(correctImageReference.path) expected in \(bundle.displayName)"
+        )
+        XCTAssertFalse(
+            context.resourceExists(with: incorrectImageReference),
+            "Images are registered and referenced by name, not path."
+        )
+    }
+    
     func testURLs() throws {
         let exampleDocumentation = Folder(name: "unit-test.docc", content: [
             Folder(name: "Symbols", content: []),

--- a/Tests/SwiftDocCTests/Infrastructure/NodeURLGeneratorTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/NodeURLGeneratorTests.swift
@@ -24,7 +24,7 @@ class NodeURLGeneratorTests: XCTestCase {
     
     /// Tests that a list of URLs are not changed by `NodeURLGenerator.fileSafeURL(_:)`
     func testFileNameSafeURLUnchanged() throws {
-        XCTAssertEqual(unchangedURLs.map({ generator.fileSafeURL($0) }), unchangedURLs)
+        XCTAssertEqual(unchangedURLs.map({ NodeURLGenerator.fileSafeURL($0) }), unchangedURLs)
     }
 
     let unsafeInputURLs = [
@@ -41,7 +41,7 @@ class NodeURLGeneratorTests: XCTestCase {
     
     /// Tests that a list of URLs are "safe-ified" successfully
     func testFileNameSafeURLSafeified() throws {
-        XCTAssertEqual(unsafeInputURLs.map({ generator.fileSafeURL($0) }), safeOutputURLs)
+        XCTAssertEqual(unsafeInputURLs.map({ NodeURLGenerator.fileSafeURL($0) }), safeOutputURLs)
     }
     
     /// Tests that baseURL is not "safe-ified" when passed
@@ -102,7 +102,7 @@ class NodeURLGeneratorTests: XCTestCase {
     /// Tests that long path components are trimmed
     func testLongPathComponents() throws {
         for offset in 0..<inputLongPaths.count {
-            XCTAssertEqual(generator.fileSafeURL(URL(fileURLWithPath: inputLongPaths[offset])), URL(fileURLWithPath: outputLongPaths[offset]) )
+            XCTAssertEqual(NodeURLGenerator.fileSafeURL(URL(fileURLWithPath: inputLongPaths[offset])), URL(fileURLWithPath: outputLongPaths[offset]) )
         }
     }
 }

--- a/Tests/SwiftDocCUtilitiesTests/JSONEncodingRenderNodeWriterTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/JSONEncodingRenderNodeWriterTests.swift
@@ -16,11 +16,21 @@ class JSONEncodingRenderNodeWriterTests: XCTestCase {
     /// Verifies that if we fail during writing a JSON file the execution
     /// does not deadlock.
     func testThrowingDuringWritingDoesNotDeadlock() throws {
+        let temporaryDirectory = try createTemporaryDirectory()
+        let indexHTML = temporaryDirectory.appendingPathComponent("index.html", isDirectory: false)
+        try "html".write(
+            to: indexHTML,
+            atomically: true,
+            encoding: .utf8
+        )
+        
         // Setting up the URL generator with a lengthy target folder path
         // that is guaranteed to throw if we try writing a file.
         let writer = JSONEncodingRenderNodeWriter(
             targetFolder: URL(fileURLWithPath: String(repeating: "A", count: 4096)),
-            fileManager: FileManager.default)
+            fileManager: FileManager.default,
+            transformForStaticHostingIndexHTML: indexHTML
+        )
         
         let renderNode = RenderNode(identifier: .init(bundleIdentifier: "com.test", path: "/documentation/test", sourceLanguage: .swift), kind: .article)
         

--- a/Tests/SwiftDocCUtilitiesTests/StaticHostableTransformerTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/StaticHostableTransformerTests.swift
@@ -53,7 +53,7 @@ class StaticHostableTransformerTests: StaticHostingBaseTests {
         let basePath =  "test/folder"
         let indexHTML = Folder.testHTMLTemplate(basePath: basePath)
         
-        let indexHTMLData = try StaticHostableTransformer.transformHTMLTemplate(htmlTemplate: testTemplateURL, hostingBasePath: basePath)
+        let indexHTMLData = try StaticHostableTransformer.indexHTMLData(in: testTemplateURL, with: basePath, fileManager: fileManager)
         
         let dataURL = targetBundleURL.appendingPathComponent(NodeURLGenerator.Path.dataFolderName)
         let dataProvider = try LocalFileSystemDataProvider(rootURL: dataURL)
@@ -114,7 +114,7 @@ class StaticHostableTransformerTests: StaticHostingBaseTests {
 
         for (basePath, testValue) in basePaths {
 
-            let indexHTMLData = try StaticHostableTransformer.transformHTMLTemplate(htmlTemplate: testTemplateURL, hostingBasePath: basePath)
+            let indexHTMLData = try StaticHostableTransformer.indexHTMLData(in: testTemplateURL, with: basePath, fileManager: FileManager.default)
             let testIndexHTML = String(decoding: indexHTMLData, as: UTF8.self)
             let indexHTML = Folder.testHTMLTemplate(basePath: testValue)
             
@@ -163,7 +163,7 @@ class StaticHostableTransformerTests: StaticHostingBaseTests {
         let fileManager = FileManager.default
         for (basePath, testValue) in basePaths {
             let outputURL = try createTemporaryDirectory().appendingPathComponent("output")
-            let indexHTMLData = try StaticHostableTransformer.transformHTMLTemplate(htmlTemplate: testTemplateURL, hostingBasePath: basePath)
+            let indexHTMLData = try StaticHostableTransformer.indexHTMLData(in: testTemplateURL, with: basePath, fileManager: FileManager.default)
           
             let transformer = StaticHostableTransformer(dataProvider: dataProvider, fileManager: fileManager, outputURL: outputURL, indexHTMLData: indexHTMLData)
 

--- a/Tests/SwiftDocCUtilitiesTests/Utility/TestFileSystem.swift
+++ b/Tests/SwiftDocCUtilitiesTests/Utility/TestFileSystem.swift
@@ -272,6 +272,10 @@ class TestFileSystem: FileManagerProtocol, DocumentationWorkspaceDataProvider {
         }
     }
     
+    func createFile(at url: URL, contents: Data, options: NSData.WritingOptions?) throws {
+        try createFile(at: url, contents: contents)
+    }
+    
     func contents(atPath: String) -> Data? {
         filesLock.lock()
         defer { filesLock.unlock() }


### PR DESCRIPTION
- **Rationale:** Resolves a ~40% performance regression in `docc convert` that was introduced by #121.
- **Risk:** Low/Med
- **Risk Detail:** Touches a large part of the codebase but each change individually is low risk.
- **Reward:** High
- **Reward Details:** Addressees a significant performance regression in Swift-DocC.
- **Original PR:** #166
- **Code Reviewed By:** @d-ronnqvist 
- **Testing Details:** The majority of these changes are intended to be non-functional and covered by existing tests. For the couple of new functions that were added, new unit tests were added. Performance CI was used to confirm the performance regression was fully addressed. Significant manual regression testing was also performed.