### PR TITLE
[5.7] Add the ability to add arbitrary attributes to a NavigatorIndex

### DIFF
--- a/Sources/SwiftDocC/SwiftDocC.docc/SwiftDocC/NavigatorIndex/NavigatorIndex.md
+++ b/Sources/SwiftDocC/SwiftDocC.docc/SwiftDocC/NavigatorIndex/NavigatorIndex.md
@@ -1,0 +1,9 @@
+# ``SwiftDocC/NavigatorIndex``
+
+## Topics
+
+### Creating an index
+
+- ``NavigatorIndex/readNavigatorIndex(url:bundleIdentifier:readNavigatorTree:presentationIdentifier:onNodeRead:)``
+
+<!-- Copyright (c) 2022 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
@@ -1813,7 +1813,7 @@ class ConvertActionTests: XCTestCase {
         
         let indexURL = targetURL.appendingPathComponent("index")
         
-        let indexFromConvertAction = try NavigatorIndex(url: indexURL)
+        let indexFromConvertAction = try NavigatorIndex.readNavigatorIndex(url: indexURL)
         XCTAssertEqual(indexFromConvertAction.count, 37)
         
         try FileManager.default.removeItem(at: indexURL)
@@ -1827,7 +1827,7 @@ class ConvertActionTests: XCTestCase {
         )
         _ = try indexAction.perform(logHandle: .standardOutput)
         
-        let indexFromIndexAction = try NavigatorIndex(url: indexURL)
+        let indexFromIndexAction = try NavigatorIndex.readNavigatorIndex(url: indexURL)
         XCTAssertEqual(indexFromIndexAction.count, 37)
         
         XCTAssertEqual(
@@ -1870,7 +1870,7 @@ class ConvertActionTests: XCTestCase {
         
         _ = try action.perform(logHandle: .none)
         
-        let index = try NavigatorIndex(url: targetDirectory.appendingPathComponent("index"))
+        let index = try NavigatorIndex.readNavigatorIndex(url: targetDirectory.appendingPathComponent("index"))
         func assertAllChildrenAreObjectiveC(_ node: NavigatorTree.Node) {
             XCTAssertEqual(
                 node.item.languageID,
@@ -1922,7 +1922,7 @@ class ConvertActionTests: XCTestCase {
         
         _ = try action.perform(logHandle: .none)
         
-        let index = try NavigatorIndex(
+        let index = try NavigatorIndex.readNavigatorIndex(
             url: temporaryTestOutputDirectory.appendingPathComponent("index")
         )
         

--- a/Tests/SwiftDocCUtilitiesTests/IndexActionTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/IndexActionTests.swift
@@ -58,7 +58,7 @@ class IndexActionTests: XCTestCase {
             )
             _ = try indexAction.perform(logHandle: .standardOutput)
             
-            let index = try NavigatorIndex(url: indexURL)
+            let index = try NavigatorIndex.readNavigatorIndex(url: indexURL)
             
             resultIndexDumps.insert(index.navigatorTree.root.dumpTree())
             XCTAssertTrue(engine.problems.isEmpty, "Indexing bundle at \(targetURL) resulted in unexpected issues")


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift-docc/pull/258

This stores a handle to the attributes in the index, the tree, and the
individual nodes. Attributes are stored in a `[String: Any]` and the client is
expected to provided extensions with computed properties as needed.

Additionaly this commits refactors the API for reading a NavigatorIndex from an
on-disk LMDB database. The prveious API used a designated initializer to do
this. However, this initializer was complex as it opened database connections
etc...  Using a static function enables clients to be more resilient to API
changes, by letting them define protocols that specify the new API and providing
a no-op default implementation that delegates to old API. This is not currently
possible with the initializer base API as the initializer would need to be
marked required to ensure subclasses of NavigatorIndex implement this. This will
be made possible in the future as clients transition to the static function
based API.

rdar://93503303

- [X] Added tests
- [X] Ran the `./bin/test` script and it succeeded
- [X] Updated documentation if necessary
