### PR TITLE
Update build script helper to use python3

### DIFF
--- a/build-script-helper.py
+++ b/build-script-helper.py
@@ -1,9 +1,9 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information

--- a/build-script-helper.py
+++ b/build-script-helper.py
@@ -93,8 +93,6 @@ def run(args):
       printerr('Executing: %s' % ' '.join(e.cmd))
       sys.exit(1)
 
-  output_dir = os.path.realpath(os.path.join(args.build_dir, args.configuration))
-
   if should_run_action('generate-xcodeproj', args.build_actions):
     print("** Generating Xcode project for %s **" % package_name)
     try:


### PR DESCRIPTION
Bug/issue #, if applicable: #272

## Summary

Python 2 is no longer supported by the Swift project. This updates the build script helper to use python3.

## Testing

Confirm that toolchains continue to build on all platforms with the change.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] ~~Added tests~~
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
