### PR TITLE
Fix error when writing multiple index.html files to the same location

### DIFF
--- a/Sources/SwiftDocCUtilities/Action/Actions/Convert/JSONEncodingRenderNodeWriter.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Convert/JSONEncodingRenderNodeWriter.swift
@@ -116,6 +116,16 @@ class JSONEncodingRenderNodeWriter {
             attributes: nil
         )
         
-        try fileManager.copyItem(at: indexHTML, to: htmlTargetFileURL)
+        do {
+            try fileManager.copyItem(at: indexHTML, to: htmlTargetFileURL)
+        } catch let error as NSError where error.code == NSFileWriteFileExistsError {
+            // We already have an 'index.html' file at this path. This could be because
+            // we're writing to an output directory that already contains built documentation
+            // or because we we're given bad input such that multiple documentation pages
+            // have the same path on the filesystem. Either way, we don't want this to error out
+            // so just remove the destination item and try the copy operation again.
+            try fileManager.removeItem(at: htmlTargetFileURL)
+            try fileManager.copyItem(at: indexHTML, to: htmlTargetFileURL)
+        }
     }
 }

--- a/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
@@ -12,6 +12,7 @@ import XCTest
 import Foundation
 @testable import SwiftDocC
 @testable import SwiftDocCUtilities
+import SymbolKit
 import Markdown
 import SwiftDocCTestUtilities
 
@@ -2329,7 +2330,75 @@ class ConvertActionTests: XCTestCase {
         var action = try ConvertAction(fromConvertCommand: convertCommand)
         _ = try action.perform(logHandle: .none)
     }
+    
+    func emitEmptySymbolGraph(moduleName: String, destination: URL) throws {
+        let symbolGraph = SymbolGraph(
+            metadata: .init(
+                formatVersion: .init(major: 0, minor: 0, patch: 1),
+                generator: "unit-test"
+            ),
+            module: .init(
+                name: moduleName,
+                platform: .init()
+            ),
+            symbols: [],
+            relationships: []
+        )
+        
+        // Create a unique subfolder to place the symbol graph in
+        // in case we're emitting multiple symbol graphs with the same filename.
+        let uniqueSubfolder = destination.appendingPathComponent(
+            ProcessInfo.processInfo.globallyUniqueString
+        )
+        try FileManager.default.createDirectory(
+            at: uniqueSubfolder,
+            withIntermediateDirectories: false
+        )
+        
+        try JSONEncoder().encode(symbolGraph).write(
+            to: uniqueSubfolder
+                .appendingPathComponent(moduleName, isDirectory: false)
+                .appendingPathExtension("symbols.json")
+        )
+    }
 
+    // Tests that when `docc convert` is given input that produces multiple pages at the same path
+    // on disk it does not throw an error when attempting to transform it for static hosting. (94311195)
+    func testConvertDocCCatalogThatProducesMultipleDocumentationPagesAtTheSamePathDoesNotThrowError() throws {
+        let temporaryDirectory = try createTemporaryDirectory()
+        
+        let catalogURL = try Folder(
+            name: "unit-test.docc",
+            content: [
+                InfoPlist(displayName: "TestBundle", identifier: "com.test.example"),
+            ]
+        ).write(inside: temporaryDirectory)
+        try emitEmptySymbolGraph(moduleName: "docc", destination: catalogURL)
+        try emitEmptySymbolGraph(moduleName: "DocC", destination: catalogURL)
+        
+        let htmlTemplateDirectory = try Folder.emptyHTMLTemplateDirectory.write(
+            inside: temporaryDirectory
+        )
+        
+        let targetDirectory = temporaryDirectory.appendingPathComponent("target.doccarchive", isDirectory: true)
+        let dataProvider = try LocalFileSystemDataProvider(rootURL: catalogURL)
+        
+        var action = try ConvertAction(
+            documentationBundleURL: catalogURL,
+            outOfProcessResolver: nil,
+            analyze: false,
+            targetDirectory: targetDirectory,
+            htmlTemplateDirectory: htmlTemplateDirectory,
+            emitDigest: false,
+            currentPlatforms: nil,
+            dataProvider: dataProvider,
+            fileManager: FileManager.default,
+            temporaryDirectory: createTemporaryDirectory(),
+            transformForStaticHosting: true
+        )
+        
+        XCTAssertNoThrow(try action.performAndHandleResult())
+    }
     func testConvertWithCustomTemplates() throws {
         let info = InfoPlist(displayName: "TestConvertWithCustomTemplates", identifier: "com.test.example")
         let index = TextFile(name: "index.html", utf8Content: """


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://94311195

## Summary

Addresses a regression introduced by #166 where `docc convert` would throw an error when writing multiple `index.html` files to the same location on disk.

This can occur if docc is writing to an output directory that already contains built documentation or when docc is given bad input such that multiple documentation pages have the same path on the filesystem.

## Details

There's some additional changes here ([ecc2774](https://github.com/apple/swift-docc/pull/277/commits/ecc2774c9f13526db2c315db2613244d7812061c)) to fix an issue with the diagnostic that was thrown when we found this issue:

```
DocC.symbols.json: error: “index.html” couldn’t be copied to “docc” because an item with the same name already exists.
```

The diagnostic was incorrectly associated with an input file because of the way DocumentationConverter currently records errors encountered when encoding RenderNodes. This made it a little more confusing to track down this issue.

## Testing

Build documentation for a small DocC catalog that includes multiple symbol graph files- one with a `"docc"` module name, and one with a `"DocC"` module name. Confirm that `docc convert` does not throw an error. (This is what the added test case does.)

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
