### PR TITLE
Add TutorialDirectiveMisuseChecker

### DIFF
--- a/Sources/SwiftDocC/Checker/Checkers/TutorialDirectiveMisuseChecker.swift
+++ b/Sources/SwiftDocC/Checker/Checkers/TutorialDirectiveMisuseChecker.swift
@@ -1,0 +1,62 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+import Markdown
+
+public struct TutorialDirectiveMisuseChecker: Checker {
+    public var problems = [Problem]()
+
+    private var sourceFile: URL?
+
+    public init(sourceFile: URL?) {
+        self.sourceFile = sourceFile
+    }
+
+    public mutating func visitBlockDirective(_ blockDirective: BlockDirective) {
+        guard let blockRange = blockDirective.range else { return }
+        
+        let diagnostic: Diagnostic
+        let solutions: [Solution]
+
+        switch blockDirective.name {
+        case ImageMedia.directiveName:
+            diagnostic = Diagnostic(
+                source: sourceFile,
+                severity: .warning,
+                range: blockRange,
+                identifier: "org.swift.docc.TutorialDirectiveMisuse",
+                summary: #"Directive 'Image' is not supported in on Articles."#,
+                explanation: #""@\#(blockDirective.name)" directive is used only on Tutorials and will be ignored on Articles."#
+            )
+            
+            let arguments = blockDirective.arguments()
+            let source = arguments["source"]?.value ?? ""
+            let altText = arguments["alt"]?.value ?? ""
+            solutions = [
+                Solution(
+                    summary: "Use the Markdown image syntax instead.",
+                    replacements: [Replacement(range: blockRange, replacement: "![\(altText)](\(source))")]
+                ),
+            ]
+        default:
+            diagnostic = Diagnostic(
+                source: sourceFile,
+                severity: .warning,
+                range: blockRange,
+                identifier: "org.swift.docc.TutorialDirectiveMisuse",
+                summary: #""@\#(blockDirective.name)" directive is not support on normal markdown file."#,
+                explanation: #""@\#(blockDirective.name)" directive is used only on Tutorials and will be ignored on Articles."#
+            )
+            solutions = []
+        }
+        problems.append(Problem(diagnostic: diagnostic, possibleSolutions: solutions))
+    }
+}

--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -385,6 +385,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
             NonOverviewHeadingChecker(sourceFile: source).any(),
             SeeAlsoInTopicsHeadingChecker(sourceFile: source).any(),
             TopicsSectionWithoutSubheading(sourceFile: source).any(),
+            TutorialDirectiveMisuseChecker(sourceFile: source).any(),
         ])
         checker.visit(document)
         diagnosticEngine.emit(checker.problems)

--- a/Tests/SwiftDocCTests/Checker/Checkers/TutorialDirectiveMisuseCheckerTests.swift
+++ b/Tests/SwiftDocCTests/Checker/Checkers/TutorialDirectiveMisuseCheckerTests.swift
@@ -1,0 +1,71 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Markdown
+@testable import SwiftDocC
+import XCTest
+
+class TutorialDirectiveMisuseCheckerTests: XCTestCase {
+    func testImageDirctive() throws {
+        do {
+            let source = """
+            ![a](a.png)
+            @Image(source: test.png)
+            ![b](b.jpg)
+            """
+            let expectedRange: SourceRange = SourceLocation(line: 2, column: 1, source: nil) ..< SourceLocation(line: 2, column: 25, source: nil)
+            let expectedReplacementText = "![](test.png)"
+
+            let document = Document(parsing: source, options: [.parseBlockDirectives, .parseSymbolLinks])
+            var checker = TutorialDirectiveMisuseChecker(sourceFile: URL(fileURLWithPath: "/dev/null"))
+            checker.visit(document)
+
+            XCTAssertEqual(checker.problems.count, 1)
+            let problem = checker.problems[0]
+
+            XCTAssertEqual(problem.diagnostic.range, expectedRange)
+
+            XCTAssertEqual(problem.possibleSolutions.count, 1)
+            let solution = problem.possibleSolutions[0]
+
+            XCTAssertEqual(solution.replacements.count, 1)
+            let replacement = solution.replacements[0]
+            XCTAssertEqual(replacement.range, expectedRange)
+            XCTAssertEqual(replacement.replacement, expectedReplacementText)
+        }
+
+        do {
+            let source = """
+            ![a](a.png)
+            @Image(source: test.png, alt: hello)
+            ![b](b.jpg)
+            """
+            let expectedRange: SourceRange = SourceLocation(line: 2, column: 1, source: nil) ..< SourceLocation(line: 2, column: 37, source: nil)
+            let expectedReplacementText = "![hello](test.png)"
+            let document = Document(parsing: source, options: [.parseBlockDirectives, .parseSymbolLinks])
+            print(document.debugDescription(options: .printSourceLocations))
+            var checker = TutorialDirectiveMisuseChecker(sourceFile: URL(fileURLWithPath: "/dev/null"))
+            checker.visit(document)
+
+            XCTAssertEqual(checker.problems.count, 1)
+            let problem = checker.problems[0]
+
+            XCTAssertEqual(problem.diagnostic.range, expectedRange)
+
+            XCTAssertEqual(problem.possibleSolutions.count, 1)
+            let solution = problem.possibleSolutions[0]
+
+            XCTAssertEqual(solution.replacements.count, 1)
+            let replacement = solution.replacements[0]
+            XCTAssertEqual(replacement.range, expectedRange)
+            XCTAssertEqual(replacement.replacement, expectedReplacementText)
+        }
+    }
+}


### PR DESCRIPTION
Bug/issue #, if applicable: 

Close #274 

## Summary

Add a warning for directive usage on non-tutorial files (Checker will only run on Articles).

Add possible altertive solutions for Image and Video Directive.

## Test

> ### Installing into Xcode
>
> You can test a locally built version of Swift-DocC in Xcode 13 or later by setting the DOCC_EXEC build setting to the path of your local docc:
> 
> Select the project in the Project Navigator.
>
> In the Build Settings tab, click '+' and then 'Add User-Defined Setting'.
>
> Create a build setting DOCC_EXEC with the value set to /path/to/docc.
>
> The next time you invoke a documentation build with the "Build Documentation" button in Xcode's Product menu, your custom docc will be used for the build. You can confirm that your custom docc is being used by opening the latest build log in Xcode's report navigator and expanding the "Compile documentation" step.

<img width="850" alt="image" src="https://user-images.githubusercontent.com/43724855/172039184-55333c21-83e3-4eed-a071-820a0b17fb7a.png">

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
