### PR TITLE
Keep manually authored topics in all variants of pages

### DIFF
--- a/Sources/SwiftDocC/Indexing/Navigator/NavigatorItem.swift
+++ b/Sources/SwiftDocC/Indexing/Navigator/NavigatorItem.swift
@@ -30,7 +30,7 @@ public final class NavigatorItem: Serializable, Codable, Equatable, CustomString
     public let pageType: UInt8
     
     /// The language identifier of the item.
-    public let languageID: UInt8
+    public internal(set) var languageID: UInt8
     
     /// The title of the entry.
     public let title: String
@@ -143,6 +143,17 @@ public final class NavigatorItem: Serializable, Codable, Equatable, CustomString
         data.append(Data(path.utf8))
         
         return data
+    }
+    
+    func withLanguageID(_ languageID: InterfaceLanguage.ID) -> NavigatorItem {
+        NavigatorItem(
+            pageType: pageType,
+            languageID: languageID,
+            title: title,
+            platformMask: platformMask,
+            availabilityID: availabilityID,
+            path: path
+        )
     }
     
     // MARK: - Equatable

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -633,6 +633,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
                         topics,
                         allowExternalLinks: false,
                         allowedTraits: [trait],
+                        availableTraits: documentationNode.availableVariantTraits,
                         contentCompiler: &contentCompiler
                     )
                 )
@@ -712,6 +713,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
                         seeAlso,
                         allowExternalLinks: true,
                         allowedTraits: [trait],
+                        availableTraits: documentationNode.availableVariantTraits,
                         contentCompiler: &contentCompiler
                     )
                 )
@@ -871,10 +873,41 @@ public struct RenderNodeTranslator: SemanticVisitor {
     }
     
     /// Renders a list of topic groups.
+    ///
+    /// When rendering topic groups for a page that is available in multiple languages,
+    /// you can provide the total available traits the parent page will be available in,
+    /// as well as the _specific_ traits this particular render section should be created for.
+    /// Any referenced pages that are included in the _available_ traits
+    /// but excluded from the _allowed_ traits will be filtered out.
+    ///
+    /// This behavior is designed to ensure that all items in the task group will be rendered
+    /// in _some_ task group of the parent page, whether in the currently provided allowed traits,
+    /// or in a different subset of the page's available traits.
+    /// However, if a task-group item's language isn't included in any of the available traits,
+    /// it will _not_ be filtered out since otherwise it would be invisible to the reader
+    /// of the documentation regardless of which of the available traits they view.
+    ///
+    /// - Parameters:
+    ///   - topics: The topic groups to be rendered.
+    ///
+    ///   - allowExternalLinks: Whether or not external links should be included in the
+    ///     rendered task groups.
+    ///
+    ///   - allowedTraits: The traits that the returned render section should filter for.
+    ///
+    ///     These traits should be a _subset_ of the given available traits.
+    ///
+    ///   - availableTraits: The traits that are available in the parent page that this render
+    ///     section belongs to.
+    ///
+    ///     This method will only filter for allowed traits that are also explicitly available.
+    ///
+    ///   - contentCompiler: The current render content compiler.
     private mutating func renderGroups(
         _ topics: GroupedSection,
         allowExternalLinks: Bool,
         allowedTraits: Set<DocumentationDataVariantsTrait>,
+        availableTraits: Set<DocumentationDataVariantsTrait>,
         contentCompiler: inout RenderContentCompiler
     ) -> [TaskGroupRenderSection] {
         return topics.taskGroups.compactMap { group in
@@ -896,12 +929,23 @@ public struct RenderNodeTranslator: SemanticVisitor {
                     return true
                 }
                 
-                return context.sourceLanguages(for: reference)
-                    .contains { sourceLanguage in
-                        allowedTraits.contains { trait in
-                            trait.interfaceLanguage == sourceLanguage.id
-                        }
+                let referenceSourceLanguageIDs = Set(context.sourceLanguages(for: reference).map(\.id))
+                
+                let availableSourceLanguageTraits = Set(availableTraits.compactMap(\.interfaceLanguage))
+                if availableSourceLanguageTraits.isDisjoint(with: referenceSourceLanguageIDs) {
+                    // The set of available source language traits has no members in common with the
+                    // set of source languages the given reference is available in.
+                    //
+                    // Since we should only filter for traits that are available in the parent page,
+                    // just return true. (See the documentation of this method for more details).
+                    return true
+                }
+                
+                return referenceSourceLanguageIDs.contains { sourceLanguageID in
+                    allowedTraits.contains { trait in
+                        trait.interfaceLanguage == sourceLanguageID
                     }
+                }
             }
             
             let taskGroupRenderSection = TaskGroupRenderSection(
@@ -1181,6 +1225,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
                         topics,
                         allowExternalLinks: false,
                         allowedTraits: [trait],
+                        availableTraits: documentationNode.availableVariantTraits,
                         contentCompiler: &contentCompiler
                     )
                 )
@@ -1287,6 +1332,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
                         seeAlso,
                         allowExternalLinks: true,
                         allowedTraits: [trait],
+                        availableTraits: documentationNode.availableVariantTraits,
                         contentCompiler: &contentCompiler
                     )
                 )

--- a/Tests/SwiftDocCTests/Indexing/RenderIndexTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/RenderIndexTests.swift
@@ -535,6 +535,126 @@ final class RenderIndexTests: XCTestCase {
         )
     }
     
+    func testRenderIndexGenerationForMixedLanguageFrameworkThatCuratesObjectiveCOnlyTopicInSwiftOnlyPage() throws {
+        let renderIndex = try generatedRenderIndex(
+            for: "MixedLanguageFrameworkSingleLanguageCuration",
+            with: "org.swift.MixedLanguageFramework"
+        )
+
+        XCTAssertEqual(
+            renderIndex,
+            try RenderIndex.fromString(#"""
+                {
+                  "interfaceLanguages": {
+                    "swift": [
+                      {
+                        "title": "Structures",
+                        "type": "groupMarker"
+                      },
+                      {
+                        "path": "/documentation/mixedlanguageframework/swiftonlystruct",
+                        "title": "SwiftOnlyStruct",
+                        "type": "struct",
+                        "children": [
+                          {
+                            "title": "Objective-C–only symbols",
+                            "type": "groupMarker"
+                          },
+                          {
+                            "title": "ObjectiveCOnlyClass",
+                            "path": "/documentation/mixedlanguageframework/objectiveconlyclass",
+                            "type": "class"
+                          },
+                          {
+                            "title": "MultiCuratedObjectiveCOnlyClass1",
+                            "path": "/documentation/mixedlanguageframework/multicuratedobjectiveconlyclass1",
+                            "type": "class"
+                          },
+                          {
+                            "title": "MultiCuratedObjectiveCOnlyClass2",
+                            "path": "/documentation/mixedlanguageframework/multicuratedobjectiveconlyclass2",
+                            "type": "class"
+                          }
+                        ]
+                      }
+                    ],
+                    "occ": [
+                      {
+                        "title": "Multi-curated Objective-C–only symbols",
+                        "type": "groupMarker"
+                      },
+                      {
+                        "path": "/documentation/mixedlanguageframework/multicuratedobjectiveconlyclass1",
+                        "title": "MultiCuratedObjectiveCOnlyClass1",
+                        "type": "class",
+                        "children": [
+                          {
+                            "title": "Multi-curated Objective-C–only symbols",
+                            "type": "groupMarker"
+                          },
+                          {
+                            "title": "MultiCuratedObjectiveCOnlyClass2",
+                            "path": "/documentation/mixedlanguageframework/multicuratedobjectiveconlyclass2",
+                            "type": "class"
+                          },
+                          {
+                            "title": "Swift-only symbols",
+                            "type": "groupMarker"
+                          },
+                          {
+                            "title": "SwiftOnlyStruct",
+                            "path": "/documentation/mixedlanguageframework/swiftonlystruct",
+                            "type": "struct"
+                          }
+                        ]
+                      },
+                      {
+                        "path": "/documentation/mixedlanguageframework/multicuratedobjectiveconlyclass1",
+                        "title": "MultiCuratedObjectiveCOnlyClass1",
+                        "type": "class",
+                        "children": [
+                          {
+                            "title": "Multi-curated Objective-C–only symbols",
+                            "type": "groupMarker"
+                          },
+                          {
+                            "title": "MultiCuratedObjectiveCOnlyClass2",
+                            "path": "/documentation/mixedlanguageframework/multicuratedobjectiveconlyclass2",
+                            "type": "class"
+                          },
+                          {
+                            "title": "Swift-only symbols",
+                            "type": "groupMarker"
+                          },
+                          {
+                            "title": "SwiftOnlyStruct",
+                            "path": "/documentation/mixedlanguageframework/swiftonlystruct",
+                            "type": "struct"
+                          }
+                        ]
+                      },
+                      {
+                        "title": "MultiCuratedObjectiveCOnlyClass2",
+                        "path": "/documentation/mixedlanguageframework/multicuratedobjectiveconlyclass2",
+                        "type": "class"
+                      }
+                    ]
+                  },
+                  "schemaVersion": {
+                    "major": 0,
+                    "minor": 1,
+                    "patch": 0
+                  }
+                }
+                """#
+            ),
+            """
+            Generated render index does not match expected index. Actual index was: \
+            \(String(data: (try? JSONEncoder().encode(renderIndex)) ?? Data(), encoding: .utf8) ?? "")
+            """
+        )
+    }
+    
     func testRenderIndexGenerationWithExternalNode() throws {
         try testRenderIndexGenerationFromJSON(
             makeRenderIndexJSONSingleNode(withOptionalProperty: "external")

--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeMultiLanguageTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeMultiLanguageTests.swift
@@ -475,6 +475,36 @@ class SemaToRenderNodeMixedLanguageTests: XCTestCase {
         ], "Both spellings of the symbol link should resolve to the canonical reference.")
     }
     
+    func testObjectiveCOnlySymbolCuratedInSwiftOnlySymbolIsNotFilteredOut() throws {
+        let outputConsumer = try mixedLanguageFrameworkConsumer(bundleName: "MixedLanguageFrameworkSingleLanguageCuration")
+        let fooRenderNode = try outputConsumer.renderNode(
+            withIdentifier: "s:22MixedLanguageFramework15SwiftOnlyStruct1V"
+        )
+        
+        assertExpectedContent(
+            fooRenderNode,
+            sourceLanguage: "swift",
+            symbolKind: "struct",
+            title: "SwiftOnlyStruct1",
+            navigatorTitle: nil,
+            abstract: "This is a Swift-only symbol.",
+            declarationTokens: nil,
+            discussionSection: nil,
+            topicSectionIdentifiers: [
+                "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/MultiCuratedObjectiveCOnlyClass",
+            ],
+            referenceTitles: [
+                "MixedLanguageFramework",
+                "MultiCuratedObjectiveCOnlyClass",
+                "SwiftOnlyStruct1",
+            ],
+            referenceFragments: [],
+            failureMessage: { fieldName in
+                "Swift variant of 'SwiftOnlySymbol' symbol has unexpected content for '\(fieldName)'."
+            }
+        )
+    }
+    
     func testArticleInMixedLanguageFramework() throws {
         let outputConsumer = try mixedLanguageFrameworkConsumer() { url in
             try """

--- a/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFramework.docc/ArticleCuratedInASingleLanguagePage.md
+++ b/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFramework.docc/ArticleCuratedInASingleLanguagePage.md
@@ -1,6 +1,6 @@
 # Article curated in a single-language page
 
-This article is curated in a Swift-only page. Therefore, it should not appear in the Objective-C tree of the 
-navigator index.
+This article is curated in a Swift-only page. However, because the page that curates is authored manually, this should
+article (and its parent page) should appear in the Objective-C navigator.
 
 <!-- Copyright (c) 2022 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFramework.docc/MixedLanguageFramework.md
+++ b/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFramework.docc/MixedLanguageFramework.md
@@ -4,6 +4,11 @@ This framework is available to both Swift and Objective-C clients.
 
 ## Topics
 
+@Comment {
+    All the topics here should appear in both Swift and Objective-C variants of the page, 
+    since they're manually curated.
+}
+
 ### Swift-only APIs
 
 - ``SwiftOnlyStruct``

--- a/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFrameworkSingleLanguageCuration.docc/Info.plist
+++ b/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFrameworkSingleLanguageCuration.docc/Info.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleName</key>
+	<string>MixedLanguageFramework</string>
+	<key>CFBundleDisplayName</key>
+	<string>MixedLanguageFramework</string>
+	<key>CFBundleIdentifier</key>
+	<string>org.swift.MixedLanguageFramework</string>
+	<key>CFBundleVersion</key>
+	<string>0.1.0</string>
+</dict>
+</plist>

--- a/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFrameworkSingleLanguageCuration.docc/MixedLanguageFramework.md
+++ b/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFrameworkSingleLanguageCuration.docc/MixedLanguageFramework.md
@@ -1,0 +1,11 @@
+# ``MixedLanguageFramework``
+
+## Topics
+
+### Multi-curated Objective-C–only symbols
+
+These symbols are Objective-C only and curated in multiple places in the catalog.
+
+- ``MultiCuratedObjectiveCOnlyClass1``
+- ``MultiCuratedObjectiveCOnlyClass1``
+- ``MultiCuratedObjectiveCOnlyClass2``

--- a/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFrameworkSingleLanguageCuration.docc/MultiCuratedObjectveCOnlyClass.md
+++ b/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFrameworkSingleLanguageCuration.docc/MultiCuratedObjectveCOnlyClass.md
@@ -1,0 +1,7 @@
+# ``MixedLanguageFramework/MultiCuratedObjectiveCOnlyClass``
+
+## Topics
+
+### Swift-only symbols
+
+- ``SwiftOnlyStruct2``

--- a/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFrameworkSingleLanguageCuration.docc/MultiCuratedObjectveCOnlyClass1.md
+++ b/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFrameworkSingleLanguageCuration.docc/MultiCuratedObjectveCOnlyClass1.md
@@ -1,0 +1,11 @@
+# ``MixedLanguageFramework/MultiCuratedObjectiveCOnlyClass1``
+
+## Topics
+
+### Multi-curated Objective-C–only symbols
+
+- ``MultiCuratedObjectiveCOnlyClass2``
+
+### Swift-only symbols
+
+- ``SwiftOnlyStruct``

--- a/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFrameworkSingleLanguageCuration.docc/SwiftOnlyStruct.md
+++ b/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFrameworkSingleLanguageCuration.docc/SwiftOnlyStruct.md
@@ -1,0 +1,11 @@
+# ``MixedLanguageFramework/SwiftOnlyStruct``
+
+This is a Swift-only symbol.
+
+## Topics
+
+### Objective-C–only symbols
+
+- ``ObjectiveCOnlyClass``
+- ``MultiCuratedObjectiveCOnlyClass1``
+- ``MultiCuratedObjectiveCOnlyClass2``

--- a/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFrameworkSingleLanguageCuration.docc/SwiftOnlyStruct1.md
+++ b/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFrameworkSingleLanguageCuration.docc/SwiftOnlyStruct1.md
@@ -1,0 +1,9 @@
+# ``MixedLanguageFramework/SwiftOnlyStruct1``
+
+This is a Swift-only symbol.
+
+## Topics
+
+### Objective-C–only symbols
+
+- ``MultiCuratedObjectiveCOnlyClass``

--- a/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFrameworkSingleLanguageCuration.docc/symbol-graph/clang/MixedLanguageFramework.symbols.json
+++ b/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFrameworkSingleLanguageCuration.docc/symbol-graph/clang/MixedLanguageFramework.symbols.json
@@ -1,0 +1,79 @@
+{
+    "metadata": {
+        "formatVersion": {
+            "major": 0,
+            "minor": 5,
+            "patch": 3
+        },
+        "generator": "clang"
+    },
+    "module": {
+        "name": "MixedLanguageFramework",
+        "platform": {
+            "architecture": "x86_64",
+            "operatingSystem": {
+                "minimumVersion": {
+                    "major": 11,
+                    "minor": 0,
+                    "patch": 0
+                },
+                "name": "macos"
+            },
+            "vendor": "apple"
+        }
+    },
+    "relationships": [],
+    "symbols": [
+        {
+            "kind": {
+                "identifier": "class",
+                "displayName": "Class"
+            },
+            "identifier": {
+                "precise": "c:@E@ObjectiveCOnlyClass",
+                "interfaceLanguage": "occ"
+            },
+            "pathComponents": [
+                "ObjectiveCOnlyClass"
+            ],
+            "names": {
+                "title": "ObjectiveCOnlyClass"
+            },
+            "accessLevel": "public"
+        },
+        {
+            "kind": {
+                "identifier": "class",
+                "displayName": "Class"
+            },
+            "identifier": {
+                "precise": "c:@E@MultiCuratedObjectiveCOnlyClass1",
+                "interfaceLanguage": "occ"
+            },
+            "pathComponents": [
+                "MultiCuratedObjectiveCOnlyClass1"
+            ],
+            "names": {
+                "title": "MultiCuratedObjectiveCOnlyClass1"
+            },
+            "accessLevel": "public"
+        },
+        {
+            "kind": {
+                "identifier": "class",
+                "displayName": "Class"
+            },
+            "identifier": {
+                "precise": "c:@E@MultiCuratedObjectiveCOnlyClass2",
+                "interfaceLanguage": "occ"
+            },
+            "pathComponents": [
+                "MultiCuratedObjectiveCOnlyClass2"
+            ],
+            "names": {
+                "title": "MultiCuratedObjectiveCOnlyClass2"
+            },
+            "accessLevel": "public"
+        }
+    ]
+}

--- a/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFrameworkSingleLanguageCuration.docc/symbol-graph/swift/MixedLanguageFramework.symbols.json
+++ b/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFrameworkSingleLanguageCuration.docc/symbol-graph/swift/MixedLanguageFramework.symbols.json
@@ -1,0 +1,45 @@
+{
+    "metadata": {
+        "formatVersion": {
+            "major": 0,
+            "minor": 5,
+            "patch": 3
+        },
+        "generator": "Apple Swift version 5.7 (swiftlang-5.7.0.104.28 clang-1400.0.12.6.3)"
+    },
+    "module": {
+        "name": "MixedLanguageFramework",
+        "platform": {
+            "architecture": "x86_64",
+            "operatingSystem": {
+                "minimumVersion": {
+                    "major": 11,
+                    "minor": 0,
+                    "patch": 0
+                },
+                "name": "macosx"
+            },
+            "vendor": "apple"
+        }
+    },
+    "relationships": [],
+    "symbols": [
+        {
+            "kind": {
+                "identifier": "swift.struct",
+                "displayName": "Structure"
+            },
+            "identifier": {
+                "precise": "s:22MixedLanguageFramework15SwiftOnlyStructV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "SwiftOnlyStruct"
+            ],
+            "names": {
+                "title": "SwiftOnlyStruct"
+            },
+            "accessLevel": "public"
+        }
+    ]
+}


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://94406023

## Summary

It used to be that the topics section would only display topics that are available in the current language variant. This commit changes that behavior by always preserving _manually_ curated topics. The filtering behavior now only applies to automatically curated topics.

This also makes navigator index changes to allow including Swift topics in the Objective-C navigator and vice-versa, in support of the change described above.

## Dependencies

_Describe any dependencies this PR might have, such as an associated branch in another repository._

## Testing

_Describe how a reviewer can test the functionality of your PR. Provide test content to test with if
applicable._

Steps:
1. _Provide setup instructions._
2. _Explain in detail how the functionality can be tested._

## Checklist

- [ ] Added tests
- [ ] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary