### PR TITLE
Don’t filter topic group items from unavailable languages

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -633,6 +633,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
                         topics,
                         allowExternalLinks: false,
                         allowedTraits: [trait],
+                        availableTraits: documentationNode.availableVariantTraits,
                         contentCompiler: &contentCompiler
                     )
                 )
@@ -712,6 +713,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
                         seeAlso,
                         allowExternalLinks: true,
                         allowedTraits: [trait],
+                        availableTraits: documentationNode.availableVariantTraits,
                         contentCompiler: &contentCompiler
                     )
                 )
@@ -871,10 +873,41 @@ public struct RenderNodeTranslator: SemanticVisitor {
     }
     
     /// Renders a list of topic groups.
+    ///
+    /// When rendering topic groups for a page that is available in multiple languages,
+    /// you can provide the total available traits the parent page will be available in,
+    /// as well as the _specific_ traits this particular render section should be created for.
+    /// Any referenced pages that are included in the _available_ traits
+    /// but excluded from the _allowed_ traits will be filtered out.
+    ///
+    /// This behavior is designed to ensure that all items in the task group will be rendered
+    /// in _some_ task group of the parent page, whether in the currently provided allowed traits,
+    /// or in a different subset of the page's available traits.
+    /// However, if a task-group item's language isn't included in any of the available traits,
+    /// it will _not_ be filtered out since otherwise it would be invisible to the reader
+    /// of the documentation regardless of which of the available traits they view.
+    ///
+    /// - Parameters:
+    ///   - topics: The topic groups to be rendered.
+    ///
+    ///   - allowExternalLinks: Whether or not external links should be included in the
+    ///     rendered task groups.
+    ///
+    ///   - allowedTraits: The traits that the returned render section should filter for.
+    ///
+    ///     These traits should be a _subset_ of the given available traits.
+    ///
+    ///   - availableTraits: The traits that are available in the parent page that this render
+    ///     section belongs to.
+    ///
+    ///     This method will only filter for allowed traits that are also explicitly available.
+    ///
+    ///   - contentCompiler: The current render content compiler.
     private mutating func renderGroups(
         _ topics: GroupedSection,
         allowExternalLinks: Bool,
         allowedTraits: Set<DocumentationDataVariantsTrait>,
+        availableTraits: Set<DocumentationDataVariantsTrait>,
         contentCompiler: inout RenderContentCompiler
     ) -> [TaskGroupRenderSection] {
         return topics.taskGroups.compactMap { group in
@@ -896,12 +929,23 @@ public struct RenderNodeTranslator: SemanticVisitor {
                     return true
                 }
                 
-                return context.sourceLanguages(for: reference)
-                    .contains { sourceLanguage in
-                        allowedTraits.contains { trait in
-                            trait.interfaceLanguage == sourceLanguage.id
-                        }
+                let referenceSourceLanguageIDs = Set(context.sourceLanguages(for: reference).map(\.id))
+                
+                let availableSourceLanguageTraits = Set(availableTraits.compactMap(\.interfaceLanguage))
+                if availableSourceLanguageTraits.isDisjoint(with: referenceSourceLanguageIDs) {
+                    // The set of available source language traits has no members in common with the
+                    // set of source languages the given reference is available in.
+                    //
+                    // Since we should only filter for traits that are available in the parent page,
+                    // just return true. (See the documentation of this method for more details).
+                    return true
+                }
+                
+                return referenceSourceLanguageIDs.contains { sourceLanguageID in
+                    allowedTraits.contains { trait in
+                        trait.interfaceLanguage == sourceLanguageID
                     }
+                }
             }
             
             let taskGroupRenderSection = TaskGroupRenderSection(
@@ -1181,6 +1225,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
                         topics,
                         allowExternalLinks: false,
                         allowedTraits: [trait],
+                        availableTraits: documentationNode.availableVariantTraits,
                         contentCompiler: &contentCompiler
                     )
                 )
@@ -1287,6 +1332,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
                         seeAlso,
                         allowExternalLinks: true,
                         allowedTraits: [trait],
+                        availableTraits: documentationNode.availableVariantTraits,
                         contentCompiler: &contentCompiler
                     )
                 )


### PR DESCRIPTION


Resolves rdar://94406023.

Bug/issue #, if applicable: 

## Summary

Addresses a regression where DocC began excluding manually curated topic group items that link to languages not otherwise locally included in the documentation content.

This is fallout from the work done to support multi-language variants of a page where we introduced filtering of topic group items based on the current variant.

So a catalog that only includes Swift content might link to a symbol that externally resolves to a Data or Objective-C source language. Then that symbol would be filtered out since the current page only includes a Swift-language variant.

The solution is to only filter topic group items based on languages that the parent page is actually available in. This ensures that we never filter out an item in a way that makes it impossible to actually view.

In other words, it’s okay to filter out Objective-C  items from the Swift variant of a Swift/Objective-C page. But it’s not okay to filter out Javascript items from this page since there is no Javascript version of that page for the reader to select in order to view that item.

## Testing

Build a Swift-only DocC catalog that curates externally resolved symbols to non-Swift content and ensure those items appear in the rendered documentation.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
