### PR TITLE
[5.7] Don’t filter topic group items from unavailable languages

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -640,6 +640,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
                         topics,
                         allowExternalLinks: false,
                         allowedTraits: [trait],
+                        availableTraits: documentationNode.availableVariantTraits,
                         contentCompiler: &contentCompiler
                     )
                 )
@@ -719,6 +720,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
                         seeAlso,
                         allowExternalLinks: true,
                         allowedTraits: [trait],
+                        availableTraits: documentationNode.availableVariantTraits,
                         contentCompiler: &contentCompiler
                     )
                 )
@@ -878,10 +880,41 @@ public struct RenderNodeTranslator: SemanticVisitor {
     }
     
     /// Renders a list of topic groups.
+    ///
+    /// When rendering topic groups for a page that is available in multiple languages,
+    /// you can provide the total available traits the parent page will be available in,
+    /// as well as the _specific_ traits this particular render section should be created for.
+    /// Any referenced pages that are included in the _available_ traits
+    /// but excluded from the _allowed_ traits will be filtered out.
+    ///
+    /// This behavior is designed to ensure that all items in the task group will be rendered
+    /// in _some_ task group of the parent page, whether in the currently provided allowed traits,
+    /// or in a different subset of the page's available traits.
+    /// However, if a task-group item's language isn't included in any of the available traits,
+    /// it will _not_ be filtered out since otherwise it would be invisible to the reader
+    /// of the documentation regardless of which of the available traits they view.
+    ///
+    /// - Parameters:
+    ///   - topics: The topic groups to be rendered.
+    ///
+    ///   - allowExternalLinks: Whether or not external links should be included in the
+    ///     rendered task groups.
+    ///
+    ///   - allowedTraits: The traits that the returned render section should filter for.
+    ///
+    ///     These traits should be a _subset_ of the given available traits.
+    ///
+    ///   - availableTraits: The traits that are available in the parent page that this render
+    ///     section belongs to.
+    ///
+    ///     This method will only filter for allowed traits that are also explicitly available.
+    ///
+    ///   - contentCompiler: The current render content compiler.
     private mutating func renderGroups(
         _ topics: GroupedSection,
         allowExternalLinks: Bool,
         allowedTraits: Set<DocumentationDataVariantsTrait>,
+        availableTraits: Set<DocumentationDataVariantsTrait>,
         contentCompiler: inout RenderContentCompiler
     ) -> [TaskGroupRenderSection] {
         return topics.taskGroups.compactMap { group in
@@ -903,12 +936,23 @@ public struct RenderNodeTranslator: SemanticVisitor {
                     return true
                 }
                 
-                return context.sourceLanguages(for: reference)
-                    .contains { sourceLanguage in
-                        allowedTraits.contains { trait in
-                            trait.interfaceLanguage == sourceLanguage.id
-                        }
+                let referenceSourceLanguageIDs = Set(context.sourceLanguages(for: reference).map(\.id))
+                
+                let availableSourceLanguageTraits = Set(availableTraits.compactMap(\.interfaceLanguage))
+                if availableSourceLanguageTraits.isDisjoint(with: referenceSourceLanguageIDs) {
+                    // The set of available source language traits has no members in common with the
+                    // set of source languages the given reference is available in.
+                    //
+                    // Since we should only filter for traits that are available in the parent page,
+                    // just return true. (See the documentation of this method for more details).
+                    return true
+                }
+                
+                return referenceSourceLanguageIDs.contains { sourceLanguageID in
+                    allowedTraits.contains { trait in
+                        trait.interfaceLanguage == sourceLanguageID
                     }
+                }
             }
             
             let taskGroupRenderSection = TaskGroupRenderSection(
@@ -1188,6 +1232,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
                         topics,
                         allowExternalLinks: false,
                         allowedTraits: [trait],
+                        availableTraits: documentationNode.availableVariantTraits,
                         contentCompiler: &contentCompiler
                     )
                 )
@@ -1294,6 +1339,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
                         seeAlso,
                         allowExternalLinks: true,
                         allowedTraits: [trait],
+                        availableTraits: documentationNode.availableVariantTraits,
                         contentCompiler: &contentCompiler
                     )
                 )

--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeMultiLanguageTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeMultiLanguageTests.swift
@@ -475,6 +475,38 @@ class SemaToRenderNodeMixedLanguageTests: XCTestCase {
         ], "Both spellings of the symbol link should resolve to the canonical reference.")
     }
     
+    func testObjectiveCOnlySymbolCuratedInSwiftOnlySymbolIsNotFilteredOut() throws {
+         let outputConsumer = try mixedLanguageFrameworkConsumer(bundleName: "MixedLanguageFrameworkSingleLanguageCuration")
+         let fooRenderNode = try outputConsumer.renderNode(
+             withIdentifier: "s:22MixedLanguageFramework15SwiftOnlyStruct1V"
+         )
+
+         assertExpectedContent(
+             fooRenderNode,
+             sourceLanguage: "swift",
+             symbolKind: "struct",
+             title: "SwiftOnlyStruct1",
+             navigatorTitle: nil,
+             abstract: "This is an awesome, Swift-only symbol.",
+             declarationTokens: nil,
+             discussionSection: nil,
+             topicSectionIdentifiers: [
+                 "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/MultiCuratedObjectiveCOnlyClass1",
+             ],
+             referenceTitles: [
+                "MixedLanguageFramework",
+                "MultiCuratedObjectiveCOnlyClass1",
+                "MultiCuratedObjectiveCOnlyClass2",
+                "SwiftOnlyStruct1",
+                "SwiftOnlyStruct2",
+             ],
+             referenceFragments: [],
+             failureMessage: { fieldName in
+                 "Swift variant of 'SwiftOnlySymbol1' symbol has unexpected content for '\(fieldName)'."
+             }
+         )
+     }
+    
     func testArticleInMixedLanguageFramework() throws {
         let outputConsumer = try renderNodeConsumer(for: "MixedLanguageFramework") { url in
             try """

--- a/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFrameworkSingleLanguageCuration.docc/Info.plist
+++ b/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFrameworkSingleLanguageCuration.docc/Info.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleName</key>
+	<string>MixedLanguageFramework</string>
+	<key>CFBundleDisplayName</key>
+	<string>MixedLanguageFramework</string>
+	<key>CFBundleIdentifier</key>
+	<string>org.swift.MixedLanguageFramework</string>
+	<key>CFBundleVersion</key>
+	<string>0.1.0</string>
+</dict>
+</plist>

--- a/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFrameworkSingleLanguageCuration.docc/MixedLanguageFramework.md
+++ b/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFrameworkSingleLanguageCuration.docc/MixedLanguageFramework.md
@@ -1,0 +1,13 @@
+# ``MixedLanguageFramework``
+
+## Topics
+
+### Multi-curated Objective-C–only symbols
+
+These symbols are Objective-C only and curated in multiple places in the catalog.
+
+- ``MultiCuratedObjectiveCOnlyClass1``
+- ``MultiCuratedObjectiveCOnlyClass1``
+- ``MultiCuratedObjectiveCOnlyClass2``
+
+<!-- Copyright (c) 2022 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFrameworkSingleLanguageCuration.docc/MultiCuratedObjectveCOnlyClass2.md
+++ b/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFrameworkSingleLanguageCuration.docc/MultiCuratedObjectveCOnlyClass2.md
@@ -1,0 +1,9 @@
+# ``MixedLanguageFramework/MultiCuratedObjectiveCOnlyClass2``
+
+## Topics
+
+### Swift-only symbols
+
+- ``SwiftOnlyStruct1``
+
+<!-- Copyright (c) 2022 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFrameworkSingleLanguageCuration.docc/SwiftOnlyStruct1.md
+++ b/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFrameworkSingleLanguageCuration.docc/SwiftOnlyStruct1.md
@@ -1,0 +1,11 @@
+# ``MixedLanguageFramework/SwiftOnlyStruct1``
+
+This is an awesome, Swift-only symbol.
+
+## Topics
+
+### Objective-C–only symbols
+
+- ``MultiCuratedObjectiveCOnlyClass1``
+
+<!-- Copyright (c) 2022 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFrameworkSingleLanguageCuration.docc/SwiftOnlyStruct2.md
+++ b/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFrameworkSingleLanguageCuration.docc/SwiftOnlyStruct2.md
@@ -1,0 +1,13 @@
+# ``MixedLanguageFramework/SwiftOnlyStruct2``
+
+This is a Swift-only symbol.
+
+## Topics
+
+### Objective-C–only symbols
+
+- ``ObjectiveCOnlyClass``
+- ``MultiCuratedObjectiveCOnlyClass1``
+- ``MultiCuratedObjectiveCOnlyClass2``
+
+<!-- Copyright (c) 2022 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFrameworkSingleLanguageCuration.docc/symbol-graph/clang/MixedLanguageFramework.symbols.json
+++ b/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFrameworkSingleLanguageCuration.docc/symbol-graph/clang/MixedLanguageFramework.symbols.json
@@ -1,0 +1,79 @@
+{
+    "metadata": {
+        "formatVersion": {
+            "major": 0,
+            "minor": 5,
+            "patch": 3
+        },
+        "generator": "clang"
+    },
+    "module": {
+        "name": "MixedLanguageFramework",
+        "platform": {
+            "architecture": "x86_64",
+            "operatingSystem": {
+                "minimumVersion": {
+                    "major": 11,
+                    "minor": 0,
+                    "patch": 0
+                },
+                "name": "macos"
+            },
+            "vendor": "apple"
+        }
+    },
+    "relationships": [],
+    "symbols": [
+        {
+            "kind": {
+                "identifier": "class",
+                "displayName": "Class"
+            },
+            "identifier": {
+                "precise": "c:@E@ObjectiveCOnlyClass",
+                "interfaceLanguage": "occ"
+            },
+            "pathComponents": [
+                "ObjectiveCOnlyClass"
+            ],
+            "names": {
+                "title": "ObjectiveCOnlyClass"
+            },
+            "accessLevel": "public"
+        },
+        {
+            "kind": {
+                "identifier": "class",
+                "displayName": "Class"
+            },
+            "identifier": {
+                "precise": "c:@E@MultiCuratedObjectiveCOnlyClass1",
+                "interfaceLanguage": "occ"
+            },
+            "pathComponents": [
+                "MultiCuratedObjectiveCOnlyClass1"
+            ],
+            "names": {
+                "title": "MultiCuratedObjectiveCOnlyClass1"
+            },
+            "accessLevel": "public"
+        },
+        {
+            "kind": {
+                "identifier": "class",
+                "displayName": "Class"
+            },
+            "identifier": {
+                "precise": "c:@E@MultiCuratedObjectiveCOnlyClass2",
+                "interfaceLanguage": "occ"
+            },
+            "pathComponents": [
+                "MultiCuratedObjectiveCOnlyClass2"
+            ],
+            "names": {
+                "title": "MultiCuratedObjectiveCOnlyClass2"
+            },
+            "accessLevel": "public"
+        }
+    ]
+}

--- a/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFrameworkSingleLanguageCuration.docc/symbol-graph/swift/MixedLanguageFramework.symbols.json
+++ b/Tests/SwiftDocCTests/Test Bundles/MixedLanguageFrameworkSingleLanguageCuration.docc/symbol-graph/swift/MixedLanguageFramework.symbols.json
@@ -1,0 +1,62 @@
+{
+    "metadata": {
+        "formatVersion": {
+            "major": 0,
+            "minor": 5,
+            "patch": 3
+        },
+        "generator": "Apple Swift version 5.7 (swiftlang-5.7.0.104.28 clang-1400.0.12.6.3)"
+    },
+    "module": {
+        "name": "MixedLanguageFramework",
+        "platform": {
+            "architecture": "x86_64",
+            "operatingSystem": {
+                "minimumVersion": {
+                    "major": 11,
+                    "minor": 0,
+                    "patch": 0
+                },
+                "name": "macosx"
+            },
+            "vendor": "apple"
+        }
+    },
+    "relationships": [],
+    "symbols": [
+        {
+            "kind": {
+                "identifier": "swift.struct",
+                "displayName": "Structure"
+            },
+            "identifier": {
+                "precise": "s:22MixedLanguageFramework15SwiftOnlyStruct1V",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "SwiftOnlyStruct1"
+            ],
+            "names": {
+                "title": "SwiftOnlyStruct1"
+            },
+            "accessLevel": "public"
+        },
+        {
+            "kind": {
+                "identifier": "swift.struct",
+                "displayName": "Structure"
+            },
+            "identifier": {
+                "precise": "s:22MixedLanguageFramework15SwiftOnlyStruct2V",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "SwiftOnlyStruct2"
+            ],
+            "names": {
+                "title": "SwiftOnlyStruct2"
+            },
+            "accessLevel": "public"
+        }
+    ]
+}


### PR DESCRIPTION
- **Rationale:** Fixes a regression where DocC began excluding manually curated topic group items that link to languages not otherwise locally included in the documentation content.
- **Risk:** Low
- **Risk Detail:** Isolated and targeted fix to topic group creation for manually curated topics.
- **Reward:** High
- **Reward Details:** Resolves a regression that resulted in content dropping from pages.
- **Original PR:** #283 
- **Code Reviewed By:** @franklinsch 
- **Testing Details:** Build a Swift-only DocC catalog that curates externally resolved symbols to non-Swift content and ensure those items appear in the rendered documentation.