### PR TITLE
Deterministic behaviour when a catalog has colliding filename

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -817,7 +817,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
         }
         
         // to preserve the order of documents by url
-        let analyzedDocumentsSorted = analyzedDocuments.sorted(by: {$0.0.path > $1.0.path})
+        let analyzedDocumentsSorted = analyzedDocuments.sorted(by: \.0.absoluteString)
 
         for analyzedDocument in analyzedDocumentsSorted {
             // Store the references we encounter to ensure they're unique. The file name is currently the only part of the URL considered for the topic reference, so collisions may occur.

--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -816,7 +816,10 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
             throw error
         }
         
-        for analyzedDocument in analyzedDocuments {
+        // to preserve the order of documents by url
+        let analyzedDocumentsSorted = analyzedDocuments.sorted(by: {String($0.0.absoluteURL) > String($1.0.absoluteURL)})
+
+        for analyzedDocument in analyzedDocumentsSorted {
             // Store the references we encounter to ensure they're unique. The file name is currently the only part of the URL considered for the topic reference, so collisions may occur.
             let (url, analyzed) = analyzedDocument
 

--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -817,7 +817,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
         }
         
         // to preserve the order of documents by url
-        let analyzedDocumentsSorted = analyzedDocuments.sorted(by: {String($0.0.absoluteURL) > String($1.0.absoluteURL)})
+        let analyzedDocumentsSorted = analyzedDocuments.sorted(by: {$0.0.path > $1.0.path})
 
         for analyzedDocument in analyzedDocumentsSorted {
             // Store the references we encounter to ensure they're unique. The file name is currently the only part of the URL considered for the topic reference, so collisions may occur.

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -660,7 +660,7 @@ class DocumentationContextTests: XCTestCase {
 
         XCTAssert(problemWithDuplicateReference.count==2)
 
-        XCTAssert(problemWithDuplicateReference[0].diagnostic.localizedDescription == "/Users/sradmin/Library/Developer/Xcode/DerivedData/swift-docc-dqymopzdtzbqmnbkvrtkjxsnnyyt/Build/Products/Debug/SwiftDocCTests.xctest/Contents/Resources/SwiftDocC_SwiftDocCTests.bundle/Contents/Resources/Test Bundles/TestBundleWithDupMD.docc/documentation1/overview.md: warning: Redeclaration of \'overview.md\'; this file will be skipped\nThis content was already declared at \'file:///Users/sradmin/Library/Developer/Xcode/DerivedData/swift-docc-dqymopzdtzbqmnbkvrtkjxsnnyyt/Build/Products/Debug/SwiftDocCTests.xctest/Contents/Resources/SwiftDocC_SwiftDocCTests.bundle/Contents/Resources/Test%20Bundles/TestBundleWithDupMD.docc/overview.md\'")
+        XCTAssert(problemWithDuplicateReference[0].diagnostic.localizedDescription == "/Users/sradmin/Library/Developer/Xcode/DerivedData/swift-docc-dqymopzdtzbqmnbkvrtkjxsnnyyt/Build/Products/Debug/SwiftDocCTests.xctest/Contents/Resources/SwiftDocC_SwiftDocCTests.bundle/Contents/Resources/Test Bundles/TestBundleWithDupMD.docc/documentation1/overview.md: warning: Redeclaration of \'overview.md\'; this file will be skipped\nThis content was already declared at \'file:///Users/sradmin/Library/Developer/Xcode/DerivedData/swift-docc-dqymopzdtzbqmnbkvrtkjxsnnyyt/Build/Products/Debug/SwiftDocCTests.xctest/Contents/Resources/SwiftDocC_SwiftDocCTests.bundle/Contents/Resources/Test%20Bundles/TestBundleWithDupMD.docc/documentation/overview.md\'")
     }
 
     func testGraphChecks() throws {

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -644,13 +644,13 @@ class DocumentationContextTests: XCTestCase {
     
     func testDetectsReferenceCollision() throws {
         let (_, context) = try testBundleAndContext(named: "TestBundleWithDupe")
-        
-        XCTAssert(
-            context.problems.contains { problem in
-                problem.diagnostic.identifier == "org.swift.docc.DuplicateReference"
-                    && problem.diagnostic.localizedSummary == "Redeclaration of 'TestTutorial.tutorial'; this file will be skipped"
-            }
-        )
+
+        let problemWithDuplicate = context.problems.filter{ $0.diagnostic.identifier == "org.swift.docc.DuplicateReference" }
+
+        XCTAssert(problemWithDuplicate.count == 1)
+
+        XCTAssert(problemWithDuplicate[0].diagnostic.localizedSummary == "Redeclaration of 'TestTutorial.tutorial'; this file will be skipped")
+
     }
     
     func testDetectsMultipleMDfilesWithSameName() throws {

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -645,11 +645,12 @@ class DocumentationContextTests: XCTestCase {
     func testDetectsReferenceCollision() throws {
         let (_, context) = try testBundleAndContext(named: "TestBundleWithDupe")
 
-        let problemWithDuplicate = context.problems.filter{ $0.diagnostic.identifier == "org.swift.docc.DuplicateReference" }
+        let problemWithDuplicate = context.problems.filter { $0.diagnostic.identifier == "org.swift.docc.DuplicateReference" }
 
-        XCTAssert(problemWithDuplicate.count == 1)
+        XCTAssertEqual(problemWithDuplicate.count, 1)
 
-        XCTAssert(problemWithDuplicate[0].diagnostic.localizedSummary == "Redeclaration of 'TestTutorial.tutorial'; this file will be skipped")
+        let localizedSummary = try XCTUnwrap(problemWithDuplicate.first?.diagnostic.localizedSummary)
+        XCTAssertEqual(localizedSummary, "Redeclaration of 'TestTutorial.tutorial'; this file will be skipped")
 
     }
     
@@ -658,9 +659,13 @@ class DocumentationContextTests: XCTestCase {
 
         let problemWithDuplicateReference = context.problems.filter { $0.diagnostic.identifier == "org.swift.docc.DuplicateReference" }
 
-        XCTAssert(problemWithDuplicateReference.count==2)
+        XCTAssertEqual(problemWithDuplicateReference.count, 2)
 
-        XCTAssert(problemWithDuplicateReference[0].diagnostic.localizedDescription == "/Users/sradmin/Library/Developer/Xcode/DerivedData/swift-docc-dqymopzdtzbqmnbkvrtkjxsnnyyt/Build/Products/Debug/SwiftDocCTests.xctest/Contents/Resources/SwiftDocC_SwiftDocCTests.bundle/Contents/Resources/Test Bundles/TestBundleWithDupMD.docc/documentation1/overview.md: warning: Redeclaration of \'overview.md\'; this file will be skipped\nThis content was already declared at \'file:///Users/sradmin/Library/Developer/Xcode/DerivedData/swift-docc-dqymopzdtzbqmnbkvrtkjxsnnyyt/Build/Products/Debug/SwiftDocCTests.xctest/Contents/Resources/SwiftDocC_SwiftDocCTests.bundle/Contents/Resources/Test%20Bundles/TestBundleWithDupMD.docc/documentation/overview.md\'")
+        let localizedSummary = try XCTUnwrap(problemWithDuplicateReference.first?.diagnostic.localizedSummary)
+        XCTAssertEqual(localizedSummary, "Redeclaration of \'overview.md\'; this file will be skipped")
+
+        let localizedSummarySecond = try XCTUnwrap(problemWithDuplicateReference[1].diagnostic.localizedSummary)
+        XCTAssertEqual(localizedSummarySecond, "Redeclaration of \'overview.md\'; this file will be skipped")
     }
 
     func testGraphChecks() throws {

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -653,6 +653,16 @@ class DocumentationContextTests: XCTestCase {
         )
     }
     
+    func testDetectsMultipleMDfilesWithSameName() throws {
+        let (_, context) = try testBundleAndContext(named: "TestBundleWithDupMD")
+
+        let problemWithDuplicateReference = context.problems.filter { $0.diagnostic.identifier == "org.swift.docc.DuplicateReference" }
+
+        XCTAssert(problemWithDuplicateReference.count==2)
+
+        XCTAssert(problemWithDuplicateReference[0].diagnostic.localizedDescription == "/Users/sradmin/Library/Developer/Xcode/DerivedData/swift-docc-dqymopzdtzbqmnbkvrtkjxsnnyyt/Build/Products/Debug/SwiftDocCTests.xctest/Contents/Resources/SwiftDocC_SwiftDocCTests.bundle/Contents/Resources/Test Bundles/TestBundleWithDupMD.docc/documentation1/overview.md: warning: Redeclaration of \'overview.md\'; this file will be skipped\nThis content was already declared at \'file:///Users/sradmin/Library/Developer/Xcode/DerivedData/swift-docc-dqymopzdtzbqmnbkvrtkjxsnnyyt/Build/Products/Debug/SwiftDocCTests.xctest/Contents/Resources/SwiftDocC_SwiftDocCTests.bundle/Contents/Resources/Test%20Bundles/TestBundleWithDupMD.docc/overview.md\'")
+    }
+
     func testGraphChecks() throws {
         let workspace = DocumentationWorkspace()
         let context = try DocumentationContext(dataProvider: workspace)

--- a/Tests/SwiftDocCTests/Test Bundles/TestBundleWithDupMD.docc/Info.plist
+++ b/Tests/SwiftDocCTests/Test Bundles/TestBundleWithDupMD.docc/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleName</key>
+	<string>TestBundleWithDupMD</string>
+	<key>CFBundleDisplayName</key>
+	<string>Test Bundle</string>
+	<key>CFBundleIdentifier</key>
+	<string>org.swift.docc.example</string>
+	<key>CFBundleIconFile</key>
+	<string>DocumentationIcon</string>
+	<key>CFBundleIconName</key>
+	<string>DocumentationIcon</string>
+	<key>CFBundlePackageType</key>
+	<string>DOCS</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>0.1.0</string>
+	<key>CFBundleShortVersionString</key>
+	<string>0.1.0</string>
+</dict>
+</plist>

--- a/Tests/SwiftDocCTests/Test Bundles/TestBundleWithDupMD.docc/documentation/overview.md
+++ b/Tests/SwiftDocCTests/Test Bundles/TestBundleWithDupMD.docc/documentation/overview.md
@@ -4,4 +4,6 @@ Create a capybara and assign personality traits and abilities.
 
 ## Overview at documentation level
 
-Capybara are complex creatures that require careful creation and a suitable habitat. After creating a sloth, you're responsible for feeding them, providing fulfilling activities, and giving them opportunities to exercise and rest. 
+Capybara are complex creatures that require careful creation and a suitable habitat. After creating a capybara, you're responsible for feeding them, providing fulfilling activities, and giving them opportunities to exercise and rest.
+
+<!-- Copyright (c) 2022 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Tests/SwiftDocCTests/Test Bundles/TestBundleWithDupMD.docc/documentation/overview.md
+++ b/Tests/SwiftDocCTests/Test Bundles/TestBundleWithDupMD.docc/documentation/overview.md
@@ -1,0 +1,7 @@
+# Getting Started with Capybara
+
+Create a capybara and assign personality traits and abilities.
+
+## Overview at documentation level
+
+Capybara are complex creatures that require careful creation and a suitable habitat. After creating a sloth, you're responsible for feeding them, providing fulfilling activities, and giving them opportunities to exercise and rest. 

--- a/Tests/SwiftDocCTests/Test Bundles/TestBundleWithDupMD.docc/documentation1/overview.md
+++ b/Tests/SwiftDocCTests/Test Bundles/TestBundleWithDupMD.docc/documentation1/overview.md
@@ -1,0 +1,7 @@
+# Getting Started with Monkeys
+
+Create a monkey and assign personality traits and abilities.
+
+## Overview at documentation1
+
+Monekys are complex creatures that require careful creation and a suitable habitat. After creating a sloth, you're responsible for feeding them, providing fulfilling activities, and giving them opportunities to exercise and rest. 

--- a/Tests/SwiftDocCTests/Test Bundles/TestBundleWithDupMD.docc/documentation1/overview.md
+++ b/Tests/SwiftDocCTests/Test Bundles/TestBundleWithDupMD.docc/documentation1/overview.md
@@ -5,3 +5,5 @@ Create a monkey and assign personality traits and abilities.
 ## Overview at documentation1
 
 Monekys are complex creatures that require careful creation and a suitable habitat. After creating a sloth, you're responsible for feeding them, providing fulfilling activities, and giving them opportunities to exercise and rest. 
+
+<!-- Copyright (c) 2022 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Tests/SwiftDocCTests/Test Bundles/TestBundleWithDupMD.docc/overview.md
+++ b/Tests/SwiftDocCTests/Test Bundles/TestBundleWithDupMD.docc/overview.md
@@ -5,3 +5,5 @@ Create a monkey and assign personality traits and abilities.
 ## Overview at parent level
 
 Monkeys are complex creatures that require careful creation and a suitable habitat. After creating a sloth, you're responsible for feeding them, providing fulfilling activities, and giving them opportunities to exercise and rest. 
+
+<!-- Copyright (c) 2022 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Tests/SwiftDocCTests/Test Bundles/TestBundleWithDupMD.docc/overview.md
+++ b/Tests/SwiftDocCTests/Test Bundles/TestBundleWithDupMD.docc/overview.md
@@ -1,0 +1,7 @@
+# Getting Started with Monkeys
+
+Create a monkey and assign personality traits and abilities.
+
+## Overview at parent level
+
+Monkeys are complex creatures that require careful creation and a suitable habitat. After creating a sloth, you're responsible for feeding them, providing fulfilling activities, and giving them opportunities to exercise and rest. 


### PR DESCRIPTION
rdar: //81691423

## Summary

Currently the behavior is not deterministic when we have multiple files with same names, whether it be tutorial or markdown files having same names. Whenever there are two or more files with same name for a type in catalog only one is picked up and rest gets Diagnostics information that its content is being dropped. The diagnostic information existed but it was always picking one of the files not in a specific order, i.e everytime it was picking a random file. The change addresses the issue by adding a sort to the url of the document, so that the behavior is deterministic, i.e the order in which a file is picked, as well as the rest who's content is ignored. 

## Dependencies

No Known dependencies 

## Testing

Steps:
1. Create a project in Xcode, it can be a swift project
2.  Create .docc folder in that.                                                       
3.  have an overview.md at .docc level, i/e /docc/overview.md
4.  also save the same file at /documentation1/overview.md and /documentation2/overview.md 
5. update the contents of documentation1/overview.md and documentation1/overview.md
6. Build documentation.


- [yes ] Added tests
- [yes ] Ran the `./bin/test` script and it succeeded
- [na ] Updated documentation if necessary
