### PR TITLE
Fix `ResolvedTopicReference` memory leak when not converting

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -312,6 +312,9 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
     ///   - bundle: The bundle that was added.
     public func dataProvider(_ dataProvider: DocumentationContextDataProvider, didAddBundle bundle: DocumentationBundle) throws {
         try benchmark(wrap: Benchmark.Duration(id: "bundle-registration")) {
+            // Enable reference caching for this documentation bundle.
+            ResolvedTopicReference.enableReferenceCaching(for: bundle.identifier)
+            
             try self.register(bundle)
         }
     }
@@ -323,7 +326,11 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
     ///   - bundle: The bundle that was removed.
     public func dataProvider(_ dataProvider: DocumentationContextDataProvider, didRemoveBundle bundle: DocumentationBundle) throws {
         referenceCache.sync { $0.removeAll() }
+        
+        // Purge the reference cache for this bundle and disable reference caching for
+        // this bundle moving forward.
         ResolvedTopicReference.purgePool(for: bundle.identifier)
+        
         unregister(bundle)
     }
     

--- a/Sources/SwiftDocC/Model/Identifier.swift
+++ b/Sources/SwiftDocC/Model/Identifier.swift
@@ -96,6 +96,15 @@ public struct ResolvedTopicReference: Hashable, Codable, Equatable, CustomString
     static func purgePool(for bundleIdentifier: String) {
         sharedPool.sync { $0.removeValue(forKey: bundleIdentifier) }
     }
+    
+    /// Enables reference caching for any identifiers created with the given bundle identifier.
+    static func enableReferenceCaching(for bundleIdentifier: ReferenceBundleIdentifier) {
+        sharedPool.sync { sharedPool in
+            if !sharedPool.keys.contains(bundleIdentifier) {
+                sharedPool[bundleIdentifier] = [:]
+            }
+        }
+    }
 
     /// The URL scheme for `doc://` links.
     public static let urlScheme = "doc"
@@ -174,7 +183,10 @@ public struct ResolvedTopicReference: Hashable, Codable, Equatable, CustomString
         )
 
         // Cache the reference
-        Self.sharedPool.sync { $0[bundleIdentifier, default: [:]][key] = self }
+        Self.sharedPool.sync { sharedPool in
+            // If we have a shared pool for this bundle identifier, cache the reference
+            sharedPool[bundleIdentifier]?[key] = self
+        }
     }
     
     private static func cacheKey(

--- a/Tests/SwiftDocCTests/Converter/RenderNodeCodableTests.swift
+++ b/Tests/SwiftDocCTests/Converter/RenderNodeCodableTests.swift
@@ -134,6 +134,30 @@ class RenderNodeCodableTests: XCTestCase {
         XCTAssertNil(decodedNode.variantOverrides)
     }
     
+    func testDecodingRenderNodeDoesNotCacheReferences() throws {
+        let exampleRenderNodeJSON = Bundle.module.url(
+            forResource: "Operator",
+            withExtension: "json",
+            subdirectory: "Test Resources"
+        )!
+        
+        let uniqueBundleIdentifier = #function
+        
+        let renderNodeWithUniqueBundleID = try String(
+            contentsOf: exampleRenderNodeJSON
+        )
+        .replacingOccurrences(
+            of: "org.swift.docc.example",
+            with: uniqueBundleIdentifier
+        )
+        
+        _ = try JSONDecoder().decode(RenderNode.self, from: Data(renderNodeWithUniqueBundleID.utf8))
+        
+        ResolvedTopicReference.sharedPool.sync { sharedPool in
+            XCTAssertNil(sharedPool[uniqueBundleIdentifier])
+        }
+    }
+    
     private func assertVariantOverrides(_ variantOverrides: VariantOverrides) throws {
         XCTAssertEqual(variantOverrides.values.count, 1)
         let variantOverride = try XCTUnwrap(variantOverrides.values.first)

--- a/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
@@ -65,10 +65,10 @@ class NavigatorIndexingTests: XCTestCase {
         return root
     }
     
-    func generateSmallTree() -> Node {
+    func generateSmallTree(bundleIdentifier: String = testBundleIdentifier) -> Node {
         var index = 1
         let rootItem = NavigatorItem(pageType: 1, languageID: Language.all.rawValue, title: "Root", platformMask: 1, availabilityID: 1)
-        let root = Node(item: rootItem, bundleIdentifier: "org.swift.docc.example")
+        let root = Node(item: rootItem, bundleIdentifier: bundleIdentifier)
         
         @discardableResult func addItems(n: Int, items: [Node], language: Language) -> [Node] {
             var leaves = [Node]()
@@ -241,6 +241,28 @@ Root
         XCTAssertTrue(validateTree(node: treeWithAttributesNonAtomic.root, validator: bundleIdentifierValidator), "The tree has bundle identifier missing.")
         XCTAssertTrue(validateTree(node: treeWithAttributesNonAtomic.root, validator: presentationIdentifierValidator), "The tree lacks the presentation identifier.")
         XCTAssertTrue(validateTree(node: treeWithAttributesNonAtomic.root, validator: attributesValidator), "The tree lacks the correct attributes.")
+    }
+    
+    func testLoadingNavigatorIndexDoesNotCacheReferences() throws {
+        let uniqueTestBundleIdentifier = #function
+        
+        let targetURL = try createTemporaryDirectory()
+        let indexURL = targetURL.appendingPathComponent("nav.index")
+        
+        let root = generateSmallTree(bundleIdentifier: uniqueTestBundleIdentifier)
+        
+        let original = NavigatorTree(root: root)
+        try original.write(to: indexURL)
+        _ = try NavigatorTree.read(
+            from: indexURL,
+            bundleIdentifier: uniqueTestBundleIdentifier,
+            interfaceLanguages: [.swift],
+            atomically: true
+        )
+        
+        ResolvedTopicReference.sharedPool.sync { sharedPool in
+            XCTAssertNil(sharedPool[uniqueTestBundleIdentifier])
+        }
     }
     
   

--- a/Tests/SwiftDocCTests/Model/IdentifierTests.swift
+++ b/Tests/SwiftDocCTests/Model/IdentifierTests.swift
@@ -68,6 +68,9 @@ class IdentifierTests: XCTestCase {
         // Verify the bundle doesn't exist in the pool
         XCTAssertFalse(ResolvedTopicReference.sharedPool.sync({ $0.keys.contains(#function) }))
         
+        // Enable caching for our test bundle identifier
+        ResolvedTopicReference.enableReferenceCaching(for: #function)
+        
         // Create a resolved reference
         let ref = ResolvedTopicReference(bundleIdentifier: #function, path: "/path/child", sourceLanguage: .swift)
         _ = ref // to suppress the warning above
@@ -89,6 +92,9 @@ class IdentifierTests: XCTestCase {
         // Verify there are no references in the pool for that bundle
         XCTAssertFalse(ResolvedTopicReference.sharedPool.sync({ $0.keys.contains(#function) }))
         
+        // Re-enable caching for our test bundle identifier
+        ResolvedTopicReference.enableReferenceCaching(for: #function)
+        
         let ref1 = ResolvedTopicReference(bundleIdentifier: #function, path: "/path/child", sourceLanguage: .swift)
         _ = ref1
         
@@ -102,6 +108,24 @@ class IdentifierTests: XCTestCase {
         XCTAssertEqual(references1.contains(where: { pair -> Bool in
             return pair.key.contains("/path/child")
         }), true)
+    }
+    
+    func testReferencesAreNotCachedByDefault() {
+        // Verify the bundle doesn't exist in the pool
+        XCTAssertFalse(ResolvedTopicReference.sharedPool.sync({ $0.keys.contains(#function) }))
+        
+        // Create a resolved reference
+        let reference = ResolvedTopicReference(
+            bundleIdentifier: #function,
+            path: "/path/child",
+            sourceLanguage: .swift
+        )
+        
+        // Verify the bundle still doesn't exist in the pool
+        XCTAssertFalse(ResolvedTopicReference.sharedPool.sync({ $0.keys.contains(#function) }))
+        
+        // Add a use of 'reference' to suppress Swift's 'reference' was never used warning
+        XCTAssertNotNil(reference)
     }
     
     func testReferenceInitialPathComponents() {

--- a/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
@@ -1563,6 +1563,38 @@ class ConvertActionTests: XCTestCase {
             "platform2" : PlatformVersion(.init(11, 12, 13), beta: false),
         ])
     }
+    
+    func testResolvedTopicReferencesAreCachedByDefaultWhenConverting() throws {
+        let bundle = Folder(
+            name: "unit-test.docc",
+            content: [
+                InfoPlist(displayName: "TestBundle", identifier: #function),
+                CopyOfFile(original: symbolGraphFile),
+            ]
+        )
+        
+        let testDataProvider = try TestFileSystem(folders: [bundle, Folder.emptyHTMLTemplateDirectory])
+        let targetDirectory = URL(fileURLWithPath: testDataProvider.currentDirectoryPath)
+            .appendingPathComponent("target", isDirectory: true)
+        
+        var action = try ConvertAction(
+            documentationBundleURL: bundle.absoluteURL,
+            outOfProcessResolver: nil,
+            analyze: false,
+            targetDirectory: targetDirectory,
+            htmlTemplateDirectory: Folder.emptyHTMLTemplateDirectory.absoluteURL,
+            emitDigest: false,
+            currentPlatforms: [:],
+            dataProvider: testDataProvider,
+            fileManager: testDataProvider,
+            temporaryDirectory: createTemporaryDirectory())
+        
+        _ = try action.perform(logHandle: .none)
+        
+        ResolvedTopicReference.sharedPool.sync { sharedPool in
+            XCTAssertEqual(sharedPool[#function]?.count, 8)
+        }
+    }
 
     func testIgnoresAnalyzerHintsByDefault() throws {
         func runCompiler(analyze: Bool) throws -> [Problem] {


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://92131596

## Summary

The caching mechanism in `ResolvedTopicReference` never releases references to the `ResolvedTopicReference`s it holds.

This has likely always been a problem since the introduction of the cache, but is just now appearing as a memory leak when profiling SwiftDocC because we recently added copy-on-write functionality to `ResolvedTopicReference`.

The current solution proposed here is to selectively enable ResolvedTopicReference caching for specific bundle IDs _only_ when running a conversion. This disables the caching by default when (for example) just using SwiftDocC as a library to load RenderNode’s in memory.

There’s more work to do here- but this resolves the immediate issue of caching (and never releasing) every reference when using SwiftDocC as a library and not to actively convert documentation.

## Testing

Use SwiftDocC to load and unload a large RenderNode in-memory and confirm that no `ResolvedTopicReference`s are held when profiling the process.

Confirm `docc convert` doesn't regress in performance when generating documentation for a large bundle.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
