### PR TITLE
Remove spaces from test bundle identifiers

### DIFF
--- a/Tests/SwiftDocCTests/Converter/Rewriter/RenderNodeVariantOverridesApplierTests.swift
+++ b/Tests/SwiftDocCTests/Converter/Rewriter/RenderNodeVariantOverridesApplierTests.swift
@@ -77,7 +77,7 @@ class RenderNodeVariantOverridesApplierTests: XCTestCase {
                 renderNode.addVariantOverride(
                     pointerComponents: ["identifier"],
                     value: ResolvedTopicReference(
-                        bundleIdentifier: "new bundle identifier",
+                        bundleIdentifier: "new-bundle-identifier",
                         path: "/path",
                         fragment: nil,
                         sourceLanguage: .objectiveC
@@ -193,7 +193,7 @@ class RenderNodeVariantOverridesApplierTests: XCTestCase {
     ) throws {
         var renderNode = RenderNode(
             identifier: ResolvedTopicReference(
-                bundleIdentifier: "bundle identifier",
+                bundleIdentifier: "bundle-identifier",
                 path: "",
                 fragment: nil,
                 sourceLanguage: .swift


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://94811638

## Summary

Removes spaces from the bundle identifiers using in Swift-DocC tests to work around a bug in macOS Ventura Beta 1 (94747378).

## Dependencies

None.

## Testing

N/A, not a user facing change.

## Checklist

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
