### PR TITLE
Ensure that children of multicurated pages get properly multicurated as well

### DIFF
--- a/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
@@ -578,6 +578,36 @@ Root
         )
     }
     
+    func testMultiCuratesChildrenOfMultiCuratedPages() throws {
+        let navigatorIndex = try generatedNavigatorIndex(for: "MultiCuratedSubtree", bundleIdentifier: "org.swift.MultiCuratedSubtree")
+        
+        XCTAssertEqual(
+            navigatorIndex.navigatorTree.root.dumpTree(),
+            """
+            [Root]
+            ┗╸Swift
+              ┗╸MultiCuratedSubtree
+                ┣╸Curation Roots
+                ┣╸FirstCurationRoot
+                ┃ ┣╸Multicurated trees
+                ┃ ┗╸MultiCuratedStruct
+                ┃   ┣╸Enumerations
+                ┃   ┗╸MultiCuratedStruct.MultiCuratedEnum
+                ┃     ┣╸Enumeration Cases
+                ┃     ┣╸MultiCuratedStruct.MultiCuratedEnum.firstCase
+                ┃     ┗╸MultiCuratedStruct.MultiCuratedEnum.secondCase
+                ┗╸SecondCurationRoot
+                  ┣╸Multicurated trees
+                  ┗╸MultiCuratedStruct
+                    ┣╸Enumerations
+                    ┗╸MultiCuratedStruct.MultiCuratedEnum
+                      ┣╸Enumeration Cases
+                      ┣╸MultiCuratedStruct.MultiCuratedEnum.firstCase
+                      ┗╸MultiCuratedStruct.MultiCuratedEnum.secondCase
+            """
+        )
+    }
+    
     func testNavigatorIndexUsingPageTitleGeneration() throws {
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
         let renderContext = RenderContext(documentationContext: context, bundle: bundle)

--- a/Tests/SwiftDocCTests/Test Bundles/MultiCuratedSubtree.docc/FirstCurationRoot.md
+++ b/Tests/SwiftDocCTests/Test Bundles/MultiCuratedSubtree.docc/FirstCurationRoot.md
@@ -1,0 +1,11 @@
+# FirstCurationRoot
+
+The first curation root for the multicurated subtree
+
+## Topics
+
+### Multicurated trees
+
+- ``MultiCuratedStruct`` 
+
+<!-- Copyright (c) 2022 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Tests/SwiftDocCTests/Test Bundles/MultiCuratedSubtree.docc/Info.plist
+++ b/Tests/SwiftDocCTests/Test Bundles/MultiCuratedSubtree.docc/Info.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleVersion</key>
+	<string>0.0.1</string>
+	<key>CFBundleDisplayName</key>
+	<string>MultiCuratedSubtree</string>
+	<key>CFBundleName</key>
+	<string>MultiCuratedSubtree</string>
+	<key>CFBundleIdentifier</key>
+	<string>org.swift.MultiCuratedSubtree</string>
+</dict>
+</plist>

--- a/Tests/SwiftDocCTests/Test Bundles/MultiCuratedSubtree.docc/MultiCuratedSubtree.md
+++ b/Tests/SwiftDocCTests/Test Bundles/MultiCuratedSubtree.docc/MultiCuratedSubtree.md
@@ -1,0 +1,12 @@
+# ``MultiCuratedSubtree``
+
+The top level page
+
+## Topics
+
+### Curation Roots
+
+- <doc:FirstCurationRoot>
+- <doc:SecondCurationRoot>
+
+<!-- Copyright (c) 2022 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Tests/SwiftDocCTests/Test Bundles/MultiCuratedSubtree.docc/MultiCuratedSubtree.symbols.json
+++ b/Tests/SwiftDocCTests/Test Bundles/MultiCuratedSubtree.docc/MultiCuratedSubtree.symbols.json
@@ -1,0 +1,139 @@
+{
+    "metadata": {
+        "formatVersion": {
+            "major": 0,
+            "minor": 5,
+            "patch": 3
+        },
+        "generator": "Apple Swift version 5.7 (swiftlang-5.7.0.113.202 clang-1400.0.16.2)"
+    },
+    "module": {
+        "name": "MultiCuratedSubtree",
+        "platform": {
+            "architecture": "x86_64",
+            "operatingSystem": {
+                "minimumVersion": {
+                    "major": 12,
+                    "minor": 4,
+                    "patch": 0
+                },
+                "name": "macosx"
+            },
+            "vendor": "apple"
+        }
+    },
+    "relationships": [
+        {
+            "kind": "memberOf",
+            "source": "s:19MultiCuratedSubtree0aB6StructV0aB4EnumO10secondCaseyA2EmF",
+            "target": "s:19MultiCuratedSubtree0aB6StructV0aB4EnumO"
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:19MultiCuratedSubtree0aB6StructV0aB4EnumO",
+            "sourceOrigin": {
+                "displayName": "Equatable.!=(_:_:)",
+                "identifier": "s:SQsE2neoiySbx_xtFZ"
+            },
+            "target": "s:19MultiCuratedSubtree0aB6StructV0aB4EnumO"
+        },
+        {
+            "kind": "conformsTo",
+            "source": "s:19MultiCuratedSubtree0aB6StructV0aB4EnumO",
+            "target": "s:SH",
+            "targetFallback": "Swift.Hashable"
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:19MultiCuratedSubtree0aB6StructV0aB4EnumO9firstCaseyA2EmF",
+            "target": "s:19MultiCuratedSubtree0aB6StructV0aB4EnumO"
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:19MultiCuratedSubtree0aB6StructV0aB4EnumO",
+            "target": "s:19MultiCuratedSubtree0aB6StructV"
+        },
+        {
+            "kind": "conformsTo",
+            "source": "s:19MultiCuratedSubtree0aB6StructV0aB4EnumO",
+            "target": "s:SQ",
+            "targetFallback": "Swift.Equatable"
+        }
+    ],
+    "symbols": [
+        {
+            "accessLevel": "public",
+            "identifier": {
+                "interfaceLanguage": "swift",
+                "precise": "s:19MultiCuratedSubtree0aB6StructV0aB4EnumO"
+            },
+            "kind": {
+                "displayName": "Enumeration",
+                "identifier": "swift.enum"
+            },
+            "names": {
+                "title": "MultiCuratedStruct.MultiCuratedEnum"
+            },
+            "pathComponents": [
+                "MultiCuratedStruct",
+                "MultiCuratedEnum"
+            ]
+        },
+        {
+            "accessLevel": "public",
+            "identifier": {
+                "interfaceLanguage": "swift",
+                "precise": "s:19MultiCuratedSubtree0aB6StructV"
+            },
+            "kind": {
+                "displayName": "Structure",
+                "identifier": "swift.struct"
+            },
+            "names": {
+                "title": "MultiCuratedStruct"
+            },
+            "pathComponents": [
+                "MultiCuratedStruct"
+            ]
+        },
+        {
+            "accessLevel": "public",
+            "identifier": {
+                "interfaceLanguage": "swift",
+                "precise": "s:19MultiCuratedSubtree0aB6StructV0aB4EnumO10secondCaseyA2EmF"
+            },
+            "kind": {
+                "displayName": "Case",
+                "identifier": "swift.enum.case"
+            },
+            "names": {
+                "title": "MultiCuratedStruct.MultiCuratedEnum.secondCase"
+            },
+            "pathComponents": [
+                "MultiCuratedStruct",
+                "MultiCuratedEnum",
+                "secondCase"
+            ]
+        },
+        {
+            "accessLevel": "public",
+            "identifier": {
+                "interfaceLanguage": "swift",
+                "precise": "s:19MultiCuratedSubtree0aB6StructV0aB4EnumO9firstCaseyA2EmF"
+            },
+            "kind": {
+                "displayName": "Case",
+                "identifier": "swift.enum.case"
+            },
+            "names": {
+                "title": "MultiCuratedStruct.MultiCuratedEnum.firstCase"
+            },
+            "pathComponents": [
+                "MultiCuratedStruct",
+                "MultiCuratedEnum",
+                "firstCase"
+            ]
+        }
+    ]
+}
+

--- a/Tests/SwiftDocCTests/Test Bundles/MultiCuratedSubtree.docc/SecondCurationRoot.md
+++ b/Tests/SwiftDocCTests/Test Bundles/MultiCuratedSubtree.docc/SecondCurationRoot.md
@@ -1,0 +1,11 @@
+# SecondCurationRoot
+
+The second curation root for the multicurated subtree
+
+## Topics
+
+### Multicurated trees
+
+- ``MultiCuratedStruct``
+
+<!-- Copyright (c) 2022 Apple Inc and the Swift Project authors. All Rights Reserved. -->


### PR DESCRIPTION
This performs a BFS traversal of multicurated pages to properly add references
to them in all the copied parents.

rdar://94798570

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran the `./bin/test` script and it succeeded
- [X] Updated documentation if necessary
