### PR TITLE
Add support for custom aside titles

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -60,7 +60,7 @@
         "repositoryURL": "https://github.com/apple/swift-markdown.git",
         "state": {
           "branch": "main",
-          "revision": "573e9a307799a2a683899bf1b702c308ef35660b",
+          "revision": "2c2354d693a15a07ce2400a16f855bc52c121ec0",
           "version": null
         }
       },

--- a/Sources/SwiftDocC/Model/Rendering/RenderContentCompiler.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderContentCompiler.swift
@@ -35,7 +35,7 @@ struct RenderContentCompiler: MarkupVisitor {
     
     mutating func visitBlockQuote(_ blockQuote: BlockQuote) -> [RenderContent] {
         let aside = Aside(blockQuote)
-        return [RenderBlockContent.aside(style: RenderBlockContent.AsideStyle(aside.kind),
+        return [RenderBlockContent.aside(style: RenderBlockContent.AsideStyle(asideKind: aside.kind),
                                          content: aside.content.reduce(into: [], { result, child in result.append(contentsOf: visit(child))}) as! [RenderBlockContent])]
     }
     

--- a/Sources/SwiftDocC/Utility/MarkupExtensions/ListItemExtractor.swift
+++ b/Sources/SwiftDocC/Utility/MarkupExtensions/ListItemExtractor.swift
@@ -103,7 +103,7 @@ extension ListItem {
     }
 
     /**
-     Extract a "simple tag" from the liset of known list item tags.
+     Extract a "simple tag" from the list of known list item tags.
 
      Expected form:
 

--- a/Tests/SwiftDocCTests/Indexing/IndexingTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/IndexingTests.swift
@@ -181,7 +181,7 @@ class IndexingTests: XCTestCase {
     }
     
     func testRenderBlockContentAside() {
-        let aside = RenderBlockContent.aside(style: .experiment, content: [.paragraph(inlineContent: [.text("Hello, world!")])])
+        let aside = RenderBlockContent.aside(style: .init(rawValue: "Experiment"), content: [.paragraph(inlineContent: [.text("Hello, world!")])])
         XCTAssertEqual([], aside.headings)
         XCTAssertEqual("Hello, world!", aside.rawIndexableTextContent(references: [:]))
     }

--- a/Tests/SwiftDocCTests/Model/RenderNodeSerializationTests.swift
+++ b/Tests/SwiftDocCTests/Model/RenderNodeSerializationTests.swift
@@ -38,7 +38,7 @@ class RenderNodeSerializationTests: XCTestCase {
         
         let blockContent: [RenderBlockContent] = [
             .paragraph(inlineContent: inlines),
-            .aside(style: .experiment, content: [
+            .aside(style: .init(rawValue: "Experiment"), content: [
                 .paragraph(inlineContent: [
                     .text("Try running the project in the Simulator using the "),
                     .strong(inlineContent: [.text("Project > Run")]),
@@ -53,7 +53,7 @@ class RenderNodeSerializationTests: XCTestCase {
             .step(content: [.paragraph(inlineContent: [.text("Lorem ipsum")])], caption: [.paragraph(inlineContent: [.text("Caption")])], media: .init("screenshot2.png"), code: nil, runtimePreview: nil),
             .step(content: [.paragraph(inlineContent: [.text("Lorem ipsum")])], caption: [], media: nil, code: .init("helloworld.swift"), runtimePreview: .init("screenshot2.png")),
             .step(content: [.paragraph(inlineContent: [.text("Lorem ipsum")])], caption: [], media: .init("screenshot3.png"), code: nil, runtimePreview: nil),
-            .aside(style: .note, content: [.paragraph(inlineContent: [.text("Lorem ipsum dolor emit.")])]),
+            .aside(style: .init(rawValue: "Note"), content: [.paragraph(inlineContent: [.text("Lorem ipsum dolor emit.")])]),
             .step(content: [.paragraph(inlineContent: [.text("Lorem ipsum")])], caption: [], media: .init("screenshot4.png"), code: nil, runtimePreview: nil),
         ]
         

--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
@@ -69,10 +69,10 @@ class SemaToRenderNodeTests: XCTestCase {
             let contentSection = tutorialSections.tasks[0].contentSection[0]
             guard case let .contentAndMedia(section) = contentSection,
                 case let .aside(note, noteContent) = section.content[1],
-                note == .note,
+                  note == .init(rawValue: "Note"),
                 case let .aside(important, importantContent) = section.content[2],
-                important == .important else {
-                    XCTFail("Expected `Note` and `Experiment` asides")
+                  important == .init(rawValue: "Important") else {
+                    XCTFail("Expected `Note` and `Important` asides")
                     return
             }
             
@@ -2302,29 +2302,29 @@ Document @1:1-11:19
     }
 
     let asidesStressTest: [RenderBlockContent] = [
-        .aside(style: .note, content: [.paragraph(inlineContent: [.text("This is a note.")])]),
-        .aside(style: .tip, content: [.paragraph(inlineContent: [.text("Here’s a tip.")])]),
-        .aside(style: .important, content: [.paragraph(inlineContent: [.text("Keep this in mind.")])]),
-        .aside(style: .experiment, content: [.paragraph(inlineContent: [.text("Try this out.")])]),
-        .aside(style: .warning, content: [.paragraph(inlineContent: [.text("Watch out for this.")])]),
-        .aside(style: .attention, content: [.paragraph(inlineContent: [.text("Head’s up!")])]),
-        .aside(style: .author, content: [.paragraph(inlineContent: [.text("I wrote this.")])]),
-        .aside(style: .authors, content: [.paragraph(inlineContent: [.text("We wrote this.")])]),
-        .aside(style: .bug, content: [.paragraph(inlineContent: [.text("This is wrong.")])]),
-        .aside(style: .complexity, content: [.paragraph(inlineContent: [.text("This takes time.")])]),
-        .aside(style: .copyright, content: [.paragraph(inlineContent: [.text("2021 Apple Inc.")])]),
-        .aside(style: .date, content: [.paragraph(inlineContent: [.text("1 January 1970")])]),
-        .aside(style: .invariant, content: [.paragraph(inlineContent: [.text("This shouldn’t change.")])]),
-        .aside(style: .mutatingVariant, content: [.paragraph(inlineContent: [.text("This will change.")])]),
-        .aside(style: .nonMutatingVariant, content: [.paragraph(inlineContent: [.text("This changes, but not in the data.")])]),
-        .aside(style: .postcondition, content: [.paragraph(inlineContent: [.text("After calling, this should be true.")])]),
-        .aside(style: .precondition, content: [.paragraph(inlineContent: [.text("Before calling, this should be true.")])]),
-        .aside(style: .remark, content: [.paragraph(inlineContent: [.text("Something you should know.")])]),
-        .aside(style: .requires, content: [.paragraph(inlineContent: [.text("This needs something.")])]),
-        .aside(style: .since, content: [.paragraph(inlineContent: [.text("The beginning of time.")])]),
-        .aside(style: .todo, content: [.paragraph(inlineContent: [.text("This needs work.")])]),
-        .aside(style: .version, content: [.paragraph(inlineContent: [.text("3.1.4")])]),
-        .aside(style: .throws, content: [.paragraph(inlineContent: [.text("A serious error.")])]),
+        .aside(style: .init(rawValue: "Note"), content: [.paragraph(inlineContent: [.text("This is a note.")])]),
+        .aside(style: .init(rawValue: "Tip"), content: [.paragraph(inlineContent: [.text("Here’s a tip.")])]),
+        .aside(style: .init(rawValue: "Important"), content: [.paragraph(inlineContent: [.text("Keep this in mind.")])]),
+        .aside(style: .init(rawValue: "Experiment"), content: [.paragraph(inlineContent: [.text("Try this out.")])]),
+        .aside(style: .init(rawValue: "Warning"), content: [.paragraph(inlineContent: [.text("Watch out for this.")])]),
+        .aside(style: .init(rawValue: "Attention"), content: [.paragraph(inlineContent: [.text("Head’s up!")])]),
+        .aside(style: .init(rawValue: "Author"), content: [.paragraph(inlineContent: [.text("I wrote this.")])]),
+        .aside(style: .init(rawValue: "Authors"), content: [.paragraph(inlineContent: [.text("We wrote this.")])]),
+        .aside(style: .init(rawValue: "Bug"), content: [.paragraph(inlineContent: [.text("This is wrong.")])]),
+        .aside(style: .init(rawValue: "Complexity"), content: [.paragraph(inlineContent: [.text("This takes time.")])]),
+        .aside(style: .init(rawValue: "Copyright"), content: [.paragraph(inlineContent: [.text("2021 Apple Inc.")])]),
+        .aside(style: .init(rawValue: "Date"), content: [.paragraph(inlineContent: [.text("1 January 1970")])]),
+        .aside(style: .init(rawValue: "Invariant"), content: [.paragraph(inlineContent: [.text("This shouldn’t change.")])]),
+        .aside(style: .init(rawValue: "MutatingVariant"), content: [.paragraph(inlineContent: [.text("This will change.")])]),
+        .aside(style: .init(rawValue: "NonMutatingVariant"), content: [.paragraph(inlineContent: [.text("This changes, but not in the data.")])]),
+        .aside(style: .init(rawValue: "Postcondition"), content: [.paragraph(inlineContent: [.text("After calling, this should be true.")])]),
+        .aside(style: .init(rawValue: "Precondition"), content: [.paragraph(inlineContent: [.text("Before calling, this should be true.")])]),
+        .aside(style: .init(rawValue: "Remark"), content: [.paragraph(inlineContent: [.text("Something you should know.")])]),
+        .aside(style: .init(rawValue: "Requires"), content: [.paragraph(inlineContent: [.text("This needs something.")])]),
+        .aside(style: .init(rawValue: "Since"), content: [.paragraph(inlineContent: [.text("The beginning of time.")])]),
+        .aside(style: .init(rawValue: "Todo"), content: [.paragraph(inlineContent: [.text("This needs work.")])]),
+        .aside(style: .init(rawValue: "Version"), content: [.paragraph(inlineContent: [.text("3.1.4")])]),
+        .aside(style: .init(rawValue: "Throws"), content: [.paragraph(inlineContent: [.text("A serious error.")])]),
     ]
     
     func testBareTechnology() throws {
@@ -2466,13 +2466,6 @@ Document @1:1-11:19
         }
         defer {
             try? FileManager.default.removeItem(at: bundleURL)
-        }
-
-        for kind in RenderBlockContent.AsideStyle.allCases {
-            XCTAssert(asidesStressTest.contains(where: {
-                guard case let RenderBlockContent.aside(innerKind, _) = $0 else { return false }
-                return innerKind == kind
-            }), "Please add \(kind) to the asidesStressTest list and Asides.symbols.json.")
         }
         
         // Both of these symbols have the same content; one just has its asides as list items and the other has blockquotes.
@@ -2799,15 +2792,15 @@ Document @1:1-11:19
             asidesStressTest,
             """
             [
-            {"type":"aside", "style":"note",
+            {"type":"aside", "style":"note", "name":"Note",
                 "content": [{"type":"paragraph", "inlineContent":[{"type":"text", "text":"This is a note."}]}]},
-            {"type":"aside", "style":"tip",
+            {"type":"aside", "style":"tip", "name":"Tip",
                 "content": [{"type":"paragraph", "inlineContent":[{"type":"text", "text":"Here’s a tip."}]}]},
-            {"type":"aside", "style":"important",
+            {"type":"aside", "style":"important", "name":"Important",
                 "content": [{"type":"paragraph", "inlineContent":[{"type":"text", "text":"Keep this in mind."}]}]},
-            {"type":"aside", "style":"experiment",
+            {"type":"aside", "style":"experiment","name":"Experiment",
                 "content": [{"type":"paragraph", "inlineContent":[{"type":"text", "text":"Try this out."}]}]},
-            {"type":"aside", "style":"warning",
+            {"type":"aside", "style":"warning", "name":"Warning",
                 "content": [{"type":"paragraph", "inlineContent":[{"type":"text", "text":"Watch out for this."}]}]},
             {"type":"aside", "style":"note", "name":"Attention",
                 "content": [{"type":"paragraph", "inlineContent":[{"type":"text", "text":"Head’s up!"}]}]},

--- a/Tests/SwiftDocCTests/Rendering/RenderBlockContent+AsideStyleTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/RenderBlockContent+AsideStyleTests.swift
@@ -1,0 +1,53 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+import XCTest
+@testable import SwiftDocC
+
+class RenderBlockContent_AsideStyleTests: XCTestCase {
+    private typealias AsideStyle = RenderBlockContent.AsideStyle
+    
+    func testDisplayNameForSpecialRawValue() {
+        XCTAssertEqual(
+            AsideStyle(rawValue: "nonmutatingvariant").displayName,
+            "Non-Mutating Variant"
+        )
+        
+        XCTAssertEqual(
+            AsideStyle(rawValue: "NonMutatingVariant").displayName,
+            "Non-Mutating Variant"
+        )
+        
+        XCTAssertEqual(
+            AsideStyle(rawValue: "mutatingvariant").displayName,
+            "Mutating Variant"
+        )
+        
+        XCTAssertEqual(
+            AsideStyle(rawValue: "todo").displayName,
+            "To Do"
+        )
+    }
+    
+    func testDisplayNameForAsideWithExistingUppercasedContent() {
+        XCTAssertEqual(
+            AsideStyle(rawValue: "Random title").displayName,
+            "Random title"
+        )
+    }
+    
+    func testDisplayNameForAsideWithLowercasedContent() {
+        XCTAssertEqual(
+            AsideStyle(rawValue: "random title").displayName,
+            "Random Title"
+        )
+    }
+}


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://65856948

## Summary

Adds support for emitting custom aside titles in render json.

## Dependencies

https://github.com/apple/swift-markdown/pull/60

## Testing

```markdown
> Custom: This is a custom aside title.
```

Steps:
1. Build documentation for a DocC catalog that contains the above markdown.
2. Verify that the rendered output displays the custom title.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [ ] Ran the `./bin/test` script and it succeeded
- [X] Updated documentation if necessary
