### PR TITLE
[5.7] Deterministic behaviour when a catalog has colliding filename (#286)

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -823,7 +823,10 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
             throw error
         }
         
-        for analyzedDocument in analyzedDocuments {
+        // to preserve the order of documents by url
+        let analyzedDocumentsSorted = analyzedDocuments.sorted(by: \.0.absoluteString)
+
+        for analyzedDocument in analyzedDocumentsSorted {
             // Store the references we encounter to ensure they're unique. The file name is currently the only part of the URL considered for the topic reference, so collisions may occur.
             let (url, analyzed) = analyzedDocument
 

--- a/Tests/SwiftDocCTests/Test Bundles/TestBundleWithDupMD.docc/Info.plist
+++ b/Tests/SwiftDocCTests/Test Bundles/TestBundleWithDupMD.docc/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleName</key>
+	<string>TestBundleWithDupMD</string>
+	<key>CFBundleDisplayName</key>
+	<string>Test Bundle</string>
+	<key>CFBundleIdentifier</key>
+	<string>org.swift.docc.example</string>
+	<key>CFBundleIconFile</key>
+	<string>DocumentationIcon</string>
+	<key>CFBundleIconName</key>
+	<string>DocumentationIcon</string>
+	<key>CFBundlePackageType</key>
+	<string>DOCS</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>0.1.0</string>
+	<key>CFBundleShortVersionString</key>
+	<string>0.1.0</string>
+</dict>
+</plist>

--- a/Tests/SwiftDocCTests/Test Bundles/TestBundleWithDupMD.docc/documentation/overview.md
+++ b/Tests/SwiftDocCTests/Test Bundles/TestBundleWithDupMD.docc/documentation/overview.md
@@ -1,0 +1,9 @@
+# Getting Started with Capybara
+
+Create a capybara and assign personality traits and abilities.
+
+## Overview at documentation level
+
+Capybara are complex creatures that require careful creation and a suitable habitat. After creating a capybara, you're responsible for feeding them, providing fulfilling activities, and giving them opportunities to exercise and rest.
+
+<!-- Copyright (c) 2022 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Tests/SwiftDocCTests/Test Bundles/TestBundleWithDupMD.docc/documentation1/overview.md
+++ b/Tests/SwiftDocCTests/Test Bundles/TestBundleWithDupMD.docc/documentation1/overview.md
@@ -1,0 +1,9 @@
+# Getting Started with Monkeys
+
+Create a monkey and assign personality traits and abilities.
+
+## Overview at documentation1
+
+Monekys are complex creatures that require careful creation and a suitable habitat. After creating a sloth, you're responsible for feeding them, providing fulfilling activities, and giving them opportunities to exercise and rest. 
+
+<!-- Copyright (c) 2022 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Tests/SwiftDocCTests/Test Bundles/TestBundleWithDupMD.docc/overview.md
+++ b/Tests/SwiftDocCTests/Test Bundles/TestBundleWithDupMD.docc/overview.md
@@ -1,0 +1,9 @@
+# Getting Started with Monkeys
+
+Create a monkey and assign personality traits and abilities.
+
+## Overview at parent level
+
+Monkeys are complex creatures that require careful creation and a suitable habitat. After creating a sloth, you're responsible for feeding them, providing fulfilling activities, and giving them opportunities to exercise and rest. 
+
+<!-- Copyright (c) 2022 Apple Inc and the Swift Project authors. All Rights Reserved. -->


### PR DESCRIPTION
Rationale: Whenever there are two or more files with same name for a type in catalog only one is picked up randomly and rest gets Diagnostics information that its content is being dropped. The change addresses the issue by adding a sort to the url of the document, so that the behavior is deterministic, i.e the order in which a file is picked, as well as the rest who's content is ignored.
Risk: Low
Risk Detail: Minor, targeted change that is covered by a test.
Reward: Medium
Reward Details: This avoid the uncertainty regarding which file's content would be dropped when there is colliding filename. 
Original PR: https://github.com/apple/swift-docc/pull/286
Issue: rdar: //81691423
Code Reviewed By: @ethan-kusters, @franklinsch 
Testing Details: Added unit tests to ensure the behavior is deterministic when colliding filenames exists within a catalog. 