### PR TITLE
[5.7] NonInclusiveLanguageChecker to flag words with multiple spaces (#302)

### DIFF
--- a/Sources/SwiftDocC/Checker/Checkers/NonInclusiveLanguageChecker.swift
+++ b/Sources/SwiftDocC/Checker/Checkers/NonInclusiveLanguageChecker.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -163,7 +163,7 @@ public struct NonInclusiveLanguageChecker: Checker {
 /// The default list of terms to look for in documentation.
 fileprivate let builtinExcludedTerms: [NonInclusiveLanguageChecker.Term] = [
     NonInclusiveLanguageChecker.Term(
-        expression: #"black\W?list\w{0,2}"#,
+        expression: #"black\W*list\w{0,2}"#,
         message: "Choose a more inclusive alternative that’s appropriate to the context, such as deny list/allow list or unapproved list/approved list.",
         replacement: "deny list"
     ),
@@ -178,7 +178,7 @@ fileprivate let builtinExcludedTerms: [NonInclusiveLanguageChecker.Term] = [
         replacement: "secondary"
     ),
     NonInclusiveLanguageChecker.Term(
-        expression: #"white\W?list\w{0,2}"#,
+        expression: #"white\W*list\w{0,2}"#,
         message: "Choose a more inclusive alternative that’s appropriate to the context, such as deny list/allow list or unapproved list/approved list.",
         replacement: "allow list"
     )

--- a/Tests/SwiftDocCTests/Checker/Checkers/NonInclusiveLanguageCheckerTests.swift
+++ b/Tests/SwiftDocCTests/Checker/Checkers/NonInclusiveLanguageCheckerTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -29,6 +29,39 @@ class NonInclusiveLanguageCheckerTests: XCTestCase {
         XCTAssertEqual(range.lowerBound.column, 5)
         XCTAssertEqual(range.upperBound.line, 1)
         XCTAssertEqual(range.upperBound.column, 16)
+    }
+
+    func testMatchTermWithSpaces() throws {
+        let source = """
+        # A White  listed title
+        # A Black    listed title
+        # A White listed title
+        """
+        let document = Document(parsing: source)
+        var checker = NonInclusiveLanguageChecker(sourceFile: nil)
+        checker.visit(document)
+        XCTAssertEqual(checker.problems.count, 3)
+
+        let problem = try XCTUnwrap(checker.problems.first)
+        let range = try XCTUnwrap(problem.diagnostic.range)
+        XCTAssertEqual(range.lowerBound.line, 1)
+        XCTAssertEqual(range.lowerBound.column, 5)
+        XCTAssertEqual(range.upperBound.line, 1)
+        XCTAssertEqual(range.upperBound.column, 18)
+
+        let problemTwo = try XCTUnwrap(checker.problems[1])
+        let rangeTwo = try XCTUnwrap(problemTwo.diagnostic.range)
+        XCTAssertEqual(rangeTwo.lowerBound.line, 2)
+        XCTAssertEqual(rangeTwo.lowerBound.column, 5)
+        XCTAssertEqual(rangeTwo.upperBound.line, 2)
+        XCTAssertEqual(rangeTwo.upperBound.column, 20)
+
+        let problemThree = try XCTUnwrap(checker.problems[2])
+        let rangeThree = try XCTUnwrap(problemThree.diagnostic.range)
+        XCTAssertEqual(rangeThree.lowerBound.line, 3)
+        XCTAssertEqual(rangeThree.lowerBound.column, 5)
+        XCTAssertEqual(rangeThree.upperBound.line, 3)
+        XCTAssertEqual(rangeThree.upperBound.column, 17)
     }
 
     func testMatchTermInAbstract() throws {


### PR DESCRIPTION
Rationale: Whenever there are multiple spaces in inclusive language diagnostic were missing, the fix here addresses that by updating the regex to catch multiple spaces. .
Risk: Low
Risk Detail: Minor, targeted change that is covered by a test.
Reward: Medium
Reward Details: Highlight non inclusive language even when are spaces in them. 
Original PR: https://github.com/apple/swift-docc/pull/302
Issue: rdar://75552499
Code Reviewed By: @ethan-kusters, @franklinsch
Testing Details: Added unit tests to ensure diagnostic information is added when there are multiple spaces in non inclusive language.