### PR TITLE
[5.7] Check the module name to know when to skip inherited doc comments.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -39,10 +39,10 @@
       },
       {
         "package": "SymbolKit",
-        "repositoryURL": "https://github.com/d-ronnqvist/swift-docc-symbolkit",
+        "repositoryURL": "https://github.com/apple/swift-docc-symbolkit",
         "state": {
-          "branch": "check-doc-comment-module-info-5.7",
-          "revision": "ddb05351b0a0a3b029ae6bdc74f5a82eb214632e",
+          "branch": "release/5.7",
+          "revision": "dfb6fe564d4378479f093f2171c14044c782c99e",
           "version": null
         }
       },

--- a/Package.resolved
+++ b/Package.resolved
@@ -42,7 +42,7 @@
         "repositoryURL": "https://github.com/d-ronnqvist/swift-docc-symbolkit",
         "state": {
           "branch": "check-doc-comment-module-info-5.7",
-          "revision": "384390a66f4f34b3b341583064b7e4123729eed5",
+          "revision": "ddb05351b0a0a3b029ae6bdc74f5a82eb214632e",
           "version": null
         }
       },

--- a/Package.resolved
+++ b/Package.resolved
@@ -39,10 +39,10 @@
       },
       {
         "package": "SymbolKit",
-        "repositoryURL": "https://github.com/apple/swift-docc-symbolkit",
+        "repositoryURL": "https://github.com/d-ronnqvist/swift-docc-symbolkit",
         "state": {
-          "branch": "release/5.7",
-          "revision": "0c3a10dcd2f7ed3dd0ab8485605cd7135ec3420e",
+          "branch": "check-doc-comment-module-info-5.7",
+          "revision": "384390a66f4f34b3b341583064b7e4123729eed5",
           "version": null
         }
       },

--- a/Package.swift
+++ b/Package.swift
@@ -124,7 +124,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(name: "swift-markdown", url: "https://github.com/apple/swift-markdown.git", .branch("release/5.7")),
         .package(name: "CLMDB", url: "https://github.com/apple/swift-lmdb.git", .branch("release/5.7")),
         .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "1.0.1")),
-        .package(name: "SymbolKit", url: "https://github.com/d-ronnqvist/swift-docc-symbolkit", .branch("check-doc-comment-module-info-5.7")),
+        .package(name: "SymbolKit", url: "https://github.com/apple/swift-docc-symbolkit", .branch("release/5.7")),
         .package(url: "https://github.com/apple/swift-crypto.git", .upToNextMinor(from: "1.1.2")),
     ]
     

--- a/Package.swift
+++ b/Package.swift
@@ -124,7 +124,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(name: "swift-markdown", url: "https://github.com/apple/swift-markdown.git", .branch("release/5.7")),
         .package(name: "CLMDB", url: "https://github.com/apple/swift-lmdb.git", .branch("release/5.7")),
         .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "1.0.1")),
-        .package(name: "SymbolKit", url: "https://github.com/apple/swift-docc-symbolkit", .branch("release/5.7")),
+        .package(name: "SymbolKit", url: "https://github.com/d-ronnqvist/swift-docc-symbolkit", .branch("check-doc-comment-module-info-5.7")),
         .package(url: "https://github.com/apple/swift-crypto.git", .upToNextMinor(from: "1.1.2")),
     ]
     

--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -1383,6 +1383,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
                                     edge: relationship,
                                     context: self,
                                     symbolIndex: &symbolIndex,
+                                    moduleName: moduleName,
                                     engine: diagnosticEngine
                                 )
                             }

--- a/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphRelationshipsBuilder.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphRelationshipsBuilder.swift
@@ -336,12 +336,14 @@ struct SymbolGraphRelationshipsBuilder {
     ///   - selector: The symbol graph selector in which the relationship is relevant.
     ///   - context: A documentation context.
     ///   - symbolIndex: A symbol lookup map by precise identifier.
+    ///   - moduleName: The symbol name of the current module.
     ///   - engine: A diagnostic collecting engine.
     static func addInheritedDefaultImplementation(
         edge: SymbolGraph.Relationship,
-        context: DocumentationContext, symbolIndex:
-        inout [String: DocumentationNode], engine:
-        DiagnosticEngine
+        context: DocumentationContext, 
+        symbolIndex: inout [String: DocumentationNode], 
+        moduleName: String, 
+        engine: DiagnosticEngine
     ) {
         func setAsInheritedSymbol(origin: SymbolGraph.Relationship.SourceOrigin, for node: inout DocumentationNode, originNode: DocumentationNode?) {
             (node.semantic as! Symbol).origin = origin
@@ -358,7 +360,7 @@ struct SymbolGraphRelationshipsBuilder {
             // Remove any inherited docs from the original symbol if the feature is disabled.
             // However, when the docs are inherited from within the same module, its content can be resolved in
             // the local context, so keeping those inherited docs provide a better user experience.
-            if !context.externalMetadata.inheritDocs && node.unifiedSymbol?.documentedSymbol?.isDocCommentFromSameModule == false {
+            if !context.externalMetadata.inheritDocs && node.unifiedSymbol?.documentedSymbol?.isDocCommentFromSameModule(symbolModuleName: moduleName) == false {
                 node.unifiedSymbol?.docComment.removeAll()
             }
         }

--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
@@ -2647,6 +2647,40 @@ Document @1:1-11:19
             let expectedRenderedAbstract: [RenderInlineContent]
         }
         let testData = [
+            // With the new module information
+            TestData(
+                docCommentJSON: """
+                {
+                  "lines": [{
+                    "text": "Authored abstract",
+                    "range": {
+                      "start": {"line": 1, "character": 4},
+                      "end": {"line": 1, "character": 21}
+                    }
+                  }],
+                  "module": "SideKit",
+                  "uri": "file://path/to/file.swift"
+                }
+                """,
+                expectedRenderedAbstract: [.text("Authored abstract")]
+            ),
+            TestData(
+                docCommentJSON: """
+                {
+                  "lines": [{
+                    "text": "Authored abstract",
+                    "range": {
+                      "start": {"line": 1, "character": 4},
+                      "end": {"line": 1, "character": 21}
+                    }
+                  }],
+                  "module": "OtherModule",
+                  "uri": "file://path/to/file.swift"
+                }
+                """,
+                expectedRenderedAbstract: [.text("Inherited from "), .codeVoice(code: "Module.Protocol.inherited()"), .text(".")]
+            ),
+            // Without the new module information
             TestData(
                 docCommentJSON: """
                 {


### PR DESCRIPTION
- **Rationale:** This is—together with the two other parts—fix an issue where documentation comments that are inherited from other modules may raise non-actionable warnings if the original documentation comment linked to other symbols in that module.
- **Risk:** Low
- **Risk Detail:** This uses the new API from https://github.com/apple/swift-docc-symbolkit/pull/43 to more reliably determine if inherited documentation comments originate from another module or from the current module.
- **Reward:** Medium
- **Reward Details:** Documentation builds successfully but documentation for protocol conformance symbols from other modules may render with broken links to symbols.
- **Original PR:** #314 
- **Issue:** rdar://92185538
- **Code Reviewed By:** @QuietMisdreavus 
- **Testing Details:** See https://github.com/apple/swift-docc/pull/314
