### PR TITLE
Fix Topics, Relationships, and See Also sections of multi-language symbols that don't have them

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -1159,9 +1159,10 @@ public struct RenderNodeTranslator: SemanticVisitor {
         }
         
         node.relationshipSectionsVariants = VariantCollection<[RelationshipsRenderSection]>(
-            from: symbol.relationshipsVariants
-        ) { trait, relationships in
-            guard !relationships.groups.isEmpty else {
+            from: documentationNode.availableVariantTraits,
+            fallbackDefaultValue: []
+        ) { trait in
+            guard let relationships = symbol.relationshipsVariants[trait], !relationships.groups.isEmpty else {
                 return []
             }
             

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -1350,22 +1350,20 @@ public struct RenderNodeTranslator: SemanticVisitor {
                 bundle: bundle,
                 renderContext: renderContext,
                 renderer: contentRenderer
-            ) {
+            ), !seeAlso.references.isEmpty {
                 contentCompiler.collectedTopicReferences.append(contentsOf: seeAlso.references)
-                seeAlsoSections.append(TaskGroupRenderSection(
-                    title: seeAlso.title,
-                    abstract: nil,
-                    discussion: nil,
-                    identifiers: seeAlso.references.map { $0.absoluteString },
-                    generated: true
-                ))
+                seeAlsoSections.append(
+                    TaskGroupRenderSection(
+                        title: seeAlso.title,
+                        abstract: nil,
+                        discussion: nil,
+                        identifiers: seeAlso.references.map { $0.absoluteString },
+                        generated: true
+                    )
+                )
             }
             
-            if seeAlsoSections.isEmpty {
-                return nil
-            } else {
-                return seeAlsoSections
-            }
+            return seeAlsoSections
         } ?? .init(defaultValue: [])
         
         node.deprecationSummaryVariants = VariantCollection<[RenderBlockContent]?>(

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -1279,11 +1279,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
                 )
             }
             
-            if sections.isEmpty {
-                return nil
-            } else {
-                return sections
-            }
+            return sections
         } ?? .init(defaultValue: [])
         
         node.defaultImplementationsSectionsVariants = VariantCollection<[TaskGroupRenderSection]>(

--- a/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorSymbolVariantsTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorSymbolVariantsTests.swift
@@ -990,6 +990,30 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
         )
     }
     
+    func testDoesNotEmitObjectiveCSeeAlsoIfEmpty() throws {
+        func makeSeeAlsoSection(destination: String) -> SeeAlsoSection {
+            SeeAlsoSection(content: [
+                UnorderedList(
+                    ListItem(Paragraph(Link(destination: destination)))
+                )
+            ])
+        }
+        
+        try assertMultiVariantSymbol(
+            configureSymbol: { symbol in
+                symbol.seeAlsoVariants[.swift] = makeSeeAlsoSection(
+                    destination: "doc://org.swift.docc.example/documentation/MyKit/MyProtocol"
+                )
+            },
+            assertOriginalRenderNode: { renderNode in
+                XCTAssertEqual(renderNode.seeAlsoSections.count, 2)
+            },
+            assertAfterApplyingVariant: { renderNode in
+                XCTAssert(renderNode.seeAlsoSections.isEmpty)
+            }
+        )
+    }
+    
     func testDeprecationSummaryVariants() throws {
         try assertMultiVariantSymbol(
             configureSymbol: { symbol in


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://92127060

## Summary

When a symbol that's available in Swift and Objective-C whose Objective-C variant doesn't have topics, relationships, or See Also sections, the Objective-C documentation page inherits the topics, relationships, and See Also information of the Swift symbol, which is incorrect. This PR resolves the issue by not emitting Topics, Relationships, and See Also sections for those cases.

The work is split into three commits:


1. Do not emit relationship sections for variants with no relationships: when an Objective-C symbol has no relationships, do not emit relationships, instead of defaulting to the Swift variant's relationships.

2. Do not emit topics section for variants that don't have topics: if the Objective-C version of a symbol doesn't have topics, do not emit a Topics section for it, instead of defaulting to the Swift symbol's topics. This logic was implemented for Topics sections in articles, but not in symbols.

3. Do not emit See Also sections for variants that have no See Also topics: when an Objective-C symbol has no See Also topics, or when it has empty See Also topic groups, dont' emit a See Also section for it, rather than defaulting to the Swift's variant's See Also topics.

## Dependencies

None.

## Testing

Build documentation for symbols that have Topics, Relationships, and See Also information for only the Swift variant. Verify that the Objective-C documentation page doesn't contain information that's specific to the Swift symbol.

## Checklist

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
