### PR TITLE
[5.7] Fix Topics, Relationships, and See Also sections of multi-language symbols that don't have them

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -1159,9 +1159,10 @@ public struct RenderNodeTranslator: SemanticVisitor {
         }
         
         node.relationshipSectionsVariants = VariantCollection<[RelationshipsRenderSection]>(
-            from: symbol.relationshipsVariants
-        ) { trait, relationships in
-            guard !relationships.groups.isEmpty else {
+            from: documentationNode.availableVariantTraits,
+            fallbackDefaultValue: []
+        ) { trait in
+            guard let relationships = symbol.relationshipsVariants[trait], !relationships.groups.isEmpty else {
                 return []
             }
             

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -1350,22 +1350,20 @@ public struct RenderNodeTranslator: SemanticVisitor {
                 bundle: bundle,
                 renderContext: renderContext,
                 renderer: contentRenderer
-            ) {
+            ), !seeAlso.references.isEmpty {
                 contentCompiler.collectedTopicReferences.append(contentsOf: seeAlso.references)
-                seeAlsoSections.append(TaskGroupRenderSection(
-                    title: seeAlso.title,
-                    abstract: nil,
-                    discussion: nil,
-                    identifiers: seeAlso.references.map { $0.absoluteString },
-                    generated: true
-                ))
+                seeAlsoSections.append(
+                    TaskGroupRenderSection(
+                        title: seeAlso.title,
+                        abstract: nil,
+                        discussion: nil,
+                        identifiers: seeAlso.references.map { $0.absoluteString },
+                        generated: true
+                    )
+                )
             }
             
-            if seeAlsoSections.isEmpty {
-                return nil
-            } else {
-                return seeAlsoSections
-            }
+            return seeAlsoSections
         } ?? .init(defaultValue: [])
         
         node.deprecationSummaryVariants = VariantCollection<[RenderBlockContent]?>(

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -1279,11 +1279,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
                 )
             }
             
-            if sections.isEmpty {
-                return nil
-            } else {
-                return sections
-            }
+            return sections
         } ?? .init(defaultValue: [])
         
         node.defaultImplementationsSectionsVariants = VariantCollection<[TaskGroupRenderSection]>(

--- a/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorSymbolVariantsTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorSymbolVariantsTests.swift
@@ -990,6 +990,30 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
         )
     }
     
+    func testDoesNotEmitObjectiveCSeeAlsoIfEmpty() throws {
+        func makeSeeAlsoSection(destination: String) -> SeeAlsoSection {
+            SeeAlsoSection(content: [
+                UnorderedList(
+                    ListItem(Paragraph(Link(destination: destination)))
+                )
+            ])
+        }
+        
+        try assertMultiVariantSymbol(
+            configureSymbol: { symbol in
+                symbol.seeAlsoVariants[.swift] = makeSeeAlsoSection(
+                    destination: "doc://org.swift.docc.example/documentation/MyKit/MyProtocol"
+                )
+            },
+            assertOriginalRenderNode: { renderNode in
+                XCTAssertEqual(renderNode.seeAlsoSections.count, 2)
+            },
+            assertAfterApplyingVariant: { renderNode in
+                XCTAssert(renderNode.seeAlsoSections.isEmpty)
+            }
+        )
+    }
+    
     func testDeprecationSummaryVariants() throws {
         try assertMultiVariantSymbol(
             configureSymbol: { symbol in


### PR DESCRIPTION
- **Explanation**: Fixes an issue where Objective-C variants of symbol pages are showing information specific to the Swift variant. See #318 for more details.
- **Scope**: DocC multi-language render JSON generation
- **Radar**: rdar://92127060
- **Risk**: Low
- **Testing**: Automated testing, manual testing
- **Reviewer**: @ethan-kusters 