### PR TITLE
[5.7] fix for replacing the term abstract with summary in diagnostic (#310)

### DIFF
--- a/Sources/SwiftDocC/Checker/Checkers/AbstractContainsFormattedTextOnly.swift
+++ b/Sources/SwiftDocC/Checker/Checkers/AbstractContainsFormattedTextOnly.swift
@@ -30,8 +30,8 @@ public struct AbstractContainsFormattedTextOnly: Checker {
         
         var diagnosticIdentifier: String {
             switch self {
-            case .image: return "org.swift.docc.AbstractContainsImage"
-            case .link: return "org.swift.docc.AbstractContainsLink"
+            case .image: return "org.swift.docc.SummaryContainsImage"
+            case .link: return "org.swift.docc.SummaryContainsLink"
             }
         }
         
@@ -45,9 +45,9 @@ public struct AbstractContainsFormattedTextOnly: Checker {
     
     private mutating func foundInvalidContent(_ invalidContent: InvalidContent, markup: Markup) {
         let explanation = """
-            Abstracts should only contain (formatted) text. To resolve this issue, place links and images elsewhere in the document, or remove them.
+            Summary should only contain (formatted) text. To resolve this issue, place links and images elsewhere in the document, or remove them.
             """
-        let diagnostic = Diagnostic(source: sourceFile, severity: .warning, range: markup.range, identifier: invalidContent.diagnosticIdentifier, summary: "\(invalidContent.description.capitalized) in document abstract will not be displayed", explanation: explanation)
+        let diagnostic = Diagnostic(source: sourceFile, severity: .warning, range: markup.range, identifier: invalidContent.diagnosticIdentifier, summary: "\(invalidContent.description.capitalized) in document summary will not be displayed", explanation: explanation)
         let problem = Problem(diagnostic: diagnostic, possibleSolutions: [])
         problems.append(problem)
     }

--- a/Sources/SwiftDocC/Checker/Checkers/MissingAbstract.swift
+++ b/Sources/SwiftDocC/Checker/Checkers/MissingAbstract.swift
@@ -56,7 +56,7 @@ public struct MissingAbstract: Checker {
                                          severity: .information,
                                          range: titleRange,
                                          identifier: "org.swift.docc.DocumentHasNoAbstract",
-                                         summary: "This document does not have an abstract.",
+                                         summary: "This document does not have a summary.",
                                          explanation: explanation)
 
         problems.append(Problem(diagnostic: diagnostic, possibleSolutions: []))

--- a/Sources/SwiftDocC/Infrastructure/Diagnostics/Diagnostic.swift
+++ b/Sources/SwiftDocC/Infrastructure/Diagnostics/Diagnostic.swift
@@ -32,7 +32,7 @@ public struct Diagnostic: DescribedError {
     ///
     /// ## Example
     ///
-    /// `org.swift.docc.AbstractContainsLink`
+    /// `org.swift.docc.SummaryContainsLink`
     public var identifier: String
 
     /// Provides the short, localized abstract provided by ``localizedExplanation`` in plain text if an

--- a/Tests/SwiftDocCTests/Checker/Checkers/AbstractContainsFormattedTextOnlyTests.swift
+++ b/Tests/SwiftDocCTests/Checker/Checkers/AbstractContainsFormattedTextOnlyTests.swift
@@ -51,7 +51,7 @@ This paragraph isn't [analyzed](http://example.com/image.jpg).
         XCTAssertTrue(problem.possibleSolutions.isEmpty)
         
         let image = document.child(at: 1)!.child(at: 0)! as! Image
-        verifyDiagnostic(diagnostic: problem.diagnostic, expectedIdentifier: "org.swift.docc.AbstractContainsImage", expectedRange: image.range!)
+        verifyDiagnostic(diagnostic: problem.diagnostic, expectedIdentifier: "org.swift.docc.SummaryContainsImage", expectedRange: image.range!)
     }
     
     func testTopLevelLink() {
@@ -71,7 +71,7 @@ More info [here](http://example.com/image.jpg).
         XCTAssertTrue(problem.possibleSolutions.isEmpty)
         
         let link = document.child(at: 1)!.child(at: 1)! as! Link
-        verifyDiagnostic(diagnostic: problem.diagnostic, expectedIdentifier: "org.swift.docc.AbstractContainsLink", expectedRange: link.range!)
+        verifyDiagnostic(diagnostic: problem.diagnostic, expectedIdentifier: "org.swift.docc.SummaryContainsLink", expectedRange: link.range!)
     }
     
     func testMultipleTopLevelInvalidElements() {
@@ -94,9 +94,9 @@ More info [here](http://example.com/image.jpg).
         let image2 = abstract.child(at: 2)! as! Link
         let image3 = abstract.child(at: 4)! as! Image
         
-        verifyDiagnostic(diagnostic: checker.problems[0].diagnostic, expectedIdentifier: "org.swift.docc.AbstractContainsImage", expectedRange: image1.range!)
-        verifyDiagnostic(diagnostic: checker.problems[1].diagnostic, expectedIdentifier: "org.swift.docc.AbstractContainsLink", expectedRange: image2.range!)
-        verifyDiagnostic(diagnostic: checker.problems[2].diagnostic, expectedIdentifier: "org.swift.docc.AbstractContainsImage", expectedRange: image3.range!)
+        verifyDiagnostic(diagnostic: checker.problems[0].diagnostic, expectedIdentifier: "org.swift.docc.SummaryContainsImage", expectedRange: image1.range!)
+        verifyDiagnostic(diagnostic: checker.problems[1].diagnostic, expectedIdentifier: "org.swift.docc.SummaryContainsLink", expectedRange: image2.range!)
+        verifyDiagnostic(diagnostic: checker.problems[2].diagnostic, expectedIdentifier: "org.swift.docc.SummaryContainsImage", expectedRange: image3.range!)
     }
     
     func testLinkWithinEmphasis() {
@@ -114,7 +114,7 @@ Hello *[world](http://example.com)*.
         }
 
         let link = document.child(at: 1)!.child(at: 1)!.child(at: 0)! as! Link
-        verifyDiagnostic(diagnostic: checker.problems[0].diagnostic, expectedIdentifier: "org.swift.docc.AbstractContainsLink", expectedRange: link.range!)
+        verifyDiagnostic(diagnostic: checker.problems[0].diagnostic, expectedIdentifier: "org.swift.docc.SummaryContainsLink", expectedRange: link.range!)
     }
     
     func testImagesWithinBold() {
@@ -131,7 +131,7 @@ Hello **![image](http://example.com/image1.jpg)** World
         }
 
         let image = document.child(at: 1)!.child(at: 1)!.child(at: 0)! as! Image
-        verifyDiagnostic(diagnostic: checker.problems[0].diagnostic, expectedIdentifier: "org.swift.docc.AbstractContainsImage", expectedRange: image.range!)
+        verifyDiagnostic(diagnostic: checker.problems[0].diagnostic, expectedIdentifier: "org.swift.docc.SummaryContainsImage", expectedRange: image.range!)
     }
     
     func testImageInALink() {
@@ -149,7 +149,7 @@ Hello **[![image](http://example.com/image1.jpg)](http://example.com)** World.
         let link = document.child(at: 1)!.child(at: 1)!.child(at: 0)! as! Link
         let image = document.child(at: 1)!.child(at: 1)!.child(at: 0)!.child(at: 0)! as! Image
         
-        verifyDiagnostic(diagnostic: checker.problems[0].diagnostic, expectedIdentifier: "org.swift.docc.AbstractContainsLink", expectedRange: link.range!)
-        verifyDiagnostic(diagnostic: checker.problems[1].diagnostic, expectedIdentifier: "org.swift.docc.AbstractContainsImage", expectedRange: image.range!)
+        verifyDiagnostic(diagnostic: checker.problems[0].diagnostic, expectedIdentifier: "org.swift.docc.SummaryContainsLink", expectedRange: link.range!)
+        verifyDiagnostic(diagnostic: checker.problems[1].diagnostic, expectedIdentifier: "org.swift.docc.SummaryContainsImage", expectedRange: image.range!)
     }
 }


### PR DESCRIPTION
Rationale: At some places usage of the term abstract was not clear in the diagnostic. The change addresses this issue by making it consistent to use 'summary' everywhere .
Risk: Low
Risk Detail: Minor, targeted change that is covered by a test.
Reward: Medium
Reward Details: 
Original PR: https://github.com/apple/swift-docc/pull/310
Issue: rdar://78015631
Code Reviewed By: @franklinsch
Testing Details: Updated unit tests to ensure diagnostic information contains the term 'summary' and not 'abstract'