### PR TITLE
Fix regression with duplicated generated implementation sections

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -1264,7 +1264,6 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
             for (_, relationships) in combinedRelationships {
                 try GeneratedDocumentationTopics.createInheritedSymbolsAPICollections(
                     relationships: relationships,
-                    parentOfFunction: { try? symbolsURLHierarchy.parent(of: $0) },
                     context: self,
                     bundle: bundle
                 )

--- a/Sources/SwiftDocC/Infrastructure/Symbol Graph/GeneratedDocumentationTopics.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Graph/GeneratedDocumentationTopics.swift
@@ -40,15 +40,36 @@ enum GeneratedDocumentationTopics {
         ///   - reference: The parent type reference.
         ///   - originDisplayName: The origin display name as provided by the symbol graph.
         ///   - extendedModuleName: Extended module name.
-        mutating func add(_ childReference: ResolvedTopicReference, to reference: ResolvedTopicReference, originDisplayName: String, originParentSymbol: ResolvedTopicReference?, extendedModuleName: String) throws {
+        mutating func add(_ childReference: ResolvedTopicReference, to reference: ResolvedTopicReference, originDisplayName: String, originSymbol: SymbolGraph.Symbol?, sourceSymbol: SymbolGraph.Symbol?, extendedModuleName: String) throws {
             let fromType: String
             let typeSimpleName: String
-            if let originParentSymbol = originParentSymbol, !originParentSymbol.pathComponents.isEmpty {
-                // If we have a resolved symbol for the parent of `sourceOrigin`, use that for the names
-                fromType = originParentSymbol.pathComponents.joined(separator: ".")
-                typeSimpleName = originParentSymbol.pathComponents.last!
+            if let originSymbol = originSymbol, originSymbol.pathComponents.count > 1 {
+                // If we have a resolved symbol for the source origin, use its path components to
+                // find the name of the parent by dropping the last path component.
+                let parentSymbolPathComponents = originSymbol.pathComponents.dropLast()
+                fromType = parentSymbolPathComponents.joined(separator: ".")
+                typeSimpleName = parentSymbolPathComponents.last!
+            } else if let sourceSymbol = sourceSymbol,
+                let sourceSymbolName = sourceSymbol.pathComponents.last,
+                originDisplayName.count > (sourceSymbolName.count + 1)
+            {
+                // In the case where we don't have a resolved symbol for the source origin,
+                // this allows us to still accurately handle cases like this:
+                //
+                //     "displayName": "SuperFancyProtocol..<..(_:_:)"
+                //
+                // Where there's no way for us to determine which of the periods is the one
+                // splitting the name of the parent type and the symbol name. Using the count
+                // of the symbol name (+1 for the period splitting the names)
+                // from the source is a reliable way to support this.
+                
+                let parentSymbolName = originDisplayName.dropLast(sourceSymbolName.count + 1)
+                fromType = String(parentSymbolName)
+                typeSimpleName = String(parentSymbolName.split(separator: ".").last ?? parentSymbolName)
             } else {
-                // If we don't have a resolved `sourceOrigin` parent, fall back to parsing its display name
+                // If we don't have a resolved source origin symbol or source symbol, fall back to
+                // parsing its display name. This should never happen since we expect to
+                // always have a source symbol.
 
                 // Detect the path components of the providing the default implementation.
                 let typeComponents = originDisplayName.split(separator: ".")
@@ -209,7 +230,7 @@ enum GeneratedDocumentationTopics {
     ///   - symbolsURLHierarchy: A symbol graph hierarchy as created during symbol registration.
     ///   - context: A documentation context to update.
     ///   - bundle: The current documentation bundle.
-    static func createInheritedSymbolsAPICollections(relationships: Set<SymbolGraph.Relationship>, parentOfFunction: (ResolvedTopicReference) -> ResolvedTopicReference?, context: DocumentationContext, bundle: DocumentationBundle) throws {
+    static func createInheritedSymbolsAPICollections(relationships: Set<SymbolGraph.Relationship>, context: DocumentationContext, bundle: DocumentationBundle) throws {
         var inheritanceIndex = InheritedSymbols()
         
         // Walk the symbol graph relationships and look for parent <-> child links that stem in a different module.
@@ -225,12 +246,11 @@ enum GeneratedDocumentationTopics {
                let child = context.symbolIndex[relationship.source],
                // Get the swift extension data
                let extends = child.symbol?.mixins[SymbolGraph.Symbol.Swift.Extension.mixinKey] as? SymbolGraph.Symbol.Swift.Extension {
-                var originParentSymbol: ResolvedTopicReference? = nil
-                if let originSymbol = context.symbolIndex[origin.identifier] {
-                    originParentSymbol = parentOfFunction(originSymbol.reference)
-                }
+                let originSymbol = context.symbolIndex[origin.identifier]?.symbol
+                let sourceSymbol = context.symbolIndex[relationship.source]?.symbol
+                
                 // Add the inherited symbol to the index.
-                try inheritanceIndex.add(child.reference, to: parent.reference, originDisplayName: origin.displayName, originParentSymbol: originParentSymbol, extendedModuleName: extends.extendedModule)
+                try inheritanceIndex.add(child.reference, to: parent.reference, originDisplayName: origin.displayName, originSymbol: originSymbol, sourceSymbol: sourceSymbol, extendedModuleName: extends.extendedModule)
             }
         }
         

--- a/Tests/SwiftDocCTests/Test Resources/InheritedDefaultImplementations.symbols.json
+++ b/Tests/SwiftDocCTests/Test Resources/InheritedDefaultImplementations.symbols.json
@@ -1,0 +1,7263 @@
+{
+    "metadata": {
+        "formatVersion": {
+            "major": 0,
+            "minor": 5,
+            "patch": 3
+        },
+        "generator": "Apple Swift version 5.7"
+    },
+    "module": {
+        "name": "FirstTarget",
+        "platform": {
+            "architecture": "x86_64",
+            "vendor": "apple",
+            "operatingSystem": {
+                "name": "macosx",
+                "minimumVersion": {
+                    "major": 11,
+                    "minor": 0,
+                    "patch": 0
+                }
+            }
+        }
+    },
+    "symbols": [
+        {
+            "kind": {
+                "identifier": "swift.func.op",
+                "displayName": "Operator"
+            },
+            "identifier": {
+                "precise": "s:SLsE3zzlopys16PartialRangeUpToVyxGxFZ::SYNTHESIZED::s:11FirstTarget10SomeStructV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "SomeStruct",
+                "..<(_:)"
+            ],
+            "names": {
+                "title": "..<(_:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "..<"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ") -> "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "PartialRangeUpTo",
+                        "preciseIdentifier": "s:s16PartialRangeUpToV"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "<"
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ">"
+                    }
+                ]
+            },
+            "docComment": {
+                "module": "Swift",
+                "lines": [
+                    {
+                        "text": "Returns a partial range up to, but not including, its upper bound."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "Use the prefix half-open range operator (prefix `..<`) to create a"
+                    },
+                    {
+                        "text": "partial range of any type that conforms to the `Comparable` protocol."
+                    },
+                    {
+                        "text": "This example creates a `PartialRangeUpTo<Double>` instance that includes"
+                    },
+                    {
+                        "text": "any value less than `5.0`."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "    let upToFive = ..<5.0"
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "    upToFive.contains(3.14)       // true"
+                    },
+                    {
+                        "text": "    upToFive.contains(6.28)       // false"
+                    },
+                    {
+                        "text": "    upToFive.contains(5.0)        // false"
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "You can use this type of partial range of a collection's indices to"
+                    },
+                    {
+                        "text": "represent the range from the start of the collection up to, but not"
+                    },
+                    {
+                        "text": "including, the partial range's upper bound."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "    let numbers = [10, 20, 30, 40, 50, 60, 70]"
+                    },
+                    {
+                        "text": "    print(numbers[..<3])"
+                    },
+                    {
+                        "text": "    // Prints \"[10, 20, 30]\""
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "- Parameter maximum: The upper bound for the range."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "- Precondition: `maximum` must compare equal to itself (i.e. cannot be NaN)."
+                    }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "maximum",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "maximum"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "PartialRangeUpTo",
+                        "preciseIdentifier": "s:s16PartialRangeUpToV"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "<"
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ">"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "Swift"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "..<"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "maximum"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ") -> "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "PartialRangeUpTo",
+                    "preciseIdentifier": "s:s16PartialRangeUpToV"
+                },
+                {
+                    "kind": "text",
+                    "spelling": "<"
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ">"
+                }
+            ],
+            "accessLevel": "public"
+        },
+        {
+            "kind": {
+                "identifier": "swift.func.op",
+                "displayName": "Operator"
+            },
+            "identifier": {
+                "precise": "s:SLsE2leoiySbx_xtFZ::SYNTHESIZED::s:11FirstTarget11OtherStructV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "OtherStruct",
+                "<=(_:_:)"
+            ],
+            "names": {
+                "title": "<=(_:_:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "<="
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ", "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ") -> "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Bool",
+                        "preciseIdentifier": "s:Sb"
+                    }
+                ]
+            },
+            "docComment": {
+                "module": "Swift",
+                "lines": [
+                    {
+                        "text": "Returns a Boolean value indicating whether the value of the first argument"
+                    },
+                    {
+                        "text": "is less than or equal to that of the second argument."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "This is the default implementation of the less-than-or-equal-to"
+                    },
+                    {
+                        "text": "operator (`<=`) for any type that conforms to `Comparable`."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "- Parameters:"
+                    },
+                    {
+                        "text": "  - lhs: A value to compare."
+                    },
+                    {
+                        "text": "  - rhs: Another value to compare."
+                    }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "lhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "lhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "rhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "rhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Bool",
+                        "preciseIdentifier": "s:Sb"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "Swift"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "<="
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "lhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ", "
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "rhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ") -> "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Bool",
+                    "preciseIdentifier": "s:Sb"
+                }
+            ],
+            "accessLevel": "public"
+        },
+        {
+            "kind": {
+                "identifier": "swift.method",
+                "displayName": "Instance Method"
+            },
+            "identifier": {
+                "precise": "s:11FirstTarget3FooPAAE23fooMemberWithDocCommentyyF",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "Foo",
+                "fooMemberWithDocComment()"
+            ],
+            "names": {
+                "title": "fooMemberWithDocComment()",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "fooMemberWithDocComment"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "docComment": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "module": "FirstTarget",
+                "lines": [
+                    {
+                        "range": {
+                            "start": {
+                                "line": 1,
+                                "character": 8
+                            },
+                            "end": {
+                                "line": 1,
+                                "character": 29
+                            }
+                        },
+                        "text": "This is my great doc."
+                    }
+                ]
+            },
+            "functionSignature": {
+                "returns": [
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "FirstTarget"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "fooMemberWithDocComment"
+                },
+                {
+                    "kind": "text",
+                    "spelling": "()"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "position": {
+                    "line": 7,
+                    "character": 9
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.func.op",
+                "displayName": "Operator"
+            },
+            "identifier": {
+                "precise": "s:SLsE2leoiySbx_xtFZ::SYNTHESIZED::s:11FirstTarget10SomeStructV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "SomeStruct",
+                "<=(_:_:)"
+            ],
+            "names": {
+                "title": "<=(_:_:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "<="
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ", "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ") -> "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Bool",
+                        "preciseIdentifier": "s:Sb"
+                    }
+                ]
+            },
+            "docComment": {
+                "module": "Swift",
+                "lines": [
+                    {
+                        "text": "Returns a Boolean value indicating whether the value of the first argument"
+                    },
+                    {
+                        "text": "is less than or equal to that of the second argument."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "This is the default implementation of the less-than-or-equal-to"
+                    },
+                    {
+                        "text": "operator (`<=`) for any type that conforms to `Comparable`."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "- Parameters:"
+                    },
+                    {
+                        "text": "  - lhs: A value to compare."
+                    },
+                    {
+                        "text": "  - rhs: Another value to compare."
+                    }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "lhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "lhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "rhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "rhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Bool",
+                        "preciseIdentifier": "s:Sb"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "Swift"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "<="
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "lhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ", "
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "rhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ") -> "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Bool",
+                    "preciseIdentifier": "s:Sb"
+                }
+            ],
+            "accessLevel": "public"
+        },
+        {
+            "kind": {
+                "identifier": "swift.struct",
+                "displayName": "Structure"
+            },
+            "identifier": {
+                "precise": "s:11FirstTarget3BarV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "Bar"
+            ],
+            "names": {
+                "title": "Bar",
+                "navigator": [
+                    {
+                        "kind": "identifier",
+                        "spelling": "Bar"
+                    }
+                ],
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "struct"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "Bar"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "struct"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "Bar"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "position": {
+                    "line": 11,
+                    "character": 14
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.func.op",
+                "displayName": "Operator"
+            },
+            "identifier": {
+                "precise": "s:SLsE3zzzopys19PartialRangeThroughVyxGxFZ::SYNTHESIZED::s:11FirstTarget11OtherStructV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "OtherStruct",
+                "...(_:)"
+            ],
+            "names": {
+                "title": "...(_:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "..."
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ") -> "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "PartialRangeThrough",
+                        "preciseIdentifier": "s:s19PartialRangeThroughV"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "<"
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ">"
+                    }
+                ]
+            },
+            "docComment": {
+                "module": "Swift",
+                "lines": [
+                    {
+                        "text": "Returns a partial range up to, and including, its upper bound."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "Use the prefix closed range operator (prefix `...`) to create a partial"
+                    },
+                    {
+                        "text": "range of any type that conforms to the `Comparable` protocol. This"
+                    },
+                    {
+                        "text": "example creates a `PartialRangeThrough<Double>` instance that includes"
+                    },
+                    {
+                        "text": "any value less than or equal to `5.0`."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "    let throughFive = ...5.0"
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "    throughFive.contains(4.0)     // true"
+                    },
+                    {
+                        "text": "    throughFive.contains(5.0)     // true"
+                    },
+                    {
+                        "text": "    throughFive.contains(6.0)     // false"
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "You can use this type of partial range of a collection's indices to"
+                    },
+                    {
+                        "text": "represent the range from the start of the collection up to, and"
+                    },
+                    {
+                        "text": "including, the partial range's upper bound."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "    let numbers = [10, 20, 30, 40, 50, 60, 70]"
+                    },
+                    {
+                        "text": "    print(numbers[...3])"
+                    },
+                    {
+                        "text": "    // Prints \"[10, 20, 30, 40]\""
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "- Parameter maximum: The upper bound for the range."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "- Precondition: `maximum` must compare equal to itself (i.e. cannot be NaN)."
+                    }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "maximum",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "maximum"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "PartialRangeThrough",
+                        "preciseIdentifier": "s:s19PartialRangeThroughV"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "<"
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ">"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "Swift"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "..."
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "maximum"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ") -> "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "PartialRangeThrough",
+                    "preciseIdentifier": "s:s19PartialRangeThroughV"
+                },
+                {
+                    "kind": "text",
+                    "spelling": "<"
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ">"
+                }
+            ],
+            "accessLevel": "public"
+        },
+        {
+            "kind": {
+                "identifier": "swift.func.op",
+                "displayName": "Operator"
+            },
+            "identifier": {
+                "precise": "s:SLsE1goiySbx_xtFZ::SYNTHESIZED::s:11FirstTarget10SomeStructV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "SomeStruct",
+                ">(_:_:)"
+            ],
+            "names": {
+                "title": ">(_:_:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": ">"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ", "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ") -> "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Bool",
+                        "preciseIdentifier": "s:Sb"
+                    }
+                ]
+            },
+            "docComment": {
+                "module": "Swift",
+                "lines": [
+                    {
+                        "text": "Returns a Boolean value indicating whether the value of the first argument"
+                    },
+                    {
+                        "text": "is greater than that of the second argument."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "This is the default implementation of the greater-than operator (`>`) for"
+                    },
+                    {
+                        "text": "any type that conforms to `Comparable`."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "- Parameters:"
+                    },
+                    {
+                        "text": "  - lhs: A value to compare."
+                    },
+                    {
+                        "text": "  - rhs: Another value to compare."
+                    }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "lhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "lhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "rhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "rhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Bool",
+                        "preciseIdentifier": "s:Sb"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "Swift"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": ">"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "lhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ", "
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "rhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ") -> "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Bool",
+                    "preciseIdentifier": "s:Sb"
+                }
+            ],
+            "accessLevel": "public"
+        },
+        {
+            "kind": {
+                "identifier": "swift.func.op",
+                "displayName": "Operator"
+            },
+            "identifier": {
+                "precise": "s:SLsE3zzzoiySNyxGx_xtFZ::SYNTHESIZED::s:11FirstTarget10SomeStructV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "SomeStruct",
+                "...(_:_:)"
+            ],
+            "names": {
+                "title": "...(_:_:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "..."
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ", "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ") -> "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "ClosedRange",
+                        "preciseIdentifier": "s:SN"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "<"
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ">"
+                    }
+                ]
+            },
+            "docComment": {
+                "module": "Swift",
+                "lines": [
+                    {
+                        "text": "Returns a closed range that contains both of its bounds."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "Use the closed range operator (`...`) to create a closed range of any type"
+                    },
+                    {
+                        "text": "that conforms to the `Comparable` protocol. This example creates a"
+                    },
+                    {
+                        "text": "`ClosedRange<Character>` from \"a\" up to, and including, \"z\"."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "    let lowercase = \"a\"...\"z\""
+                    },
+                    {
+                        "text": "    print(lowercase.contains(\"z\"))"
+                    },
+                    {
+                        "text": "    // Prints \"true\""
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "- Parameters:"
+                    },
+                    {
+                        "text": "  - minimum: The lower bound for the range."
+                    },
+                    {
+                        "text": "  - maximum: The upper bound for the range."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "- Precondition: `minimum <= maximum`."
+                    }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "minimum",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "minimum"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "maximum",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "maximum"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "ClosedRange",
+                        "preciseIdentifier": "s:SN"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "<"
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ">"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "Swift"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "..."
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "minimum"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ", "
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "maximum"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ") -> "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "ClosedRange",
+                    "preciseIdentifier": "s:SN"
+                },
+                {
+                    "kind": "text",
+                    "spelling": "<"
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ">"
+                }
+            ],
+            "accessLevel": "public"
+        },
+        {
+            "kind": {
+                "identifier": "swift.method",
+                "displayName": "Instance Method"
+            },
+            "identifier": {
+                "precise": "s:SL11FirstTargetE26localDefaultImplementationyyF::SYNTHESIZED::s:11FirstTarget11OtherStructV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "OtherStruct",
+                "localDefaultImplementation()"
+            ],
+            "names": {
+                "title": "localDefaultImplementation()",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "localDefaultImplementation"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "functionSignature": {
+                "returns": [
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "Swift"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "localDefaultImplementation"
+                },
+                {
+                    "kind": "text",
+                    "spelling": "()"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "position": {
+                    "line": 46,
+                    "character": 16
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.method",
+                "displayName": "Instance Method"
+            },
+            "identifier": {
+                "precise": "s:11FirstTarget3FooP26fooMemberWithoutDocCommentyyF",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "Foo",
+                "fooMemberWithoutDocComment()"
+            ],
+            "names": {
+                "title": "fooMemberWithoutDocComment()",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "fooMemberWithoutDocComment"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "functionSignature": {
+                "returns": [
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "fooMemberWithoutDocComment"
+                },
+                {
+                    "kind": "text",
+                    "spelling": "()"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "position": {
+                    "line": 3,
+                    "character": 9
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.func.op",
+                "displayName": "Operator"
+            },
+            "identifier": {
+                "precise": "s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:11FirstTarget11OtherStructV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "OtherStruct",
+                "!=(_:_:)"
+            ],
+            "names": {
+                "title": "!=(_:_:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "!="
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ", "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ") -> "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Bool",
+                        "preciseIdentifier": "s:Sb"
+                    }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "lhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "lhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "rhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "rhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Bool",
+                        "preciseIdentifier": "s:Sb"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "Swift"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "!="
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "lhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ", "
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "rhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ") -> "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Bool",
+                    "preciseIdentifier": "s:Sb"
+                }
+            ],
+            "accessLevel": "public"
+        },
+        {
+            "kind": {
+                "identifier": "swift.func.op",
+                "displayName": "Operator"
+            },
+            "identifier": {
+                "precise": "s:SLsE3zzloiySnyxGx_xtFZ::SYNTHESIZED::s:11FirstTarget11OtherStructV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "OtherStruct",
+                "..<(_:_:)"
+            ],
+            "names": {
+                "title": "..<(_:_:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "..<"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ", "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ") -> "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Range",
+                        "preciseIdentifier": "s:Sn"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "<"
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ">"
+                    }
+                ]
+            },
+            "docComment": {
+                "module": "Swift",
+                "lines": [
+                    {
+                        "text": "Returns a half-open range that contains its lower bound but not its upper"
+                    },
+                    {
+                        "text": "bound."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "Use the half-open range operator (`..<`) to create a range of any type"
+                    },
+                    {
+                        "text": "that conforms to the `Comparable` protocol. This example creates a"
+                    },
+                    {
+                        "text": "`Range<Double>` from zero up to, but not including, 5.0."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "    let lessThanFive = 0.0..<5.0"
+                    },
+                    {
+                        "text": "    print(lessThanFive.contains(3.14))  // Prints \"true\""
+                    },
+                    {
+                        "text": "    print(lessThanFive.contains(5.0))   // Prints \"false\""
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "- Parameters:"
+                    },
+                    {
+                        "text": "  - minimum: The lower bound for the range."
+                    },
+                    {
+                        "text": "  - maximum: The upper bound for the range."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "- Precondition: `minimum <= maximum`."
+                    }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "minimum",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "minimum"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "maximum",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "maximum"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Range",
+                        "preciseIdentifier": "s:Sn"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "<"
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ">"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "Swift"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "..<"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "minimum"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ", "
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "maximum"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ") -> "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Range",
+                    "preciseIdentifier": "s:Sn"
+                },
+                {
+                    "kind": "text",
+                    "spelling": "<"
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ">"
+                }
+            ],
+            "accessLevel": "public"
+        },
+        {
+            "kind": {
+                "identifier": "swift.func.op",
+                "displayName": "Operator"
+            },
+            "identifier": {
+                "precise": "s:SLsE2geoiySbx_xtFZ::SYNTHESIZED::s:11FirstTarget11OtherStructV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "OtherStruct",
+                ">=(_:_:)"
+            ],
+            "names": {
+                "title": ">=(_:_:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": ">="
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ", "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ") -> "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Bool",
+                        "preciseIdentifier": "s:Sb"
+                    }
+                ]
+            },
+            "docComment": {
+                "module": "Swift",
+                "lines": [
+                    {
+                        "text": "Returns a Boolean value indicating whether the value of the first argument"
+                    },
+                    {
+                        "text": "is greater than or equal to that of the second argument."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "This is the default implementation of the greater-than-or-equal-to operator"
+                    },
+                    {
+                        "text": "(`>=`) for any type that conforms to `Comparable`."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "- Parameters:"
+                    },
+                    {
+                        "text": "  - lhs: A value to compare."
+                    },
+                    {
+                        "text": "  - rhs: Another value to compare."
+                    },
+                    {
+                        "text": "- Returns: `true` if `lhs` is greater than or equal to `rhs`; otherwise,"
+                    },
+                    {
+                        "text": "  `false`."
+                    }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "lhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "lhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "rhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "rhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Bool",
+                        "preciseIdentifier": "s:Sb"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "Swift"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": ">="
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "lhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ", "
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "rhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ") -> "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Bool",
+                    "preciseIdentifier": "s:Sb"
+                }
+            ],
+            "accessLevel": "public"
+        },
+        {
+            "kind": {
+                "identifier": "swift.func.op",
+                "displayName": "Operator"
+            },
+            "identifier": {
+                "precise": "s:SLsE3zzzoPys16PartialRangeFromVyxGxFZ::SYNTHESIZED::s:11FirstTarget11OtherStructV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "OtherStruct",
+                "...(_:)"
+            ],
+            "names": {
+                "title": "...(_:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "..."
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ") -> "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "PartialRangeFrom",
+                        "preciseIdentifier": "s:s16PartialRangeFromV"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "<"
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ">"
+                    }
+                ]
+            },
+            "docComment": {
+                "module": "Swift",
+                "lines": [
+                    {
+                        "text": "Returns a partial range extending upward from a lower bound."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "Use the postfix range operator (postfix `...`) to create a partial range"
+                    },
+                    {
+                        "text": "of any type that conforms to the `Comparable` protocol. This example"
+                    },
+                    {
+                        "text": "creates a `PartialRangeFrom<Double>` instance that includes any value"
+                    },
+                    {
+                        "text": "greater than or equal to `5.0`."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "    let atLeastFive = 5.0..."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "    atLeastFive.contains(4.0)     // false"
+                    },
+                    {
+                        "text": "    atLeastFive.contains(5.0)     // true"
+                    },
+                    {
+                        "text": "    atLeastFive.contains(6.0)     // true"
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "You can use this type of partial range of a collection's indices to"
+                    },
+                    {
+                        "text": "represent the range from the partial range's lower bound up to the end"
+                    },
+                    {
+                        "text": "of the collection."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "    let numbers = [10, 20, 30, 40, 50, 60, 70]"
+                    },
+                    {
+                        "text": "    print(numbers[3...])"
+                    },
+                    {
+                        "text": "    // Prints \"[40, 50, 60, 70]\""
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "- Parameter minimum: The lower bound for the range."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "- Precondition: `minimum` must compare equal to itself (i.e. cannot be NaN)."
+                    }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "minimum",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "minimum"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "PartialRangeFrom",
+                        "preciseIdentifier": "s:s16PartialRangeFromV"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "<"
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ">"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "Swift"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "..."
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "minimum"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ") -> "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "PartialRangeFrom",
+                    "preciseIdentifier": "s:s16PartialRangeFromV"
+                },
+                {
+                    "kind": "text",
+                    "spelling": "<"
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ">"
+                }
+            ],
+            "accessLevel": "public"
+        },
+        {
+            "kind": {
+                "identifier": "swift.func.op",
+                "displayName": "Operator"
+            },
+            "identifier": {
+                "precise": "s:11FirstTarget13FancyProtocolPAAE4zzzzoiyyAaB_p_AaB_ptFZ::SYNTHESIZED::s:11FirstTarget10SomeStructV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "SomeStruct",
+                "....(_:_:)"
+            ],
+            "names": {
+                "title": "....(_:_:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "...."
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "FancyProtocol",
+                        "preciseIdentifier": "s:11FirstTarget13FancyProtocolP"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ", "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "FancyProtocol",
+                        "preciseIdentifier": "s:11FirstTarget13FancyProtocolP"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ")"
+                    }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "lhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "lhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "FancyProtocol",
+                                "preciseIdentifier": "s:11FirstTarget13FancyProtocolP"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "rhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "rhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "FancyProtocol",
+                                "preciseIdentifier": "s:11FirstTarget13FancyProtocolP"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "FirstTarget"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "...."
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "lhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "FancyProtocol",
+                    "preciseIdentifier": "s:11FirstTarget13FancyProtocolP"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ", "
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "rhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "FancyProtocol",
+                    "preciseIdentifier": "s:11FirstTarget13FancyProtocolP"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ")"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "position": {
+                    "line": 27,
+                    "character": 16
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.method",
+                "displayName": "Instance Method"
+            },
+            "identifier": {
+                "precise": "s:11FirstTarget3FooPAAE26fooMemberWithoutDocCommentyyF::SYNTHESIZED::s:11FirstTarget3BarV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "Bar",
+                "fooMemberWithoutDocComment()"
+            ],
+            "names": {
+                "title": "fooMemberWithoutDocComment()",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "fooMemberWithoutDocComment"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "functionSignature": {
+                "returns": [
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "FirstTarget"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "fooMemberWithoutDocComment"
+                },
+                {
+                    "kind": "text",
+                    "spelling": "()"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "position": {
+                    "line": 8,
+                    "character": 9
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.func.op",
+                "displayName": "Operator"
+            },
+            "identifier": {
+                "precise": "s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:11FirstTarget10SomeStructV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "SomeStruct",
+                "!=(_:_:)"
+            ],
+            "names": {
+                "title": "!=(_:_:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "!="
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ", "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ") -> "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Bool",
+                        "preciseIdentifier": "s:Sb"
+                    }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "lhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "lhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "rhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "rhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Bool",
+                        "preciseIdentifier": "s:Sb"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "Swift"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "!="
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "lhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ", "
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "rhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ") -> "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Bool",
+                    "preciseIdentifier": "s:Sb"
+                }
+            ],
+            "accessLevel": "public"
+        },
+        {
+            "kind": {
+                "identifier": "swift.func.op",
+                "displayName": "Operator"
+            },
+            "identifier": {
+                "precise": "s:SLsE3zzloiySnyxGx_xtFZ::SYNTHESIZED::s:11FirstTarget10SomeStructV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "SomeStruct",
+                "..<(_:_:)"
+            ],
+            "names": {
+                "title": "..<(_:_:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "..<"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ", "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ") -> "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Range",
+                        "preciseIdentifier": "s:Sn"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "<"
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ">"
+                    }
+                ]
+            },
+            "docComment": {
+                "module": "Swift",
+                "lines": [
+                    {
+                        "text": "Returns a half-open range that contains its lower bound but not its upper"
+                    },
+                    {
+                        "text": "bound."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "Use the half-open range operator (`..<`) to create a range of any type"
+                    },
+                    {
+                        "text": "that conforms to the `Comparable` protocol. This example creates a"
+                    },
+                    {
+                        "text": "`Range<Double>` from zero up to, but not including, 5.0."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "    let lessThanFive = 0.0..<5.0"
+                    },
+                    {
+                        "text": "    print(lessThanFive.contains(3.14))  // Prints \"true\""
+                    },
+                    {
+                        "text": "    print(lessThanFive.contains(5.0))   // Prints \"false\""
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "- Parameters:"
+                    },
+                    {
+                        "text": "  - minimum: The lower bound for the range."
+                    },
+                    {
+                        "text": "  - maximum: The upper bound for the range."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "- Precondition: `minimum <= maximum`."
+                    }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "minimum",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "minimum"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "maximum",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "maximum"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Range",
+                        "preciseIdentifier": "s:Sn"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "<"
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ">"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "Swift"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "..<"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "minimum"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ", "
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "maximum"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ") -> "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Range",
+                    "preciseIdentifier": "s:Sn"
+                },
+                {
+                    "kind": "text",
+                    "spelling": "<"
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ">"
+                }
+            ],
+            "accessLevel": "public"
+        },
+        {
+            "kind": {
+                "identifier": "swift.func.op",
+                "displayName": "Operator"
+            },
+            "identifier": {
+                "precise": "s:11FirstTarget13FancyProtocolPAAE4zzzzoiyyAaB_p_AaB_ptFZ",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "FancyProtocol",
+                "....(_:_:)"
+            ],
+            "names": {
+                "title": "....(_:_:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "...."
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "FancyProtocol",
+                        "preciseIdentifier": "s:11FirstTarget13FancyProtocolP"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ", "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "FancyProtocol",
+                        "preciseIdentifier": "s:11FirstTarget13FancyProtocolP"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ")"
+                    }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "lhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "lhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "FancyProtocol",
+                                "preciseIdentifier": "s:11FirstTarget13FancyProtocolP"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "rhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "rhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "FancyProtocol",
+                                "preciseIdentifier": "s:11FirstTarget13FancyProtocolP"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "FirstTarget"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "...."
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "lhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "FancyProtocol",
+                    "preciseIdentifier": "s:11FirstTarget13FancyProtocolP"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ", "
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "rhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "FancyProtocol",
+                    "preciseIdentifier": "s:11FirstTarget13FancyProtocolP"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ")"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "position": {
+                    "line": 27,
+                    "character": 16
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.protocol",
+                "displayName": "Protocol"
+            },
+            "identifier": {
+                "precise": "s:11FirstTarget3FooP",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "Foo"
+            ],
+            "names": {
+                "title": "Foo",
+                "navigator": [
+                    {
+                        "kind": "identifier",
+                        "spelling": "Foo"
+                    }
+                ],
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "protocol"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "Foo"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "protocol"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "Foo"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "position": {
+                    "line": 0,
+                    "character": 16
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.struct",
+                "displayName": "Structure"
+            },
+            "identifier": {
+                "precise": "s:11FirstTarget10SomeStructV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "SomeStruct"
+            ],
+            "names": {
+                "title": "SomeStruct",
+                "navigator": [
+                    {
+                        "kind": "identifier",
+                        "spelling": "SomeStruct"
+                    }
+                ],
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "struct"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "SomeStruct"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "struct"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "SomeStruct"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "position": {
+                    "line": 13,
+                    "character": 14
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.func.op",
+                "displayName": "Operator"
+            },
+            "identifier": {
+                "precise": "s:SLsE3zzzoPys16PartialRangeFromVyxGxFZ::SYNTHESIZED::s:11FirstTarget10SomeStructV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "SomeStruct",
+                "...(_:)"
+            ],
+            "names": {
+                "title": "...(_:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "..."
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ") -> "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "PartialRangeFrom",
+                        "preciseIdentifier": "s:s16PartialRangeFromV"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "<"
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ">"
+                    }
+                ]
+            },
+            "docComment": {
+                "module": "Swift",
+                "lines": [
+                    {
+                        "text": "Returns a partial range extending upward from a lower bound."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "Use the postfix range operator (postfix `...`) to create a partial range"
+                    },
+                    {
+                        "text": "of any type that conforms to the `Comparable` protocol. This example"
+                    },
+                    {
+                        "text": "creates a `PartialRangeFrom<Double>` instance that includes any value"
+                    },
+                    {
+                        "text": "greater than or equal to `5.0`."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "    let atLeastFive = 5.0..."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "    atLeastFive.contains(4.0)     // false"
+                    },
+                    {
+                        "text": "    atLeastFive.contains(5.0)     // true"
+                    },
+                    {
+                        "text": "    atLeastFive.contains(6.0)     // true"
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "You can use this type of partial range of a collection's indices to"
+                    },
+                    {
+                        "text": "represent the range from the partial range's lower bound up to the end"
+                    },
+                    {
+                        "text": "of the collection."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "    let numbers = [10, 20, 30, 40, 50, 60, 70]"
+                    },
+                    {
+                        "text": "    print(numbers[3...])"
+                    },
+                    {
+                        "text": "    // Prints \"[40, 50, 60, 70]\""
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "- Parameter minimum: The lower bound for the range."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "- Precondition: `minimum` must compare equal to itself (i.e. cannot be NaN)."
+                    }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "minimum",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "minimum"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "PartialRangeFrom",
+                        "preciseIdentifier": "s:s16PartialRangeFromV"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "<"
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ">"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "Swift"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "..."
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "minimum"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ") -> "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "PartialRangeFrom",
+                    "preciseIdentifier": "s:s16PartialRangeFromV"
+                },
+                {
+                    "kind": "text",
+                    "spelling": "<"
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ">"
+                }
+            ],
+            "accessLevel": "public"
+        },
+        {
+            "kind": {
+                "identifier": "swift.func.op",
+                "displayName": "Operator"
+            },
+            "identifier": {
+                "precise": "s:11FirstTarget13FancyProtocolP4zzzzoiyyAaB_p_AaB_ptFZ",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "FancyProtocol",
+                "....(_:_:)"
+            ],
+            "names": {
+                "title": "....(_:_:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "...."
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "FancyProtocol",
+                        "preciseIdentifier": "s:11FirstTarget13FancyProtocolP"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ", "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "FancyProtocol",
+                        "preciseIdentifier": "s:11FirstTarget13FancyProtocolP"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ")"
+                    }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "lhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "lhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "FancyProtocol",
+                                "preciseIdentifier": "s:11FirstTarget13FancyProtocolP"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "rhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "rhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "FancyProtocol",
+                                "preciseIdentifier": "s:11FirstTarget13FancyProtocolP"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "...."
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "lhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "FancyProtocol",
+                    "preciseIdentifier": "s:11FirstTarget13FancyProtocolP"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ", "
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "rhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "FancyProtocol",
+                    "preciseIdentifier": "s:11FirstTarget13FancyProtocolP"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ")"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "position": {
+                    "line": 23,
+                    "character": 16
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.func.op",
+                "displayName": "Operator"
+            },
+            "identifier": {
+                "precise": "s:11FirstTarget11OtherStructV1loiySbAC_ACtFZ",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "OtherStruct",
+                "<(_:_:)"
+            ],
+            "names": {
+                "title": "<(_:_:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "<"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "OtherStruct",
+                        "preciseIdentifier": "s:11FirstTarget11OtherStructV"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ", "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "OtherStruct",
+                        "preciseIdentifier": "s:11FirstTarget11OtherStructV"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ") -> "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Bool",
+                        "preciseIdentifier": "s:Sb"
+                    }
+                ]
+            },
+            "docComment": {
+                "module": "Swift",
+                "lines": [
+                    {
+                        "text": "Returns a Boolean value indicating whether the value of the first"
+                    },
+                    {
+                        "text": "argument is less than that of the second argument."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "This function is the only requirement of the `Comparable` protocol. The"
+                    },
+                    {
+                        "text": "remainder of the relational operator functions are implemented by the"
+                    },
+                    {
+                        "text": "standard library for any type that conforms to `Comparable`."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "- Parameters:"
+                    },
+                    {
+                        "text": "  - lhs: A value to compare."
+                    },
+                    {
+                        "text": "  - rhs: Another value to compare."
+                    }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "lhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "lhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "OtherStruct",
+                                "preciseIdentifier": "s:11FirstTarget11OtherStructV"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "rhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "rhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "OtherStruct",
+                                "preciseIdentifier": "s:11FirstTarget11OtherStructV"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Bool",
+                        "preciseIdentifier": "s:Sb"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "<"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "lhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "OtherStruct",
+                    "preciseIdentifier": "s:11FirstTarget11OtherStructV"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ", "
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "rhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "OtherStruct",
+                    "preciseIdentifier": "s:11FirstTarget11OtherStructV"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ") -> "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Bool",
+                    "preciseIdentifier": "s:Sb"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "position": {
+                    "line": 40,
+                    "character": 23
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.struct",
+                "displayName": "Structure"
+            },
+            "identifier": {
+                "precise": "s:11FirstTarget11OtherStructV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "OtherStruct"
+            ],
+            "names": {
+                "title": "OtherStruct",
+                "navigator": [
+                    {
+                        "kind": "identifier",
+                        "spelling": "OtherStruct"
+                    }
+                ],
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "struct"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "OtherStruct"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "struct"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "OtherStruct"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "position": {
+                    "line": 39,
+                    "character": 14
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.func.op",
+                "displayName": "Operator"
+            },
+            "identifier": {
+                "precise": "s:SLsE3zzzoiySNyxGx_xtFZ::SYNTHESIZED::s:11FirstTarget11OtherStructV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "OtherStruct",
+                "...(_:_:)"
+            ],
+            "names": {
+                "title": "...(_:_:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "..."
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ", "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ") -> "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "ClosedRange",
+                        "preciseIdentifier": "s:SN"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "<"
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ">"
+                    }
+                ]
+            },
+            "docComment": {
+                "module": "Swift",
+                "lines": [
+                    {
+                        "text": "Returns a closed range that contains both of its bounds."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "Use the closed range operator (`...`) to create a closed range of any type"
+                    },
+                    {
+                        "text": "that conforms to the `Comparable` protocol. This example creates a"
+                    },
+                    {
+                        "text": "`ClosedRange<Character>` from \"a\" up to, and including, \"z\"."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "    let lowercase = \"a\"...\"z\""
+                    },
+                    {
+                        "text": "    print(lowercase.contains(\"z\"))"
+                    },
+                    {
+                        "text": "    // Prints \"true\""
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "- Parameters:"
+                    },
+                    {
+                        "text": "  - minimum: The lower bound for the range."
+                    },
+                    {
+                        "text": "  - maximum: The upper bound for the range."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "- Precondition: `minimum <= maximum`."
+                    }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "minimum",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "minimum"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "maximum",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "maximum"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "ClosedRange",
+                        "preciseIdentifier": "s:SN"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "<"
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ">"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "Swift"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "..."
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "minimum"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ", "
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "maximum"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ") -> "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "ClosedRange",
+                    "preciseIdentifier": "s:SN"
+                },
+                {
+                    "kind": "text",
+                    "spelling": "<"
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ">"
+                }
+            ],
+            "accessLevel": "public"
+        },
+        {
+            "kind": {
+                "identifier": "swift.method",
+                "displayName": "Instance Method"
+            },
+            "identifier": {
+                "precise": "s:SL11FirstTargetE26localDefaultImplementationyyF::SYNTHESIZED::s:11FirstTarget10SomeStructV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "SomeStruct",
+                "localDefaultImplementation()"
+            ],
+            "names": {
+                "title": "localDefaultImplementation()",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "localDefaultImplementation"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "functionSignature": {
+                "returns": [
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "Swift"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "localDefaultImplementation"
+                },
+                {
+                    "kind": "text",
+                    "spelling": "()"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "position": {
+                    "line": 46,
+                    "character": 16
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.protocol",
+                "displayName": "Protocol"
+            },
+            "identifier": {
+                "precise": "s:11FirstTarget18OtherFancyProtocolP",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "OtherFancyProtocol"
+            ],
+            "names": {
+                "title": "OtherFancyProtocol",
+                "navigator": [
+                    {
+                        "kind": "identifier",
+                        "spelling": "OtherFancyProtocol"
+                    }
+                ],
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "protocol"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "OtherFancyProtocol"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "protocol"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "OtherFancyProtocol"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "position": {
+                    "line": 31,
+                    "character": 16
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.method",
+                "displayName": "Instance Method"
+            },
+            "identifier": {
+                "precise": "s:11FirstTarget3FooPAAE23fooMemberWithDocCommentyyF::SYNTHESIZED::s:11FirstTarget3BarV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "Bar",
+                "fooMemberWithDocComment()"
+            ],
+            "names": {
+                "title": "fooMemberWithDocComment()",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "fooMemberWithDocComment"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "docComment": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "module": "FirstTarget",
+                "lines": [
+                    {
+                        "range": {
+                            "start": {
+                                "line": 1,
+                                "character": 8
+                            },
+                            "end": {
+                                "line": 1,
+                                "character": 29
+                            }
+                        },
+                        "text": "This is my great doc."
+                    }
+                ]
+            },
+            "functionSignature": {
+                "returns": [
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "FirstTarget"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "fooMemberWithDocComment"
+                },
+                {
+                    "kind": "text",
+                    "spelling": "()"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "position": {
+                    "line": 7,
+                    "character": 9
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.func.op",
+                "displayName": "Operator"
+            },
+            "identifier": {
+                "precise": "s:SLsE2geoiySbx_xtFZ::SYNTHESIZED::s:11FirstTarget10SomeStructV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "SomeStruct",
+                ">=(_:_:)"
+            ],
+            "names": {
+                "title": ">=(_:_:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": ">="
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ", "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ") -> "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Bool",
+                        "preciseIdentifier": "s:Sb"
+                    }
+                ]
+            },
+            "docComment": {
+                "module": "Swift",
+                "lines": [
+                    {
+                        "text": "Returns a Boolean value indicating whether the value of the first argument"
+                    },
+                    {
+                        "text": "is greater than or equal to that of the second argument."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "This is the default implementation of the greater-than-or-equal-to operator"
+                    },
+                    {
+                        "text": "(`>=`) for any type that conforms to `Comparable`."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "- Parameters:"
+                    },
+                    {
+                        "text": "  - lhs: A value to compare."
+                    },
+                    {
+                        "text": "  - rhs: Another value to compare."
+                    },
+                    {
+                        "text": "- Returns: `true` if `lhs` is greater than or equal to `rhs`; otherwise,"
+                    },
+                    {
+                        "text": "  `false`."
+                    }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "lhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "lhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "rhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "rhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Bool",
+                        "preciseIdentifier": "s:Sb"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "Swift"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": ">="
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "lhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ", "
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "rhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ") -> "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Bool",
+                    "preciseIdentifier": "s:Sb"
+                }
+            ],
+            "accessLevel": "public"
+        },
+        {
+            "kind": {
+                "identifier": "swift.func.op",
+                "displayName": "Operator"
+            },
+            "identifier": {
+                "precise": "s:11FirstTarget18OtherFancyProtocolP4zlzzoiyyAaB_p_AaB_ptFZ",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "OtherFancyProtocol",
+                ".<..(_:_:)"
+            ],
+            "names": {
+                "title": ".<..(_:_:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": ".<.."
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "OtherFancyProtocol",
+                        "preciseIdentifier": "s:11FirstTarget18OtherFancyProtocolP"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ", "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "OtherFancyProtocol",
+                        "preciseIdentifier": "s:11FirstTarget18OtherFancyProtocolP"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ")"
+                    }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "lhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "lhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "OtherFancyProtocol",
+                                "preciseIdentifier": "s:11FirstTarget18OtherFancyProtocolP"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "rhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "rhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "OtherFancyProtocol",
+                                "preciseIdentifier": "s:11FirstTarget18OtherFancyProtocolP"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": ".<.."
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "lhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "OtherFancyProtocol",
+                    "preciseIdentifier": "s:11FirstTarget18OtherFancyProtocolP"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ", "
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "rhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "OtherFancyProtocol",
+                    "preciseIdentifier": "s:11FirstTarget18OtherFancyProtocolP"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ")"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "position": {
+                    "line": 32,
+                    "character": 16
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.func.op",
+                "displayName": "Operator"
+            },
+            "identifier": {
+                "precise": "s:SLsE3zzzopys19PartialRangeThroughVyxGxFZ::SYNTHESIZED::s:11FirstTarget10SomeStructV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "SomeStruct",
+                "...(_:)"
+            ],
+            "names": {
+                "title": "...(_:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "..."
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ") -> "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "PartialRangeThrough",
+                        "preciseIdentifier": "s:s19PartialRangeThroughV"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "<"
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ">"
+                    }
+                ]
+            },
+            "docComment": {
+                "module": "Swift",
+                "lines": [
+                    {
+                        "text": "Returns a partial range up to, and including, its upper bound."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "Use the prefix closed range operator (prefix `...`) to create a partial"
+                    },
+                    {
+                        "text": "range of any type that conforms to the `Comparable` protocol. This"
+                    },
+                    {
+                        "text": "example creates a `PartialRangeThrough<Double>` instance that includes"
+                    },
+                    {
+                        "text": "any value less than or equal to `5.0`."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "    let throughFive = ...5.0"
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "    throughFive.contains(4.0)     // true"
+                    },
+                    {
+                        "text": "    throughFive.contains(5.0)     // true"
+                    },
+                    {
+                        "text": "    throughFive.contains(6.0)     // false"
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "You can use this type of partial range of a collection's indices to"
+                    },
+                    {
+                        "text": "represent the range from the start of the collection up to, and"
+                    },
+                    {
+                        "text": "including, the partial range's upper bound."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "    let numbers = [10, 20, 30, 40, 50, 60, 70]"
+                    },
+                    {
+                        "text": "    print(numbers[...3])"
+                    },
+                    {
+                        "text": "    // Prints \"[10, 20, 30, 40]\""
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "- Parameter maximum: The upper bound for the range."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "- Precondition: `maximum` must compare equal to itself (i.e. cannot be NaN)."
+                    }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "maximum",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "maximum"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "PartialRangeThrough",
+                        "preciseIdentifier": "s:s19PartialRangeThroughV"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "<"
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ">"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "Swift"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "..."
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "maximum"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ") -> "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "PartialRangeThrough",
+                    "preciseIdentifier": "s:s19PartialRangeThroughV"
+                },
+                {
+                    "kind": "text",
+                    "spelling": "<"
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ">"
+                }
+            ],
+            "accessLevel": "public"
+        },
+        {
+            "kind": {
+                "identifier": "swift.property",
+                "displayName": "Instance Property"
+            },
+            "identifier": {
+                "precise": "s:11FirstTarget10SomeStructV7someVarSSvp",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "SomeStruct",
+                "someVar"
+            ],
+            "names": {
+                "title": "someVar",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "var"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "someVar"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ": "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "String",
+                        "preciseIdentifier": "s:SS"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "var"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "someVar"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "String",
+                    "preciseIdentifier": "s:SS"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "position": {
+                    "line": 18,
+                    "character": 15
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.method",
+                "displayName": "Instance Method"
+            },
+            "identifier": {
+                "precise": "s:11FirstTarget3FooPAAE26fooMemberWithoutDocCommentyyF",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "Foo",
+                "fooMemberWithoutDocComment()"
+            ],
+            "names": {
+                "title": "fooMemberWithoutDocComment()",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "fooMemberWithoutDocComment"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "functionSignature": {
+                "returns": [
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "FirstTarget"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "fooMemberWithoutDocComment"
+                },
+                {
+                    "kind": "text",
+                    "spelling": "()"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "position": {
+                    "line": 8,
+                    "character": 9
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.func.op",
+                "displayName": "Operator"
+            },
+            "identifier": {
+                "precise": "s:11FirstTarget18OtherFancyProtocolPAAE4zlzzoiyyAaB_p_AaB_ptFZ::SYNTHESIZED::s:11FirstTarget10SomeStructV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "SomeStruct",
+                ".<..(_:_:)"
+            ],
+            "names": {
+                "title": ".<..(_:_:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": ".<.."
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "OtherFancyProtocol",
+                        "preciseIdentifier": "s:11FirstTarget18OtherFancyProtocolP"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ", "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "OtherFancyProtocol",
+                        "preciseIdentifier": "s:11FirstTarget18OtherFancyProtocolP"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ")"
+                    }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "lhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "lhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "OtherFancyProtocol",
+                                "preciseIdentifier": "s:11FirstTarget18OtherFancyProtocolP"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "rhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "rhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "OtherFancyProtocol",
+                                "preciseIdentifier": "s:11FirstTarget18OtherFancyProtocolP"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "FirstTarget"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": ".<.."
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "lhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "OtherFancyProtocol",
+                    "preciseIdentifier": "s:11FirstTarget18OtherFancyProtocolP"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ", "
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "rhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "OtherFancyProtocol",
+                    "preciseIdentifier": "s:11FirstTarget18OtherFancyProtocolP"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ")"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "position": {
+                    "line": 36,
+                    "character": 16
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.func.op",
+                "displayName": "Operator"
+            },
+            "identifier": {
+                "precise": "s:11FirstTarget18OtherFancyProtocolPAAE4zlzzoiyyAaB_p_AaB_ptFZ",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "OtherFancyProtocol",
+                ".<..(_:_:)"
+            ],
+            "names": {
+                "title": ".<..(_:_:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": ".<.."
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "OtherFancyProtocol",
+                        "preciseIdentifier": "s:11FirstTarget18OtherFancyProtocolP"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ", "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "OtherFancyProtocol",
+                        "preciseIdentifier": "s:11FirstTarget18OtherFancyProtocolP"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ")"
+                    }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "lhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "lhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "OtherFancyProtocol",
+                                "preciseIdentifier": "s:11FirstTarget18OtherFancyProtocolP"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "rhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "rhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "OtherFancyProtocol",
+                                "preciseIdentifier": "s:11FirstTarget18OtherFancyProtocolP"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "FirstTarget"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": ".<.."
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "lhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "OtherFancyProtocol",
+                    "preciseIdentifier": "s:11FirstTarget18OtherFancyProtocolP"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ", "
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "rhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "OtherFancyProtocol",
+                    "preciseIdentifier": "s:11FirstTarget18OtherFancyProtocolP"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ")"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "position": {
+                    "line": 36,
+                    "character": 16
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.func.op",
+                "displayName": "Operator"
+            },
+            "identifier": {
+                "precise": "s:SLsE3zzlopys16PartialRangeUpToVyxGxFZ::SYNTHESIZED::s:11FirstTarget11OtherStructV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "OtherStruct",
+                "..<(_:)"
+            ],
+            "names": {
+                "title": "..<(_:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "..<"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ") -> "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "PartialRangeUpTo",
+                        "preciseIdentifier": "s:s16PartialRangeUpToV"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "<"
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ">"
+                    }
+                ]
+            },
+            "docComment": {
+                "module": "Swift",
+                "lines": [
+                    {
+                        "text": "Returns a partial range up to, but not including, its upper bound."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "Use the prefix half-open range operator (prefix `..<`) to create a"
+                    },
+                    {
+                        "text": "partial range of any type that conforms to the `Comparable` protocol."
+                    },
+                    {
+                        "text": "This example creates a `PartialRangeUpTo<Double>` instance that includes"
+                    },
+                    {
+                        "text": "any value less than `5.0`."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "    let upToFive = ..<5.0"
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "    upToFive.contains(3.14)       // true"
+                    },
+                    {
+                        "text": "    upToFive.contains(6.28)       // false"
+                    },
+                    {
+                        "text": "    upToFive.contains(5.0)        // false"
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "You can use this type of partial range of a collection's indices to"
+                    },
+                    {
+                        "text": "represent the range from the start of the collection up to, but not"
+                    },
+                    {
+                        "text": "including, the partial range's upper bound."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "    let numbers = [10, 20, 30, 40, 50, 60, 70]"
+                    },
+                    {
+                        "text": "    print(numbers[..<3])"
+                    },
+                    {
+                        "text": "    // Prints \"[10, 20, 30]\""
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "- Parameter maximum: The upper bound for the range."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "- Precondition: `maximum` must compare equal to itself (i.e. cannot be NaN)."
+                    }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "maximum",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "maximum"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "PartialRangeUpTo",
+                        "preciseIdentifier": "s:s16PartialRangeUpToV"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "<"
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ">"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "Swift"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "..<"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "maximum"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ") -> "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "PartialRangeUpTo",
+                    "preciseIdentifier": "s:s16PartialRangeUpToV"
+                },
+                {
+                    "kind": "text",
+                    "spelling": "<"
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ">"
+                }
+            ],
+            "accessLevel": "public"
+        },
+        {
+            "kind": {
+                "identifier": "swift.func.op",
+                "displayName": "Operator"
+            },
+            "identifier": {
+                "precise": "s:SLsE1goiySbx_xtFZ::SYNTHESIZED::s:11FirstTarget11OtherStructV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "OtherStruct",
+                ">(_:_:)"
+            ],
+            "names": {
+                "title": ">(_:_:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": ">"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ", "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ") -> "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Bool",
+                        "preciseIdentifier": "s:Sb"
+                    }
+                ]
+            },
+            "docComment": {
+                "module": "Swift",
+                "lines": [
+                    {
+                        "text": "Returns a Boolean value indicating whether the value of the first argument"
+                    },
+                    {
+                        "text": "is greater than that of the second argument."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "This is the default implementation of the greater-than operator (`>`) for"
+                    },
+                    {
+                        "text": "any type that conforms to `Comparable`."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "- Parameters:"
+                    },
+                    {
+                        "text": "  - lhs: A value to compare."
+                    },
+                    {
+                        "text": "  - rhs: Another value to compare."
+                    }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "lhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "lhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "rhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "rhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Bool",
+                        "preciseIdentifier": "s:Sb"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "Swift"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": ">"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "lhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ", "
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "rhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ") -> "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Bool",
+                    "preciseIdentifier": "s:Sb"
+                }
+            ],
+            "accessLevel": "public"
+        },
+        {
+            "kind": {
+                "identifier": "swift.method",
+                "displayName": "Instance Method"
+            },
+            "identifier": {
+                "precise": "s:11FirstTarget3FooP23fooMemberWithDocCommentyyF",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "Foo",
+                "fooMemberWithDocComment()"
+            ],
+            "names": {
+                "title": "fooMemberWithDocComment()",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "fooMemberWithDocComment"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "docComment": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "module": "FirstTarget",
+                "lines": [
+                    {
+                        "range": {
+                            "start": {
+                                "line": 1,
+                                "character": 8
+                            },
+                            "end": {
+                                "line": 1,
+                                "character": 29
+                            }
+                        },
+                        "text": "This is my great doc."
+                    }
+                ]
+            },
+            "functionSignature": {
+                "returns": [
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "fooMemberWithDocComment"
+                },
+                {
+                    "kind": "text",
+                    "spelling": "()"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "position": {
+                    "line": 2,
+                    "character": 9
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.protocol",
+                "displayName": "Protocol"
+            },
+            "identifier": {
+                "precise": "s:11FirstTarget13FancyProtocolP",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "FancyProtocol"
+            ],
+            "names": {
+                "title": "FancyProtocol",
+                "navigator": [
+                    {
+                        "kind": "identifier",
+                        "spelling": "FancyProtocol"
+                    }
+                ],
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "protocol"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "FancyProtocol"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "protocol"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "FancyProtocol"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "position": {
+                    "line": 22,
+                    "character": 16
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.func.op",
+                "displayName": "Operator"
+            },
+            "identifier": {
+                "precise": "s:11FirstTarget10SomeStructV1loiySbAC_ACtFZ",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "SomeStruct",
+                "<(_:_:)"
+            ],
+            "names": {
+                "title": "<(_:_:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "<"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "SomeStruct",
+                        "preciseIdentifier": "s:11FirstTarget10SomeStructV"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ", "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "SomeStruct",
+                        "preciseIdentifier": "s:11FirstTarget10SomeStructV"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ") -> "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Bool",
+                        "preciseIdentifier": "s:Sb"
+                    }
+                ]
+            },
+            "docComment": {
+                "module": "Swift",
+                "lines": [
+                    {
+                        "text": "Returns a Boolean value indicating whether the value of the first"
+                    },
+                    {
+                        "text": "argument is less than that of the second argument."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "This function is the only requirement of the `Comparable` protocol. The"
+                    },
+                    {
+                        "text": "remainder of the relational operator functions are implemented by the"
+                    },
+                    {
+                        "text": "standard library for any type that conforms to `Comparable`."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "- Parameters:"
+                    },
+                    {
+                        "text": "  - lhs: A value to compare."
+                    },
+                    {
+                        "text": "  - rhs: Another value to compare."
+                    }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "lhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "lhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "SomeStruct",
+                                "preciseIdentifier": "s:11FirstTarget10SomeStructV"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "rhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "rhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "SomeStruct",
+                                "preciseIdentifier": "s:11FirstTarget10SomeStructV"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Bool",
+                        "preciseIdentifier": "s:Sb"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "<"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "lhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "SomeStruct",
+                    "preciseIdentifier": "s:11FirstTarget10SomeStructV"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ", "
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "rhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "SomeStruct",
+                    "preciseIdentifier": "s:11FirstTarget10SomeStructV"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ") -> "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Bool",
+                    "preciseIdentifier": "s:Sb"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "position": {
+                    "line": 14,
+                    "character": 23
+                }
+            }
+        }
+    ],
+    "relationships": [
+        {
+            "kind": "conformsTo",
+            "source": "s:11FirstTarget10SomeStructV",
+            "target": "s:11FirstTarget13FancyProtocolP"
+        },
+        {
+            "kind": "defaultImplementationOf",
+            "source": "s:11FirstTarget18OtherFancyProtocolPAAE4zlzzoiyyAaB_p_AaB_ptFZ",
+            "target": "s:11FirstTarget18OtherFancyProtocolP4zlzzoiyyAaB_p_AaB_ptFZ"
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:SLsE1goiySbx_xtFZ::SYNTHESIZED::s:11FirstTarget11OtherStructV",
+            "target": "s:11FirstTarget11OtherStructV",
+            "sourceOrigin": {
+                "identifier": "s:SLsE1goiySbx_xtFZ",
+                "displayName": "Comparable.>(_:_:)"
+            }
+        },
+        {
+            "kind": "conformsTo",
+            "source": "s:11FirstTarget10SomeStructV",
+            "target": "s:SQ",
+            "targetFallback": "Swift.Equatable"
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:SLsE1goiySbx_xtFZ::SYNTHESIZED::s:11FirstTarget10SomeStructV",
+            "target": "s:11FirstTarget10SomeStructV",
+            "sourceOrigin": {
+                "identifier": "s:SLsE1goiySbx_xtFZ",
+                "displayName": "Comparable.>(_:_:)"
+            }
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:SLsE3zzzopys19PartialRangeThroughVyxGxFZ::SYNTHESIZED::s:11FirstTarget11OtherStructV",
+            "target": "s:11FirstTarget11OtherStructV",
+            "sourceOrigin": {
+                "identifier": "s:SLsE3zzzopys19PartialRangeThroughVyxGxFZ",
+                "displayName": "Comparable....(_:)"
+            }
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:SLsE3zzlopys16PartialRangeUpToVyxGxFZ::SYNTHESIZED::s:11FirstTarget10SomeStructV",
+            "target": "s:11FirstTarget10SomeStructV",
+            "sourceOrigin": {
+                "identifier": "s:SLsE3zzlopys16PartialRangeUpToVyxGxFZ",
+                "displayName": "Comparable...<(_:)"
+            }
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:SLsE2leoiySbx_xtFZ::SYNTHESIZED::s:11FirstTarget11OtherStructV",
+            "target": "s:11FirstTarget11OtherStructV",
+            "sourceOrigin": {
+                "identifier": "s:SLsE2leoiySbx_xtFZ",
+                "displayName": "Comparable.<=(_:_:)"
+            }
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:11FirstTarget3FooPAAE23fooMemberWithDocCommentyyF::SYNTHESIZED::s:11FirstTarget3BarV",
+            "target": "s:11FirstTarget3BarV",
+            "sourceOrigin": {
+                "identifier": "s:11FirstTarget3FooP23fooMemberWithDocCommentyyF",
+                "displayName": "Foo.fooMemberWithDocComment()"
+            }
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:SLsE3zzlopys16PartialRangeUpToVyxGxFZ::SYNTHESIZED::s:11FirstTarget11OtherStructV",
+            "target": "s:11FirstTarget11OtherStructV",
+            "sourceOrigin": {
+                "identifier": "s:SLsE3zzlopys16PartialRangeUpToVyxGxFZ",
+                "displayName": "Comparable...<(_:)"
+            }
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:SLsE2leoiySbx_xtFZ::SYNTHESIZED::s:11FirstTarget10SomeStructV",
+            "target": "s:11FirstTarget10SomeStructV",
+            "sourceOrigin": {
+                "identifier": "s:SLsE2leoiySbx_xtFZ",
+                "displayName": "Comparable.<=(_:_:)"
+            }
+        },
+        {
+            "kind": "conformsTo",
+            "source": "s:11FirstTarget10SomeStructV",
+            "target": "s:11FirstTarget18OtherFancyProtocolP"
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:11FirstTarget11OtherStructV1loiySbAC_ACtFZ",
+            "target": "s:11FirstTarget11OtherStructV",
+            "sourceOrigin": {
+                "identifier": "s:SL1loiySbx_xtFZ",
+                "displayName": "Comparable.<(_:_:)"
+            }
+        },
+        {
+            "kind": "requirementOf",
+            "source": "s:11FirstTarget3FooP23fooMemberWithDocCommentyyF",
+            "target": "s:11FirstTarget3FooP"
+        },
+        {
+            "kind": "requirementOf",
+            "source": "s:11FirstTarget13FancyProtocolP4zzzzoiyyAaB_p_AaB_ptFZ",
+            "target": "s:11FirstTarget13FancyProtocolP"
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:11FirstTarget13FancyProtocolPAAE4zzzzoiyyAaB_p_AaB_ptFZ::SYNTHESIZED::s:11FirstTarget10SomeStructV",
+            "target": "s:11FirstTarget10SomeStructV",
+            "sourceOrigin": {
+                "identifier": "s:11FirstTarget13FancyProtocolPAAE4zzzzoiyyAaB_p_AaB_ptFZ",
+                "displayName": "FancyProtocol.....(_:_:)"
+            }
+        },
+        {
+            "kind": "requirementOf",
+            "source": "s:11FirstTarget18OtherFancyProtocolP4zlzzoiyyAaB_p_AaB_ptFZ",
+            "target": "s:11FirstTarget18OtherFancyProtocolP"
+        },
+        {
+            "kind": "conformsTo",
+            "source": "s:11FirstTarget10SomeStructV",
+            "target": "s:SL",
+            "targetFallback": "Swift.Comparable"
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:SLsE3zzzoiySNyxGx_xtFZ::SYNTHESIZED::s:11FirstTarget10SomeStructV",
+            "target": "s:11FirstTarget10SomeStructV",
+            "sourceOrigin": {
+                "identifier": "s:SLsE3zzzoiySNyxGx_xtFZ",
+                "displayName": "Comparable....(_:_:)"
+            }
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:SLsE3zzzoiySNyxGx_xtFZ::SYNTHESIZED::s:11FirstTarget11OtherStructV",
+            "target": "s:11FirstTarget11OtherStructV",
+            "sourceOrigin": {
+                "identifier": "s:SLsE3zzzoiySNyxGx_xtFZ",
+                "displayName": "Comparable....(_:_:)"
+            }
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:SL11FirstTargetE26localDefaultImplementationyyF::SYNTHESIZED::s:11FirstTarget11OtherStructV",
+            "target": "s:11FirstTarget11OtherStructV",
+            "sourceOrigin": {
+                "identifier": "s:SL11FirstTargetE26localDefaultImplementationyyF",
+                "displayName": "Comparable.localDefaultImplementation()"
+            }
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:SLsE2geoiySbx_xtFZ::SYNTHESIZED::s:11FirstTarget11OtherStructV",
+            "target": "s:11FirstTarget11OtherStructV",
+            "sourceOrigin": {
+                "identifier": "s:SLsE2geoiySbx_xtFZ",
+                "displayName": "Comparable.>=(_:_:)"
+            }
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:SL11FirstTargetE26localDefaultImplementationyyF::SYNTHESIZED::s:11FirstTarget10SomeStructV",
+            "target": "s:11FirstTarget10SomeStructV",
+            "sourceOrigin": {
+                "identifier": "s:SL11FirstTargetE26localDefaultImplementationyyF",
+                "displayName": "Comparable.localDefaultImplementation()"
+            }
+        },
+        {
+            "kind": "defaultImplementationOf",
+            "source": "s:11FirstTarget3FooPAAE26fooMemberWithoutDocCommentyyF",
+            "target": "s:11FirstTarget3FooP26fooMemberWithoutDocCommentyyF"
+        },
+        {
+            "kind": "conformsTo",
+            "source": "s:11FirstTarget11OtherStructV",
+            "target": "s:SL",
+            "targetFallback": "Swift.Comparable"
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:SLsE2geoiySbx_xtFZ::SYNTHESIZED::s:11FirstTarget10SomeStructV",
+            "target": "s:11FirstTarget10SomeStructV",
+            "sourceOrigin": {
+                "identifier": "s:SLsE2geoiySbx_xtFZ",
+                "displayName": "Comparable.>=(_:_:)"
+            }
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:11FirstTarget10SomeStructV",
+            "target": "s:11FirstTarget10SomeStructV",
+            "sourceOrigin": {
+                "identifier": "s:SQsE2neoiySbx_xtFZ",
+                "displayName": "Equatable.!=(_:_:)"
+            }
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:SLsE3zzloiySnyxGx_xtFZ::SYNTHESIZED::s:11FirstTarget10SomeStructV",
+            "target": "s:11FirstTarget10SomeStructV",
+            "sourceOrigin": {
+                "identifier": "s:SLsE3zzloiySnyxGx_xtFZ",
+                "displayName": "Comparable...<(_:_:)"
+            }
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:11FirstTarget10SomeStructV7someVarSSvp",
+            "target": "s:11FirstTarget10SomeStructV"
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:SLsE3zzzoPys16PartialRangeFromVyxGxFZ::SYNTHESIZED::s:11FirstTarget11OtherStructV",
+            "target": "s:11FirstTarget11OtherStructV",
+            "sourceOrigin": {
+                "identifier": "s:SLsE3zzzoPys16PartialRangeFromVyxGxFZ",
+                "displayName": "Comparable....(_:)"
+            }
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:SLsE3zzzoPys16PartialRangeFromVyxGxFZ::SYNTHESIZED::s:11FirstTarget10SomeStructV",
+            "target": "s:11FirstTarget10SomeStructV",
+            "sourceOrigin": {
+                "identifier": "s:SLsE3zzzoPys16PartialRangeFromVyxGxFZ",
+                "displayName": "Comparable....(_:)"
+            }
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:11FirstTarget11OtherStructV",
+            "target": "s:11FirstTarget11OtherStructV",
+            "sourceOrigin": {
+                "identifier": "s:SQsE2neoiySbx_xtFZ",
+                "displayName": "Equatable.!=(_:_:)"
+            }
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:SLsE3zzloiySnyxGx_xtFZ::SYNTHESIZED::s:11FirstTarget11OtherStructV",
+            "target": "s:11FirstTarget11OtherStructV",
+            "sourceOrigin": {
+                "identifier": "s:SLsE3zzloiySnyxGx_xtFZ",
+                "displayName": "Comparable...<(_:_:)"
+            }
+        },
+        {
+            "kind": "conformsTo",
+            "source": "s:11FirstTarget3BarV",
+            "target": "s:11FirstTarget3FooP"
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:11FirstTarget10SomeStructV1loiySbAC_ACtFZ",
+            "target": "s:11FirstTarget10SomeStructV",
+            "sourceOrigin": {
+                "identifier": "s:SL1loiySbx_xtFZ",
+                "displayName": "Comparable.<(_:_:)"
+            }
+        },
+        {
+            "kind": "conformsTo",
+            "source": "s:11FirstTarget11OtherStructV",
+            "target": "s:SQ",
+            "targetFallback": "Swift.Equatable"
+        },
+        {
+            "kind": "requirementOf",
+            "source": "s:11FirstTarget3FooP26fooMemberWithoutDocCommentyyF",
+            "target": "s:11FirstTarget3FooP"
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:SLsE3zzzopys19PartialRangeThroughVyxGxFZ::SYNTHESIZED::s:11FirstTarget10SomeStructV",
+            "target": "s:11FirstTarget10SomeStructV",
+            "sourceOrigin": {
+                "identifier": "s:SLsE3zzzopys19PartialRangeThroughVyxGxFZ",
+                "displayName": "Comparable....(_:)"
+            }
+        },
+        {
+            "kind": "defaultImplementationOf",
+            "source": "s:11FirstTarget13FancyProtocolPAAE4zzzzoiyyAaB_p_AaB_ptFZ",
+            "target": "s:11FirstTarget13FancyProtocolP4zzzzoiyyAaB_p_AaB_ptFZ"
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:11FirstTarget3FooPAAE26fooMemberWithoutDocCommentyyF::SYNTHESIZED::s:11FirstTarget3BarV",
+            "target": "s:11FirstTarget3BarV",
+            "sourceOrigin": {
+                "identifier": "s:11FirstTarget3FooPAAE26fooMemberWithoutDocCommentyyF",
+                "displayName": "Foo.fooMemberWithoutDocComment()"
+            }
+        },
+        {
+            "kind": "defaultImplementationOf",
+            "source": "s:11FirstTarget3FooPAAE23fooMemberWithDocCommentyyF",
+            "target": "s:11FirstTarget3FooP23fooMemberWithDocCommentyyF",
+            "sourceOrigin": {
+                "identifier": "s:11FirstTarget3FooP23fooMemberWithDocCommentyyF",
+                "displayName": "Foo.fooMemberWithDocComment()"
+            }
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:11FirstTarget18OtherFancyProtocolPAAE4zlzzoiyyAaB_p_AaB_ptFZ::SYNTHESIZED::s:11FirstTarget10SomeStructV",
+            "target": "s:11FirstTarget10SomeStructV",
+            "sourceOrigin": {
+                "identifier": "s:11FirstTarget18OtherFancyProtocolPAAE4zlzzoiyyAaB_p_AaB_ptFZ",
+                "displayName": "OtherFancyProtocol..<..(_:_:)"
+            }
+        }
+    ]
+}

--- a/Tests/SwiftDocCTests/Test Resources/InheritedDefaultImplementations@Swift.symbols.json
+++ b/Tests/SwiftDocCTests/Test Resources/InheritedDefaultImplementations@Swift.symbols.json
@@ -1,0 +1,107 @@
+{
+    "metadata": {
+        "formatVersion": {
+            "major": 0,
+            "minor": 5,
+            "patch": 3
+        },
+        "generator": "Apple Swift version 5.7"
+    },
+    "module": {
+        "name": "FirstTarget",
+        "platform": {
+            "architecture": "x86_64",
+            "vendor": "apple",
+            "operatingSystem": {
+                "name": "macosx",
+                "minimumVersion": {
+                    "major": 11,
+                    "minor": 0,
+                    "patch": 0
+                }
+            }
+        }
+    },
+    "symbols": [
+        {
+            "kind": {
+                "identifier": "swift.method",
+                "displayName": "Instance Method"
+            },
+            "identifier": {
+                "precise": "s:SL11FirstTargetE26localDefaultImplementationyyF",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "Comparable",
+                "localDefaultImplementation()"
+            ],
+            "names": {
+                "title": "localDefaultImplementation()",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "localDefaultImplementation"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "functionSignature": {
+                "returns": [
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "Swift"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "localDefaultImplementation"
+                },
+                {
+                    "kind": "text",
+                    "spelling": "()"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "position": {
+                    "line": 46,
+                    "character": 16
+                }
+            }
+        }
+    ],
+    "relationships": [
+        {
+            "kind": "memberOf",
+            "source": "s:SL11FirstTargetE26localDefaultImplementationyyF",
+            "target": "s:SL",
+            "targetFallback": "Swift.Comparable"
+        }
+    ]
+}

--- a/Tests/SwiftDocCTests/Test Resources/InheritedDefaultImplementationsFromExternalModule.symbols.json
+++ b/Tests/SwiftDocCTests/Test Resources/InheritedDefaultImplementationsFromExternalModule.symbols.json
@@ -1,0 +1,792 @@
+{
+    "metadata": {
+        "formatVersion": {
+            "major": 0,
+            "minor": 5,
+            "patch": 3
+        },
+        "generator": "Apple Swift version 5.7"
+    },
+    "module": {
+        "name": "SecondTarget",
+        "platform": {
+            "architecture": "x86_64",
+            "vendor": "apple",
+            "operatingSystem": {
+                "name": "macosx",
+                "minimumVersion": {
+                    "major": 11,
+                    "minor": 0,
+                    "patch": 0
+                }
+            }
+        }
+    },
+    "symbols": [
+        {
+            "kind": {
+                "identifier": "swift.func.op",
+                "displayName": "Operator"
+            },
+            "identifier": {
+                "precise": "s:11FirstTarget13FancyProtocolPAAE4zzzzoiyyAaB_p_AaB_ptFZ::SYNTHESIZED::s:12SecondTarget22FancyProtocolConformerV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "FancyProtocolConformer",
+                "....(_:_:)"
+            ],
+            "names": {
+                "title": "....(_:_:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "...."
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "FancyProtocol",
+                        "preciseIdentifier": "s:11FirstTarget13FancyProtocolP"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ", "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "FancyProtocol",
+                        "preciseIdentifier": "s:11FirstTarget13FancyProtocolP"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ")"
+                    }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "lhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "lhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "FancyProtocol",
+                                "preciseIdentifier": "s:11FirstTarget13FancyProtocolP"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "rhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "rhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "FancyProtocol",
+                                "preciseIdentifier": "s:11FirstTarget13FancyProtocolP"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "FirstTarget"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "...."
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "lhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "FancyProtocol",
+                    "preciseIdentifier": "s:11FirstTarget13FancyProtocolP"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ", "
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "rhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "FancyProtocol",
+                    "preciseIdentifier": "s:11FirstTarget13FancyProtocolP"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ")"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "position": {
+                    "line": 27,
+                    "character": 16
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.struct",
+                "displayName": "Structure"
+            },
+            "identifier": {
+                "precise": "s:12SecondTarget22FancyProtocolConformerV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "FancyProtocolConformer"
+            ],
+            "names": {
+                "title": "FancyProtocolConformer",
+                "navigator": [
+                    {
+                        "kind": "identifier",
+                        "spelling": "FancyProtocolConformer"
+                    }
+                ],
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "struct"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "FancyProtocolConformer"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "struct"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "FancyProtocolConformer"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/SecondTarget/Source.swift",
+                "position": {
+                    "line": 4,
+                    "character": 14
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.method",
+                "displayName": "Instance Method"
+            },
+            "identifier": {
+                "precise": "s:11FirstTarget3FooPAAE23fooMemberWithDocCommentyyF::SYNTHESIZED::s:12SecondTarget12FooConformerV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "FooConformer",
+                "fooMemberWithDocComment()"
+            ],
+            "names": {
+                "title": "fooMemberWithDocComment()",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "fooMemberWithDocComment"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "docComment": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "module": "FirstTarget",
+                "lines": [
+                    {
+                        "range": {
+                            "start": {
+                                "line": 1,
+                                "character": 8
+                            },
+                            "end": {
+                                "line": 1,
+                                "character": 29
+                            }
+                        },
+                        "text": "This is my great doc."
+                    }
+                ]
+            },
+            "functionSignature": {
+                "returns": [
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "FirstTarget"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "fooMemberWithDocComment"
+                },
+                {
+                    "kind": "text",
+                    "spelling": "()"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "position": {
+                    "line": 7,
+                    "character": 9
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.func.op",
+                "displayName": "Operator"
+            },
+            "identifier": {
+                "precise": "s:11FirstTarget18OtherFancyProtocolPAAE4zlzzoiyyAaB_p_AaB_ptFZ::SYNTHESIZED::s:12SecondTarget27OtherFancyProtocolConformerV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "OtherFancyProtocolConformer",
+                ".<..(_:_:)"
+            ],
+            "names": {
+                "title": ".<..(_:_:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": ".<.."
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "OtherFancyProtocol",
+                        "preciseIdentifier": "s:11FirstTarget18OtherFancyProtocolP"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ", "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "OtherFancyProtocol",
+                        "preciseIdentifier": "s:11FirstTarget18OtherFancyProtocolP"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ")"
+                    }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "lhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "lhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "OtherFancyProtocol",
+                                "preciseIdentifier": "s:11FirstTarget18OtherFancyProtocolP"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "rhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "rhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "OtherFancyProtocol",
+                                "preciseIdentifier": "s:11FirstTarget18OtherFancyProtocolP"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "FirstTarget"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": ".<.."
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "lhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "OtherFancyProtocol",
+                    "preciseIdentifier": "s:11FirstTarget18OtherFancyProtocolP"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ", "
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "rhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "OtherFancyProtocol",
+                    "preciseIdentifier": "s:11FirstTarget18OtherFancyProtocolP"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ")"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "position": {
+                    "line": 36,
+                    "character": 16
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.struct",
+                "displayName": "Structure"
+            },
+            "identifier": {
+                "precise": "s:12SecondTarget12FooConformerV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "FooConformer"
+            ],
+            "names": {
+                "title": "FooConformer",
+                "navigator": [
+                    {
+                        "kind": "identifier",
+                        "spelling": "FooConformer"
+                    }
+                ],
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "struct"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "FooConformer"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "struct"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "FooConformer"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/SecondTarget/Source.swift",
+                "position": {
+                    "line": 2,
+                    "character": 14
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.method",
+                "displayName": "Instance Method"
+            },
+            "identifier": {
+                "precise": "s:11FirstTarget3FooPAAE26fooMemberWithoutDocCommentyyF::SYNTHESIZED::s:12SecondTarget12FooConformerV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "FooConformer",
+                "fooMemberWithoutDocComment()"
+            ],
+            "names": {
+                "title": "fooMemberWithoutDocComment()",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "fooMemberWithoutDocComment"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "functionSignature": {
+                "returns": [
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "FirstTarget"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "fooMemberWithoutDocComment"
+                },
+                {
+                    "kind": "text",
+                    "spelling": "()"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "position": {
+                    "line": 8,
+                    "character": 9
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.struct",
+                "displayName": "Structure"
+            },
+            "identifier": {
+                "precise": "s:12SecondTarget27OtherFancyProtocolConformerV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "OtherFancyProtocolConformer"
+            ],
+            "names": {
+                "title": "OtherFancyProtocolConformer",
+                "navigator": [
+                    {
+                        "kind": "identifier",
+                        "spelling": "OtherFancyProtocolConformer"
+                    }
+                ],
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "struct"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "OtherFancyProtocolConformer"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "struct"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "OtherFancyProtocolConformer"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/SecondTarget/Source.swift",
+                "position": {
+                    "line": 6,
+                    "character": 14
+                }
+            }
+        }
+    ],
+    "relationships": [
+        {
+            "kind": "conformsTo",
+            "source": "s:12SecondTarget22FancyProtocolConformerV",
+            "target": "s:11FirstTarget13FancyProtocolP",
+            "targetFallback": "FirstTarget.FancyProtocol"
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:11FirstTarget3FooPAAE23fooMemberWithDocCommentyyF::SYNTHESIZED::s:12SecondTarget12FooConformerV",
+            "target": "s:12SecondTarget12FooConformerV",
+            "sourceOrigin": {
+                "identifier": "s:11FirstTarget3FooP23fooMemberWithDocCommentyyF",
+                "displayName": "Foo.fooMemberWithDocComment()"
+            }
+        },
+        {
+            "kind": "conformsTo",
+            "source": "s:12SecondTarget27OtherFancyProtocolConformerV",
+            "target": "s:11FirstTarget18OtherFancyProtocolP",
+            "targetFallback": "FirstTarget.OtherFancyProtocol"
+        },
+        {
+            "kind": "conformsTo",
+            "source": "s:12SecondTarget12FooConformerV",
+            "target": "s:11FirstTarget3FooP",
+            "targetFallback": "FirstTarget.Foo"
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:11FirstTarget3FooPAAE26fooMemberWithoutDocCommentyyF::SYNTHESIZED::s:12SecondTarget12FooConformerV",
+            "target": "s:12SecondTarget12FooConformerV",
+            "sourceOrigin": {
+                "identifier": "s:11FirstTarget3FooPAAE26fooMemberWithoutDocCommentyyF",
+                "displayName": "Foo.fooMemberWithoutDocComment()"
+            }
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:11FirstTarget13FancyProtocolPAAE4zzzzoiyyAaB_p_AaB_ptFZ::SYNTHESIZED::s:12SecondTarget22FancyProtocolConformerV",
+            "target": "s:12SecondTarget22FancyProtocolConformerV",
+            "sourceOrigin": {
+                "identifier": "s:11FirstTarget13FancyProtocolPAAE4zzzzoiyyAaB_p_AaB_ptFZ",
+                "displayName": "FancyProtocol.....(_:_:)"
+            }
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:11FirstTarget18OtherFancyProtocolPAAE4zlzzoiyyAaB_p_AaB_ptFZ::SYNTHESIZED::s:12SecondTarget27OtherFancyProtocolConformerV",
+            "target": "s:12SecondTarget27OtherFancyProtocolConformerV",
+            "sourceOrigin": {
+                "identifier": "s:11FirstTarget18OtherFancyProtocolPAAE4zlzzoiyyAaB_p_AaB_ptFZ",
+                "displayName": "OtherFancyProtocol..<..(_:_:)"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://95808950

## Summary

With the recent fix for supporting generated implementation sections for
symbols that include periods (like `Comparable...<`) (#257), we introduced a
regression where it's possible to end up with a duplicate default
implementation section.

This can happen when a protocol has a mix of documentation coverage. For example

```swift
public protocol Foo {
    /// This is my great doc.
    func fooMemberWithDocComment()
    func fooMemberWithoutDocComment()
}

public extension Foo {
    func fooMemberWithDocComment() { }
    func fooMemberWithoutDocComment() { }
}

public struct Bar: Foo {}
```

Here `Bar` would end up with two "Foo Implementations" sections.

This is because we're able to access the original parent symbol for
`fooMemberWithDocComment()` but not for `fooMemberWithoutDocComment` so
these relationships end up with a different unique identifier but the same
collection name: "Foo Implementations".

The fix is to not rely on the parent relationship being there and instead
look at the origin symbol's parent path components. We can rely on the origin
symbol always being there for protocols defined in the current module.

----

This also resolves an issue where conforming to compmlicated protocols in a
different module would produce a misnamed collection. For example:

```swift
// FirstTarget

infix operator .<.. : RangeFormationPrecedence
public protocol OtherFancyProtocol {
    static func .<.. (lhs: OtherFancyProtocol, rhs: OtherFancyProtocol)
}

public extension OtherFancyProtocol {
    static func .<.. (lhs: OtherFancyProtocol, rhs: OtherFancyProtocol) {}
}
```

```swift
// SecondTarget
import FirstTarget

public struct OtherFancyProtocolConformer: OtherFancyProtocol {}
```

Here we would end up with a default collection named "< Implementations"
instead of "OtherFancyProtocol Implementations". The solution is to figure
out the actual name of the symbol based on the source symbol which is always
guaranteed to be there. We can use this to split out the parent symbol's name
from the source origin display name.


## Testing

Build documentation with the examples included in the summary (also included in the [attached Swift Package](https://github.com/apple/swift-docc/files/8981636/r81423267-reproducer.zip)) and confirm that they produce automatic collections as expected.


## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
