### PR TITLE
[5.7] Fix regression with duplicated generated implementation sections

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -1468,7 +1468,6 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
             for (_, relationships) in combinedRelationships {
                 try GeneratedDocumentationTopics.createInheritedSymbolsAPICollections(
                     relationships: relationships,
-                    symbolsURLHierarchy: &symbolsURLHierarchy,
                     context: self,
                     bundle: bundle
                 )

--- a/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorTests.swift
@@ -11,6 +11,7 @@
 import Foundation
 import XCTest
 @testable import SwiftDocC
+import SwiftDocCTestUtilities
 import Markdown
 
 class RenderNodeTranslatorTests: XCTestCase {
@@ -653,6 +654,120 @@ class RenderNodeTranslatorTests: XCTestCase {
             "FancyProtocol Implementations",
         ])
 
+    }
+    
+    func testAutomaticImplementationsWithExtraDotsFromExternalModule() throws {
+        let inheritedDefaultImplementationsFromExternalModuleSGF = Bundle.module.url(
+            forResource: "InheritedDefaultImplementationsFromExternalModule.symbols",
+            withExtension: "json",
+            subdirectory: "Test Resources"
+        )!
+        
+        let testBundle = try Folder(
+            name: "unit-test.docc",
+            content: [
+                InfoPlist(displayName: "TestBundle", identifier: "com.test.example"),
+                CopyOfFile(original: inheritedDefaultImplementationsFromExternalModuleSGF),
+            ]
+        ).write(inside: createTemporaryDirectory())
+        
+        try assertDefaultImplementationCollectionTitles(
+            in: try loadRenderNode(at: "/documentation/SecondTarget/FancyProtocolConformer", in: testBundle),
+            [
+                "FancyProtocol Implementations",
+            ]
+        )
+        
+        try assertDefaultImplementationCollectionTitles(
+            in: try loadRenderNode(at: "/documentation/SecondTarget/OtherFancyProtocolConformer", in: testBundle),
+            [
+                "OtherFancyProtocol Implementations",
+            ]
+        )
+        
+        try assertDefaultImplementationCollectionTitles(
+            in: try loadRenderNode(at: "/documentation/SecondTarget/FooConformer", in: testBundle),
+            [
+                "Foo Implementations",
+            ]
+        )
+    }
+    
+    func testAutomaticImplementationsFromCurrentModuleWithMixOfDocCoverage() throws {
+        let inheritedDefaultImplementationsSGF = Bundle.module.url(
+            forResource: "InheritedDefaultImplementations.symbols",
+            withExtension: "json",
+            subdirectory: "Test Resources"
+        )!
+        let inheritedDefaultImplementationsAtSwiftSGF = Bundle.module.url(
+            forResource: "InheritedDefaultImplementations@Swift.symbols",
+            withExtension: "json",
+            subdirectory: "Test Resources"
+        )!
+        
+        let testBundle = try Folder(
+            name: "unit-test.docc",
+            content: [
+                InfoPlist(displayName: "TestBundle", identifier: "com.test.example"),
+                CopyOfFile(original: inheritedDefaultImplementationsSGF),
+                CopyOfFile(original: inheritedDefaultImplementationsAtSwiftSGF),
+            ]
+        ).write(inside: createTemporaryDirectory())
+        
+        try assertDefaultImplementationCollectionTitles(
+            in: try loadRenderNode(at: "/documentation/FirstTarget/Bar", in: testBundle),
+            [
+                "Foo Implementations",
+            ]
+        )
+        
+        try assertDefaultImplementationCollectionTitles(
+            in: try loadRenderNode(at: "/documentation/FirstTarget/OtherStruct", in: testBundle),
+            [
+                "Comparable Implementations",
+                "Equatable Implementations",
+            ]
+        )
+        
+        try assertDefaultImplementationCollectionTitles(
+            in: try loadRenderNode(at: "/documentation/FirstTarget/SomeStruct", in: testBundle),
+            [
+                "Comparable Implementations",
+                "Equatable Implementations",
+                "FancyProtocol Implementations",
+                "OtherFancyProtocol Implementations",
+            ]
+        )
+    }
+    
+    func assertDefaultImplementationCollectionTitles(
+        in renderNode: RenderNode,
+        _ expectedTitles: [String],
+        file: StaticString = #file,
+        line: UInt = #line
+    ) throws {
+        let defaultImplementationSection = try XCTUnwrap(
+            renderNode.topicSections.first(where: { $0.title == "Default Implementations" }),
+            "Expected to find default implementations topic section.",
+            file: file,
+            line: line
+        )
+        
+        let references = defaultImplementationSection.identifiers.compactMap { identifier in
+            renderNode.references[identifier] as? TopicRenderReference
+        }
+        
+        XCTAssertEqual(references.map(\.title), expectedTitles, file: file, line: line)
+    }
+    
+    func loadRenderNode(at path: String, in bundleURL: URL) throws -> RenderNode {
+        let (_, bundle, context) = try loadBundle(from: bundleURL)
+
+        let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: path, sourceLanguage: .swift)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference, source: nil)
+        let node = try context.entity(with: reference)
+        let symbol = try XCTUnwrap(node.semantic as? Symbol)
+        return try XCTUnwrap(translator.visitSymbol(symbol) as? RenderNode)
     }
     
     func testAutomaticTaskGroupTopicsAreSorted() throws {

--- a/Tests/SwiftDocCTests/Test Resources/InheritedDefaultImplementations.symbols.json
+++ b/Tests/SwiftDocCTests/Test Resources/InheritedDefaultImplementations.symbols.json
@@ -1,0 +1,7263 @@
+{
+    "metadata": {
+        "formatVersion": {
+            "major": 0,
+            "minor": 5,
+            "patch": 3
+        },
+        "generator": "Apple Swift version 5.7"
+    },
+    "module": {
+        "name": "FirstTarget",
+        "platform": {
+            "architecture": "x86_64",
+            "vendor": "apple",
+            "operatingSystem": {
+                "name": "macosx",
+                "minimumVersion": {
+                    "major": 11,
+                    "minor": 0,
+                    "patch": 0
+                }
+            }
+        }
+    },
+    "symbols": [
+        {
+            "kind": {
+                "identifier": "swift.func.op",
+                "displayName": "Operator"
+            },
+            "identifier": {
+                "precise": "s:SLsE3zzlopys16PartialRangeUpToVyxGxFZ::SYNTHESIZED::s:11FirstTarget10SomeStructV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "SomeStruct",
+                "..<(_:)"
+            ],
+            "names": {
+                "title": "..<(_:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "..<"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ") -> "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "PartialRangeUpTo",
+                        "preciseIdentifier": "s:s16PartialRangeUpToV"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "<"
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ">"
+                    }
+                ]
+            },
+            "docComment": {
+                "module": "Swift",
+                "lines": [
+                    {
+                        "text": "Returns a partial range up to, but not including, its upper bound."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "Use the prefix half-open range operator (prefix `..<`) to create a"
+                    },
+                    {
+                        "text": "partial range of any type that conforms to the `Comparable` protocol."
+                    },
+                    {
+                        "text": "This example creates a `PartialRangeUpTo<Double>` instance that includes"
+                    },
+                    {
+                        "text": "any value less than `5.0`."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "    let upToFive = ..<5.0"
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "    upToFive.contains(3.14)       // true"
+                    },
+                    {
+                        "text": "    upToFive.contains(6.28)       // false"
+                    },
+                    {
+                        "text": "    upToFive.contains(5.0)        // false"
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "You can use this type of partial range of a collection's indices to"
+                    },
+                    {
+                        "text": "represent the range from the start of the collection up to, but not"
+                    },
+                    {
+                        "text": "including, the partial range's upper bound."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "    let numbers = [10, 20, 30, 40, 50, 60, 70]"
+                    },
+                    {
+                        "text": "    print(numbers[..<3])"
+                    },
+                    {
+                        "text": "    // Prints \"[10, 20, 30]\""
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "- Parameter maximum: The upper bound for the range."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "- Precondition: `maximum` must compare equal to itself (i.e. cannot be NaN)."
+                    }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "maximum",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "maximum"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "PartialRangeUpTo",
+                        "preciseIdentifier": "s:s16PartialRangeUpToV"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "<"
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ">"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "Swift"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "..<"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "maximum"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ") -> "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "PartialRangeUpTo",
+                    "preciseIdentifier": "s:s16PartialRangeUpToV"
+                },
+                {
+                    "kind": "text",
+                    "spelling": "<"
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ">"
+                }
+            ],
+            "accessLevel": "public"
+        },
+        {
+            "kind": {
+                "identifier": "swift.func.op",
+                "displayName": "Operator"
+            },
+            "identifier": {
+                "precise": "s:SLsE2leoiySbx_xtFZ::SYNTHESIZED::s:11FirstTarget11OtherStructV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "OtherStruct",
+                "<=(_:_:)"
+            ],
+            "names": {
+                "title": "<=(_:_:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "<="
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ", "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ") -> "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Bool",
+                        "preciseIdentifier": "s:Sb"
+                    }
+                ]
+            },
+            "docComment": {
+                "module": "Swift",
+                "lines": [
+                    {
+                        "text": "Returns a Boolean value indicating whether the value of the first argument"
+                    },
+                    {
+                        "text": "is less than or equal to that of the second argument."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "This is the default implementation of the less-than-or-equal-to"
+                    },
+                    {
+                        "text": "operator (`<=`) for any type that conforms to `Comparable`."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "- Parameters:"
+                    },
+                    {
+                        "text": "  - lhs: A value to compare."
+                    },
+                    {
+                        "text": "  - rhs: Another value to compare."
+                    }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "lhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "lhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "rhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "rhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Bool",
+                        "preciseIdentifier": "s:Sb"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "Swift"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "<="
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "lhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ", "
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "rhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ") -> "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Bool",
+                    "preciseIdentifier": "s:Sb"
+                }
+            ],
+            "accessLevel": "public"
+        },
+        {
+            "kind": {
+                "identifier": "swift.method",
+                "displayName": "Instance Method"
+            },
+            "identifier": {
+                "precise": "s:11FirstTarget3FooPAAE23fooMemberWithDocCommentyyF",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "Foo",
+                "fooMemberWithDocComment()"
+            ],
+            "names": {
+                "title": "fooMemberWithDocComment()",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "fooMemberWithDocComment"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "docComment": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "module": "FirstTarget",
+                "lines": [
+                    {
+                        "range": {
+                            "start": {
+                                "line": 1,
+                                "character": 8
+                            },
+                            "end": {
+                                "line": 1,
+                                "character": 29
+                            }
+                        },
+                        "text": "This is my great doc."
+                    }
+                ]
+            },
+            "functionSignature": {
+                "returns": [
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "FirstTarget"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "fooMemberWithDocComment"
+                },
+                {
+                    "kind": "text",
+                    "spelling": "()"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "position": {
+                    "line": 7,
+                    "character": 9
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.func.op",
+                "displayName": "Operator"
+            },
+            "identifier": {
+                "precise": "s:SLsE2leoiySbx_xtFZ::SYNTHESIZED::s:11FirstTarget10SomeStructV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "SomeStruct",
+                "<=(_:_:)"
+            ],
+            "names": {
+                "title": "<=(_:_:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "<="
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ", "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ") -> "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Bool",
+                        "preciseIdentifier": "s:Sb"
+                    }
+                ]
+            },
+            "docComment": {
+                "module": "Swift",
+                "lines": [
+                    {
+                        "text": "Returns a Boolean value indicating whether the value of the first argument"
+                    },
+                    {
+                        "text": "is less than or equal to that of the second argument."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "This is the default implementation of the less-than-or-equal-to"
+                    },
+                    {
+                        "text": "operator (`<=`) for any type that conforms to `Comparable`."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "- Parameters:"
+                    },
+                    {
+                        "text": "  - lhs: A value to compare."
+                    },
+                    {
+                        "text": "  - rhs: Another value to compare."
+                    }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "lhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "lhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "rhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "rhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Bool",
+                        "preciseIdentifier": "s:Sb"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "Swift"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "<="
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "lhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ", "
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "rhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ") -> "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Bool",
+                    "preciseIdentifier": "s:Sb"
+                }
+            ],
+            "accessLevel": "public"
+        },
+        {
+            "kind": {
+                "identifier": "swift.struct",
+                "displayName": "Structure"
+            },
+            "identifier": {
+                "precise": "s:11FirstTarget3BarV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "Bar"
+            ],
+            "names": {
+                "title": "Bar",
+                "navigator": [
+                    {
+                        "kind": "identifier",
+                        "spelling": "Bar"
+                    }
+                ],
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "struct"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "Bar"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "struct"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "Bar"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "position": {
+                    "line": 11,
+                    "character": 14
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.func.op",
+                "displayName": "Operator"
+            },
+            "identifier": {
+                "precise": "s:SLsE3zzzopys19PartialRangeThroughVyxGxFZ::SYNTHESIZED::s:11FirstTarget11OtherStructV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "OtherStruct",
+                "...(_:)"
+            ],
+            "names": {
+                "title": "...(_:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "..."
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ") -> "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "PartialRangeThrough",
+                        "preciseIdentifier": "s:s19PartialRangeThroughV"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "<"
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ">"
+                    }
+                ]
+            },
+            "docComment": {
+                "module": "Swift",
+                "lines": [
+                    {
+                        "text": "Returns a partial range up to, and including, its upper bound."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "Use the prefix closed range operator (prefix `...`) to create a partial"
+                    },
+                    {
+                        "text": "range of any type that conforms to the `Comparable` protocol. This"
+                    },
+                    {
+                        "text": "example creates a `PartialRangeThrough<Double>` instance that includes"
+                    },
+                    {
+                        "text": "any value less than or equal to `5.0`."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "    let throughFive = ...5.0"
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "    throughFive.contains(4.0)     // true"
+                    },
+                    {
+                        "text": "    throughFive.contains(5.0)     // true"
+                    },
+                    {
+                        "text": "    throughFive.contains(6.0)     // false"
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "You can use this type of partial range of a collection's indices to"
+                    },
+                    {
+                        "text": "represent the range from the start of the collection up to, and"
+                    },
+                    {
+                        "text": "including, the partial range's upper bound."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "    let numbers = [10, 20, 30, 40, 50, 60, 70]"
+                    },
+                    {
+                        "text": "    print(numbers[...3])"
+                    },
+                    {
+                        "text": "    // Prints \"[10, 20, 30, 40]\""
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "- Parameter maximum: The upper bound for the range."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "- Precondition: `maximum` must compare equal to itself (i.e. cannot be NaN)."
+                    }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "maximum",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "maximum"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "PartialRangeThrough",
+                        "preciseIdentifier": "s:s19PartialRangeThroughV"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "<"
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ">"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "Swift"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "..."
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "maximum"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ") -> "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "PartialRangeThrough",
+                    "preciseIdentifier": "s:s19PartialRangeThroughV"
+                },
+                {
+                    "kind": "text",
+                    "spelling": "<"
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ">"
+                }
+            ],
+            "accessLevel": "public"
+        },
+        {
+            "kind": {
+                "identifier": "swift.func.op",
+                "displayName": "Operator"
+            },
+            "identifier": {
+                "precise": "s:SLsE1goiySbx_xtFZ::SYNTHESIZED::s:11FirstTarget10SomeStructV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "SomeStruct",
+                ">(_:_:)"
+            ],
+            "names": {
+                "title": ">(_:_:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": ">"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ", "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ") -> "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Bool",
+                        "preciseIdentifier": "s:Sb"
+                    }
+                ]
+            },
+            "docComment": {
+                "module": "Swift",
+                "lines": [
+                    {
+                        "text": "Returns a Boolean value indicating whether the value of the first argument"
+                    },
+                    {
+                        "text": "is greater than that of the second argument."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "This is the default implementation of the greater-than operator (`>`) for"
+                    },
+                    {
+                        "text": "any type that conforms to `Comparable`."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "- Parameters:"
+                    },
+                    {
+                        "text": "  - lhs: A value to compare."
+                    },
+                    {
+                        "text": "  - rhs: Another value to compare."
+                    }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "lhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "lhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "rhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "rhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Bool",
+                        "preciseIdentifier": "s:Sb"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "Swift"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": ">"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "lhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ", "
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "rhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ") -> "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Bool",
+                    "preciseIdentifier": "s:Sb"
+                }
+            ],
+            "accessLevel": "public"
+        },
+        {
+            "kind": {
+                "identifier": "swift.func.op",
+                "displayName": "Operator"
+            },
+            "identifier": {
+                "precise": "s:SLsE3zzzoiySNyxGx_xtFZ::SYNTHESIZED::s:11FirstTarget10SomeStructV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "SomeStruct",
+                "...(_:_:)"
+            ],
+            "names": {
+                "title": "...(_:_:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "..."
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ", "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ") -> "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "ClosedRange",
+                        "preciseIdentifier": "s:SN"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "<"
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ">"
+                    }
+                ]
+            },
+            "docComment": {
+                "module": "Swift",
+                "lines": [
+                    {
+                        "text": "Returns a closed range that contains both of its bounds."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "Use the closed range operator (`...`) to create a closed range of any type"
+                    },
+                    {
+                        "text": "that conforms to the `Comparable` protocol. This example creates a"
+                    },
+                    {
+                        "text": "`ClosedRange<Character>` from \"a\" up to, and including, \"z\"."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "    let lowercase = \"a\"...\"z\""
+                    },
+                    {
+                        "text": "    print(lowercase.contains(\"z\"))"
+                    },
+                    {
+                        "text": "    // Prints \"true\""
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "- Parameters:"
+                    },
+                    {
+                        "text": "  - minimum: The lower bound for the range."
+                    },
+                    {
+                        "text": "  - maximum: The upper bound for the range."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "- Precondition: `minimum <= maximum`."
+                    }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "minimum",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "minimum"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "maximum",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "maximum"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "ClosedRange",
+                        "preciseIdentifier": "s:SN"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "<"
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ">"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "Swift"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "..."
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "minimum"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ", "
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "maximum"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ") -> "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "ClosedRange",
+                    "preciseIdentifier": "s:SN"
+                },
+                {
+                    "kind": "text",
+                    "spelling": "<"
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ">"
+                }
+            ],
+            "accessLevel": "public"
+        },
+        {
+            "kind": {
+                "identifier": "swift.method",
+                "displayName": "Instance Method"
+            },
+            "identifier": {
+                "precise": "s:SL11FirstTargetE26localDefaultImplementationyyF::SYNTHESIZED::s:11FirstTarget11OtherStructV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "OtherStruct",
+                "localDefaultImplementation()"
+            ],
+            "names": {
+                "title": "localDefaultImplementation()",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "localDefaultImplementation"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "functionSignature": {
+                "returns": [
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "Swift"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "localDefaultImplementation"
+                },
+                {
+                    "kind": "text",
+                    "spelling": "()"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "position": {
+                    "line": 46,
+                    "character": 16
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.method",
+                "displayName": "Instance Method"
+            },
+            "identifier": {
+                "precise": "s:11FirstTarget3FooP26fooMemberWithoutDocCommentyyF",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "Foo",
+                "fooMemberWithoutDocComment()"
+            ],
+            "names": {
+                "title": "fooMemberWithoutDocComment()",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "fooMemberWithoutDocComment"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "functionSignature": {
+                "returns": [
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "fooMemberWithoutDocComment"
+                },
+                {
+                    "kind": "text",
+                    "spelling": "()"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "position": {
+                    "line": 3,
+                    "character": 9
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.func.op",
+                "displayName": "Operator"
+            },
+            "identifier": {
+                "precise": "s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:11FirstTarget11OtherStructV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "OtherStruct",
+                "!=(_:_:)"
+            ],
+            "names": {
+                "title": "!=(_:_:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "!="
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ", "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ") -> "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Bool",
+                        "preciseIdentifier": "s:Sb"
+                    }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "lhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "lhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "rhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "rhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Bool",
+                        "preciseIdentifier": "s:Sb"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "Swift"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "!="
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "lhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ", "
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "rhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ") -> "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Bool",
+                    "preciseIdentifier": "s:Sb"
+                }
+            ],
+            "accessLevel": "public"
+        },
+        {
+            "kind": {
+                "identifier": "swift.func.op",
+                "displayName": "Operator"
+            },
+            "identifier": {
+                "precise": "s:SLsE3zzloiySnyxGx_xtFZ::SYNTHESIZED::s:11FirstTarget11OtherStructV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "OtherStruct",
+                "..<(_:_:)"
+            ],
+            "names": {
+                "title": "..<(_:_:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "..<"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ", "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ") -> "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Range",
+                        "preciseIdentifier": "s:Sn"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "<"
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ">"
+                    }
+                ]
+            },
+            "docComment": {
+                "module": "Swift",
+                "lines": [
+                    {
+                        "text": "Returns a half-open range that contains its lower bound but not its upper"
+                    },
+                    {
+                        "text": "bound."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "Use the half-open range operator (`..<`) to create a range of any type"
+                    },
+                    {
+                        "text": "that conforms to the `Comparable` protocol. This example creates a"
+                    },
+                    {
+                        "text": "`Range<Double>` from zero up to, but not including, 5.0."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "    let lessThanFive = 0.0..<5.0"
+                    },
+                    {
+                        "text": "    print(lessThanFive.contains(3.14))  // Prints \"true\""
+                    },
+                    {
+                        "text": "    print(lessThanFive.contains(5.0))   // Prints \"false\""
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "- Parameters:"
+                    },
+                    {
+                        "text": "  - minimum: The lower bound for the range."
+                    },
+                    {
+                        "text": "  - maximum: The upper bound for the range."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "- Precondition: `minimum <= maximum`."
+                    }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "minimum",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "minimum"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "maximum",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "maximum"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Range",
+                        "preciseIdentifier": "s:Sn"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "<"
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ">"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "Swift"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "..<"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "minimum"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ", "
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "maximum"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ") -> "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Range",
+                    "preciseIdentifier": "s:Sn"
+                },
+                {
+                    "kind": "text",
+                    "spelling": "<"
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ">"
+                }
+            ],
+            "accessLevel": "public"
+        },
+        {
+            "kind": {
+                "identifier": "swift.func.op",
+                "displayName": "Operator"
+            },
+            "identifier": {
+                "precise": "s:SLsE2geoiySbx_xtFZ::SYNTHESIZED::s:11FirstTarget11OtherStructV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "OtherStruct",
+                ">=(_:_:)"
+            ],
+            "names": {
+                "title": ">=(_:_:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": ">="
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ", "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ") -> "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Bool",
+                        "preciseIdentifier": "s:Sb"
+                    }
+                ]
+            },
+            "docComment": {
+                "module": "Swift",
+                "lines": [
+                    {
+                        "text": "Returns a Boolean value indicating whether the value of the first argument"
+                    },
+                    {
+                        "text": "is greater than or equal to that of the second argument."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "This is the default implementation of the greater-than-or-equal-to operator"
+                    },
+                    {
+                        "text": "(`>=`) for any type that conforms to `Comparable`."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "- Parameters:"
+                    },
+                    {
+                        "text": "  - lhs: A value to compare."
+                    },
+                    {
+                        "text": "  - rhs: Another value to compare."
+                    },
+                    {
+                        "text": "- Returns: `true` if `lhs` is greater than or equal to `rhs`; otherwise,"
+                    },
+                    {
+                        "text": "  `false`."
+                    }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "lhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "lhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "rhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "rhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Bool",
+                        "preciseIdentifier": "s:Sb"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "Swift"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": ">="
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "lhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ", "
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "rhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ") -> "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Bool",
+                    "preciseIdentifier": "s:Sb"
+                }
+            ],
+            "accessLevel": "public"
+        },
+        {
+            "kind": {
+                "identifier": "swift.func.op",
+                "displayName": "Operator"
+            },
+            "identifier": {
+                "precise": "s:SLsE3zzzoPys16PartialRangeFromVyxGxFZ::SYNTHESIZED::s:11FirstTarget11OtherStructV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "OtherStruct",
+                "...(_:)"
+            ],
+            "names": {
+                "title": "...(_:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "..."
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ") -> "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "PartialRangeFrom",
+                        "preciseIdentifier": "s:s16PartialRangeFromV"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "<"
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ">"
+                    }
+                ]
+            },
+            "docComment": {
+                "module": "Swift",
+                "lines": [
+                    {
+                        "text": "Returns a partial range extending upward from a lower bound."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "Use the postfix range operator (postfix `...`) to create a partial range"
+                    },
+                    {
+                        "text": "of any type that conforms to the `Comparable` protocol. This example"
+                    },
+                    {
+                        "text": "creates a `PartialRangeFrom<Double>` instance that includes any value"
+                    },
+                    {
+                        "text": "greater than or equal to `5.0`."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "    let atLeastFive = 5.0..."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "    atLeastFive.contains(4.0)     // false"
+                    },
+                    {
+                        "text": "    atLeastFive.contains(5.0)     // true"
+                    },
+                    {
+                        "text": "    atLeastFive.contains(6.0)     // true"
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "You can use this type of partial range of a collection's indices to"
+                    },
+                    {
+                        "text": "represent the range from the partial range's lower bound up to the end"
+                    },
+                    {
+                        "text": "of the collection."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "    let numbers = [10, 20, 30, 40, 50, 60, 70]"
+                    },
+                    {
+                        "text": "    print(numbers[3...])"
+                    },
+                    {
+                        "text": "    // Prints \"[40, 50, 60, 70]\""
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "- Parameter minimum: The lower bound for the range."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "- Precondition: `minimum` must compare equal to itself (i.e. cannot be NaN)."
+                    }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "minimum",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "minimum"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "PartialRangeFrom",
+                        "preciseIdentifier": "s:s16PartialRangeFromV"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "<"
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ">"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "Swift"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "..."
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "minimum"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ") -> "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "PartialRangeFrom",
+                    "preciseIdentifier": "s:s16PartialRangeFromV"
+                },
+                {
+                    "kind": "text",
+                    "spelling": "<"
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ">"
+                }
+            ],
+            "accessLevel": "public"
+        },
+        {
+            "kind": {
+                "identifier": "swift.func.op",
+                "displayName": "Operator"
+            },
+            "identifier": {
+                "precise": "s:11FirstTarget13FancyProtocolPAAE4zzzzoiyyAaB_p_AaB_ptFZ::SYNTHESIZED::s:11FirstTarget10SomeStructV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "SomeStruct",
+                "....(_:_:)"
+            ],
+            "names": {
+                "title": "....(_:_:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "...."
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "FancyProtocol",
+                        "preciseIdentifier": "s:11FirstTarget13FancyProtocolP"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ", "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "FancyProtocol",
+                        "preciseIdentifier": "s:11FirstTarget13FancyProtocolP"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ")"
+                    }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "lhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "lhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "FancyProtocol",
+                                "preciseIdentifier": "s:11FirstTarget13FancyProtocolP"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "rhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "rhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "FancyProtocol",
+                                "preciseIdentifier": "s:11FirstTarget13FancyProtocolP"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "FirstTarget"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "...."
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "lhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "FancyProtocol",
+                    "preciseIdentifier": "s:11FirstTarget13FancyProtocolP"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ", "
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "rhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "FancyProtocol",
+                    "preciseIdentifier": "s:11FirstTarget13FancyProtocolP"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ")"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "position": {
+                    "line": 27,
+                    "character": 16
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.method",
+                "displayName": "Instance Method"
+            },
+            "identifier": {
+                "precise": "s:11FirstTarget3FooPAAE26fooMemberWithoutDocCommentyyF::SYNTHESIZED::s:11FirstTarget3BarV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "Bar",
+                "fooMemberWithoutDocComment()"
+            ],
+            "names": {
+                "title": "fooMemberWithoutDocComment()",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "fooMemberWithoutDocComment"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "functionSignature": {
+                "returns": [
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "FirstTarget"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "fooMemberWithoutDocComment"
+                },
+                {
+                    "kind": "text",
+                    "spelling": "()"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "position": {
+                    "line": 8,
+                    "character": 9
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.func.op",
+                "displayName": "Operator"
+            },
+            "identifier": {
+                "precise": "s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:11FirstTarget10SomeStructV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "SomeStruct",
+                "!=(_:_:)"
+            ],
+            "names": {
+                "title": "!=(_:_:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "!="
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ", "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ") -> "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Bool",
+                        "preciseIdentifier": "s:Sb"
+                    }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "lhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "lhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "rhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "rhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Bool",
+                        "preciseIdentifier": "s:Sb"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "Swift"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "!="
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "lhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ", "
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "rhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ") -> "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Bool",
+                    "preciseIdentifier": "s:Sb"
+                }
+            ],
+            "accessLevel": "public"
+        },
+        {
+            "kind": {
+                "identifier": "swift.func.op",
+                "displayName": "Operator"
+            },
+            "identifier": {
+                "precise": "s:SLsE3zzloiySnyxGx_xtFZ::SYNTHESIZED::s:11FirstTarget10SomeStructV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "SomeStruct",
+                "..<(_:_:)"
+            ],
+            "names": {
+                "title": "..<(_:_:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "..<"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ", "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ") -> "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Range",
+                        "preciseIdentifier": "s:Sn"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "<"
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ">"
+                    }
+                ]
+            },
+            "docComment": {
+                "module": "Swift",
+                "lines": [
+                    {
+                        "text": "Returns a half-open range that contains its lower bound but not its upper"
+                    },
+                    {
+                        "text": "bound."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "Use the half-open range operator (`..<`) to create a range of any type"
+                    },
+                    {
+                        "text": "that conforms to the `Comparable` protocol. This example creates a"
+                    },
+                    {
+                        "text": "`Range<Double>` from zero up to, but not including, 5.0."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "    let lessThanFive = 0.0..<5.0"
+                    },
+                    {
+                        "text": "    print(lessThanFive.contains(3.14))  // Prints \"true\""
+                    },
+                    {
+                        "text": "    print(lessThanFive.contains(5.0))   // Prints \"false\""
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "- Parameters:"
+                    },
+                    {
+                        "text": "  - minimum: The lower bound for the range."
+                    },
+                    {
+                        "text": "  - maximum: The upper bound for the range."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "- Precondition: `minimum <= maximum`."
+                    }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "minimum",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "minimum"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "maximum",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "maximum"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Range",
+                        "preciseIdentifier": "s:Sn"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "<"
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ">"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "Swift"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "..<"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "minimum"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ", "
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "maximum"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ") -> "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Range",
+                    "preciseIdentifier": "s:Sn"
+                },
+                {
+                    "kind": "text",
+                    "spelling": "<"
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ">"
+                }
+            ],
+            "accessLevel": "public"
+        },
+        {
+            "kind": {
+                "identifier": "swift.func.op",
+                "displayName": "Operator"
+            },
+            "identifier": {
+                "precise": "s:11FirstTarget13FancyProtocolPAAE4zzzzoiyyAaB_p_AaB_ptFZ",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "FancyProtocol",
+                "....(_:_:)"
+            ],
+            "names": {
+                "title": "....(_:_:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "...."
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "FancyProtocol",
+                        "preciseIdentifier": "s:11FirstTarget13FancyProtocolP"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ", "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "FancyProtocol",
+                        "preciseIdentifier": "s:11FirstTarget13FancyProtocolP"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ")"
+                    }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "lhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "lhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "FancyProtocol",
+                                "preciseIdentifier": "s:11FirstTarget13FancyProtocolP"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "rhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "rhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "FancyProtocol",
+                                "preciseIdentifier": "s:11FirstTarget13FancyProtocolP"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "FirstTarget"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "...."
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "lhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "FancyProtocol",
+                    "preciseIdentifier": "s:11FirstTarget13FancyProtocolP"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ", "
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "rhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "FancyProtocol",
+                    "preciseIdentifier": "s:11FirstTarget13FancyProtocolP"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ")"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "position": {
+                    "line": 27,
+                    "character": 16
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.protocol",
+                "displayName": "Protocol"
+            },
+            "identifier": {
+                "precise": "s:11FirstTarget3FooP",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "Foo"
+            ],
+            "names": {
+                "title": "Foo",
+                "navigator": [
+                    {
+                        "kind": "identifier",
+                        "spelling": "Foo"
+                    }
+                ],
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "protocol"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "Foo"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "protocol"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "Foo"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "position": {
+                    "line": 0,
+                    "character": 16
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.struct",
+                "displayName": "Structure"
+            },
+            "identifier": {
+                "precise": "s:11FirstTarget10SomeStructV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "SomeStruct"
+            ],
+            "names": {
+                "title": "SomeStruct",
+                "navigator": [
+                    {
+                        "kind": "identifier",
+                        "spelling": "SomeStruct"
+                    }
+                ],
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "struct"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "SomeStruct"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "struct"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "SomeStruct"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "position": {
+                    "line": 13,
+                    "character": 14
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.func.op",
+                "displayName": "Operator"
+            },
+            "identifier": {
+                "precise": "s:SLsE3zzzoPys16PartialRangeFromVyxGxFZ::SYNTHESIZED::s:11FirstTarget10SomeStructV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "SomeStruct",
+                "...(_:)"
+            ],
+            "names": {
+                "title": "...(_:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "..."
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ") -> "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "PartialRangeFrom",
+                        "preciseIdentifier": "s:s16PartialRangeFromV"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "<"
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ">"
+                    }
+                ]
+            },
+            "docComment": {
+                "module": "Swift",
+                "lines": [
+                    {
+                        "text": "Returns a partial range extending upward from a lower bound."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "Use the postfix range operator (postfix `...`) to create a partial range"
+                    },
+                    {
+                        "text": "of any type that conforms to the `Comparable` protocol. This example"
+                    },
+                    {
+                        "text": "creates a `PartialRangeFrom<Double>` instance that includes any value"
+                    },
+                    {
+                        "text": "greater than or equal to `5.0`."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "    let atLeastFive = 5.0..."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "    atLeastFive.contains(4.0)     // false"
+                    },
+                    {
+                        "text": "    atLeastFive.contains(5.0)     // true"
+                    },
+                    {
+                        "text": "    atLeastFive.contains(6.0)     // true"
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "You can use this type of partial range of a collection's indices to"
+                    },
+                    {
+                        "text": "represent the range from the partial range's lower bound up to the end"
+                    },
+                    {
+                        "text": "of the collection."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "    let numbers = [10, 20, 30, 40, 50, 60, 70]"
+                    },
+                    {
+                        "text": "    print(numbers[3...])"
+                    },
+                    {
+                        "text": "    // Prints \"[40, 50, 60, 70]\""
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "- Parameter minimum: The lower bound for the range."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "- Precondition: `minimum` must compare equal to itself (i.e. cannot be NaN)."
+                    }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "minimum",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "minimum"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "PartialRangeFrom",
+                        "preciseIdentifier": "s:s16PartialRangeFromV"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "<"
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ">"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "Swift"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "..."
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "minimum"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ") -> "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "PartialRangeFrom",
+                    "preciseIdentifier": "s:s16PartialRangeFromV"
+                },
+                {
+                    "kind": "text",
+                    "spelling": "<"
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ">"
+                }
+            ],
+            "accessLevel": "public"
+        },
+        {
+            "kind": {
+                "identifier": "swift.func.op",
+                "displayName": "Operator"
+            },
+            "identifier": {
+                "precise": "s:11FirstTarget13FancyProtocolP4zzzzoiyyAaB_p_AaB_ptFZ",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "FancyProtocol",
+                "....(_:_:)"
+            ],
+            "names": {
+                "title": "....(_:_:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "...."
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "FancyProtocol",
+                        "preciseIdentifier": "s:11FirstTarget13FancyProtocolP"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ", "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "FancyProtocol",
+                        "preciseIdentifier": "s:11FirstTarget13FancyProtocolP"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ")"
+                    }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "lhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "lhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "FancyProtocol",
+                                "preciseIdentifier": "s:11FirstTarget13FancyProtocolP"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "rhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "rhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "FancyProtocol",
+                                "preciseIdentifier": "s:11FirstTarget13FancyProtocolP"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "...."
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "lhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "FancyProtocol",
+                    "preciseIdentifier": "s:11FirstTarget13FancyProtocolP"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ", "
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "rhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "FancyProtocol",
+                    "preciseIdentifier": "s:11FirstTarget13FancyProtocolP"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ")"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "position": {
+                    "line": 23,
+                    "character": 16
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.func.op",
+                "displayName": "Operator"
+            },
+            "identifier": {
+                "precise": "s:11FirstTarget11OtherStructV1loiySbAC_ACtFZ",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "OtherStruct",
+                "<(_:_:)"
+            ],
+            "names": {
+                "title": "<(_:_:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "<"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "OtherStruct",
+                        "preciseIdentifier": "s:11FirstTarget11OtherStructV"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ", "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "OtherStruct",
+                        "preciseIdentifier": "s:11FirstTarget11OtherStructV"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ") -> "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Bool",
+                        "preciseIdentifier": "s:Sb"
+                    }
+                ]
+            },
+            "docComment": {
+                "module": "Swift",
+                "lines": [
+                    {
+                        "text": "Returns a Boolean value indicating whether the value of the first"
+                    },
+                    {
+                        "text": "argument is less than that of the second argument."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "This function is the only requirement of the `Comparable` protocol. The"
+                    },
+                    {
+                        "text": "remainder of the relational operator functions are implemented by the"
+                    },
+                    {
+                        "text": "standard library for any type that conforms to `Comparable`."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "- Parameters:"
+                    },
+                    {
+                        "text": "  - lhs: A value to compare."
+                    },
+                    {
+                        "text": "  - rhs: Another value to compare."
+                    }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "lhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "lhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "OtherStruct",
+                                "preciseIdentifier": "s:11FirstTarget11OtherStructV"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "rhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "rhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "OtherStruct",
+                                "preciseIdentifier": "s:11FirstTarget11OtherStructV"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Bool",
+                        "preciseIdentifier": "s:Sb"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "<"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "lhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "OtherStruct",
+                    "preciseIdentifier": "s:11FirstTarget11OtherStructV"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ", "
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "rhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "OtherStruct",
+                    "preciseIdentifier": "s:11FirstTarget11OtherStructV"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ") -> "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Bool",
+                    "preciseIdentifier": "s:Sb"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "position": {
+                    "line": 40,
+                    "character": 23
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.struct",
+                "displayName": "Structure"
+            },
+            "identifier": {
+                "precise": "s:11FirstTarget11OtherStructV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "OtherStruct"
+            ],
+            "names": {
+                "title": "OtherStruct",
+                "navigator": [
+                    {
+                        "kind": "identifier",
+                        "spelling": "OtherStruct"
+                    }
+                ],
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "struct"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "OtherStruct"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "struct"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "OtherStruct"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "position": {
+                    "line": 39,
+                    "character": 14
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.func.op",
+                "displayName": "Operator"
+            },
+            "identifier": {
+                "precise": "s:SLsE3zzzoiySNyxGx_xtFZ::SYNTHESIZED::s:11FirstTarget11OtherStructV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "OtherStruct",
+                "...(_:_:)"
+            ],
+            "names": {
+                "title": "...(_:_:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "..."
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ", "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ") -> "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "ClosedRange",
+                        "preciseIdentifier": "s:SN"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "<"
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ">"
+                    }
+                ]
+            },
+            "docComment": {
+                "module": "Swift",
+                "lines": [
+                    {
+                        "text": "Returns a closed range that contains both of its bounds."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "Use the closed range operator (`...`) to create a closed range of any type"
+                    },
+                    {
+                        "text": "that conforms to the `Comparable` protocol. This example creates a"
+                    },
+                    {
+                        "text": "`ClosedRange<Character>` from \"a\" up to, and including, \"z\"."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "    let lowercase = \"a\"...\"z\""
+                    },
+                    {
+                        "text": "    print(lowercase.contains(\"z\"))"
+                    },
+                    {
+                        "text": "    // Prints \"true\""
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "- Parameters:"
+                    },
+                    {
+                        "text": "  - minimum: The lower bound for the range."
+                    },
+                    {
+                        "text": "  - maximum: The upper bound for the range."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "- Precondition: `minimum <= maximum`."
+                    }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "minimum",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "minimum"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "maximum",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "maximum"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "ClosedRange",
+                        "preciseIdentifier": "s:SN"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "<"
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ">"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "Swift"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "..."
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "minimum"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ", "
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "maximum"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ") -> "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "ClosedRange",
+                    "preciseIdentifier": "s:SN"
+                },
+                {
+                    "kind": "text",
+                    "spelling": "<"
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ">"
+                }
+            ],
+            "accessLevel": "public"
+        },
+        {
+            "kind": {
+                "identifier": "swift.method",
+                "displayName": "Instance Method"
+            },
+            "identifier": {
+                "precise": "s:SL11FirstTargetE26localDefaultImplementationyyF::SYNTHESIZED::s:11FirstTarget10SomeStructV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "SomeStruct",
+                "localDefaultImplementation()"
+            ],
+            "names": {
+                "title": "localDefaultImplementation()",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "localDefaultImplementation"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "functionSignature": {
+                "returns": [
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "Swift"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "localDefaultImplementation"
+                },
+                {
+                    "kind": "text",
+                    "spelling": "()"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "position": {
+                    "line": 46,
+                    "character": 16
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.protocol",
+                "displayName": "Protocol"
+            },
+            "identifier": {
+                "precise": "s:11FirstTarget18OtherFancyProtocolP",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "OtherFancyProtocol"
+            ],
+            "names": {
+                "title": "OtherFancyProtocol",
+                "navigator": [
+                    {
+                        "kind": "identifier",
+                        "spelling": "OtherFancyProtocol"
+                    }
+                ],
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "protocol"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "OtherFancyProtocol"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "protocol"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "OtherFancyProtocol"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "position": {
+                    "line": 31,
+                    "character": 16
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.method",
+                "displayName": "Instance Method"
+            },
+            "identifier": {
+                "precise": "s:11FirstTarget3FooPAAE23fooMemberWithDocCommentyyF::SYNTHESIZED::s:11FirstTarget3BarV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "Bar",
+                "fooMemberWithDocComment()"
+            ],
+            "names": {
+                "title": "fooMemberWithDocComment()",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "fooMemberWithDocComment"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "docComment": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "module": "FirstTarget",
+                "lines": [
+                    {
+                        "range": {
+                            "start": {
+                                "line": 1,
+                                "character": 8
+                            },
+                            "end": {
+                                "line": 1,
+                                "character": 29
+                            }
+                        },
+                        "text": "This is my great doc."
+                    }
+                ]
+            },
+            "functionSignature": {
+                "returns": [
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "FirstTarget"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "fooMemberWithDocComment"
+                },
+                {
+                    "kind": "text",
+                    "spelling": "()"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "position": {
+                    "line": 7,
+                    "character": 9
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.func.op",
+                "displayName": "Operator"
+            },
+            "identifier": {
+                "precise": "s:SLsE2geoiySbx_xtFZ::SYNTHESIZED::s:11FirstTarget10SomeStructV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "SomeStruct",
+                ">=(_:_:)"
+            ],
+            "names": {
+                "title": ">=(_:_:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": ">="
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ", "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ") -> "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Bool",
+                        "preciseIdentifier": "s:Sb"
+                    }
+                ]
+            },
+            "docComment": {
+                "module": "Swift",
+                "lines": [
+                    {
+                        "text": "Returns a Boolean value indicating whether the value of the first argument"
+                    },
+                    {
+                        "text": "is greater than or equal to that of the second argument."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "This is the default implementation of the greater-than-or-equal-to operator"
+                    },
+                    {
+                        "text": "(`>=`) for any type that conforms to `Comparable`."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "- Parameters:"
+                    },
+                    {
+                        "text": "  - lhs: A value to compare."
+                    },
+                    {
+                        "text": "  - rhs: Another value to compare."
+                    },
+                    {
+                        "text": "- Returns: `true` if `lhs` is greater than or equal to `rhs`; otherwise,"
+                    },
+                    {
+                        "text": "  `false`."
+                    }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "lhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "lhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "rhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "rhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Bool",
+                        "preciseIdentifier": "s:Sb"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "Swift"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": ">="
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "lhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ", "
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "rhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ") -> "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Bool",
+                    "preciseIdentifier": "s:Sb"
+                }
+            ],
+            "accessLevel": "public"
+        },
+        {
+            "kind": {
+                "identifier": "swift.func.op",
+                "displayName": "Operator"
+            },
+            "identifier": {
+                "precise": "s:11FirstTarget18OtherFancyProtocolP4zlzzoiyyAaB_p_AaB_ptFZ",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "OtherFancyProtocol",
+                ".<..(_:_:)"
+            ],
+            "names": {
+                "title": ".<..(_:_:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": ".<.."
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "OtherFancyProtocol",
+                        "preciseIdentifier": "s:11FirstTarget18OtherFancyProtocolP"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ", "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "OtherFancyProtocol",
+                        "preciseIdentifier": "s:11FirstTarget18OtherFancyProtocolP"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ")"
+                    }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "lhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "lhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "OtherFancyProtocol",
+                                "preciseIdentifier": "s:11FirstTarget18OtherFancyProtocolP"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "rhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "rhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "OtherFancyProtocol",
+                                "preciseIdentifier": "s:11FirstTarget18OtherFancyProtocolP"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": ".<.."
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "lhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "OtherFancyProtocol",
+                    "preciseIdentifier": "s:11FirstTarget18OtherFancyProtocolP"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ", "
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "rhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "OtherFancyProtocol",
+                    "preciseIdentifier": "s:11FirstTarget18OtherFancyProtocolP"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ")"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "position": {
+                    "line": 32,
+                    "character": 16
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.func.op",
+                "displayName": "Operator"
+            },
+            "identifier": {
+                "precise": "s:SLsE3zzzopys19PartialRangeThroughVyxGxFZ::SYNTHESIZED::s:11FirstTarget10SomeStructV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "SomeStruct",
+                "...(_:)"
+            ],
+            "names": {
+                "title": "...(_:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "..."
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ") -> "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "PartialRangeThrough",
+                        "preciseIdentifier": "s:s19PartialRangeThroughV"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "<"
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ">"
+                    }
+                ]
+            },
+            "docComment": {
+                "module": "Swift",
+                "lines": [
+                    {
+                        "text": "Returns a partial range up to, and including, its upper bound."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "Use the prefix closed range operator (prefix `...`) to create a partial"
+                    },
+                    {
+                        "text": "range of any type that conforms to the `Comparable` protocol. This"
+                    },
+                    {
+                        "text": "example creates a `PartialRangeThrough<Double>` instance that includes"
+                    },
+                    {
+                        "text": "any value less than or equal to `5.0`."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "    let throughFive = ...5.0"
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "    throughFive.contains(4.0)     // true"
+                    },
+                    {
+                        "text": "    throughFive.contains(5.0)     // true"
+                    },
+                    {
+                        "text": "    throughFive.contains(6.0)     // false"
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "You can use this type of partial range of a collection's indices to"
+                    },
+                    {
+                        "text": "represent the range from the start of the collection up to, and"
+                    },
+                    {
+                        "text": "including, the partial range's upper bound."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "    let numbers = [10, 20, 30, 40, 50, 60, 70]"
+                    },
+                    {
+                        "text": "    print(numbers[...3])"
+                    },
+                    {
+                        "text": "    // Prints \"[10, 20, 30, 40]\""
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "- Parameter maximum: The upper bound for the range."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "- Precondition: `maximum` must compare equal to itself (i.e. cannot be NaN)."
+                    }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "maximum",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "maximum"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "PartialRangeThrough",
+                        "preciseIdentifier": "s:s19PartialRangeThroughV"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "<"
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ">"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "Swift"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "..."
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "maximum"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ") -> "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "PartialRangeThrough",
+                    "preciseIdentifier": "s:s19PartialRangeThroughV"
+                },
+                {
+                    "kind": "text",
+                    "spelling": "<"
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ">"
+                }
+            ],
+            "accessLevel": "public"
+        },
+        {
+            "kind": {
+                "identifier": "swift.property",
+                "displayName": "Instance Property"
+            },
+            "identifier": {
+                "precise": "s:11FirstTarget10SomeStructV7someVarSSvp",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "SomeStruct",
+                "someVar"
+            ],
+            "names": {
+                "title": "someVar",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "var"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "someVar"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ": "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "String",
+                        "preciseIdentifier": "s:SS"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "var"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "someVar"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "String",
+                    "preciseIdentifier": "s:SS"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "position": {
+                    "line": 18,
+                    "character": 15
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.method",
+                "displayName": "Instance Method"
+            },
+            "identifier": {
+                "precise": "s:11FirstTarget3FooPAAE26fooMemberWithoutDocCommentyyF",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "Foo",
+                "fooMemberWithoutDocComment()"
+            ],
+            "names": {
+                "title": "fooMemberWithoutDocComment()",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "fooMemberWithoutDocComment"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "functionSignature": {
+                "returns": [
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "FirstTarget"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "fooMemberWithoutDocComment"
+                },
+                {
+                    "kind": "text",
+                    "spelling": "()"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "position": {
+                    "line": 8,
+                    "character": 9
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.func.op",
+                "displayName": "Operator"
+            },
+            "identifier": {
+                "precise": "s:11FirstTarget18OtherFancyProtocolPAAE4zlzzoiyyAaB_p_AaB_ptFZ::SYNTHESIZED::s:11FirstTarget10SomeStructV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "SomeStruct",
+                ".<..(_:_:)"
+            ],
+            "names": {
+                "title": ".<..(_:_:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": ".<.."
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "OtherFancyProtocol",
+                        "preciseIdentifier": "s:11FirstTarget18OtherFancyProtocolP"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ", "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "OtherFancyProtocol",
+                        "preciseIdentifier": "s:11FirstTarget18OtherFancyProtocolP"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ")"
+                    }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "lhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "lhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "OtherFancyProtocol",
+                                "preciseIdentifier": "s:11FirstTarget18OtherFancyProtocolP"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "rhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "rhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "OtherFancyProtocol",
+                                "preciseIdentifier": "s:11FirstTarget18OtherFancyProtocolP"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "FirstTarget"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": ".<.."
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "lhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "OtherFancyProtocol",
+                    "preciseIdentifier": "s:11FirstTarget18OtherFancyProtocolP"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ", "
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "rhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "OtherFancyProtocol",
+                    "preciseIdentifier": "s:11FirstTarget18OtherFancyProtocolP"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ")"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "position": {
+                    "line": 36,
+                    "character": 16
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.func.op",
+                "displayName": "Operator"
+            },
+            "identifier": {
+                "precise": "s:11FirstTarget18OtherFancyProtocolPAAE4zlzzoiyyAaB_p_AaB_ptFZ",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "OtherFancyProtocol",
+                ".<..(_:_:)"
+            ],
+            "names": {
+                "title": ".<..(_:_:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": ".<.."
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "OtherFancyProtocol",
+                        "preciseIdentifier": "s:11FirstTarget18OtherFancyProtocolP"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ", "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "OtherFancyProtocol",
+                        "preciseIdentifier": "s:11FirstTarget18OtherFancyProtocolP"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ")"
+                    }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "lhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "lhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "OtherFancyProtocol",
+                                "preciseIdentifier": "s:11FirstTarget18OtherFancyProtocolP"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "rhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "rhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "OtherFancyProtocol",
+                                "preciseIdentifier": "s:11FirstTarget18OtherFancyProtocolP"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "FirstTarget"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": ".<.."
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "lhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "OtherFancyProtocol",
+                    "preciseIdentifier": "s:11FirstTarget18OtherFancyProtocolP"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ", "
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "rhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "OtherFancyProtocol",
+                    "preciseIdentifier": "s:11FirstTarget18OtherFancyProtocolP"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ")"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "position": {
+                    "line": 36,
+                    "character": 16
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.func.op",
+                "displayName": "Operator"
+            },
+            "identifier": {
+                "precise": "s:SLsE3zzlopys16PartialRangeUpToVyxGxFZ::SYNTHESIZED::s:11FirstTarget11OtherStructV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "OtherStruct",
+                "..<(_:)"
+            ],
+            "names": {
+                "title": "..<(_:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "..<"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ") -> "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "PartialRangeUpTo",
+                        "preciseIdentifier": "s:s16PartialRangeUpToV"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "<"
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ">"
+                    }
+                ]
+            },
+            "docComment": {
+                "module": "Swift",
+                "lines": [
+                    {
+                        "text": "Returns a partial range up to, but not including, its upper bound."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "Use the prefix half-open range operator (prefix `..<`) to create a"
+                    },
+                    {
+                        "text": "partial range of any type that conforms to the `Comparable` protocol."
+                    },
+                    {
+                        "text": "This example creates a `PartialRangeUpTo<Double>` instance that includes"
+                    },
+                    {
+                        "text": "any value less than `5.0`."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "    let upToFive = ..<5.0"
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "    upToFive.contains(3.14)       // true"
+                    },
+                    {
+                        "text": "    upToFive.contains(6.28)       // false"
+                    },
+                    {
+                        "text": "    upToFive.contains(5.0)        // false"
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "You can use this type of partial range of a collection's indices to"
+                    },
+                    {
+                        "text": "represent the range from the start of the collection up to, but not"
+                    },
+                    {
+                        "text": "including, the partial range's upper bound."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "    let numbers = [10, 20, 30, 40, 50, 60, 70]"
+                    },
+                    {
+                        "text": "    print(numbers[..<3])"
+                    },
+                    {
+                        "text": "    // Prints \"[10, 20, 30]\""
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "- Parameter maximum: The upper bound for the range."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "- Precondition: `maximum` must compare equal to itself (i.e. cannot be NaN)."
+                    }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "maximum",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "maximum"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "PartialRangeUpTo",
+                        "preciseIdentifier": "s:s16PartialRangeUpToV"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "<"
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ">"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "Swift"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "..<"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "maximum"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ") -> "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "PartialRangeUpTo",
+                    "preciseIdentifier": "s:s16PartialRangeUpToV"
+                },
+                {
+                    "kind": "text",
+                    "spelling": "<"
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ">"
+                }
+            ],
+            "accessLevel": "public"
+        },
+        {
+            "kind": {
+                "identifier": "swift.func.op",
+                "displayName": "Operator"
+            },
+            "identifier": {
+                "precise": "s:SLsE1goiySbx_xtFZ::SYNTHESIZED::s:11FirstTarget11OtherStructV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "OtherStruct",
+                ">(_:_:)"
+            ],
+            "names": {
+                "title": ">(_:_:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": ">"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ", "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Self"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ") -> "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Bool",
+                        "preciseIdentifier": "s:Sb"
+                    }
+                ]
+            },
+            "docComment": {
+                "module": "Swift",
+                "lines": [
+                    {
+                        "text": "Returns a Boolean value indicating whether the value of the first argument"
+                    },
+                    {
+                        "text": "is greater than that of the second argument."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "This is the default implementation of the greater-than operator (`>`) for"
+                    },
+                    {
+                        "text": "any type that conforms to `Comparable`."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "- Parameters:"
+                    },
+                    {
+                        "text": "  - lhs: A value to compare."
+                    },
+                    {
+                        "text": "  - rhs: Another value to compare."
+                    }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "lhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "lhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "rhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "rhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Self"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Bool",
+                        "preciseIdentifier": "s:Sb"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "Swift"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": ">"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "lhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ", "
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "rhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Self"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ") -> "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Bool",
+                    "preciseIdentifier": "s:Sb"
+                }
+            ],
+            "accessLevel": "public"
+        },
+        {
+            "kind": {
+                "identifier": "swift.method",
+                "displayName": "Instance Method"
+            },
+            "identifier": {
+                "precise": "s:11FirstTarget3FooP23fooMemberWithDocCommentyyF",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "Foo",
+                "fooMemberWithDocComment()"
+            ],
+            "names": {
+                "title": "fooMemberWithDocComment()",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "fooMemberWithDocComment"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "docComment": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "module": "FirstTarget",
+                "lines": [
+                    {
+                        "range": {
+                            "start": {
+                                "line": 1,
+                                "character": 8
+                            },
+                            "end": {
+                                "line": 1,
+                                "character": 29
+                            }
+                        },
+                        "text": "This is my great doc."
+                    }
+                ]
+            },
+            "functionSignature": {
+                "returns": [
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "fooMemberWithDocComment"
+                },
+                {
+                    "kind": "text",
+                    "spelling": "()"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "position": {
+                    "line": 2,
+                    "character": 9
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.protocol",
+                "displayName": "Protocol"
+            },
+            "identifier": {
+                "precise": "s:11FirstTarget13FancyProtocolP",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "FancyProtocol"
+            ],
+            "names": {
+                "title": "FancyProtocol",
+                "navigator": [
+                    {
+                        "kind": "identifier",
+                        "spelling": "FancyProtocol"
+                    }
+                ],
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "protocol"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "FancyProtocol"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "protocol"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "FancyProtocol"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "position": {
+                    "line": 22,
+                    "character": 16
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.func.op",
+                "displayName": "Operator"
+            },
+            "identifier": {
+                "precise": "s:11FirstTarget10SomeStructV1loiySbAC_ACtFZ",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "SomeStruct",
+                "<(_:_:)"
+            ],
+            "names": {
+                "title": "<(_:_:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "<"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "SomeStruct",
+                        "preciseIdentifier": "s:11FirstTarget10SomeStructV"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ", "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "SomeStruct",
+                        "preciseIdentifier": "s:11FirstTarget10SomeStructV"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ") -> "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Bool",
+                        "preciseIdentifier": "s:Sb"
+                    }
+                ]
+            },
+            "docComment": {
+                "module": "Swift",
+                "lines": [
+                    {
+                        "text": "Returns a Boolean value indicating whether the value of the first"
+                    },
+                    {
+                        "text": "argument is less than that of the second argument."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "This function is the only requirement of the `Comparable` protocol. The"
+                    },
+                    {
+                        "text": "remainder of the relational operator functions are implemented by the"
+                    },
+                    {
+                        "text": "standard library for any type that conforms to `Comparable`."
+                    },
+                    {
+                        "text": ""
+                    },
+                    {
+                        "text": "- Parameters:"
+                    },
+                    {
+                        "text": "  - lhs: A value to compare."
+                    },
+                    {
+                        "text": "  - rhs: Another value to compare."
+                    }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "lhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "lhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "SomeStruct",
+                                "preciseIdentifier": "s:11FirstTarget10SomeStructV"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "rhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "rhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "SomeStruct",
+                                "preciseIdentifier": "s:11FirstTarget10SomeStructV"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Bool",
+                        "preciseIdentifier": "s:Sb"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "<"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "lhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "SomeStruct",
+                    "preciseIdentifier": "s:11FirstTarget10SomeStructV"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ", "
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "rhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "SomeStruct",
+                    "preciseIdentifier": "s:11FirstTarget10SomeStructV"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ") -> "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Bool",
+                    "preciseIdentifier": "s:Sb"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "position": {
+                    "line": 14,
+                    "character": 23
+                }
+            }
+        }
+    ],
+    "relationships": [
+        {
+            "kind": "conformsTo",
+            "source": "s:11FirstTarget10SomeStructV",
+            "target": "s:11FirstTarget13FancyProtocolP"
+        },
+        {
+            "kind": "defaultImplementationOf",
+            "source": "s:11FirstTarget18OtherFancyProtocolPAAE4zlzzoiyyAaB_p_AaB_ptFZ",
+            "target": "s:11FirstTarget18OtherFancyProtocolP4zlzzoiyyAaB_p_AaB_ptFZ"
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:SLsE1goiySbx_xtFZ::SYNTHESIZED::s:11FirstTarget11OtherStructV",
+            "target": "s:11FirstTarget11OtherStructV",
+            "sourceOrigin": {
+                "identifier": "s:SLsE1goiySbx_xtFZ",
+                "displayName": "Comparable.>(_:_:)"
+            }
+        },
+        {
+            "kind": "conformsTo",
+            "source": "s:11FirstTarget10SomeStructV",
+            "target": "s:SQ",
+            "targetFallback": "Swift.Equatable"
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:SLsE1goiySbx_xtFZ::SYNTHESIZED::s:11FirstTarget10SomeStructV",
+            "target": "s:11FirstTarget10SomeStructV",
+            "sourceOrigin": {
+                "identifier": "s:SLsE1goiySbx_xtFZ",
+                "displayName": "Comparable.>(_:_:)"
+            }
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:SLsE3zzzopys19PartialRangeThroughVyxGxFZ::SYNTHESIZED::s:11FirstTarget11OtherStructV",
+            "target": "s:11FirstTarget11OtherStructV",
+            "sourceOrigin": {
+                "identifier": "s:SLsE3zzzopys19PartialRangeThroughVyxGxFZ",
+                "displayName": "Comparable....(_:)"
+            }
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:SLsE3zzlopys16PartialRangeUpToVyxGxFZ::SYNTHESIZED::s:11FirstTarget10SomeStructV",
+            "target": "s:11FirstTarget10SomeStructV",
+            "sourceOrigin": {
+                "identifier": "s:SLsE3zzlopys16PartialRangeUpToVyxGxFZ",
+                "displayName": "Comparable...<(_:)"
+            }
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:SLsE2leoiySbx_xtFZ::SYNTHESIZED::s:11FirstTarget11OtherStructV",
+            "target": "s:11FirstTarget11OtherStructV",
+            "sourceOrigin": {
+                "identifier": "s:SLsE2leoiySbx_xtFZ",
+                "displayName": "Comparable.<=(_:_:)"
+            }
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:11FirstTarget3FooPAAE23fooMemberWithDocCommentyyF::SYNTHESIZED::s:11FirstTarget3BarV",
+            "target": "s:11FirstTarget3BarV",
+            "sourceOrigin": {
+                "identifier": "s:11FirstTarget3FooP23fooMemberWithDocCommentyyF",
+                "displayName": "Foo.fooMemberWithDocComment()"
+            }
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:SLsE3zzlopys16PartialRangeUpToVyxGxFZ::SYNTHESIZED::s:11FirstTarget11OtherStructV",
+            "target": "s:11FirstTarget11OtherStructV",
+            "sourceOrigin": {
+                "identifier": "s:SLsE3zzlopys16PartialRangeUpToVyxGxFZ",
+                "displayName": "Comparable...<(_:)"
+            }
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:SLsE2leoiySbx_xtFZ::SYNTHESIZED::s:11FirstTarget10SomeStructV",
+            "target": "s:11FirstTarget10SomeStructV",
+            "sourceOrigin": {
+                "identifier": "s:SLsE2leoiySbx_xtFZ",
+                "displayName": "Comparable.<=(_:_:)"
+            }
+        },
+        {
+            "kind": "conformsTo",
+            "source": "s:11FirstTarget10SomeStructV",
+            "target": "s:11FirstTarget18OtherFancyProtocolP"
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:11FirstTarget11OtherStructV1loiySbAC_ACtFZ",
+            "target": "s:11FirstTarget11OtherStructV",
+            "sourceOrigin": {
+                "identifier": "s:SL1loiySbx_xtFZ",
+                "displayName": "Comparable.<(_:_:)"
+            }
+        },
+        {
+            "kind": "requirementOf",
+            "source": "s:11FirstTarget3FooP23fooMemberWithDocCommentyyF",
+            "target": "s:11FirstTarget3FooP"
+        },
+        {
+            "kind": "requirementOf",
+            "source": "s:11FirstTarget13FancyProtocolP4zzzzoiyyAaB_p_AaB_ptFZ",
+            "target": "s:11FirstTarget13FancyProtocolP"
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:11FirstTarget13FancyProtocolPAAE4zzzzoiyyAaB_p_AaB_ptFZ::SYNTHESIZED::s:11FirstTarget10SomeStructV",
+            "target": "s:11FirstTarget10SomeStructV",
+            "sourceOrigin": {
+                "identifier": "s:11FirstTarget13FancyProtocolPAAE4zzzzoiyyAaB_p_AaB_ptFZ",
+                "displayName": "FancyProtocol.....(_:_:)"
+            }
+        },
+        {
+            "kind": "requirementOf",
+            "source": "s:11FirstTarget18OtherFancyProtocolP4zlzzoiyyAaB_p_AaB_ptFZ",
+            "target": "s:11FirstTarget18OtherFancyProtocolP"
+        },
+        {
+            "kind": "conformsTo",
+            "source": "s:11FirstTarget10SomeStructV",
+            "target": "s:SL",
+            "targetFallback": "Swift.Comparable"
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:SLsE3zzzoiySNyxGx_xtFZ::SYNTHESIZED::s:11FirstTarget10SomeStructV",
+            "target": "s:11FirstTarget10SomeStructV",
+            "sourceOrigin": {
+                "identifier": "s:SLsE3zzzoiySNyxGx_xtFZ",
+                "displayName": "Comparable....(_:_:)"
+            }
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:SLsE3zzzoiySNyxGx_xtFZ::SYNTHESIZED::s:11FirstTarget11OtherStructV",
+            "target": "s:11FirstTarget11OtherStructV",
+            "sourceOrigin": {
+                "identifier": "s:SLsE3zzzoiySNyxGx_xtFZ",
+                "displayName": "Comparable....(_:_:)"
+            }
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:SL11FirstTargetE26localDefaultImplementationyyF::SYNTHESIZED::s:11FirstTarget11OtherStructV",
+            "target": "s:11FirstTarget11OtherStructV",
+            "sourceOrigin": {
+                "identifier": "s:SL11FirstTargetE26localDefaultImplementationyyF",
+                "displayName": "Comparable.localDefaultImplementation()"
+            }
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:SLsE2geoiySbx_xtFZ::SYNTHESIZED::s:11FirstTarget11OtherStructV",
+            "target": "s:11FirstTarget11OtherStructV",
+            "sourceOrigin": {
+                "identifier": "s:SLsE2geoiySbx_xtFZ",
+                "displayName": "Comparable.>=(_:_:)"
+            }
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:SL11FirstTargetE26localDefaultImplementationyyF::SYNTHESIZED::s:11FirstTarget10SomeStructV",
+            "target": "s:11FirstTarget10SomeStructV",
+            "sourceOrigin": {
+                "identifier": "s:SL11FirstTargetE26localDefaultImplementationyyF",
+                "displayName": "Comparable.localDefaultImplementation()"
+            }
+        },
+        {
+            "kind": "defaultImplementationOf",
+            "source": "s:11FirstTarget3FooPAAE26fooMemberWithoutDocCommentyyF",
+            "target": "s:11FirstTarget3FooP26fooMemberWithoutDocCommentyyF"
+        },
+        {
+            "kind": "conformsTo",
+            "source": "s:11FirstTarget11OtherStructV",
+            "target": "s:SL",
+            "targetFallback": "Swift.Comparable"
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:SLsE2geoiySbx_xtFZ::SYNTHESIZED::s:11FirstTarget10SomeStructV",
+            "target": "s:11FirstTarget10SomeStructV",
+            "sourceOrigin": {
+                "identifier": "s:SLsE2geoiySbx_xtFZ",
+                "displayName": "Comparable.>=(_:_:)"
+            }
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:11FirstTarget10SomeStructV",
+            "target": "s:11FirstTarget10SomeStructV",
+            "sourceOrigin": {
+                "identifier": "s:SQsE2neoiySbx_xtFZ",
+                "displayName": "Equatable.!=(_:_:)"
+            }
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:SLsE3zzloiySnyxGx_xtFZ::SYNTHESIZED::s:11FirstTarget10SomeStructV",
+            "target": "s:11FirstTarget10SomeStructV",
+            "sourceOrigin": {
+                "identifier": "s:SLsE3zzloiySnyxGx_xtFZ",
+                "displayName": "Comparable...<(_:_:)"
+            }
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:11FirstTarget10SomeStructV7someVarSSvp",
+            "target": "s:11FirstTarget10SomeStructV"
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:SLsE3zzzoPys16PartialRangeFromVyxGxFZ::SYNTHESIZED::s:11FirstTarget11OtherStructV",
+            "target": "s:11FirstTarget11OtherStructV",
+            "sourceOrigin": {
+                "identifier": "s:SLsE3zzzoPys16PartialRangeFromVyxGxFZ",
+                "displayName": "Comparable....(_:)"
+            }
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:SLsE3zzzoPys16PartialRangeFromVyxGxFZ::SYNTHESIZED::s:11FirstTarget10SomeStructV",
+            "target": "s:11FirstTarget10SomeStructV",
+            "sourceOrigin": {
+                "identifier": "s:SLsE3zzzoPys16PartialRangeFromVyxGxFZ",
+                "displayName": "Comparable....(_:)"
+            }
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:11FirstTarget11OtherStructV",
+            "target": "s:11FirstTarget11OtherStructV",
+            "sourceOrigin": {
+                "identifier": "s:SQsE2neoiySbx_xtFZ",
+                "displayName": "Equatable.!=(_:_:)"
+            }
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:SLsE3zzloiySnyxGx_xtFZ::SYNTHESIZED::s:11FirstTarget11OtherStructV",
+            "target": "s:11FirstTarget11OtherStructV",
+            "sourceOrigin": {
+                "identifier": "s:SLsE3zzloiySnyxGx_xtFZ",
+                "displayName": "Comparable...<(_:_:)"
+            }
+        },
+        {
+            "kind": "conformsTo",
+            "source": "s:11FirstTarget3BarV",
+            "target": "s:11FirstTarget3FooP"
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:11FirstTarget10SomeStructV1loiySbAC_ACtFZ",
+            "target": "s:11FirstTarget10SomeStructV",
+            "sourceOrigin": {
+                "identifier": "s:SL1loiySbx_xtFZ",
+                "displayName": "Comparable.<(_:_:)"
+            }
+        },
+        {
+            "kind": "conformsTo",
+            "source": "s:11FirstTarget11OtherStructV",
+            "target": "s:SQ",
+            "targetFallback": "Swift.Equatable"
+        },
+        {
+            "kind": "requirementOf",
+            "source": "s:11FirstTarget3FooP26fooMemberWithoutDocCommentyyF",
+            "target": "s:11FirstTarget3FooP"
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:SLsE3zzzopys19PartialRangeThroughVyxGxFZ::SYNTHESIZED::s:11FirstTarget10SomeStructV",
+            "target": "s:11FirstTarget10SomeStructV",
+            "sourceOrigin": {
+                "identifier": "s:SLsE3zzzopys19PartialRangeThroughVyxGxFZ",
+                "displayName": "Comparable....(_:)"
+            }
+        },
+        {
+            "kind": "defaultImplementationOf",
+            "source": "s:11FirstTarget13FancyProtocolPAAE4zzzzoiyyAaB_p_AaB_ptFZ",
+            "target": "s:11FirstTarget13FancyProtocolP4zzzzoiyyAaB_p_AaB_ptFZ"
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:11FirstTarget3FooPAAE26fooMemberWithoutDocCommentyyF::SYNTHESIZED::s:11FirstTarget3BarV",
+            "target": "s:11FirstTarget3BarV",
+            "sourceOrigin": {
+                "identifier": "s:11FirstTarget3FooPAAE26fooMemberWithoutDocCommentyyF",
+                "displayName": "Foo.fooMemberWithoutDocComment()"
+            }
+        },
+        {
+            "kind": "defaultImplementationOf",
+            "source": "s:11FirstTarget3FooPAAE23fooMemberWithDocCommentyyF",
+            "target": "s:11FirstTarget3FooP23fooMemberWithDocCommentyyF",
+            "sourceOrigin": {
+                "identifier": "s:11FirstTarget3FooP23fooMemberWithDocCommentyyF",
+                "displayName": "Foo.fooMemberWithDocComment()"
+            }
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:11FirstTarget18OtherFancyProtocolPAAE4zlzzoiyyAaB_p_AaB_ptFZ::SYNTHESIZED::s:11FirstTarget10SomeStructV",
+            "target": "s:11FirstTarget10SomeStructV",
+            "sourceOrigin": {
+                "identifier": "s:11FirstTarget18OtherFancyProtocolPAAE4zlzzoiyyAaB_p_AaB_ptFZ",
+                "displayName": "OtherFancyProtocol..<..(_:_:)"
+            }
+        }
+    ]
+}

--- a/Tests/SwiftDocCTests/Test Resources/InheritedDefaultImplementations@Swift.symbols.json
+++ b/Tests/SwiftDocCTests/Test Resources/InheritedDefaultImplementations@Swift.symbols.json
@@ -1,0 +1,107 @@
+{
+    "metadata": {
+        "formatVersion": {
+            "major": 0,
+            "minor": 5,
+            "patch": 3
+        },
+        "generator": "Apple Swift version 5.7"
+    },
+    "module": {
+        "name": "FirstTarget",
+        "platform": {
+            "architecture": "x86_64",
+            "vendor": "apple",
+            "operatingSystem": {
+                "name": "macosx",
+                "minimumVersion": {
+                    "major": 11,
+                    "minor": 0,
+                    "patch": 0
+                }
+            }
+        }
+    },
+    "symbols": [
+        {
+            "kind": {
+                "identifier": "swift.method",
+                "displayName": "Instance Method"
+            },
+            "identifier": {
+                "precise": "s:SL11FirstTargetE26localDefaultImplementationyyF",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "Comparable",
+                "localDefaultImplementation()"
+            ],
+            "names": {
+                "title": "localDefaultImplementation()",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "localDefaultImplementation"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "functionSignature": {
+                "returns": [
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "Swift"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "localDefaultImplementation"
+                },
+                {
+                    "kind": "text",
+                    "spelling": "()"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "position": {
+                    "line": 46,
+                    "character": 16
+                }
+            }
+        }
+    ],
+    "relationships": [
+        {
+            "kind": "memberOf",
+            "source": "s:SL11FirstTargetE26localDefaultImplementationyyF",
+            "target": "s:SL",
+            "targetFallback": "Swift.Comparable"
+        }
+    ]
+}

--- a/Tests/SwiftDocCTests/Test Resources/InheritedDefaultImplementationsFromExternalModule.symbols.json
+++ b/Tests/SwiftDocCTests/Test Resources/InheritedDefaultImplementationsFromExternalModule.symbols.json
@@ -1,0 +1,792 @@
+{
+    "metadata": {
+        "formatVersion": {
+            "major": 0,
+            "minor": 5,
+            "patch": 3
+        },
+        "generator": "Apple Swift version 5.7"
+    },
+    "module": {
+        "name": "SecondTarget",
+        "platform": {
+            "architecture": "x86_64",
+            "vendor": "apple",
+            "operatingSystem": {
+                "name": "macosx",
+                "minimumVersion": {
+                    "major": 11,
+                    "minor": 0,
+                    "patch": 0
+                }
+            }
+        }
+    },
+    "symbols": [
+        {
+            "kind": {
+                "identifier": "swift.func.op",
+                "displayName": "Operator"
+            },
+            "identifier": {
+                "precise": "s:11FirstTarget13FancyProtocolPAAE4zzzzoiyyAaB_p_AaB_ptFZ::SYNTHESIZED::s:12SecondTarget22FancyProtocolConformerV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "FancyProtocolConformer",
+                "....(_:_:)"
+            ],
+            "names": {
+                "title": "....(_:_:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "...."
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "FancyProtocol",
+                        "preciseIdentifier": "s:11FirstTarget13FancyProtocolP"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ", "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "FancyProtocol",
+                        "preciseIdentifier": "s:11FirstTarget13FancyProtocolP"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ")"
+                    }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "lhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "lhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "FancyProtocol",
+                                "preciseIdentifier": "s:11FirstTarget13FancyProtocolP"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "rhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "rhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "FancyProtocol",
+                                "preciseIdentifier": "s:11FirstTarget13FancyProtocolP"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "FirstTarget"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "...."
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "lhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "FancyProtocol",
+                    "preciseIdentifier": "s:11FirstTarget13FancyProtocolP"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ", "
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "rhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "FancyProtocol",
+                    "preciseIdentifier": "s:11FirstTarget13FancyProtocolP"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ")"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "position": {
+                    "line": 27,
+                    "character": 16
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.struct",
+                "displayName": "Structure"
+            },
+            "identifier": {
+                "precise": "s:12SecondTarget22FancyProtocolConformerV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "FancyProtocolConformer"
+            ],
+            "names": {
+                "title": "FancyProtocolConformer",
+                "navigator": [
+                    {
+                        "kind": "identifier",
+                        "spelling": "FancyProtocolConformer"
+                    }
+                ],
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "struct"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "FancyProtocolConformer"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "struct"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "FancyProtocolConformer"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/SecondTarget/Source.swift",
+                "position": {
+                    "line": 4,
+                    "character": 14
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.method",
+                "displayName": "Instance Method"
+            },
+            "identifier": {
+                "precise": "s:11FirstTarget3FooPAAE23fooMemberWithDocCommentyyF::SYNTHESIZED::s:12SecondTarget12FooConformerV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "FooConformer",
+                "fooMemberWithDocComment()"
+            ],
+            "names": {
+                "title": "fooMemberWithDocComment()",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "fooMemberWithDocComment"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "docComment": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "module": "FirstTarget",
+                "lines": [
+                    {
+                        "range": {
+                            "start": {
+                                "line": 1,
+                                "character": 8
+                            },
+                            "end": {
+                                "line": 1,
+                                "character": 29
+                            }
+                        },
+                        "text": "This is my great doc."
+                    }
+                ]
+            },
+            "functionSignature": {
+                "returns": [
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "FirstTarget"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "fooMemberWithDocComment"
+                },
+                {
+                    "kind": "text",
+                    "spelling": "()"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "position": {
+                    "line": 7,
+                    "character": 9
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.func.op",
+                "displayName": "Operator"
+            },
+            "identifier": {
+                "precise": "s:11FirstTarget18OtherFancyProtocolPAAE4zlzzoiyyAaB_p_AaB_ptFZ::SYNTHESIZED::s:12SecondTarget27OtherFancyProtocolConformerV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "OtherFancyProtocolConformer",
+                ".<..(_:_:)"
+            ],
+            "names": {
+                "title": ".<..(_:_:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": ".<.."
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "OtherFancyProtocol",
+                        "preciseIdentifier": "s:11FirstTarget18OtherFancyProtocolP"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ", "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "OtherFancyProtocol",
+                        "preciseIdentifier": "s:11FirstTarget18OtherFancyProtocolP"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ")"
+                    }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "lhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "lhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "OtherFancyProtocol",
+                                "preciseIdentifier": "s:11FirstTarget18OtherFancyProtocolP"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "rhs",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "rhs"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "OtherFancyProtocol",
+                                "preciseIdentifier": "s:11FirstTarget18OtherFancyProtocolP"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "FirstTarget"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": ".<.."
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "lhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "OtherFancyProtocol",
+                    "preciseIdentifier": "s:11FirstTarget18OtherFancyProtocolP"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ", "
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "rhs"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "OtherFancyProtocol",
+                    "preciseIdentifier": "s:11FirstTarget18OtherFancyProtocolP"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ")"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "position": {
+                    "line": 36,
+                    "character": 16
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.struct",
+                "displayName": "Structure"
+            },
+            "identifier": {
+                "precise": "s:12SecondTarget12FooConformerV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "FooConformer"
+            ],
+            "names": {
+                "title": "FooConformer",
+                "navigator": [
+                    {
+                        "kind": "identifier",
+                        "spelling": "FooConformer"
+                    }
+                ],
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "struct"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "FooConformer"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "struct"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "FooConformer"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/SecondTarget/Source.swift",
+                "position": {
+                    "line": 2,
+                    "character": 14
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.method",
+                "displayName": "Instance Method"
+            },
+            "identifier": {
+                "precise": "s:11FirstTarget3FooPAAE26fooMemberWithoutDocCommentyyF::SYNTHESIZED::s:12SecondTarget12FooConformerV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "FooConformer",
+                "fooMemberWithoutDocComment()"
+            ],
+            "names": {
+                "title": "fooMemberWithoutDocComment()",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "fooMemberWithoutDocComment"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "functionSignature": {
+                "returns": [
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "FirstTarget"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "fooMemberWithoutDocComment"
+                },
+                {
+                    "kind": "text",
+                    "spelling": "()"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/FirstTarget/Source.swift",
+                "position": {
+                    "line": 8,
+                    "character": 9
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.struct",
+                "displayName": "Structure"
+            },
+            "identifier": {
+                "precise": "s:12SecondTarget27OtherFancyProtocolConformerV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "OtherFancyProtocolConformer"
+            ],
+            "names": {
+                "title": "OtherFancyProtocolConformer",
+                "navigator": [
+                    {
+                        "kind": "identifier",
+                        "spelling": "OtherFancyProtocolConformer"
+                    }
+                ],
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "struct"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "OtherFancyProtocolConformer"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "struct"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "OtherFancyProtocolConformer"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///r81423267-reproducer/Sources/SecondTarget/Source.swift",
+                "position": {
+                    "line": 6,
+                    "character": 14
+                }
+            }
+        }
+    ],
+    "relationships": [
+        {
+            "kind": "conformsTo",
+            "source": "s:12SecondTarget22FancyProtocolConformerV",
+            "target": "s:11FirstTarget13FancyProtocolP",
+            "targetFallback": "FirstTarget.FancyProtocol"
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:11FirstTarget3FooPAAE23fooMemberWithDocCommentyyF::SYNTHESIZED::s:12SecondTarget12FooConformerV",
+            "target": "s:12SecondTarget12FooConformerV",
+            "sourceOrigin": {
+                "identifier": "s:11FirstTarget3FooP23fooMemberWithDocCommentyyF",
+                "displayName": "Foo.fooMemberWithDocComment()"
+            }
+        },
+        {
+            "kind": "conformsTo",
+            "source": "s:12SecondTarget27OtherFancyProtocolConformerV",
+            "target": "s:11FirstTarget18OtherFancyProtocolP",
+            "targetFallback": "FirstTarget.OtherFancyProtocol"
+        },
+        {
+            "kind": "conformsTo",
+            "source": "s:12SecondTarget12FooConformerV",
+            "target": "s:11FirstTarget3FooP",
+            "targetFallback": "FirstTarget.Foo"
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:11FirstTarget3FooPAAE26fooMemberWithoutDocCommentyyF::SYNTHESIZED::s:12SecondTarget12FooConformerV",
+            "target": "s:12SecondTarget12FooConformerV",
+            "sourceOrigin": {
+                "identifier": "s:11FirstTarget3FooPAAE26fooMemberWithoutDocCommentyyF",
+                "displayName": "Foo.fooMemberWithoutDocComment()"
+            }
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:11FirstTarget13FancyProtocolPAAE4zzzzoiyyAaB_p_AaB_ptFZ::SYNTHESIZED::s:12SecondTarget22FancyProtocolConformerV",
+            "target": "s:12SecondTarget22FancyProtocolConformerV",
+            "sourceOrigin": {
+                "identifier": "s:11FirstTarget13FancyProtocolPAAE4zzzzoiyyAaB_p_AaB_ptFZ",
+                "displayName": "FancyProtocol.....(_:_:)"
+            }
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:11FirstTarget18OtherFancyProtocolPAAE4zlzzoiyyAaB_p_AaB_ptFZ::SYNTHESIZED::s:12SecondTarget27OtherFancyProtocolConformerV",
+            "target": "s:12SecondTarget27OtherFancyProtocolConformerV",
+            "sourceOrigin": {
+                "identifier": "s:11FirstTarget18OtherFancyProtocolPAAE4zlzzoiyyAaB_p_AaB_ptFZ",
+                "displayName": "OtherFancyProtocol..<..(_:_:)"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
- **Explanation**: Resolves a regression where auto-generated "Protocol Implementations" API collections could be duplicated on a page.
- **Scope**: Affects documentation for symbols that conform to protocls with mixed documentation coverage (some documented members and some undocumented)
- **Bug**: rdar://95808950
- **Original PR**: #321 
- **Risk**: Low. Targeted fix.
- **Testing**: Regression testing and specific testing for auto-generated protocol conformance has been performed.
- **Reviewers**: @d-ronnqvist @QuietMisdreavus 