### PR TITLE
Send SIGABRT to signal-test-app

### DIFF
--- a/Tests/signal-test-app/main.swift
+++ b/Tests/signal-test-app/main.swift
@@ -24,7 +24,7 @@ Signal.on(Signal.all) { _ in
 }
 
 DispatchQueue.global().asyncAfter(deadline: .now() + 1) {
-    kill(getpid(), SIGINT)
+    kill(getpid(), SIGABRT)
 }
 
 print("Signal test app running.")


### PR DESCRIPTION
Bug/issue #: rdar://90715477

## Summary

Thread sanitizer doesn't handle `SIGINT` properly, and this causes the
signal-test-app to hang when tests are run under TSan. Sending `SIGABRT`
causes signal-test-app to exit under all circumstances.

## Dependencies

None

## Testing

Steps:
1. Open the package in Xcode
2. Select the SwiftDocC-Package scheme
3. Select Product > Scheme > Edit Scheme...
4. Select the Test row on the left side of the scheme editor window
5. Select the Diagnostics tab
6. Turn on the Thread Santizier
7. Select Product > Test
8. Verify that the tests complete, specifically that `SignalTests.testTrappingSignal()` doesn't hang.

Alternatively, run `xcrun swift test --sanitize thread` and verify that the test run completes.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary
