### PR TITLE
Stop duplicating auto-generated collections per-platform

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -1261,13 +1261,11 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
             }
             
             // Create inherited API collections
-            for (_, relationships) in combinedRelationships {
-                try GeneratedDocumentationTopics.createInheritedSymbolsAPICollections(
-                    relationships: relationships,
-                    context: self,
-                    bundle: bundle
-                )
-            }
+            try GeneratedDocumentationTopics.createInheritedSymbolsAPICollections(
+                relationships: combinedRelationships.flatMap(\.value),
+                context: self,
+                bundle: bundle
+            )
 
             // Parse and prepare the nodes' content concurrently.
             let updatedNodes: [(node: DocumentationNode, matchedArticleURL: URL?)] = Array(symbolIndex.values)

--- a/Sources/SwiftDocC/Infrastructure/Symbol Graph/GeneratedDocumentationTopics.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Graph/GeneratedDocumentationTopics.swift
@@ -224,12 +224,17 @@ enum GeneratedDocumentationTopics {
     ///   ╰ View Implementations
     ///     ╰ accessibilityValue()
     /// ```
+    ///
+    /// > Warning: This method tracks internal state via an ``InheritedSymbols`` inheritance index.
+    /// It must be called **once** per symbol by passing in _all_ of the relationships that apply
+    /// to a symbol.
+    ///
     /// - Parameters:
     ///   - relationships: A set of relationships to inspect.
     ///   - symbolsURLHierarchy: A symbol graph hierarchy as created during symbol registration.
     ///   - context: A documentation context to update.
     ///   - bundle: The current documentation bundle.
-    static func createInheritedSymbolsAPICollections(relationships: Set<SymbolGraph.Relationship>, context: DocumentationContext, bundle: DocumentationBundle) throws {
+    static func createInheritedSymbolsAPICollections(relationships: [SymbolGraph.Relationship], context: DocumentationContext, bundle: DocumentationBundle) throws {
         var inheritanceIndex = InheritedSymbols()
         
         // Walk the symbol graph relationships and look for parent <-> child links that stem in a different module.


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://95882462

## Summary

Resolves a regression introduced by #304 where auto-generated "Protocol Implementations" collections were being duplicated per platform.

The immediate fix is to call the `createInheritedSymbolsAPICollection` method a single time with all of the relevant relationships, instead of once per platform. It tracks internal state while building up the API collections so it's important to provide all possible relationships when calling the method.

I think there's a likely a longer-term fix we should make here in the way we're handling multi-platform symbol graph information since currently we're handling it similarly to multi-language symbol graph information but don't actually emit variants for it.

## Testing

Build documentation for multiple platforms, save the symbol graphs, and pass them to `docc convert`. Confirm that any auto-generated "Protocol Implementations" sections are only created once. 


Attaching a [small DocC catalog](https://github.com/apple/swift-docc/files/9014799/r95882462-reproducer.docc.zip) that reproduces the issue created by following these instructions for the following Swift snippet:

```swift
public struct BestStruct: MyProtocol {}

public protocol MyProtocol {}

extension MyProtocol {
    public func bestFunc() {}
}
```

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
