### PR TITLE
update SymbolKit to include apple/swift-docc-symbolkit#44

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -42,7 +42,7 @@
         "repositoryURL": "https://github.com/apple/swift-docc-symbolkit",
         "state": {
           "branch": "main",
-          "revision": "d46f68840547ec8a0324ff79a31f2c513339574f",
+          "revision": "cfa80d701f7d8699d64237c7bcc760d6c9616529",
           "version": null
         }
       },

--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
@@ -2661,8 +2661,40 @@ Document @1:1-11:19
                       "end": {"line": 1, "character": 21}
                     }
                   }],
+                  "module": "SideKit",
+                  "uri": "file://path/with spaces/to/file.swift"
+                }
+                """,
+                expectedRenderedAbstract: [.text("Authored abstract")]
+            ),
+            TestData(
+                docCommentJSON: """
+                {
+                  "lines": [{
+                    "text": "Authored abstract",
+                    "range": {
+                      "start": {"line": 1, "character": 4},
+                      "end": {"line": 1, "character": 21}
+                    }
+                  }],
                   "module": "OtherModule",
                   "uri": "file://path/to/file.swift"
+                }
+                """,
+                expectedRenderedAbstract: [.text("Inherited from "), .codeVoice(code: "Module.Protocol.inherited()"), .text(".")]
+            ),
+            TestData(
+                docCommentJSON: """
+                {
+                  "lines": [{
+                    "text": "Authored abstract",
+                    "range": {
+                      "start": {"line": 1, "character": 4},
+                      "end": {"line": 1, "character": 21}
+                    }
+                  }],
+                  "module": "OtherModule",
+                  "uri": "file://path/with spaces/to/file.swift"
                 }
                 """,
                 expectedRenderedAbstract: [.text("Inherited from "), .codeVoice(code: "Module.Protocol.inherited()"), .text(".")]


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://96216773

## Summary

When https://github.com/apple/swift-docc/pull/314 was added, it didn't include all the relevant changes to SymbolKit. Specifically, it didn't include https://github.com/apple/swift-docc-symbolkit/pull/44, which handles decoding ill-formatted URLs that include unescaped spaces. This caused a failure when building documentation for swift-argument-parser, which uses spaces in its source directories.

I've also added tests that ensure that doc comment file paths that include spaces in the JSON properly decode without error.

## Dependencies

None (the relevant change has already been merged)

## Testing

Build documentation with symbol graphs that use spaces in their file names, e.g. [swift-argument-parser](https://github.com/apple/swift-argument-parser).

Steps:
1. Clone ArgumentParser, if you haven't already.
2. Build Swift-DocC with this change.
3. With Xcode 14 Beta or higher, run `xcodebuild clean docbuild -scheme ArgumentParser -destination platform=macOS DOCC_EXEC=/path/to/swift-docc/.build/debug/docc`
4. Make sure that Swift-DocC builds documentation successfully.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ n/a ] Updated documentation if necessary
