### PR TITLE
update doc-comment file-path tests to include paths with spaces

### DIFF
--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
@@ -2667,8 +2667,40 @@ Document @1:1-11:19
                       "end": {"line": 1, "character": 21}
                     }
                   }],
+                  "module": "SideKit",
+                  "uri": "file://path/with spaces/to/file.swift"
+                }
+                """,
+                expectedRenderedAbstract: [.text("Authored abstract")]
+            ),
+            TestData(
+                docCommentJSON: """
+                {
+                  "lines": [{
+                    "text": "Authored abstract",
+                    "range": {
+                      "start": {"line": 1, "character": 4},
+                      "end": {"line": 1, "character": 21}
+                    }
+                  }],
                   "module": "OtherModule",
                   "uri": "file://path/to/file.swift"
+                }
+                """,
+                expectedRenderedAbstract: [.text("Inherited from "), .codeVoice(code: "Module.Protocol.inherited()"), .text(".")]
+            ),
+            TestData(
+                docCommentJSON: """
+                {
+                  "lines": [{
+                    "text": "Authored abstract",
+                    "range": {
+                      "start": {"line": 1, "character": 4},
+                      "end": {"line": 1, "character": 21}
+                    }
+                  }],
+                  "module": "OtherModule",
+                  "uri": "file://path/with spaces/to/file.swift"
                 }
                 """,
                 expectedRenderedAbstract: [.text("Inherited from "), .codeVoice(code: "Module.Protocol.inherited()"), .text(".")]


### PR DESCRIPTION
- **Explanation**: Adds tests to ensure that doc comments whose filename include spaces can still properly parse.
- **Scope**: No change to behavior (this already worked on the release branch)
- **Radar**: rdar://96216773 (the commit is not tagged with it since the issue was wholly on the `main` branch)
- **Risk**: None. This is only an update to tests.
- **Testing**: Ensure that automated tests pass.
- **Original PR**: https://github.com/apple/swift-docc/pull/326 (This only includes the tests from that PR; the SymbolKit change is already present on this branch)
- **Reviewer**: @franklinsch (He hasn't reviewed the original PR, but we chatted offline while i was working on it)