### PR TITLE
[5.7] Stop duplicating auto-generated collections per-platform

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -1465,13 +1465,11 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
             }
             
             // Create inherited API collections
-            for (_, relationships) in combinedRelationships {
-                try GeneratedDocumentationTopics.createInheritedSymbolsAPICollections(
-                    relationships: relationships,
-                    context: self,
-                    bundle: bundle
-                )
-            }
+            try GeneratedDocumentationTopics.createInheritedSymbolsAPICollections(
+                relationships: combinedRelationships.flatMap(\.value),
+                context: self,
+                bundle: bundle
+            )
 
             // Parse and prepare the nodes' content concurrently.
             let updatedNodes: [(node: DocumentationNode, matchedArticleURL: URL?)] = Array(symbolIndex.values)

--- a/Sources/SwiftDocC/Infrastructure/Symbol Graph/GeneratedDocumentationTopics.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Graph/GeneratedDocumentationTopics.swift
@@ -224,12 +224,17 @@ enum GeneratedDocumentationTopics {
     ///   ╰ View Implementations
     ///     ╰ accessibilityValue()
     /// ```
+    ///
+    /// > Warning: This method tracks internal state via an ``InheritedSymbols`` inheritance index.
+    /// It must be called **once** per symbol by passing in _all_ of the relationships that apply
+    /// to a symbol.
+    ///
     /// - Parameters:
     ///   - relationships: A set of relationships to inspect.
     ///   - symbolsURLHierarchy: A symbol graph hierarchy as created during symbol registration.
     ///   - context: A documentation context to update.
     ///   - bundle: The current documentation bundle.
-    static func createInheritedSymbolsAPICollections(relationships: Set<SymbolGraph.Relationship>, context: DocumentationContext, bundle: DocumentationBundle) throws {
+    static func createInheritedSymbolsAPICollections(relationships: [SymbolGraph.Relationship], context: DocumentationContext, bundle: DocumentationBundle) throws {
         var inheritanceIndex = InheritedSymbols()
         
         // Walk the symbol graph relationships and look for parent <-> child links that stem in a different module.

--- a/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorTests.swift
@@ -740,6 +740,81 @@ class RenderNodeTranslatorTests: XCTestCase {
         )
     }
     
+    func testAutomaticImplementationsFromMultiPlatformSymbolGraphs() throws {
+        let inheritedDefaultImplementationsSGF = Bundle.module.url(
+            forResource: "InheritedDefaultImplementations.symbols",
+            withExtension: "json",
+            subdirectory: "Test Resources"
+        )!
+        
+        let symbolGraphWithModifiedPlatform = try String(
+            contentsOf: inheritedDefaultImplementationsSGF
+        )
+        .replacingOccurrences(
+            of: """
+                "architecture": "x86_64",
+                """,
+            with: """
+                "architecture": "arm64",
+                """
+        )
+        .replacingOccurrences(
+            of: """
+                "name": "macosx",
+                """,
+            with: """
+                "name": "ios",
+                """
+        )
+        
+        let testBundle = try Folder(
+            name: "unit-test.docc",
+            content: [
+                InfoPlist(displayName: "TestBundle", identifier: "com.test.example"),
+                Folder(
+                    name: "x86_64-apple-macos",
+                    content: [
+                        CopyOfFile(original: inheritedDefaultImplementationsSGF),
+                    ]
+                ),
+                Folder(
+                    name: "arm64-apple-ios",
+                    content: [
+                        DataFile(
+                            name: inheritedDefaultImplementationsSGF.lastPathComponent,
+                            data: Data(symbolGraphWithModifiedPlatform.utf8)
+                        ),
+                    ]
+                ),
+            ]
+        ).write(inside: createTemporaryDirectory())
+        
+        try assertDefaultImplementationCollectionTitles(
+            in: try loadRenderNode(at: "/documentation/FirstTarget/Bar", in: testBundle),
+            [
+                "Foo Implementations",
+            ]
+        )
+        
+        try assertDefaultImplementationCollectionTitles(
+            in: try loadRenderNode(at: "/documentation/FirstTarget/OtherStruct", in: testBundle),
+            [
+                "Comparable Implementations",
+                "Equatable Implementations",
+            ]
+        )
+        
+        try assertDefaultImplementationCollectionTitles(
+            in: try loadRenderNode(at: "/documentation/FirstTarget/SomeStruct", in: testBundle),
+            [
+                "Comparable Implementations",
+                "Equatable Implementations",
+                "FancyProtocol Implementations",
+                "OtherFancyProtocol Implementations",
+            ]
+        )
+    }
+    
     func assertDefaultImplementationCollectionTitles(
         in renderNode: RenderNode,
         _ expectedTitles: [String],


### PR DESCRIPTION
- **Explanation**: Resolves a regression where auto-generated "Protocol Implementations"
collections were being duplicated per platform.
- **Scope**: Affects documentation builds that include symbol graphs from multiple platforms.
- **Bug/issue #**: rdar://95882462
- **Original PR**: #325 
- **Risk**: Low. Targeted fix.
- **Testing**: A test has been added to confirm auto-generated protocol implementations sections are correct for multi-platform builds.
- **Reviewer**: @QuietMisdreavus 