### PR TITLE
load cross-import overlay module data, even for extensions

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -39,10 +39,10 @@
       },
       {
         "package": "SymbolKit",
-        "repositoryURL": "https://github.com/apple/swift-docc-symbolkit",
+        "repositoryURL": "https://github.com/QuietMisdreavus/swift-docc-symbolkit",
         "state": {
-          "branch": "main",
-          "revision": "cfa80d701f7d8699d64237c7bcc760d6c9616529",
+          "branch": "graph-module",
+          "revision": "0cd77227d1e5cd62ddb7a1e2619d2a330bfe79e2",
           "version": null
         }
       },

--- a/Package.resolved
+++ b/Package.resolved
@@ -39,10 +39,10 @@
       },
       {
         "package": "SymbolKit",
-        "repositoryURL": "https://github.com/QuietMisdreavus/swift-docc-symbolkit",
+        "repositoryURL": "https://github.com/apple/swift-docc-symbolkit",
         "state": {
-          "branch": "graph-module",
-          "revision": "0cd77227d1e5cd62ddb7a1e2619d2a330bfe79e2",
+          "branch": "main",
+          "revision": "318e45f5f884f2e172fbcd00d294af2123fb36d1",
           "version": null
         }
       },

--- a/Package.swift
+++ b/Package.swift
@@ -124,7 +124,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(name: "swift-markdown", url: "https://github.com/apple/swift-markdown.git", .branch("main")),
         .package(name: "CLMDB", url: "https://github.com/apple/swift-lmdb.git", .branch("main")),
         .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "1.0.1")),
-        .package(name: "SymbolKit", url: "https://github.com/apple/swift-docc-symbolkit", .branch("main")),
+        .package(name: "SymbolKit", url: "https://github.com/QuietMisdreavus/swift-docc-symbolkit", .branch("graph-module")),
         .package(url: "https://github.com/apple/swift-crypto.git", .upToNextMinor(from: "1.1.2")),
     ]
     

--- a/Package.swift
+++ b/Package.swift
@@ -124,7 +124,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(name: "swift-markdown", url: "https://github.com/apple/swift-markdown.git", .branch("main")),
         .package(name: "CLMDB", url: "https://github.com/apple/swift-lmdb.git", .branch("main")),
         .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "1.0.1")),
-        .package(name: "SymbolKit", url: "https://github.com/QuietMisdreavus/swift-docc-symbolkit", .branch("graph-module")),
+        .package(name: "SymbolKit", url: "https://github.com/apple/swift-docc-symbolkit", .branch("main")),
         .package(url: "https://github.com/apple/swift-crypto.git", .upToNextMinor(from: "1.1.2")),
     ]
     

--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -986,7 +986,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
     
     /// Creates a topic graph node and a documentation node for the given symbol.
     private func preparedSymbolData(_ symbol: UnifiedSymbolGraph.Symbol, reference: ResolvedTopicReference, module: SymbolGraph.Module, moduleReference: ResolvedTopicReference, bundle: DocumentationBundle, fileURL symbolGraphURL: URL?) -> AddSymbolResultWithProblems {
-        let documentation = DocumentationNode(reference: reference, unifiedSymbol: symbol, platformName: module.platform.name, moduleReference: moduleReference, bystanderModules: module.bystanders)
+        let documentation = DocumentationNode(reference: reference, unifiedSymbol: symbol, moduleData: module, moduleReference: moduleReference)
         let source: TopicGraph.Node.ContentLocation // TODO: use a list of URLs for the files in a unified graph
         if let symbolGraphURL = symbolGraphURL {
             source = .file(url: symbolGraphURL)

--- a/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphLoader.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphLoader.swift
@@ -139,7 +139,7 @@ struct SymbolGraphLoader {
         var symbolGraph = symbolGraphs[url]!
         let (moduleName, isMainSymbolGraph) = Self.moduleNameFor(symbolGraph, at: url)
         
-        if !isMainSymbolGraph {
+        if !isMainSymbolGraph && symbolGraph.module.bystanders == nil {
             // If this is an extending another module, change the module name to match the exteneded module.
             // This makes the symbols in this graph have a path that starts with the extended module's name.
             symbolGraph.module.name = moduleName
@@ -250,7 +250,7 @@ struct SymbolGraphLoader {
         let isMainSymbolGraph = !url.lastPathComponent.contains("@")
         
         let moduleName: String
-        if isMainSymbolGraph {
+        if isMainSymbolGraph || symbolGraph.module.bystanders != nil {
             // For main symbol graphs, get the module name from the symbol graph's data
             moduleName = symbolGraph.module.name
         } else {

--- a/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphLoader.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphLoader.swift
@@ -252,6 +252,10 @@ struct SymbolGraphLoader {
         let moduleName: String
         if isMainSymbolGraph || symbolGraph.module.bystanders != nil {
             // For main symbol graphs, get the module name from the symbol graph's data
+
+            // When bystander modules are present, the symbol graph is a cross-import overlay, and
+            // we need to preserve the original module name to properly render it. It is still
+            // kept with the extension symbols, due to the merging behavior of UnifiedSymbolGraph.
             moduleName = symbolGraph.module.name
         } else {
             // For extension symbol graphs, derive the extended module's name from the file name.

--- a/Sources/SwiftDocC/Model/DocumentationNode.swift
+++ b/Sources/SwiftDocC/Model/DocumentationNode.swift
@@ -159,7 +159,7 @@ public struct DocumentationNode {
     ///   - symbol: The symbol to create a documentation node for.
     ///   - platformName: The name of the platforms for which the node is available.
     ///   - moduleName: The name of the module that the symbol belongs to.
-    init(reference: ResolvedTopicReference, unifiedSymbol: UnifiedSymbolGraph.Symbol, platformName: String?, moduleReference: ResolvedTopicReference, bystanderModules: [String]? = nil) {
+    init(reference: ResolvedTopicReference, unifiedSymbol: UnifiedSymbolGraph.Symbol, moduleData: SymbolGraph.Module, moduleReference: ResolvedTopicReference) {
         self.reference = reference
         
         guard let defaultSymbol = unifiedSymbol.defaultSymbol else {
@@ -175,6 +175,8 @@ public struct DocumentationNode {
         self.markup = Document()
         self.docChunks = []
         self.tags = (returns: [], throws: [], parameters: [])
+
+        let platformName = moduleData.platform.name
         
         let symbolAvailabilityVariants = DocumentationDataVariants(
             symbolData: unifiedSymbol.mixins,
@@ -259,7 +261,7 @@ public struct DocumentationNode {
             returnsSectionVariants: .empty,
             parametersSectionVariants: .empty,
             redirectsVariants: .empty,
-            bystanderModuleNames: bystanderModules
+            crossImportOverlayModule: moduleData.bystanders.map({ (moduleData.name, $0) })
         )
 
         try! semanticSymbol.mergeDeclarations(unifiedSymbol: unifiedSymbol)
@@ -468,9 +470,9 @@ public struct DocumentationNode {
     }
 
     @available(*, deprecated, message: "Use init(reference:symbol:platformName:moduleReference:article:engine:bystanderModules:) instead")
-    public init(reference: ResolvedTopicReference, symbol: SymbolGraph.Symbol, platformName: String?, moduleName: String, article: Article?, engine: DiagnosticEngine, bystanderModules: [String]? = nil) {
+    public init(reference: ResolvedTopicReference, symbol: SymbolGraph.Symbol, platformName: String?, moduleName: String, article: Article?, engine: DiagnosticEngine) {
         let assumedModuleReference = ResolvedTopicReference(bundleIdentifier: reference.bundleIdentifier, path: reference.pathComponents.prefix(2).joined(separator: "/"), sourceLanguage: reference.sourceLanguage)
-        self.init(reference: reference, symbol: symbol, platformName: platformName, moduleReference: assumedModuleReference, article: article, engine: engine, bystanderModules: bystanderModules)
+        self.init(reference: reference, symbol: symbol, platformName: platformName, moduleReference: assumedModuleReference, article: article, engine: engine)
     }
     
     /// Initializes a documentation node to represent a symbol from a symbol graph.
@@ -483,7 +485,7 @@ public struct DocumentationNode {
     ///   - article: The documentation extension content for this symbol.
     ///   - engine:The engine that collects any problems encountered during initialization.
     ///   - bystanderModules: An optional list of cross-import module names.
-    public init(reference: ResolvedTopicReference, symbol: SymbolGraph.Symbol, platformName: String?, moduleReference: ResolvedTopicReference, article: Article?, engine: DiagnosticEngine, bystanderModules: [String]? = nil) {
+    public init(reference: ResolvedTopicReference, symbol: SymbolGraph.Symbol, platformName: String?, moduleReference: ResolvedTopicReference, article: Article?, engine: DiagnosticEngine) {
         self.reference = reference
         
         guard reference.sourceLanguage == .swift else {
@@ -559,8 +561,7 @@ public struct DocumentationNode {
             seeAlsoVariants: .init(swiftVariant: markupModel.seeAlsoSection),
             returnsSectionVariants: .init(swiftVariant: markupModel.discussionTags.flatMap({ $0.returns.isEmpty ? nil : ReturnsSection(content: $0.returns[0].contents) })),
             parametersSectionVariants: .init(swiftVariant: markupModel.discussionTags.flatMap({ $0.parameters.isEmpty ? nil : ParametersSection(parameters: $0.parameters) })),
-            redirectsVariants: .init(swiftVariant: article?.redirects),
-            bystanderModuleNames: bystanderModules
+            redirectsVariants: .init(swiftVariant: article?.redirects)
         )
         
         updateAnchorSections()

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -1057,10 +1057,13 @@ public struct RenderNodeTranslator: SemanticVisitor {
         }
         
         let moduleName = context.moduleName(forModuleReference: symbol.moduleReference)
-        
-        node.metadata.modulesVariants = VariantCollection(defaultValue:
-            [RenderMetadata.Module(name: moduleName.displayName, relatedModules: symbol.bystanderModuleNames)]
-        )
+
+        if let crossImportOverlayModule = symbol.crossImportOverlayModule {
+            node.metadata.modulesVariants = VariantCollection(defaultValue: [RenderMetadata.Module(name: crossImportOverlayModule.declaringModule, relatedModules: crossImportOverlayModule.bystanderModules)])
+        } else {
+            node.metadata.modulesVariants = VariantCollection(defaultValue: [RenderMetadata.Module(name: moduleName.displayName, relatedModules: nil)]
+            )
+        }
         
         node.metadata.extendedModuleVariants = VariantCollection<String?>(defaultValue: symbol.extendedModule)
         

--- a/Sources/SwiftDocC/Semantics/ReferenceResolver.swift
+++ b/Sources/SwiftDocC/Semantics/ReferenceResolver.swift
@@ -423,7 +423,7 @@ struct ReferenceResolver: SemanticVisitor {
             returnsSectionVariants: newReturnsVariants,
             parametersSectionVariants: newParametersVariants,
             redirectsVariants: symbol.redirectsVariants,
-            bystanderModuleNames: symbol.bystanderModuleNames,
+            crossImportOverlayModule: symbol.crossImportOverlayModule,
             originVariants: symbol.originVariants,
             automaticTaskGroupsVariants: symbol.automaticTaskGroupsVariants
         )

--- a/Sources/SwiftDocC/Semantics/Symbol/Symbol.swift
+++ b/Sources/SwiftDocC/Semantics/Symbol/Symbol.swift
@@ -113,6 +113,12 @@ public final class Symbol: Semantic, Abstracted, Redirected, AutomaticTaskGroups
     
     /// The name of the module extension in which the symbol is defined, if applicable.
     internal(set) public var extendedModule: String?
+
+    /// The names of any "bystander" modules required for this symbol, if it came from a cross-import overlay.
+    @available(*, deprecated, message: "Use crossImportOverlayModule instead")
+    public var bystanderModuleNames: [String]? {
+        self.crossImportOverlayModule?.bystanderModules
+    }
     
     /// Optional cross-import module names of the symbol.
     internal(set) public var crossImportOverlayModule: (declaringModule: String, bystanderModules: [String])?

--- a/Sources/SwiftDocC/Semantics/Symbol/Symbol.swift
+++ b/Sources/SwiftDocC/Semantics/Symbol/Symbol.swift
@@ -115,7 +115,7 @@ public final class Symbol: Semantic, Abstracted, Redirected, AutomaticTaskGroups
     internal(set) public var extendedModule: String?
     
     /// Optional cross-import module names of the symbol.
-    internal(set) public var bystanderModuleNames: [String]?
+    internal(set) public var crossImportOverlayModule: (declaringModule: String, bystanderModules: [String])?
     
     /// Whether the symbol is required in its context, in each language variant the symbol is available in.
     public var isRequiredVariants: DocumentationDataVariants<Bool>
@@ -227,7 +227,7 @@ public final class Symbol: Semantic, Abstracted, Redirected, AutomaticTaskGroups
         returnsSectionVariants: DocumentationDataVariants<ReturnsSection>,
         parametersSectionVariants: DocumentationDataVariants<ParametersSection>,
         redirectsVariants: DocumentationDataVariants<[Redirect]>,
-        bystanderModuleNames: [String]? = nil,
+        crossImportOverlayModule: (declaringModule: String, bystanderModules: [String])? = nil,
         originVariants: DocumentationDataVariants<SymbolGraph.Relationship.SourceOrigin> = .init(),
         automaticTaskGroupsVariants: DocumentationDataVariants<[AutomaticTaskGroupSection]> = .init(defaultVariantValue: [])
     ) {
@@ -238,7 +238,7 @@ public final class Symbol: Semantic, Abstracted, Redirected, AutomaticTaskGroups
         self.roleHeadingVariants = roleHeadingVariants
         self.platformNameVariants = platformNameVariants
         self.moduleReference = moduleReference
-        self.bystanderModuleNames = bystanderModuleNames
+        self.crossImportOverlayModule = crossImportOverlayModule
         self.isRequiredVariants = requiredVariants
         self.externalIDVariants = externalIDVariants
         self.accessLevelVariants = accessLevelVariants

--- a/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorSymbolVariantsTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorSymbolVariantsTests.swift
@@ -56,7 +56,35 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
                 context.preResolveModuleNames()
             },
             configureSymbol: { symbol in
-                symbol.bystanderModuleNames = ["Custom Bystander Title"]
+                symbol.crossImportOverlayModule = ("Custom Module Title", ["Custom Bystander Title"])
+            },
+            assertOriginalRenderNode: { renderNode in
+                try assertModule(
+                    renderNode.metadata.modules,
+                    expectedName: "Custom Module Title",
+                    expectedRelatedModules: ["Custom Bystander Title"]
+                )
+            },
+            assertAfterApplyingVariant: { renderNode in
+                try assertModule(
+                    renderNode.metadata.modules,
+                    expectedName: "Custom Module Title",
+                    expectedRelatedModules: ["Custom Bystander Title"]
+                )
+            }
+        )
+    }
+
+    /// Make sure that when a symbol has `crossImportOverlayModule` information, that module name is used instead of its `moduleReference`.
+    func testMultipleModulesWithDifferentBystanderModule() throws {
+        try assertMultiVariantSymbol(
+            configureContext: { context, resolvedTopicReference in
+                let moduleReference = ResolvedTopicReference(bundleIdentifier: resolvedTopicReference.bundleIdentifier, path: "/documentation/MyKit", sourceLanguage: .swift)
+                context.documentationCache[moduleReference]?.name = .conceptual(title: "Extended Module Title")
+                context.preResolveModuleNames()
+            },
+            configureSymbol: { symbol in
+                symbol.crossImportOverlayModule = ("Custom Module Title", ["Custom Bystander Title"])
             },
             assertOriginalRenderNode: { renderNode in
                 try assertModule(

--- a/Tests/SwiftDocCTests/Test Resources/BaseKit.symbols.json
+++ b/Tests/SwiftDocCTests/Test Resources/BaseKit.symbols.json
@@ -1,0 +1,86 @@
+{
+    "metadata": {
+        "formatVersion": {
+            "major": 0,
+            "minor": 5,
+            "patch": 3
+        },
+        "generator": "app/1.0"
+    },
+    "module": {
+        "name": "BaseKit",
+        "platform": {
+            "architecture": "x86_64",
+            "vendor": "apple",
+            "operatingSystem": {
+                "name": "macosx",
+                "minimumVersion": {
+                    "major": 12,
+                    "minor": 3,
+                    "patch": 0
+                }
+            }
+        }
+    },
+    "symbols": [
+        {
+            "kind": {
+                "identifier": "swift.struct",
+                "displayName": "Structure"
+            },
+            "identifier": {
+                "precise": "s:7BaseKit11OtherStructV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "OtherStruct"
+            ],
+            "names": {
+                "title": "OtherStruct",
+                "navigator": [
+                    {
+                        "kind": "identifier",
+                        "spelling": "OtherStruct"
+                    }
+                ],
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "struct"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "OtherStruct"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "struct"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "OtherStruct"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///path/to/OverlayTest/BaseKit/BaseKit.swift",
+                "position": {
+                    "line": 9,
+                    "character": 14
+                }
+            }
+        }
+    ],
+    "relationships": []
+}

--- a/Tests/SwiftDocCTests/Test Resources/_OverlayTest_BaseKit@BaseKit.symbols.json
+++ b/Tests/SwiftDocCTests/Test Resources/_OverlayTest_BaseKit@BaseKit.symbols.json
@@ -1,0 +1,108 @@
+{
+    "metadata": {
+        "formatVersion": {
+            "major": 0,
+            "minor": 5,
+            "patch": 3
+        },
+        "generator": "app/1.0"
+    },
+    "module": {
+        "name": "OverlayTest",
+        "bystanders": ["BaseKit"],
+        "platform": {
+            "architecture": "x86_64",
+            "vendor": "apple",
+            "operatingSystem": {
+                "name": "macosx",
+                "minimumVersion": {
+                    "major": 12,
+                    "minor": 3,
+                    "patch": 0
+                }
+            }
+        }
+    },
+    "symbols": [
+        {
+            "kind": {
+                "identifier": "swift.method",
+                "displayName": "Instance Method"
+            },
+            "identifier": {
+                "precise": "s:7BaseKit11OtherStructV013_OverlayTest_aB0E8someFuncyyF",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "OtherStruct",
+                "someFunc()"
+            ],
+            "names": {
+                "title": "someFunc()",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "someFunc"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "functionSignature": {
+                "returns": [
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "BaseKit"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "someFunc"
+                },
+                {
+                    "kind": "text",
+                    "spelling": "()"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///path/to/OverlayTest/_OverlayTest_BaseKit/_OverlayTest_BaseKit.swift",
+                "position": {
+                    "line": 13,
+                    "character": 14
+                }
+            }
+        }
+    ],
+    "relationships": [
+        {
+            "kind": "memberOf",
+            "source": "s:7BaseKit11OtherStructV013_OverlayTest_aB0E8someFuncyyF",
+            "target": "s:7BaseKit11OtherStructV",
+            "targetFallback": "BaseKit.OtherStruct"
+        }
+    ]
+}


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://94736726

## Summary

Swift symbol graphs format the file names of cross-import overlays as if they were extension symbol graphs: `_OverlayModule@DeclaringModule.symbols.json`. However, if that overlay *also* declares some extensions, an extension symbol graph is also emitted: `_OverlayModule@SomeOtherModule.symbols.json`. In both cases, SymbolKit and Swift-DocC overwrite the symbol graph's module name with the name after the `@` in the file name. This creates a situation for cross-import overlays which declare extensions where the rendered module name is incorrect.

This PR changes how module information is loaded to preserve the parsed module name in the symbol graph if it indicates that it is from a cross-import overlay (i.e. it declares a "bystander" module). It also uses this information to emit the parsed module name alongside the bystander module(s) in the Render JSON for these symbols.

## Dependencies

https://github.com/apple/swift-docc-symbolkit/pull/46

## Testing

Generate a doc archive for a module which contains extensions from a cross-import overlay. (I couldn't get Xcode to generate symbol graphs that properly used cross-import overlay information, so you may need to use the symbol graphs i added as test data in this PR.) Make sure that symbols from the overlay properly have both the declaring and bystander modules in the Render JSON and/or on the page, instead of just the module being extended (which may be the same as the bystander module, as in the test data).

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ n/a ] Updated documentation if necessary
