### PR TITLE
Restore SymbolKit branch to release/5.7

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -39,10 +39,10 @@
       },
       {
         "package": "SymbolKit",
-        "repositoryURL": "https://github.com/bitjammer/swift-docc-symbolkit",
+        "repositoryURL": "https://github.com/apple/swift-docc-symbolkit",
         "state": {
-          "branch": "acgarland/5.7/rdar-95220716-snippet-slice-data-model",
-          "revision": "54e260c7364a0a16e0645bdd52e73df9da5d142a",
+          "branch": "release/5.7",
+          "revision": "8682202025906dce29a8b04f9263f40ba87b89d8",
           "version": null
         }
       },

--- a/Package.swift
+++ b/Package.swift
@@ -124,7 +124,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(name: "swift-markdown", url: "https://github.com/apple/swift-markdown.git", .branch("release/5.7")),
         .package(name: "CLMDB", url: "https://github.com/apple/swift-lmdb.git", .branch("release/5.7")),
         .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "1.0.1")),
-        .package(name: "SymbolKit", url: "https://github.com/bitjammer/swift-docc-symbolkit", .branch("acgarland/5.7/rdar-95220716-snippet-slice-data-model")),
+        .package(name: "SymbolKit", url: "https://github.com/apple/swift-docc-symbolkit", .branch("release/5.7")),
         .package(url: "https://github.com/apple/swift-crypto.git", .upToNextMinor(from: "1.1.2")),
     ]
     


### PR DESCRIPTION
Accidentally committed temporary branch point on SymbolKit in the manifest. This PR moves it back to `release/5.7`.