### PR TITLE
Update testMalformedPath to make it use an actually invalid URL

### DIFF
--- a/Tests/SwiftDocCUtilitiesTests/PreviewServer/PreviewHTTPHandlerTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/PreviewServer/PreviewHTTPHandlerTests.swift
@@ -43,7 +43,7 @@ class PreviewHTTPHandlerTests: XCTestCase {
 
         // Request a page
         do {
-            let request = makeRequestHead(path: "/tutorials")
+            let request = makeRequestHead(uri: "/tutorials")
             XCTAssertNoThrow(try channel.writeInbound(HTTPServerRequestPart.head(request)))
             XCTAssertNoThrow(try channel.writeInbound(HTTPServerRequestPart.end(nil)))
             
@@ -53,7 +53,7 @@ class PreviewHTTPHandlerTests: XCTestCase {
 
         // Request an asset
         do {
-            let request = makeRequestHead(path: "/css/test.css")
+            let request = makeRequestHead(uri: "/css/test.css")
             XCTAssertNoThrow(try channel.writeInbound(HTTPServerRequestPart.head(request)))
             XCTAssertNoThrow(try channel.writeInbound(HTTPServerRequestPart.end(nil)))
             
@@ -63,7 +63,7 @@ class PreviewHTTPHandlerTests: XCTestCase {
 
         // Not found error
         do {
-            let request = makeRequestHead(path: "/css/notfound.css")
+            let request = makeRequestHead(uri: "/css/notfound.css")
             XCTAssertNoThrow(try channel.writeInbound(HTTPServerRequestPart.head(request)))
             XCTAssertNoThrow(try channel.writeInbound(HTTPServerRequestPart.end(nil)))
             
@@ -73,7 +73,7 @@ class PreviewHTTPHandlerTests: XCTestCase {
         
         // Passed credentials when none required
         do {
-            let request = makeRequestHead(path: "/tutorials", headers: [("Authorization", "Basic \("USER:PASS".data(using: .utf8)!.base64EncodedString())")])
+            let request = makeRequestHead(uri: "/tutorials", headers: [("Authorization", "Basic \("USER:PASS".data(using: .utf8)!.base64EncodedString())")])
             XCTAssertNoThrow(try channel.writeInbound(HTTPServerRequestPart.head(request)))
             XCTAssertNoThrow(try channel.writeInbound(HTTPServerRequestPart.end(nil)))
             
@@ -109,7 +109,7 @@ class PreviewHTTPHandlerTests: XCTestCase {
 
         // Request page without credentials
         do {
-            let request = makeRequestHead(path: "/tutorials")
+            let request = makeRequestHead(uri: "/tutorials")
             XCTAssertNoThrow(try channel.writeInbound(HTTPServerRequestPart.head(request)))
             XCTAssertNoThrow(try channel.writeInbound(HTTPServerRequestPart.end(nil)))
             
@@ -119,7 +119,7 @@ class PreviewHTTPHandlerTests: XCTestCase {
 
         // Request asset without credentials, e.g. verify we authorize before serving content
         do {
-            let request = makeRequestHead(path: "/css/test.css")
+            let request = makeRequestHead(uri: "/css/test.css")
             XCTAssertNoThrow(try channel.writeInbound(HTTPServerRequestPart.head(request)))
             XCTAssertNoThrow(try channel.writeInbound(HTTPServerRequestPart.end(nil)))
             
@@ -129,7 +129,7 @@ class PreviewHTTPHandlerTests: XCTestCase {
 
         // Request error without credentials, e.g. verify we authorize before error handler
         do {
-            let request = makeRequestHead(path: "/css/notfound.css")
+            let request = makeRequestHead(uri: "/css/notfound.css")
             XCTAssertNoThrow(try channel.writeInbound(HTTPServerRequestPart.head(request)))
             XCTAssertNoThrow(try channel.writeInbound(HTTPServerRequestPart.end(nil)))
             
@@ -139,7 +139,7 @@ class PreviewHTTPHandlerTests: XCTestCase {
 
         // Request with valid credentials
         do {
-            let request = makeRequestHead(path: "/tutorials", headers: [("Authorization", "Basic \("user:pass".data(using: .utf8)!.base64EncodedString())")])
+            let request = makeRequestHead(uri: "/tutorials", headers: [("Authorization", "Basic \("user:pass".data(using: .utf8)!.base64EncodedString())")])
             XCTAssertNoThrow(try channel.writeInbound(HTTPServerRequestPart.head(request)))
             XCTAssertNoThrow(try channel.writeInbound(HTTPServerRequestPart.end(nil)))
             
@@ -149,7 +149,7 @@ class PreviewHTTPHandlerTests: XCTestCase {
 
         // Request error with valid credentials
         do {
-            let request = makeRequestHead(path: "/css/notfound.css", headers: [("Authorization", "Basic \("user:pass".data(using: .utf8)!.base64EncodedString())")])
+            let request = makeRequestHead(uri: "/css/notfound.css", headers: [("Authorization", "Basic \("user:pass".data(using: .utf8)!.base64EncodedString())")])
             XCTAssertNoThrow(try channel.writeInbound(HTTPServerRequestPart.head(request)))
             XCTAssertNoThrow(try channel.writeInbound(HTTPServerRequestPart.end(nil)))
             
@@ -159,7 +159,7 @@ class PreviewHTTPHandlerTests: XCTestCase {
 
         // Request with invalid credentials
         do {
-            let request = makeRequestHead(path: "/tutorials", headers: [("Authorization", "Basic \("USER:PASS".data(using: .utf8)!.base64EncodedString())")])
+            let request = makeRequestHead(uri: "/tutorials", headers: [("Authorization", "Basic \("USER:PASS".data(using: .utf8)!.base64EncodedString())")])
             XCTAssertNoThrow(try channel.writeInbound(HTTPServerRequestPart.head(request)))
             XCTAssertNoThrow(try channel.writeInbound(HTTPServerRequestPart.end(nil)))
             

--- a/Tests/SwiftDocCUtilitiesTests/PreviewServer/RequestHandler/DefaultRequestHandlerTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/PreviewServer/RequestHandler/DefaultRequestHandlerTests.swift
@@ -25,7 +25,7 @@ class DefaultRequestHandlerTests: XCTestCase {
         ])
 
         // Default handler should be invoked for any non-asset path
-        let request = makeRequestHead(path: "/random-path")
+        let request = makeRequestHead(uri: "/random-path")
         let factory = DefaultRequestHandler(rootURL: tempFolderURL)
         let response = try responseWithPipeline(request: request, handler: factory)
         
@@ -48,7 +48,7 @@ class DefaultRequestHandlerTests: XCTestCase {
         ])
 
         // Default handler should handle even paths that do exist on disc
-        let request = makeRequestHead(path: "/existing.html")
+        let request = makeRequestHead(uri: "/existing.html")
         let factory = DefaultRequestHandler(rootURL: tempFolderURL)
         let response = try responseWithPipeline(request: request, handler: factory)
         

--- a/Tests/SwiftDocCUtilitiesTests/PreviewServer/RequestHandler/ErrorRequestHandlerTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/PreviewServer/RequestHandler/ErrorRequestHandlerTests.swift
@@ -18,7 +18,7 @@ import NIOHTTP1
 
 class ErrorRequestHandlerTests: XCTestCase {
     func testErrorHandlerDefault() throws {
-        let request = makeRequestHead(path: "/random-path")
+        let request = makeRequestHead(uri: "/random-path")
         let factory = ErrorRequestHandler()
         let response = try responseWithPipeline(request: request, handler: factory)
         
@@ -27,7 +27,7 @@ class ErrorRequestHandlerTests: XCTestCase {
     }
 
     func testErrorHandlerStatus() throws {
-        let request = makeRequestHead(path: "/random-path")
+        let request = makeRequestHead(uri: "/random-path")
         let factory = ErrorRequestHandler(error: RequestError(status: .notFound))
         let response = try responseWithPipeline(request: request, handler: factory)
         
@@ -36,7 +36,7 @@ class ErrorRequestHandlerTests: XCTestCase {
     }
 
     func testErrorHandlerCustomHeader() throws {
-        let request = makeRequestHead(path: "/random-path")
+        let request = makeRequestHead(uri: "/random-path")
         let factory = ErrorRequestHandler(error: RequestError(status: .notFound), headers: [("Name", "Value")])
         let response = try responseWithPipeline(request: request, handler: factory)
         
@@ -46,7 +46,7 @@ class ErrorRequestHandlerTests: XCTestCase {
     }
 
     func testErrorHandlerCustomHeaderCustomMessage() throws {
-        let request = makeRequestHead(path: "/random-path")
+        let request = makeRequestHead(uri: "/random-path")
         let factory = ErrorRequestHandler(error: RequestError(status: .notFound, message: "Message!"))
         let response = try responseWithPipeline(request: request, handler: factory)
         

--- a/Tests/SwiftDocCUtilitiesTests/PreviewServer/RequestHandler/FileRequestHandlerTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/PreviewServer/RequestHandler/FileRequestHandlerTests.swift
@@ -21,7 +21,7 @@ class FileRequestHandlerTests: XCTestCase {
     let fileIO = NonBlockingFileIO(threadPool: NIOThreadPool(numberOfThreads: 2))
 
     private func verifyAsset(root: URL, path: String, body: String, type: String, file: StaticString = #file, line: UInt = #line) throws {
-        let request = makeRequestHead(path: path)
+        let request = makeRequestHead(uri: path)
         let factory = FileRequestHandler(rootURL: root, fileIO: fileIO)
         let response = try responseWithPipeline(request: request, handler: factory)
         
@@ -95,7 +95,7 @@ class FileRequestHandlerTests: XCTestCase {
     func testFileHandlerAssetsMissing() throws {
         let tempFolderURL = try createTempFolder(content: [])
 
-        let request = makeRequestHead(path: "/css/b00011100.css")
+        let request = makeRequestHead(uri: "/css/b00011100.css")
         let factory = FileRequestHandler(rootURL: tempFolderURL, fileIO: fileIO)
         let response = try responseWithPipeline(request: request, handler: factory)
         
@@ -109,7 +109,7 @@ class FileRequestHandlerTests: XCTestCase {
             ])
         ])
 
-        let request = makeRequestHead(path: "/videos/video.mov", headers: [("Range", "bytes=0-1")])
+        let request = makeRequestHead(uri: "/videos/video.mov", headers: [("Range", "bytes=0-1")])
         let factory = FileRequestHandler(rootURL: tempFolderURL, fileIO: fileIO)
         let response = try responseWithPipeline(request: request, handler: factory)
         
@@ -128,7 +128,7 @@ class FileRequestHandlerTests: XCTestCase {
             ])
         ])
 
-        let request = makeRequestHead(path: "/videos/../video.mov", headers: [("Range", "bytes=0-1")])
+        let request = makeRequestHead(uri: "/videos/../video.mov", headers: [("Range", "bytes=0-1")])
         let factory = FileRequestHandler(rootURL: tempFolderURL, fileIO: fileIO)
         let response = try responseWithPipeline(request: request, handler: factory)
         
@@ -143,7 +143,7 @@ class FileRequestHandlerTests: XCTestCase {
             ])
         ])
 
-        let request = makeRequestHead(path: "/videos/.  ? ? ? ./video.mov", headers: [("Range", "bytes=0-1")])
+        let request = makeRequestHead(uri: "/videos/.  ? ? ? ./video.mov", headers: [("Range", "bytes=0-1")])
         let factory = FileRequestHandler(rootURL: tempFolderURL, fileIO: fileIO)
         let response = try responseWithPipeline(request: request, handler: factory)
         

--- a/Tests/SwiftDocCUtilitiesTests/PreviewServer/RequestHandler/FileRequestHandlerTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/PreviewServer/RequestHandler/FileRequestHandlerTests.swift
@@ -136,14 +136,14 @@ class FileRequestHandlerTests: XCTestCase {
         XCTAssertEqual(response.requestError?.status.code, RequestError.init(status: .unauthorized).status.code)
     }
 
-    func testMalformedPath() throws {
+    func testMalformedURI() throws {
         let tempFolderURL = try createTempFolder(content: [
             Folder(name: "videos", content: [
                 TextFile(name: "video.mov", utf8Content: "Hello!"),
             ])
         ])
 
-        let request = makeRequestHead(uri: "/videos/.  ? ? ? ./video.mov", headers: [("Range", "bytes=0-1")])
+        let request = makeRequestHead(uri: "https://invalid host.com", headers: [("Range", "bytes=0-1")])
         let factory = FileRequestHandler(rootURL: tempFolderURL, fileIO: fileIO)
         let response = try responseWithPipeline(request: request, handler: factory)
         

--- a/Tests/SwiftDocCUtilitiesTests/PreviewServer/ServerTestUtils.swift
+++ b/Tests/SwiftDocCUtilitiesTests/PreviewServer/ServerTestUtils.swift
@@ -14,9 +14,9 @@ import NIOHTTP1
 import XCTest
 @testable import SwiftDocCUtilities
 
-/// Makes a request head part with the given path and headers.
-func makeRequestHead(path: String, headers: [(String, String)]? = nil) -> HTTPRequestHead {
-    var head = HTTPRequestHead(version: .init(major: 1, minor: 1), method: .GET, uri: path)
+/// Makes a request head part with the given URI and headers.
+func makeRequestHead(uri: String, headers: [(String, String)]? = nil) -> HTTPRequestHead {
+    var head = HTTPRequestHead(version: .init(major: 1, minor: 1), method: .GET, uri: uri)
     if let headers = headers {
         for header in headers {
             head.headers.add(name: header.0, value: header.1)


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://95878818

## Summary

The `testMalformedPath` used a URL that wasn't actually invalid per the URL specification. This made the test incorrectly fail when running using macOS Ventura Beta. This updates the test to make it use a URL that's actually invalid, and updates the `makeRequestHead`'s `path` parameter to `uri`, since that's what it represents.

## Dependencies

None.

## Testing

N/A

## Checklist

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
