### PR TITLE
Update swift-markdown

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -60,7 +60,7 @@
         "repositoryURL": "https://github.com/apple/swift-markdown.git",
         "state": {
           "branch": "main",
-          "revision": "395fbf23fc09e76efaecbb731edb2aebf910948b",
+          "revision": "69f31f83a5dca9a3401d3e8fc8ff74804b0dd0ca",
           "version": null
         }
       },

--- a/Tests/SwiftDocCTests/Model/DocumentationMarkupTests.swift
+++ b/Tests/SwiftDocCTests/Model/DocumentationMarkupTests.swift
@@ -662,4 +662,60 @@ class DocumentationMarkupTests: XCTestCase {
             )
         }
     }
+    
+    func testComments() {
+        let source = """
+        # Title
+        <!--Line a-->
+        
+        Line b
+        
+        @Comment { Line c This is a single-line comment }
+        
+        Line d
+        
+        @Comment{
+            Line e
+        }
+        
+        Line f
+        """
+        let documentation = Document(parsing: source, options: .parseBlockDirectives)
+        let expected = """
+        Document
+        ├─ Heading level: 1
+        │  └─ Text "Title"
+        ├─ HTMLBlock
+        │  <!--Line a-->
+        ├─ Paragraph
+        │  └─ Text "Line b"
+        ├─ BlockDirective name: "Comment"
+        │  └─ Paragraph
+        │     └─ Text "Line c This is a single-line comment"
+        ├─ Paragraph
+        │  └─ Text "Line d"
+        ├─ BlockDirective name: "Comment"
+        │  └─ Paragraph
+        │     └─ Text "Line e"
+        └─ Paragraph
+           └─ Text "Line f"
+        """
+        XCTAssertEqual(expected, documentation.debugDescription())
+        
+        let model = DocumentationMarkup(markup: documentation)
+        let expectedAbstract = """
+        Text \"Line b\"
+        """
+        let expectedDiscussion = """
+        Paragraph
+        └─ Text "Line d"
+        BlockDirective name: "Comment"
+        └─ Paragraph
+           └─ Text "Line e"
+        Paragraph
+        └─ Text "Line f"
+        """
+        XCTAssertEqual(expectedAbstract, model.abstractSection?.content.map{ $0.detachedFromParent.debugDescription() }.joined(separator: "\n"))
+        XCTAssertEqual(expectedDiscussion, model.discussionSection?.content.map{ $0.detachedFromParent.debugDescription() }.joined(separator: "\n"))
+    }
 }


### PR DESCRIPTION
<!--
If you're opening a PR to cherry-pick a change for a release branch, use this template instead:
https://github.com/apple/swift-docc/blob/main/.github/PULL_REQUEST_TEMPLATE/CHERRY_PICK.md
-->

Bug/issue #, if applicable: 

## Summary

Update Package.resolved to get the latest swift-markdown which fixed 
[apple/swift-markdown#64](https://github.com/apple/swift-markdown/issues/64) and [apple/swift-markdown#65](https://github.com/apple/swift-markdown/issues/65)
(originally swift-docc repo's issues)

## Dependencies

[apple/swift-markdowm#66
](https://github.com/apple/swift-markdown/pull/66)

## Testing

See the issues mentioned above
