### PR TITLE
Allow processing symbol graphs of unknown languages

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolReference.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolReference.swift
@@ -182,8 +182,9 @@ extension UnifiedSymbolGraph.Symbol {
         // Adding a dedicated SymbolKit API for this purpose is tracked
         // with github.com/apple/swift-docc-symbolkit/issues/32 and rdar://85982095.
         return Set(
-            pathComponents.keys.compactMap { selector in
-                return SourceLanguage(knownLanguageIdentifier: selector.interfaceLanguage)
+            pathComponents.keys.map { selector in
+                SourceLanguage(knownLanguageIdentifier: selector.interfaceLanguage)
+                    ?? SourceLanguage(id: selector.interfaceLanguage)
             }
         )
     }

--- a/Tests/SwiftDocCTests/Infrastructure/SymbolReferenceTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/SymbolReferenceTests.swift
@@ -216,4 +216,52 @@ class SymbolReferenceTests: XCTestCase {
             ]
         )
     }
+    
+    func testKnownSourceLanguagesOfUnifiedGraphSymbol() {
+        let module = SymbolGraph.Module(
+            name: "os",
+            platform: SymbolGraph.Platform()
+        )
+        
+        let unifiedSymbol = UnifiedSymbolGraph.Symbol(
+            fromSingleSymbol: makeSymbol(interfaceLanguage: "swift"),
+            module: module,
+            isMainGraph: true
+        )
+        
+        unifiedSymbol.mergeSymbol(
+            symbol: makeSymbol(interfaceLanguage: "c"),
+            module: module,
+            isMainGraph: true
+        )
+        
+        XCTAssertEqual(unifiedSymbol.sourceLanguages.map(\.id).sorted(), ["occ", "swift"])
+    }
+    
+    func testUnknownSourceLanguagesOfUnifiedGraphSymbol() {
+        let module = SymbolGraph.Module(
+            name: "os",
+            platform: SymbolGraph.Platform()
+        )
+        
+        let unifiedSymbol = UnifiedSymbolGraph.Symbol(
+            fromSingleSymbol: makeSymbol(interfaceLanguage: "unknown-language"),
+            module: module,
+            isMainGraph: true
+        )
+        
+        XCTAssertEqual(unifiedSymbol.sourceLanguages.map(\.id).sorted(), ["unknown-language"])
+    }
+    
+    private func makeSymbol(interfaceLanguage: String) -> SymbolGraph.Symbol {
+        SymbolGraph.Symbol(
+            identifier: .init(precise: "abcd", interfaceLanguage: interfaceLanguage),
+            names: .init(title: "abcd", navigator: nil, subHeading: nil, prose: nil),
+            pathComponents: ["test", "abcd"],
+            docComment: nil,
+            accessLevel: .init(rawValue: "public"),
+            kind: .init(parsedIdentifier: .module, displayName: "Framework"),
+            mixins: [:]
+        )
+    }
 }


### PR DESCRIPTION
Bug/issue #, if applicable: N/A

## Summary

DocC currently has a set of 'known' programming languages for which it has display names, and loading symbol graphs currently requires the symbols' language to be known by DocC. There's no reason to not process allow processing symbols of unknown language though, and this fix makes DocC more flexible in that respect. The end-to-end compilation flow works fine with the change.

## Dependencies

N/A

## Testing

Build documentation for a symbol graph with an unknown language, e.g., by taking an existing Swift compiler symbol graph and replacing the 'swift' language with 'unknown-language'.

## Checklist

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
