### PR TITLE
Add support for "warnings as errors"

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Diagnostics/DiagnosticEngine.swift
+++ b/Sources/SwiftDocC/Infrastructure/Diagnostics/DiagnosticEngine.swift
@@ -69,7 +69,7 @@ public final class DiagnosticEngine {
     /// - Parameter problems: The array of diagnostics to dispatch to this engine's currently subscribed consumers.
     /// > Note: Diagnostics are dispatched asynchronously.
     public func emit(_ problems: [Problem]) {
-        let mappedProblems = problems.map { problem in
+        let mappedProblems = problems.map { problem -> Problem in
             var problem = problem
             if warningsAsErrors, problem.diagnostic.severity == .warning {
                 problem.diagnostic.severity = .error

--- a/Sources/SwiftDocC/Infrastructure/Diagnostics/DiagnosticEngine.swift
+++ b/Sources/SwiftDocC/Infrastructure/Diagnostics/DiagnosticEngine.swift
@@ -34,7 +34,7 @@ public final class DiagnosticEngine {
     }
     
     /// Determines whether warning will be treated as error
-    private let warningAsError: Bool
+    private let warningsAsErrors: Bool
 
     /// Determines which problems should be emitted.
     private var filter: (Problem) -> Bool
@@ -45,9 +45,9 @@ public final class DiagnosticEngine {
     }
 
     /// Creates a new diagnostic engine instance with no consumers.
-    public init(filterLevel: DiagnosticSeverity = .warning, warningAsError: Bool = false) {
+    public init(filterLevel: DiagnosticSeverity = .warning, warningsAsErrors: Bool = false) {
         self.filterLevel = filterLevel
-        self.warningAsError = warningAsError
+        self.warningsAsErrors = warningsAsErrors
         self.filter = { $0.diagnostic.severity.rawValue <= filterLevel.rawValue }
     }
 
@@ -71,7 +71,7 @@ public final class DiagnosticEngine {
     public func emit(_ problems: [Problem]) {
         let mappedProblems = problems.map { problem in
             var problem = problem
-            if warningAsError, problem.diagnostic.severity == .warning {
+            if warningsAsErrors, problem.diagnostic.severity == .warning {
                 problem.diagnostic.severity = .error
             }
             return problem

--- a/Sources/SwiftDocC/Infrastructure/Diagnostics/DiagnosticEngine.swift
+++ b/Sources/SwiftDocC/Infrastructure/Diagnostics/DiagnosticEngine.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -32,6 +32,9 @@ public final class DiagnosticEngine {
             self.filter = { $0.diagnostic.severity.rawValue <= self.filterLevel.rawValue }
         }
     }
+    
+    /// Determines whether warning will be treated as error
+    private let warningAsError: Bool
 
     /// Determines which problems should be emitted.
     private var filter: (Problem) -> Bool
@@ -42,8 +45,9 @@ public final class DiagnosticEngine {
     }
 
     /// Creates a new diagnostic engine instance with no consumers.
-    public init(filterLevel: DiagnosticSeverity = .warning) {
+    public init(filterLevel: DiagnosticSeverity = .warning, warningAsError: Bool = false) {
         self.filterLevel = filterLevel
+        self.warningAsError = warningAsError
         self.filter = { $0.diagnostic.severity.rawValue <= filterLevel.rawValue }
     }
 
@@ -65,7 +69,14 @@ public final class DiagnosticEngine {
     /// - Parameter problems: The array of diagnostics to dispatch to this engine's currently subscribed consumers.
     /// > Note: Diagnostics are dispatched asynchronously.
     public func emit(_ problems: [Problem]) {
-        let filteredProblems = problems.filter(filter)
+        let mappedProblems = problems.map { problem in
+            var problem = problem
+            if warningAsError, problem.diagnostic.severity == .warning {
+                problem.diagnostic.severity = .error
+            }
+            return problem
+        }
+        let filteredProblems = mappedProblems.filter(filter)
         guard !filteredProblems.isEmpty else { return }
 
         if filteredProblems.containsErrors {

--- a/Sources/SwiftDocC/Infrastructure/Diagnostics/DiagnosticEngine.swift
+++ b/Sources/SwiftDocC/Infrastructure/Diagnostics/DiagnosticEngine.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -33,8 +33,8 @@ public final class DiagnosticEngine {
         }
     }
     
-    /// Determines whether warning will be treated as error
-    private let warningsAsErrors: Bool
+    /// Determines whether warnings will be treated as errors.
+    private let treatWarningsAsErrors: Bool
 
     /// Determines which problems should be emitted.
     private var filter: (Problem) -> Bool
@@ -45,9 +45,9 @@ public final class DiagnosticEngine {
     }
 
     /// Creates a new diagnostic engine instance with no consumers.
-    public init(filterLevel: DiagnosticSeverity = .warning, warningsAsErrors: Bool = false) {
+    public init(filterLevel: DiagnosticSeverity = .warning, treatWarningsAsErrors: Bool = false) {
         self.filterLevel = filterLevel
-        self.warningsAsErrors = warningsAsErrors
+        self.treatWarningsAsErrors = treatWarningsAsErrors
         self.filter = { $0.diagnostic.severity.rawValue <= filterLevel.rawValue }
     }
 
@@ -71,7 +71,7 @@ public final class DiagnosticEngine {
     public func emit(_ problems: [Problem]) {
         let mappedProblems = problems.map { problem -> Problem in
             var problem = problem
-            if warningsAsErrors, problem.diagnostic.severity == .warning {
+            if treatWarningsAsErrors, problem.diagnostic.severity == .warning {
                 problem.diagnostic.severity = .error
             }
             return problem

--- a/Sources/SwiftDocCUtilities/Action/Actions/Convert/ConvertAction.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Convert/ConvertAction.swift
@@ -33,7 +33,7 @@ public struct ConvertAction: Action, RecreatingContext {
     let htmlTemplateDirectory: URL?
     let emitDigest: Bool
     let inheritDocs: Bool
-    let warningsAsErrors: Bool
+    let treatWarningsAsErrors: Bool
     let experimentalEnableCustomTemplates: Bool
     let buildLMDBIndex: Bool
     let documentationCoverageOptions: DocumentationCoverageOptions
@@ -100,7 +100,7 @@ public struct ConvertAction: Action, RecreatingContext {
         diagnosticEngine: DiagnosticEngine? = nil,
         emitFixits: Bool = false,
         inheritDocs: Bool = false,
-        warningsAsErrors: Bool = false,
+        treatWarningsAsErrors: Bool = false,
         experimentalEnableCustomTemplates: Bool = false,
         transformForStaticHosting: Bool = false,
         hostingBasePath: String? = nil,
@@ -137,11 +137,11 @@ public struct ConvertAction: Action, RecreatingContext {
             formattingOptions = []
         }
         self.inheritDocs = inheritDocs
-        self.warningsAsErrors = warningsAsErrors
+        self.treatWarningsAsErrors = treatWarningsAsErrors
 
         self.experimentalEnableCustomTemplates = experimentalEnableCustomTemplates
         
-        let engine = diagnosticEngine ?? DiagnosticEngine(warningsAsErrors: warningsAsErrors)
+        let engine = diagnosticEngine ?? DiagnosticEngine(treatWarningsAsErrors: treatWarningsAsErrors)
         engine.filterLevel = filterLevel
         engine.add(DiagnosticConsoleWriter(formattingOptions: formattingOptions))
         

--- a/Sources/SwiftDocCUtilities/Action/Actions/Convert/ConvertAction.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Convert/ConvertAction.swift
@@ -33,7 +33,7 @@ public struct ConvertAction: Action, RecreatingContext {
     let htmlTemplateDirectory: URL?
     let emitDigest: Bool
     let inheritDocs: Bool
-    let warningAsError: Bool
+    let warningsAsErrors: Bool
     let experimentalEnableCustomTemplates: Bool
     let buildLMDBIndex: Bool
     let documentationCoverageOptions: DocumentationCoverageOptions
@@ -100,7 +100,7 @@ public struct ConvertAction: Action, RecreatingContext {
         diagnosticEngine: DiagnosticEngine? = nil,
         emitFixits: Bool = false,
         inheritDocs: Bool = false,
-        warningAsError: Bool = false,
+        warningsAsErrors: Bool = false,
         experimentalEnableCustomTemplates: Bool = false,
         transformForStaticHosting: Bool = false,
         hostingBasePath: String? = nil,
@@ -137,11 +137,11 @@ public struct ConvertAction: Action, RecreatingContext {
             formattingOptions = []
         }
         self.inheritDocs = inheritDocs
-        self.warningAsError = warningAsError
+        self.warningsAsErrors = warningsAsErrors
 
         self.experimentalEnableCustomTemplates = experimentalEnableCustomTemplates
         
-        let engine = diagnosticEngine ?? DiagnosticEngine(warningAsError: warningAsError)
+        let engine = diagnosticEngine ?? DiagnosticEngine(warningsAsErrors: warningsAsErrors)
         engine.filterLevel = filterLevel
         engine.add(DiagnosticConsoleWriter(formattingOptions: formattingOptions))
         

--- a/Sources/SwiftDocCUtilities/Action/Actions/Convert/ConvertAction.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Convert/ConvertAction.swift
@@ -33,6 +33,7 @@ public struct ConvertAction: Action, RecreatingContext {
     let htmlTemplateDirectory: URL?
     let emitDigest: Bool
     let inheritDocs: Bool
+    let warningAsError: Bool
     let experimentalEnableCustomTemplates: Bool
     let buildLMDBIndex: Bool
     let documentationCoverageOptions: DocumentationCoverageOptions
@@ -99,6 +100,7 @@ public struct ConvertAction: Action, RecreatingContext {
         diagnosticEngine: DiagnosticEngine? = nil,
         emitFixits: Bool = false,
         inheritDocs: Bool = false,
+        warningAsError: Bool = false,
         experimentalEnableCustomTemplates: Bool = false,
         transformForStaticHosting: Bool = false,
         hostingBasePath: String? = nil,
@@ -135,10 +137,11 @@ public struct ConvertAction: Action, RecreatingContext {
             formattingOptions = []
         }
         self.inheritDocs = inheritDocs
+        self.warningAsError = warningAsError
 
         self.experimentalEnableCustomTemplates = experimentalEnableCustomTemplates
         
-        let engine = diagnosticEngine ?? DiagnosticEngine()
+        let engine = diagnosticEngine ?? DiagnosticEngine(warningAsError: warningAsError)
         engine.filterLevel = filterLevel
         engine.add(DiagnosticConsoleWriter(formattingOptions: formattingOptions))
         

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/ActionExtensions/ConvertAction+CommandInitialization.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/ActionExtensions/ConvertAction+CommandInitialization.swift
@@ -78,6 +78,7 @@ extension ConvertAction {
             diagnosticLevel: convert.diagnosticLevel,
             emitFixits: convert.emitFixits,
             inheritDocs: convert.enableInheritedDocs,
+            warningAsError: convert.treatWarningAsError,
             experimentalEnableCustomTemplates: convert.experimentalEnableCustomTemplates,
             transformForStaticHosting: convert.transformForStaticHosting,
             hostingBasePath: convert.hostingBasePath,

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/ActionExtensions/ConvertAction+CommandInitialization.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/ActionExtensions/ConvertAction+CommandInitialization.swift
@@ -78,7 +78,7 @@ extension ConvertAction {
             diagnosticLevel: convert.diagnosticLevel,
             emitFixits: convert.emitFixits,
             inheritDocs: convert.enableInheritedDocs,
-            warningsAsErrors: convert.warningsAsErrors,
+            treatWarningsAsErrors: convert.warningsAsErrors,
             experimentalEnableCustomTemplates: convert.experimentalEnableCustomTemplates,
             transformForStaticHosting: convert.transformForStaticHosting,
             hostingBasePath: convert.hostingBasePath,

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/ActionExtensions/ConvertAction+CommandInitialization.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/ActionExtensions/ConvertAction+CommandInitialization.swift
@@ -78,7 +78,7 @@ extension ConvertAction {
             diagnosticLevel: convert.diagnosticLevel,
             emitFixits: convert.emitFixits,
             inheritDocs: convert.enableInheritedDocs,
-            warningAsError: convert.treatWarningAsError,
+            warningsAsErrors: convert.warningsAsErrors,
             experimentalEnableCustomTemplates: convert.experimentalEnableCustomTemplates,
             transformForStaticHosting: convert.transformForStaticHosting,
             hostingBasePath: convert.hostingBasePath,

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Convert.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Convert.swift
@@ -140,7 +140,7 @@ extension Docc {
         
         
         @Flag(help: "Treat diagnostics level of warning as error")
-        public var treatWarningAsError = false
+        public var warningsAsErrors = false
         
         /// Arguments for specifying information about the source code repository that hosts the documented project's code.
         @OptionGroup()

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Convert.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Convert.swift
@@ -139,7 +139,7 @@ extension Docc {
         public var enableInheritedDocs = false
         
         
-        @Flag(help: "Treat diagnostics level of warning as error")
+        @Flag(help: "Treat warnings as errors")
         public var warningsAsErrors = false
         
         /// Arguments for specifying information about the source code repository that hosts the documented project's code.

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Convert.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Convert.swift
@@ -138,6 +138,10 @@ extension Docc {
         @Flag(help: "Inherit documentation for inherited symbols")
         public var enableInheritedDocs = false
         
+        
+        @Flag(help: "Treat diagnostics level of warning as error")
+        public var treatWarningAsError = false
+        
         /// Arguments for specifying information about the source code repository that hosts the documented project's code.
         @OptionGroup()
         public var sourceRepositoryArguments: SourceRepositoryArguments

--- a/Tests/SwiftDocCTests/Diagnostics/DiagnosticEngineTests.swift
+++ b/Tests/SwiftDocCTests/Diagnostics/DiagnosticEngineTests.swift
@@ -130,7 +130,7 @@ class DiagnosticEngineTests: XCTestCase {
             """)
     }
     
-    func testWarningAsError() {
+    func testWarningsAsErrors() {
         let error = Problem(diagnostic: Diagnostic(source: nil, severity: .error, range: nil, identifier: "org.swift.docc.tests", summary: "Test error"), possibleSolutions: [])
         let warning = Problem(diagnostic: Diagnostic(source: nil, severity: .warning, range: nil, identifier: "org.swift.docc.tests", summary: "Test warning"), possibleSolutions: [])
         let information = Problem(diagnostic: Diagnostic(source: nil, severity: .information, range: nil, identifier: "org.swift.docc.tests", summary: "Test information"), possibleSolutions: [])
@@ -145,7 +145,7 @@ class DiagnosticEngineTests: XCTestCase {
             warning: Test warning
             """)
 
-        let engine = DiagnosticEngine(filterLevel: .information, warningAsError: true)
+        let engine = DiagnosticEngine(filterLevel: .information, warningsAsErrors: true)
         engine.emit(error)
         engine.emit(warning)
         engine.emit(information)

--- a/Tests/SwiftDocCTests/Diagnostics/DiagnosticEngineTests.swift
+++ b/Tests/SwiftDocCTests/Diagnostics/DiagnosticEngineTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -130,13 +130,12 @@ class DiagnosticEngineTests: XCTestCase {
             """)
     }
     
-    func testWarningsAsErrors() {
+    func testTreatWarningsAsErrors() {
         let error = Problem(diagnostic: Diagnostic(source: nil, severity: .error, range: nil, identifier: "org.swift.docc.tests", summary: "Test error"), possibleSolutions: [])
         let warning = Problem(diagnostic: Diagnostic(source: nil, severity: .warning, range: nil, identifier: "org.swift.docc.tests", summary: "Test warning"), possibleSolutions: [])
         let information = Problem(diagnostic: Diagnostic(source: nil, severity: .information, range: nil, identifier: "org.swift.docc.tests", summary: "Test information"), possibleSolutions: [])
 
         let defaultEngine = DiagnosticEngine()
-
         defaultEngine.emit(error)
         defaultEngine.emit(warning)
         defaultEngine.emit(information)
@@ -145,7 +144,7 @@ class DiagnosticEngineTests: XCTestCase {
             warning: Test warning
             """)
 
-        let engine = DiagnosticEngine(filterLevel: .information, warningsAsErrors: true)
+        let engine = DiagnosticEngine(filterLevel: .information, treatWarningsAsErrors: true)
         engine.emit(error)
         engine.emit(warning)
         engine.emit(information)
@@ -153,6 +152,15 @@ class DiagnosticEngineTests: XCTestCase {
             error: Test error
             error: Test warning
             note: Test information
+            """)
+        
+        let errorFilterLevelEngine = DiagnosticEngine(filterLevel: .error, treatWarningsAsErrors: true)
+        errorFilterLevelEngine.emit(error)
+        errorFilterLevelEngine.emit(warning)
+        errorFilterLevelEngine.emit(information)
+        XCTAssertEqual(errorFilterLevelEngine.problems.localizedDescription, """
+            error: Test error
+            error: Test warning
             """)
     }
 }

--- a/Tests/SwiftDocCTests/Diagnostics/DiagnosticEngineTests.swift
+++ b/Tests/SwiftDocCTests/Diagnostics/DiagnosticEngineTests.swift
@@ -129,4 +129,30 @@ class DiagnosticEngineTests: XCTestCase {
             note: Test information
             """)
     }
+    
+    func testWarningAsError() {
+        let error = Problem(diagnostic: Diagnostic(source: nil, severity: .error, range: nil, identifier: "org.swift.docc.tests", summary: "Test error"), possibleSolutions: [])
+        let warning = Problem(diagnostic: Diagnostic(source: nil, severity: .warning, range: nil, identifier: "org.swift.docc.tests", summary: "Test warning"), possibleSolutions: [])
+        let information = Problem(diagnostic: Diagnostic(source: nil, severity: .information, range: nil, identifier: "org.swift.docc.tests", summary: "Test information"), possibleSolutions: [])
+
+        let defaultEngine = DiagnosticEngine()
+
+        defaultEngine.emit(error)
+        defaultEngine.emit(warning)
+        defaultEngine.emit(information)
+        XCTAssertEqual(defaultEngine.problems.localizedDescription, """
+            error: Test error
+            warning: Test warning
+            """)
+
+        let engine = DiagnosticEngine(filterLevel: .information, warningAsError: true)
+        engine.emit(error)
+        engine.emit(warning)
+        engine.emit(information)
+        XCTAssertEqual(engine.problems.localizedDescription, """
+            error: Test error
+            error: Test warning
+            note: Test information
+            """)
+    }
 }

--- a/Tests/SwiftDocCUtilitiesTests/ArgumentParsing/ConvertSubcommandTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ArgumentParsing/ConvertSubcommandTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -444,7 +444,7 @@ class ConvertSubcommandTests: XCTestCase {
             // Passing no argument should default to the current working directory.
             let convert = try Docc.Convert.parse([])
             let convertAction = try ConvertAction(fromConvertCommand: convert)
-            XCTAssertEqual(convertAction.warningsAsErrors, false)
+            XCTAssertEqual(convertAction.treatWarningsAsErrors, false)
         } catch {
             XCTFail("Failed to run docc convert without arguments.")
         }
@@ -454,7 +454,7 @@ class ConvertSubcommandTests: XCTestCase {
                 "--warnings-as-errors"
             ])
             let convertAction = try ConvertAction(fromConvertCommand: convert)
-            XCTAssertEqual(convertAction.warningsAsErrors, true)
+            XCTAssertEqual(convertAction.treatWarningsAsErrors, true)
         } catch {
             XCTFail("Failed to run docc convert without arguments.")
         }

--- a/Tests/SwiftDocCUtilitiesTests/ArgumentParsing/ConvertSubcommandTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ArgumentParsing/ConvertSubcommandTests.swift
@@ -444,17 +444,17 @@ class ConvertSubcommandTests: XCTestCase {
             // Passing no argument should default to the current working directory.
             let convert = try Docc.Convert.parse([])
             let convertAction = try ConvertAction(fromConvertCommand: convert)
-            XCTAssertEqual(convertAction.warningAsError, false)
+            XCTAssertEqual(convertAction.warningsAsErrors, false)
         } catch {
             XCTFail("Failed to run docc convert without arguments.")
         }
         do {
             // Passing no argument should default to the current working directory.
             let convert = try Docc.Convert.parse([
-                "--treat-warning-as-error"
+                "--warnings-as-errors"
             ])
             let convertAction = try ConvertAction(fromConvertCommand: convert)
-            XCTAssertEqual(convertAction.warningAsError, true)
+            XCTAssertEqual(convertAction.warningsAsErrors, true)
         } catch {
             XCTFail("Failed to run docc convert without arguments.")
         }

--- a/Tests/SwiftDocCUtilitiesTests/ArgumentParsing/ConvertSubcommandTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ArgumentParsing/ConvertSubcommandTests.swift
@@ -437,4 +437,26 @@ class ConvertSubcommandTests: XCTestCase {
             XCTAssertFalse(convertOptions.transformForStaticHosting)
         }
     }
+    
+    func testTreatWarningAsrror() throws {
+        setenv(TemplateOption.environmentVariableKey, testTemplateURL.path, 1)
+        do {
+            // Passing no argument should default to the current working directory.
+            let convert = try Docc.Convert.parse([])
+            let convertAction = try ConvertAction(fromConvertCommand: convert)
+            XCTAssertEqual(convertAction.warningAsError, false)
+        } catch {
+            XCTFail("Failed to run docc convert without arguments.")
+        }
+        do {
+            // Passing no argument should default to the current working directory.
+            let convert = try Docc.Convert.parse([
+                "--treat-warning-as-error"
+            ])
+            let convertAction = try ConvertAction(fromConvertCommand: convert)
+            XCTAssertEqual(convertAction.warningAsError, true)
+        } catch {
+            XCTFail("Failed to run docc convert without arguments.")
+        }
+    }
 }

--- a/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -2557,7 +2557,7 @@ class ConvertActionTests: XCTestCase {
         expectedOutput.assertExist(at: result.outputs[0], fileManager: FileManager.default)
     }
     
-    func testWarningsAsErrors() throws {
+    func testTreatWarningsAsErrors() throws {
         let bundle = Folder(name: "unit-test.docc", content: [
             InfoPlist(displayName: "TestBundle", identifier: "com.test.example"),
             CopyOfFile(original: symbolGraphFile, newName: "MyKit.symbols.json"),
@@ -2573,8 +2573,9 @@ class ConvertActionTests: XCTestCase {
         let targetDirectory = URL(fileURLWithPath: testDataProvider.currentDirectoryPath)
             .appendingPathComponent("target", isDirectory: true)
 
+        // Test DiagnosticEngine with "treatWarningsAsErrors" set to false
         do {
-            let engine = DiagnosticEngine()
+            let engine = DiagnosticEngine(treatWarningsAsErrors: false)
             var action = try ConvertAction(
                 documentationBundleURL: bundle.absoluteURL,
                 outOfProcessResolver: nil,
@@ -2593,8 +2594,10 @@ class ConvertActionTests: XCTestCase {
             XCTAssertTrue(engine.problems.contains(where: { $0.diagnostic.severity == .warning }))
             XCTAssertFalse(result.didEncounterError)
         }
+        
+        // Test DiagnosticEngine with "treatWarningsAsErrors" set to true
         do {
-            let engine = DiagnosticEngine(warningsAsErrors: true)
+            let engine = DiagnosticEngine(treatWarningsAsErrors: true)
             var action = try ConvertAction(
                 documentationBundleURL: bundle.absoluteURL,
                 outOfProcessResolver: nil,
@@ -2626,7 +2629,7 @@ class ConvertActionTests: XCTestCase {
                 fileManager: testDataProvider,
                 temporaryDirectory: createTemporaryDirectory(),
                 diagnosticEngine: nil,
-                warningsAsErrors: true
+                treatWarningsAsErrors: true
             )
             let result = try action.perform(logHandle: .none)
             XCTAssertTrue(result.didEncounterError)

--- a/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
@@ -2557,7 +2557,7 @@ class ConvertActionTests: XCTestCase {
         expectedOutput.assertExist(at: result.outputs[0], fileManager: FileManager.default)
     }
     
-    func testWarningAsError() throws {
+    func testWarningsAsErrors() throws {
         let bundle = Folder(name: "unit-test.docc", content: [
             InfoPlist(displayName: "TestBundle", identifier: "com.test.example"),
             CopyOfFile(original: symbolGraphFile, newName: "MyKit.symbols.json"),
@@ -2594,7 +2594,7 @@ class ConvertActionTests: XCTestCase {
             XCTAssertFalse(result.didEncounterError)
         }
         do {
-            let engine = DiagnosticEngine(warningAsError: true)
+            let engine = DiagnosticEngine(warningsAsErrors: true)
             var action = try ConvertAction(
                 documentationBundleURL: bundle.absoluteURL,
                 outOfProcessResolver: nil,
@@ -2626,7 +2626,7 @@ class ConvertActionTests: XCTestCase {
                 fileManager: testDataProvider,
                 temporaryDirectory: createTemporaryDirectory(),
                 diagnosticEngine: nil,
-                warningAsError: true
+                warningsAsErrors: true
             )
             let result = try action.perform(logHandle: .none)
             XCTAssertTrue(result.didEncounterError)


### PR DESCRIPTION
<!--
If you're opening a PR to cherry-pick a change for a release branch, use this template instead:
https://github.com/apple/swift-docc/blob/main/.github/PULL_REQUEST_TEMPLATE/CHERRY_PICK.md
-->

Bug/issue #, if applicable: 
Close #363 

## Summary

Add a new flag "--warnings-as-errors" for "docc convert" Command.

If this flag is set, the engine will treat the warning severity level as an error severity level

Forum discussion post: https://forums.swift.org/t/add-support-for-warnings-as-errors/59832

## Dependencies

None

## Testing

1. `git clone https://github.com/apple/swift-markdown.git`
2. Generate `swift-markdown`'s symbol-graph
3. Run 
```
docc convert swift-markdown/Sources/Markdown/Markdown.docc`
--fallback-display-name SwiftDocC
--fallback-bundle-identifier org.swift.SwiftDocC 
--fallback-bundle-version 1.0.0
--additional-symbol-graph-dir xx/swift-markdown.build/Debug/Markdown.build/symbol-graph
```
and see a list of warnings.
4. Run 
```
docc convert swift-markdown/Sources/Markdown/Markdown.docc`
--fallback-display-name SwiftDocC
--fallback-bundle-identifier org.swift.SwiftDocC 
--fallback-bundle-version 1.0.0
--additional-symbol-graph-dir xx/swift-markdown.build/Debug/Markdown.build/symbol-graph
--warnings-as-errors
```
and see all the warnings are treated as errors.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
