### PR TITLE
[5.7] Update build script helper to use python3

### DIFF
--- a/build-script-helper.py
+++ b/build-script-helper.py
@@ -1,9 +1,9 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -92,8 +92,6 @@ def run(args):
       printerr('FAIL: Building %s failed' % package_name)
       printerr('Executing: %s' % ' '.join(e.cmd))
       sys.exit(1)
-
-  output_dir = os.path.realpath(os.path.join(args.build_dir, args.configuration))
 
   if should_run_action('generate-xcodeproj', args.build_actions):
     print("** Generating Xcode project for %s **" % package_name)


### PR DESCRIPTION
* Use `python3` in build-script-helper

Python2 is no longer supported by the Swift project.

* Remove unused variable from build script

`output_dir` is written to but never used.

(cherry picked from commit 41f116f72cd3cf6392c2f82d7b72ed3c5ccb735a)
