### PR TITLE
Remove deprecated path properties

### DIFF
--- a/Sources/SwiftDocC/LinkTargets/LinkDestinationSummary.swift
+++ b/Sources/SwiftDocC/LinkTargets/LinkDestinationSummary.swift
@@ -80,14 +80,6 @@ public struct LinkDestinationSummary: Codable, Equatable {
     /// The language of the summarized element.
     public let language: SourceLanguage
     
-    /// The relative path to this element.
-    ///
-    /// > Note: For elements representing on-page elements, this value will include a fragment component.
-    @available(*, deprecated, message: "Use 'relativePresentationURL' instead.")
-    public var path: String {
-        return relativePresentationURL.absoluteString
-    }
-    
     /// The relative presentation URL for this element.
     public let relativePresentationURL: URL
     
@@ -170,12 +162,6 @@ public struct LinkDestinationSummary: Codable, Equatable {
         
         /// The source language of the variant or `nil` if the kind is the same as the summarized element.
         public let language: VariantValue<SourceLanguage>
-        
-        /// The relative path of the variant or `nil` if the relative is the same as the summarized element.
-        @available(*, deprecated, message: "Use 'relativePresentationURL' instead.")
-        public var path: VariantValue<String> {
-            return relativePresentationURL?.absoluteString
-        }
         
         /// The relative presentation URL of the variant or `nil` if the relative is the same as the summarized element.
         public let relativePresentationURL: VariantValue<URL>

--- a/Tests/SwiftDocCTests/LinkTargets/LinkDestinationSummaryTests.swift
+++ b/Tests/SwiftDocCTests/LinkTargets/LinkDestinationSummaryTests.swift
@@ -110,7 +110,6 @@ class ExternalLinkableTests: XCTestCase {
         let summaries = node.externallyLinkableElementSummaries(context: context, renderNode: renderNode)
         let pageSummary = summaries[0]
         XCTAssertEqual(pageSummary.title, "Basic Augmented Reality App 💻")
-        XCTAssertEqual(pageSummary.path, "/tutorials/testbundle/tutorial")
         XCTAssertEqual(pageSummary.relativePresentationURL.absoluteString, "/tutorials/testbundle/tutorial")
         XCTAssertEqual(pageSummary.referenceURL.absoluteString, "doc://com.test.example/tutorials/TestBundle/Tutorial")
         XCTAssertEqual(pageSummary.language, .swift)
@@ -129,7 +128,6 @@ class ExternalLinkableTests: XCTestCase {
 
         let sectionSummary = summaries[1]
         XCTAssertEqual(sectionSummary.title, "Create a New AR Project 💻")
-        XCTAssertEqual(sectionSummary.path, "/tutorials/testbundle/tutorial#Create-a-New-AR-Project-%F0%9F%92%BB")
         XCTAssertEqual(sectionSummary.relativePresentationURL.absoluteString, "/tutorials/testbundle/tutorial#Create-a-New-AR-Project-%F0%9F%92%BB")
         XCTAssertEqual(sectionSummary.referenceURL.absoluteString, "doc://com.test.example/tutorials/TestBundle/Tutorial#Create-a-New-AR-Project-%F0%9F%92%BB")
         XCTAssertEqual(sectionSummary.language, .swift)
@@ -164,7 +162,6 @@ class ExternalLinkableTests: XCTestCase {
             let summary = node.externallyLinkableElementSummaries(context: context, renderNode: renderNode)[0]
             
             XCTAssertEqual(summary.title, "MyClass")
-            XCTAssertEqual(summary.path, "/documentation/mykit/myclass")
             XCTAssertEqual(summary.relativePresentationURL.absoluteString, "/documentation/mykit/myclass")
             XCTAssertEqual(summary.referenceURL.absoluteString, "doc://org.swift.docc.example/documentation/MyKit/MyClass")
             XCTAssertEqual(summary.language, .swift)
@@ -203,7 +200,6 @@ class ExternalLinkableTests: XCTestCase {
             let summary = node.externallyLinkableElementSummaries(context: context, renderNode: renderNode)[0]
             
             XCTAssertEqual(summary.title, "MyProtocol")
-            XCTAssertEqual(summary.path, "/documentation/mykit/myprotocol")
             XCTAssertEqual(summary.relativePresentationURL.absoluteString, "/documentation/mykit/myprotocol")
             XCTAssertEqual(summary.referenceURL.absoluteString, "doc://org.swift.docc.example/documentation/MyKit/MyProtocol")
             XCTAssertEqual(summary.language, .swift)
@@ -239,7 +235,6 @@ class ExternalLinkableTests: XCTestCase {
             let summary = node.externallyLinkableElementSummaries(context: context, renderNode: renderNode)[0]
             
             XCTAssertEqual(summary.title, "myFunction()")
-            XCTAssertEqual(summary.path, "/documentation/mykit/myclass/myfunction()")
             XCTAssertEqual(summary.relativePresentationURL.absoluteString, "/documentation/mykit/myclass/myfunction()")
             XCTAssertEqual(summary.referenceURL.absoluteString, "doc://org.swift.docc.example/documentation/MyKit/MyClass/myFunction()")
             XCTAssertEqual(summary.language, .swift)
@@ -259,7 +254,6 @@ class ExternalLinkableTests: XCTestCase {
             let summary = node.externallyLinkableElementSummaries(context: context, renderNode: renderNode)[0]
             
             XCTAssertEqual(summary.title, "globalFunction(_:considering:)")
-            XCTAssertEqual(summary.path, "/documentation/mykit/globalfunction(_:considering:)")
             XCTAssertEqual(summary.relativePresentationURL.absoluteString, "/documentation/mykit/globalfunction(_:considering:)")
             XCTAssertEqual(summary.referenceURL.absoluteString, "doc://org.swift.docc.example/documentation/MyKit/globalFunction(_:considering:)")
             XCTAssertEqual(summary.language, .swift)
@@ -297,7 +291,6 @@ class ExternalLinkableTests: XCTestCase {
             let summary = node.externallyLinkableElementSummaries(context: context, renderNode: renderNode)[0]
             
             XCTAssertEqual(summary.title, "Bar")
-            XCTAssertEqual(summary.path, "/documentation/mixedlanguageframework/bar")
             XCTAssertEqual(summary.relativePresentationURL.absoluteString, "/documentation/mixedlanguageframework/bar")
             XCTAssertEqual(summary.referenceURL.absoluteString, "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/Bar")
             XCTAssertEqual(summary.language, .swift)
@@ -337,7 +330,6 @@ class ExternalLinkableTests: XCTestCase {
             // Check variant content that is the same as the summarized element
             XCTAssertEqual(variant.title, nil)
             XCTAssertEqual(variant.abstract, nil)
-            XCTAssertEqual(variant.path, nil)
             XCTAssertEqual(variant.usr, nil)
             XCTAssertEqual(variant.kind, nil)
             XCTAssertEqual(variant.taskGroups, nil)
@@ -351,7 +343,6 @@ class ExternalLinkableTests: XCTestCase {
             let summary = node.externallyLinkableElementSummaries(context: context, renderNode: renderNode)[0]
             
             XCTAssertEqual(summary.title, "myStringFunction(_:)")
-            XCTAssertEqual(summary.path, "/documentation/mixedlanguageframework/bar/mystringfunction(_:)")
             XCTAssertEqual(summary.relativePresentationURL.absoluteString, "/documentation/mixedlanguageframework/bar/mystringfunction(_:)")
             XCTAssertEqual(summary.referenceURL.absoluteString, "doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/Bar/myStringFunction(_:)")
             XCTAssertEqual(summary.language, .swift)
@@ -405,7 +396,6 @@ class ExternalLinkableTests: XCTestCase {
             
             // Check variant content that is the same as the summarized element
             XCTAssertEqual(variant.abstract, nil)
-            XCTAssertEqual(variant.path, nil)
             XCTAssertEqual(variant.usr, nil)
             XCTAssertEqual(variant.kind, nil)
             XCTAssertEqual(
@@ -474,7 +464,6 @@ class ExternalLinkableTests: XCTestCase {
         XCTAssertEqual(decoded.kind, .class)
         XCTAssertEqual(decoded.title, "ClassName")
         XCTAssertEqual(decoded.abstract?.plainText, "A brief explanation of my class.")
-        XCTAssertEqual(decoded.path, "documentation/MyKit/ClassName")
         XCTAssertEqual(decoded.relativePresentationURL.absoluteString, "documentation/MyKit/ClassName")
         XCTAssertEqual(decoded.declarationFragments, [
             .init(text: "class", kind: .keyword, identifier: nil),


### PR DESCRIPTION
<!--
If you're opening a PR to cherry-pick a change for a release branch, use this template instead:
https://github.com/apple/swift-docc/blob/main/.github/PULL_REQUEST_TEMPLATE/CHERRY_PICK.md
-->

Bug/issue #, if applicable: none

## Summary

This removes the deprecated `path` properties on `LinkDestinationSummary` and `LinkDestinationSummary/Variant`. 

Doing this gets rid of a handful of deprecation warnings that add noise when running the tests. 

## Dependencies

n/a

## Testing

n/a

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- ~[ ] Added tests~
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
