### PR TITLE
Update default preview server port

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,12 +227,12 @@ Input: ~/Developer/swift-docc/Sources/SwiftDocC/SwiftDocC.docc
 Template: ~/Developer/swift-docc-render-artifact/dist
 ========================================
 Starting Local Preview Server
-   Address: http://localhost:8000/documentation/swiftdocc
+   Address: http://localhost:8080/documentation/swiftdocc
 ========================================
 Monitoring ~/Developer/swift-docc/Sources/SwiftDocC/SwiftDocC.docc for changes...
 ```
 
-And if you navigate to <http://localhost:8000/documentation/swiftdocc> you'll see
+And if you navigate to <http://localhost:8080/documentation/swiftdocc> you'll see
 the rendered documentation for `SwiftDocC`.
   
 ## Versioning

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/Options/PreviewOptions.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/Options/PreviewOptions.swift
@@ -27,13 +27,13 @@ public struct PreviewOptions: ParsableArguments {
 
     /// The port number to use for the preview web server.
     ///
-    /// Defaults to `8000`.
+    /// Defaults to `8080`.
     @Option(
         name: .shortAndLong,
         help: ArgumentHelp(
             "Port number to use for the preview web server.",
             valueName: "port-number"))
-    public var port: Int = 8000
+    public var port: Int = 8080
 
     /// The options used when configuring the preview server for external connections.
     ///

--- a/Tests/SwiftDocCUtilitiesTests/PreviewActionIntegrationTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/PreviewActionIntegrationTests.swift
@@ -102,7 +102,7 @@ class PreviewActionIntegrationTests: XCTestCase {
 //                tlsCertificateChain: nil,
 //                serverUsername: nil,
 //                serverPassword: nil,
-//                port: 8000, // We ignore this value when we set the `bindServerToSocketPath` property below.
+//                port: 8080, // We ignore this value when we set the `bindServerToSocketPath` property below.
 //                createConvertAction: createConvertAction) else {
 //            XCTFail("Could not create preview action from parameters")
 //            return
@@ -158,8 +158,8 @@ class PreviewActionIntegrationTests: XCTestCase {
 //                let previewInfoEnd = logOutput[previewInfoStart...].range(of: "\n=====")?.lowerBound {
 //                XCTAssertEqual(logOutput[previewInfoStart..<previewInfoEnd], """
 //                Starting Local Preview Server
-//                \t Address: http://localhost:8000/documentation/mykit
-//                \t          http://localhost:8000/tutorials/overview
+//                \t Address: http://localhost:8080/documentation/mykit
+//                \t          http://localhost:8080/tutorials/overview
 //                """)
 //            } else {
 //                XCTFail("Missing preview information in log/print output")
@@ -456,7 +456,7 @@ class PreviewActionIntegrationTests: XCTestCase {
                 tlsCertificateChain: nil,
                 serverUsername: nil,
                 serverPassword: nil,
-                port: 8000, // We ignore this value when we set the `bindServerToSocketPath` property below.
+                port: 8080, // We ignore this value when we set the `bindServerToSocketPath` property below.
                 createConvertAction: createConvertAction) else {
             XCTFail("Could not create preview action from parameters")
             return

--- a/Tests/SwiftDocCUtilitiesTests/Utility/LogHandleTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/Utility/LogHandleTests.swift
@@ -31,7 +31,7 @@ class LogHandleTests: XCTestCase {
         handle.write("""
             ========================================
             Starting Local Preview Server
-                Address: http://localhost:8000/documentation/my-framework
+                Address: http://localhost:8080/documentation/my-framework
             ========================================
             """
         )
@@ -46,7 +46,7 @@ class LogHandleTests: XCTestCase {
         XCTAssertEqual(text, """
             ========================================
             Starting Local Preview Server
-                Address: http://localhost:8000/documentation/my-framework
+                Address: http://localhost:8080/documentation/my-framework
             ========================================
             """
         )


### PR DESCRIPTION
<!--
If you're opening a PR to cherry-pick a change for a release branch, use this template instead:
https://github.com/apple/swift-docc/blob/main/.github/PULL_REQUEST_TEMPLATE/CHERRY_PICK.md
-->

Bug/issue #, if applicable: 

Close #371 

Source: https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml?search=http

Thanks @amartini51 for providing the source explanation

## Summary

Update default preview server port

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
