### PR TITLE
Fix two flakyOutOfProcessReferenceResolver tests

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/External Data/OutOfProcessReferenceResolver.swift
+++ b/Sources/SwiftDocC/Infrastructure/External Data/OutOfProcessReferenceResolver.swift
@@ -462,23 +462,32 @@ private class LongRunningProcess: ExternalLinkResolving {
         
     func sendAndWait<Request: Codable & CustomStringConvertible, Response: Codable>(request: Request?) throws -> Response {
         if let request = request {
-            guard let requestString = String(
-                    data: try JSONEncoder().encode(request), encoding: .utf8)?.appending("\n"),
+            guard let requestString = String(data: try JSONEncoder().encode(request), encoding: .utf8)?.appending("\n"),
                   let requestData = requestString.data(using: .utf8)
             else {
                 throw OutOfProcessReferenceResolver.Error.unableToEncodeRequestToClient(requestDescription: request.description)
             }
             input.fileHandleForWriting.write(requestData)
         }
-        let response = output.fileHandleForReading.availableData
+        var response = output.fileHandleForReading.availableData
         guard !response.isEmpty else {
             throw OutOfProcessReferenceResolver.Error.processDidExit(code: Int(process.terminationStatus))
         }
         
-        do {
-            return try JSONDecoder().decode(Response.self, from: response)
-        } catch {
-            throw OutOfProcessReferenceResolver.Error.unableToDecodeResponseFromClient(response, error)
+        // It's not guaranteed that the full response will be available all at once.
+        while true {
+            // If a pipe is empty, checking `availableData` will block until there is new data to read.
+            do {
+                // To avoid blocking forever we check if the response can be decoded after each chunk of data.
+                return try JSONDecoder().decode(Response.self, from: response)
+            } catch DecodingError.dataCorrupted {
+                // If the data wasn't valid JSON we read more data and try to decode it again.
+                response += output.fileHandleForReading.availableData
+                continue
+            } catch {
+                // Other errors are re-thrown as wrapped errors.
+                throw OutOfProcessReferenceResolver.Error.unableToDecodeResponseFromClient(response, error)
+            }
         }
     }
     

--- a/Sources/SwiftDocC/Infrastructure/External Data/OutOfProcessReferenceResolver.swift
+++ b/Sources/SwiftDocC/Infrastructure/External Data/OutOfProcessReferenceResolver.swift
@@ -437,7 +437,7 @@ private class LongRunningProcess: ExternalLinkResolving {
         
         try process.run()
         
-        let errorReadSource = DispatchSource.makeReadSource(fileDescriptor: errorOutput.fileHandleForReading.fileDescriptor)
+        let errorReadSource = DispatchSource.makeReadSource(fileDescriptor: errorOutput.fileHandleForReading.fileDescriptor, queue: .main)
         errorReadSource.setEventHandler { [errorOutput] in
             let data = errorOutput.fileHandleForReading.availableData
             let errorMessage = String(data: data, encoding: .utf8)

--- a/Tests/SwiftDocCUtilitiesTests/OutOfProcessReferenceResolverTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/OutOfProcessReferenceResolverTests.swift
@@ -145,27 +145,25 @@ class OutOfProcessReferenceResolverTests: XCTestCase {
     
     func testResolvingTopicLinkProcess() throws {
         #if os(macOS)
-        throw XCTSkip("This test is flaky (rdar://91678333)")
-        
-//        try assertResolvesTopicLink(makeResolver: { testMetadata in
-//            let temporaryFolder = try createTemporaryDirectory()
-//            let executableLocation = temporaryFolder.appendingPathComponent("link-resolver-executable")
-//            
-//            let encodedMetadata = try String(data: JSONEncoder().encode(testMetadata), encoding: .utf8)!
-//            
-//            try """
-//            #!/bin/bash
-//            echo '{"bundleIdentifier":"com.test.bundle"}'       # Write this resolver's bundle identifier
-//            read                                                # Wait for docc to send a topic URL
-//            echo '{"resolvedInformation":\(encodedMetadata)}'   # Respond with the test metadata (above)
-//            """.write(to: executableLocation, atomically: true, encoding: .utf8)
-//            
-//            // `0o0700` is `-rwx------` (read, write, & execute only for owner)
-//            try FileManager.default.setAttributes([.posixPermissions: 0o0700], ofItemAtPath: executableLocation.path)
-//            XCTAssert(FileManager.default.isExecutableFile(atPath: executableLocation.path))
-//             
-//            return try OutOfProcessReferenceResolver(processLocation: executableLocation, errorOutputHandler: { _ in })
-//        })
+        try assertResolvesTopicLink(makeResolver: { testMetadata in
+            let temporaryFolder = try createTemporaryDirectory()
+            let executableLocation = temporaryFolder.appendingPathComponent("link-resolver-executable")
+            
+            let encodedMetadata = try String(data: JSONEncoder().encode(testMetadata), encoding: .utf8)!
+            
+            try """
+            #!/bin/bash
+            echo '{"bundleIdentifier":"com.test.bundle"}'       # Write this resolver's bundle identifier
+            read                                                # Wait for docc to send a topic URL
+            echo '{"resolvedInformation":\(encodedMetadata)}'   # Respond with the test metadata (above)
+            """.write(to: executableLocation, atomically: true, encoding: .utf8)
+            
+            // `0o0700` is `-rwx------` (read, write, & execute only for owner)
+            try FileManager.default.setAttributes([.posixPermissions: 0o0700], ofItemAtPath: executableLocation.path)
+            XCTAssert(FileManager.default.isExecutableFile(atPath: executableLocation.path))
+             
+            return try OutOfProcessReferenceResolver(processLocation: executableLocation, errorOutputHandler: { _ in })
+        })
         
         #endif
     }


### PR DESCRIPTION
<!--
If you're opening a PR to cherry-pick a change for a release branch, use this template instead:
https://github.com/apple/swift-docc/blob/main/.github/PULL_REQUEST_TEMPLATE/CHERRY_PICK.md
-->

Bug/issue #, if applicable: rdar://91678333 rdar://88498898

## Summary

This fixes two flaky OutOfProcessReferenceResolver tests. 

59a4e20dfb694560fd062c618fdb07aa9eeaecea fixes a bug where the resolver would fail to decode the response if it hadn't received the full response yet (since the JSON would be incomplete and therefore not decodable).

With these changes `testForwardsErrorOutputProcess` got less flaky but still consistently failed after about 3100-3200 iterations. I think this failure new failure could be because of a leaked file descriptor. e68b809c05ef23d38c1cb7f0f455cb0e9d6824a9 updates the error output pipe to be processed on the main thread and updates the test to 
- Use the built in XCTestExpectation (since this is a macOS only test)
- Create the resolver inline in the test without asynchronously dispatching to the global queue.

## Dependencies

n/a

## Testing

Run these tests repeatedly. I've run them 10k times a handful of times without failures. 

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] ~Added~ Updated tests
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
