### PR TITLE
Add authoring support for @TabNavigator directive

### DIFF
--- a/Sources/SwiftDocC/Indexing/RenderBlockContent+TextIndexing.swift
+++ b/Sources/SwiftDocC/Indexing/RenderBlockContent+TextIndexing.swift
@@ -64,6 +64,10 @@ extension RenderBlockContent: TextIndexing {
             }.joined(separator: " ")
         case .small(let small):
             return small.inlineContent.rawIndexableTextContent(references: references)
+        case .tabNavigator(let tabNavigator):
+            return tabNavigator.tabs.map { tab in
+                return tab.content.rawIndexableTextContent(references: references)
+            }.joined(separator: " ")
         default:
             fatalError("unknown RenderBlockContent case in rawIndexableTextContent")
         }

--- a/Sources/SwiftDocC/Semantics/DirectiveInfrastructure/DirectiveIndex.swift
+++ b/Sources/SwiftDocC/Semantics/DirectiveInfrastructure/DirectiveIndex.swift
@@ -19,6 +19,7 @@ struct DirectiveIndex {
         Row.self,
         Options.self,
         Small.self,
+        TabNavigator.self,
     ]
     
     private static let topLevelTutorialDirectives: [AutomaticDirectiveConvertible.Type] = [

--- a/Sources/SwiftDocC/Semantics/Reference/TabNavigator.swift
+++ b/Sources/SwiftDocC/Semantics/Reference/TabNavigator.swift
@@ -1,0 +1,103 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+import Markdown
+
+/// A container directive that arranges content into a tab-based layout.
+///
+/// Create a new tab navigator by writing a `@TabNavigator` directive that contains child
+/// `@Tab` directives.
+///
+/// ```md
+/// @TabNavigator {
+///    @Tab("Powers") {
+///       ![A diagram with the five sloth power types.](sloth-powers)
+///    }
+///
+///    @Tab("Excerise routines") {
+///       ![A sloth relaxing and enjoying a good book.](sloth-exercise)
+///    }
+///
+///    @Tab("Hats") {
+///       ![A sloth discovering newfound confidence after donning a fedora.](sloth-hats)
+///    }
+/// }
+/// ```
+public final class TabNavigator: Semantic, AutomaticDirectiveConvertible, MarkupContaining {
+    public let originalMarkup: BlockDirective
+    
+    /// The tabs that make up this tab navigator.
+    @ChildDirective(requirements: .oneOrMore)
+    public private(set) var tabs: [Tab]
+    
+    static var keyPaths: [String : AnyKeyPath] = [
+        "tabs" : \TabNavigator._tabs,
+    ]
+    
+    var childMarkup: [Markup] {
+        return tabs.flatMap(\.childMarkup)
+    }
+    
+    @available(*, deprecated,
+        message: "Do not call directly. Required for 'AutomaticDirectiveConvertible'."
+    )
+    init(originalMarkup: BlockDirective) {
+        self.originalMarkup = originalMarkup
+    }
+}
+
+extension TabNavigator {
+    /// A container directive that holds general markup content describing an individual
+    /// tab within a tab-based layout.
+    public final class Tab: Semantic, AutomaticDirectiveConvertible, MarkupContaining {
+        public let originalMarkup: BlockDirective
+        
+        /// The title that should identify the content in this tab when rendered.
+        @DirectiveArgumentWrapped(name: .unnamed)
+        public private(set) var title: String
+        
+        /// The markup content in this tab.
+        @ChildMarkup(numberOfParagraphs: .oneOrMore, supportsStructure: true)
+        public private(set) var content: MarkupContainer
+        
+        static var keyPaths: [String : AnyKeyPath] = [
+            "title"      : \Tab._title,
+            "content"   : \Tab._content,
+        ]
+        
+        var childMarkup: [Markup] {
+            return content.elements
+        }
+        
+        @available(*, deprecated,
+            message: "Do not call directly. Required for 'AutomaticDirectiveConvertible'."
+        )
+        init(originalMarkup: BlockDirective) {
+            self.originalMarkup = originalMarkup
+        }
+    }
+}
+
+extension TabNavigator: RenderableDirectiveConvertible {
+     func render(with contentCompiler: inout RenderContentCompiler) -> [RenderContent] {
+         let renderedTabs = tabs.map { tab in
+             return RenderBlockContent.TabNavigator.Tab(
+                title: tab.title,
+                content: tab.content.elements.flatMap { markupElement in
+                    return contentCompiler.visit(markupElement) as! [RenderBlockContent]
+                }
+             )
+         }
+
+         let renderedNavigator = RenderBlockContent.TabNavigator(tabs: renderedTabs)
+         return [RenderBlockContent.tabNavigator(renderedNavigator)]
+     }
+ }

--- a/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderNode.spec.json
+++ b/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderNode.spec.json
@@ -432,6 +432,9 @@
                         "$ref": "#/components/schemas/Row"
                     },
                     {
+                        "$ref": "#/components/schemas/TabNavigator"
+                    },
+                    {
                         "$ref": "#/components/schemas/Aside"
                     },
                     {
@@ -592,6 +595,43 @@
                     },
                     "size": {
                         "type": "number"
+                    }
+                }
+            },
+            "TabNavigator": {
+                "type": "object",
+                "required": [
+                    "kind",
+                    "tabs"
+                ],
+                "properties": {
+                    "kind": {
+                        "type": "string",
+                        "enum": ["tabNavigator"]
+                    },
+                    "tabs": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Tab"
+                        }
+                    }
+                }
+            },
+            "Tab": {
+                "type": "object",
+                "required": [
+                    "content",
+                    "title"
+                ],
+                "properties": {
+                    "title": {
+                        "type": "string"
+                    },
+                    "content": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/RenderBlockContent"
+                        }
                     }
                 }
             },

--- a/Tests/SwiftDocCTests/Indexing/RenderIndexTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/RenderIndexTests.swift
@@ -657,6 +657,11 @@ final class RenderIndexTests: XCTestCase {
                         "title" : "My Article",
                         "icon" : "plus.svg",
                         "type" : "article"
+                      },
+                      {
+                        "path" : "\/documentation\/bestbook\/tabnavigatorarticle",
+                        "title" : "Tab Navigator Article",
+                        "type" : "article"
                       }
                     ]
                   },

--- a/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorTests.swift
@@ -1092,6 +1092,48 @@ class RenderNodeTranslatorTests: XCTestCase {
         )
     }
     
+    func testTabNavigator() throws {
+        let (bundle, context) = try testBundleAndContext(named: "BookLikeContent")
+        let reference = ResolvedTopicReference(
+            bundleIdentifier: bundle.identifier,
+            path: "/documentation/BestBook/TabNavigatorArticle",
+            sourceLanguage: .swift
+        )
+        let article = try XCTUnwrap(context.entity(with: reference).semantic as? Article)
+        var translator = RenderNodeTranslator(
+            context: context,
+            bundle: bundle,
+            identifier: reference,
+            source: nil
+        )
+        let renderNode = try XCTUnwrap(translator.visitArticle(article) as? RenderNode)
+        
+        let discussion = try XCTUnwrap(
+            renderNode.primaryContentSections.first(
+                where: { $0.kind == .content }
+            ) as? ContentRenderSection
+        )
+        
+        guard case let .tabNavigator(tabNavigator) = discussion.content.dropFirst().first else {
+            XCTFail("Expected to find tab as first child.")
+            return
+        }
+        
+
+        guard tabNavigator.tabs.count == 3 else {
+            XCTFail("Expected to find a tab navigator with '3' tabs")
+            return
+        }
+        
+        XCTAssertEqual(tabNavigator.tabs[0].title, "Powers")
+        XCTAssertEqual(tabNavigator.tabs[1].title, "Exercise routines")
+        XCTAssertEqual(tabNavigator.tabs[2].title, "Hats")
+        
+        XCTAssertEqual(tabNavigator.tabs[0].content.count, 1)
+        XCTAssertEqual(tabNavigator.tabs[1].content.count, 2)
+        XCTAssertEqual(tabNavigator.tabs[2].content.count, 1)
+    }
+    
     func testCustomPageImage() throws {
          let (bundle, context) = try testBundleAndContext(named: "BookLikeContent")
          let reference = ResolvedTopicReference(

--- a/Tests/SwiftDocCTests/Semantics/DirectiveInfrastructure/DirectiveIndexTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/DirectiveInfrastructure/DirectiveIndexTests.swift
@@ -37,6 +37,8 @@ class DirectiveIndexTests: XCTestCase {
                 "Small",
                 "Snippet",
                 "Stack",
+                "Tab",
+                "TabNavigator",
                 "TechnologyRoot",
                 "TopicsVisualStyle",
                 "Tutorial",
@@ -53,6 +55,7 @@ class DirectiveIndexTests: XCTestCase {
             [
                 "Row",
                 "Small",
+                "TabNavigator",
             ]
         )
     }

--- a/Tests/SwiftDocCTests/Semantics/Reference/TabNavigatorTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/Reference/TabNavigatorTests.swift
@@ -1,0 +1,201 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+
+import XCTest
+@testable import SwiftDocC
+import Markdown
+
+class TabNavigatorTests: XCTestCase {
+    func testNoTabs() throws {
+        let (renderBlockContent, problems, tabNavigator) = try parseDirective(TabNavigator.self) {
+            """
+            @TabNavigator
+            """
+        }
+        
+        XCTAssertNotNil(tabNavigator)
+        
+        XCTAssertEqual(
+            problems,
+            ["1: warning – org.swift.docc.HasAtLeastOne<TabNavigator, Tab>"]
+        )
+        
+        XCTAssertEqual(renderBlockContent.count, 1)
+        XCTAssertEqual(
+            renderBlockContent.first,
+            .tabNavigator(.init(tabs: []))
+        )
+    }
+    
+    func testEmptyTab() throws {
+        let (renderBlockContent, problems, tabNavigator) = try parseDirective(TabNavigator.self) {
+            """
+            @TabNavigator {
+                @Tab("hiya") {
+                    
+                }
+            }
+            """
+        }
+        
+        XCTAssertNotNil(tabNavigator)
+        XCTAssertEqual(
+            problems,
+            ["2: warning – org.swift.docc.Tab.HasContent"]
+        )
+        
+        XCTAssertEqual(renderBlockContent.count, 1)
+        XCTAssertEqual(
+            renderBlockContent.first,
+            .tabNavigator(RenderBlockContent.TabNavigator(
+                tabs: [RenderBlockContent.TabNavigator.Tab(title: "hiya", content: [])]
+            ))
+        )
+        
+    }
+    
+    func testInvalidParametersAndContent() throws {
+        let (renderBlockContent, problems, tabNavigator) = try parseDirective(TabNavigator.self) {
+            """
+            @TabNavigator(tabs: 3) {
+                @Tab("hi") {
+                    Hello there.
+                }
+            
+                @Tab("hey") {
+                    Hey there.
+            
+                    @TabNavigator(weird: true) {
+                        @Tab("bad") {
+                            @Unkown {
+                                
+                            }
+                        }
+                    }
+                }
+            }
+            """
+        }
+        
+        XCTAssertNotNil(tabNavigator)
+        
+        XCTAssertEqual(
+            problems,
+            [
+                "1: warning – org.swift.docc.UnknownArgument",
+                "9: warning – org.swift.docc.UnknownArgument",
+                "11: warning – org.swift.docc.HasOnlyKnownDirectives",
+                "11: warning – org.swift.docc.unknownDirective",
+            ]
+        )
+        
+        XCTAssertEqual(renderBlockContent.count, 1)
+        XCTAssertEqual(
+            renderBlockContent.first,
+            .tabNavigator(RenderBlockContent.TabNavigator(
+                tabs: [
+                    RenderBlockContent.TabNavigator.Tab(
+                        title: "hi",
+                        content: ["Hello there."]
+                    ),
+                    
+                    RenderBlockContent.TabNavigator.Tab(
+                        title: "hey",
+                        content: [
+                            "Hey there.",
+                            .tabNavigator(RenderBlockContent.TabNavigator(
+                                tabs: [
+                                    RenderBlockContent.TabNavigator.Tab(
+                                        title: "bad",
+                                        content: []
+                                    ),
+                                ]
+                            ))
+                        ]
+                    ),
+                ]
+            ))
+        )
+    }
+    
+    func testNestedStructuredMarkup() throws {
+        let (renderBlockContent, problems, tabNavigator) = try parseDirective(TabNavigator.self) {
+            """
+            @TabNavigator {
+                @Tab("hi") {
+                    @Row {
+                        @Column {
+                            Hello!
+                        }
+            
+                        @Column {
+                            Hello there!
+                        }
+                    }
+            
+                    Hello there.
+                }
+            
+                @Tab("hey") {
+                    Hey there.
+            
+                    @Small {
+                        Hey but small.
+                    }
+                }
+            }
+            """
+        }
+        
+        XCTAssertNotNil(tabNavigator)
+        XCTAssertEqual(problems, [])
+        
+        XCTAssertEqual(renderBlockContent.count, 1)
+        XCTAssertEqual(
+            renderBlockContent.first,
+            .tabNavigator(RenderBlockContent.TabNavigator(
+                tabs: [
+                    RenderBlockContent.TabNavigator.Tab(
+                        title: "hi",
+                        content: [
+                            .row(RenderBlockContent.Row(
+                                numberOfColumns: 2,
+                                columns: [
+                                    RenderBlockContent.Row.Column(
+                                        size: 1,
+                                        content: ["Hello!"]
+                                    ),
+                                    
+                                    RenderBlockContent.Row.Column(
+                                        size: 1,
+                                        content: ["Hello there!"]
+                                    )
+                                ]
+                            )),
+                            
+                            "Hello there.",
+                        ]
+                    ),
+                    
+                    RenderBlockContent.TabNavigator.Tab(
+                        title: "hey",
+                        content: [
+                            "Hey there.",
+    
+                            .small(RenderBlockContent.Small(inlineContent: [.text("Hey but small.")])),
+                        ]
+                    ),
+                ]
+            ))
+        )
+    }
+}

--- a/Tests/SwiftDocCTests/Test Bundles/BookLikeContent.docc/MyBook.md
+++ b/Tests/SwiftDocCTests/Test Bundles/BookLikeContent.docc/MyBook.md
@@ -11,5 +11,6 @@ The best book.
 ### Articles
 
 - <doc:MyArticle>
+- <doc:TabNavigatorArticle>
 
 <!-- Copyright (c) 2022 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Tests/SwiftDocCTests/Test Bundles/BookLikeContent.docc/TabNavigatorArticle.md
+++ b/Tests/SwiftDocCTests/Test Bundles/BookLikeContent.docc/TabNavigatorArticle.md
@@ -1,0 +1,21 @@
+# Tab Navigator Article
+
+This is the abstract of my article. Nice!
+
+@TabNavigator {
+    @Tab("Powers") {
+        ![A diagram with the five sloth power types.](figure1)
+    }
+
+    @Tab("Exercise routines") {
+        ![A sloth relaxing and enjoying a good book.](figure1)
+        
+        📚
+    }
+
+    @Tab("Hats") {
+        ![A sloth donning a fedora.](figure1)
+    }
+}
+
+<!-- Copyright (c) 2022 Apple Inc and the Swift Project authors. All Rights Reserved. -->


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://97739641

## Summary

Add support for the tab navigator directive as described here: https://forums.swift.org/t/supporting-more-dynamic-content-in-swift-docc-reference-documentation/59527#tabnavigator-14

## Dependencies

- https://github.com/apple/swift-docc-render/pull/403

<!--

## Testing

_Describe how a reviewer can test the functionality of your PR. Provide test content to test with if
applicable._

Steps:
1. _Provide setup instructions._
2. _Explain in detail how the functionality can be tested._

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [ ] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary

-->
