### PR TITLE
Add @Image and @Video directives to reference documentation with caption support

### DIFF
--- a/Sources/SwiftDocC/Indexing/RenderBlockContent+TextIndexing.swift
+++ b/Sources/SwiftDocC/Indexing/RenderBlockContent+TextIndexing.swift
@@ -75,6 +75,8 @@ extension RenderBlockContent: TextIndexing {
                 .compactMap { references[$0] as? TopicRenderReference }
                 .map(\.title)
                 .joined(separator: " ")
+        case .video(let video):
+            return video.metadata?.rawIndexableTextContent(references: references) ?? ""
         default:
             fatalError("unknown RenderBlockContent case in rawIndexableTextContent")
         }

--- a/Sources/SwiftDocC/Model/Rendering/RenderContentCompiler.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderContentCompiler.swift
@@ -90,7 +90,9 @@ struct RenderContentCompiler: MarkupVisitor {
         altText: String?,
         caption: [RenderInlineContent]?
     ) -> [RenderContent] {
-        let imageIdentifier = resolveImage(source: source, altText: altText)
+        guard let imageIdentifier = resolveImage(source: source, altText: altText) else {
+            return []
+        }
         
         var metadata: RenderContentMetadata?
         if let caption = caption {
@@ -100,20 +102,22 @@ struct RenderContentCompiler: MarkupVisitor {
         return [RenderInlineContent.image(identifier: imageIdentifier, metadata: metadata)]
     }
     
-    mutating func resolveImage(source: String, altText: String? = nil) -> RenderReferenceIdentifier {
+    mutating func resolveImage(source: String, altText: String? = nil) -> RenderReferenceIdentifier? {
         let unescapedSource = source.removingPercentEncoding ?? source
         let imageIdentifier: RenderReferenceIdentifier = .init(unescapedSource)
-        if let resolvedImages = context.resolveAsset(
+        guard let resolvedImages = context.resolveAsset(
             named: unescapedSource,
             in: identifier,
             withType: .image
-        ) {
-            imageReferences[unescapedSource] = ImageReference(
-                identifier: imageIdentifier,
-                altText: altText,
-                imageAsset: resolvedImages
-            )
+        ) else {
+            return nil
         }
+        
+        imageReferences[unescapedSource] = ImageReference(
+            identifier: imageIdentifier,
+            altText: altText,
+            imageAsset: resolvedImages
+        )
         
         return imageIdentifier
     }

--- a/Sources/SwiftDocC/Model/Rendering/RenderContentCompiler.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderContentCompiler.swift
@@ -78,14 +78,44 @@ struct RenderContentCompiler: MarkupVisitor {
     }
     
     mutating func visitImage(_ image: Image) -> [RenderContent] {
-        let source = image.source ?? ""
-        let unescapedSource = source.removingPercentEncoding ?? source
-        let imageIdentifier: RenderReferenceIdentifier = .init(unescapedSource)
-        if let resolvedImages = context.resolveAsset(named: unescapedSource, in: identifier) {
-            imageReferences[unescapedSource] = ImageReference(identifier: imageIdentifier, altText: image.altText, imageAsset: resolvedImages)
+        return visitImage(
+            source: image.source ?? "",
+            altText: image.altText,
+            caption: nil
+        )
+    }
+    
+    mutating func visitImage(
+        source: String,
+        altText: String?,
+        caption: [RenderInlineContent]?
+    ) -> [RenderContent] {
+        let imageIdentifier = resolveImage(source: source, altText: altText)
+        
+        var metadata: RenderContentMetadata?
+        if let caption = caption {
+            metadata = RenderContentMetadata(abstract: caption)
         }
         
-        return [RenderInlineContent.image(identifier: imageIdentifier, metadata: nil)]
+        return [RenderInlineContent.image(identifier: imageIdentifier, metadata: metadata)]
+    }
+    
+    mutating func resolveImage(source: String, altText: String? = nil) -> RenderReferenceIdentifier {
+        let unescapedSource = source.removingPercentEncoding ?? source
+        let imageIdentifier: RenderReferenceIdentifier = .init(unescapedSource)
+        if let resolvedImages = context.resolveAsset(
+            named: unescapedSource,
+            in: identifier,
+            withType: .image
+        ) {
+            imageReferences[unescapedSource] = ImageReference(
+                identifier: imageIdentifier,
+                altText: altText,
+                imageAsset: resolvedImages
+            )
+        }
+        
+        return imageIdentifier
     }
     
     mutating func visitLink(_ link: Link) -> [RenderContent] {

--- a/Sources/SwiftDocC/Model/Rendering/RenderContentCompiler.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderContentCompiler.swift
@@ -23,6 +23,7 @@ struct RenderContentCompiler: MarkupVisitor {
     var bundle: DocumentationBundle
     var identifier: ResolvedTopicReference
     var imageReferences: [String: ImageReference] = [:]
+    var videoReferences: [String: VideoReference] = [:]
     /// Resolved topic references that were seen by the visitor. These should be used to populate the references dictionary.
     var collectedTopicReferences = GroupedSequence<String, ResolvedTopicReference> { $0.absoluteString }
     var linkReferences: [String: LinkReference] = [:]

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -305,6 +305,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
         collectedTopicReferences.append(contentsOf: contentCompiler.collectedTopicReferences)
         // Copy all the image references found in the markup container.
         imageReferences.merge(contentCompiler.imageReferences) { (_, new) in new }
+        videoReferences.merge(contentCompiler.videoReferences) { (_, new) in new }
         linkReferences.merge(contentCompiler.linkReferences) { (_, new) in new }
         return content
     }
@@ -316,6 +317,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
         collectedTopicReferences.append(contentsOf: contentCompiler.collectedTopicReferences)
         // Copy all the image references.
         imageReferences.merge(contentCompiler.imageReferences) { (_, new) in new }
+        videoReferences.merge(contentCompiler.videoReferences) { (_, new) in new }
         return content
     }
 
@@ -1468,6 +1470,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
         node.references = createTopicRenderReferences()
         
         addReferences(imageReferences, to: &node)
+        addReferences(videoReferences, to: &node)
         // See Also can contain external links, we need to separately transfer
         // link references from the content compiler
         addReferences(contentCompiler.linkReferences, to: &node)

--- a/Sources/SwiftDocC/Semantics/DirectiveInfrastructure/DirectiveIndex.swift
+++ b/Sources/SwiftDocC/Semantics/DirectiveInfrastructure/DirectiveIndex.swift
@@ -21,6 +21,8 @@ struct DirectiveIndex {
         Small.self,
         TabNavigator.self,
         Links.self,
+        ImageMedia.self,
+        VideoMedia.self,
     ]
     
     private static let topLevelTutorialDirectives: [AutomaticDirectiveConvertible.Type] = [

--- a/Sources/SwiftDocC/Semantics/MarkupReferenceResolver.swift
+++ b/Sources/SwiftDocC/Semantics/MarkupReferenceResolver.swift
@@ -168,6 +168,56 @@ struct MarkupReferenceResolver: MarkupRewriter {
             } else {
                 return blockDirective
             }
+        case ImageMedia.directiveName:
+            guard let imageMedia = ImageMedia(from: blockDirective, source: source, for: bundle, in: context) else {
+                return blockDirective
+            }
+            
+            if !context.resourceExists(with: imageMedia.source, ofType: .image) {
+                problems.append(
+                    unresolvedResourceProblem(
+                        resource: imageMedia.source,
+                        expectedType: .image,
+                        source: source,
+                        range: imageMedia.originalMarkup.range,
+                        severity: .warning
+                    )
+                )
+            }
+            
+            return blockDirective
+        case VideoMedia.directiveName:
+            guard let videoMedia = VideoMedia(from: blockDirective, source: source, for: bundle, in: context) else {
+                return blockDirective
+            }
+            
+            if !context.resourceExists(with: videoMedia.source, ofType: .video) {
+                problems.append(
+                    unresolvedResourceProblem(
+                        resource: videoMedia.source,
+                        expectedType: .video,
+                        source: source,
+                        range: videoMedia.originalMarkup.range,
+                        severity: .warning
+                    )
+                )
+            }
+            
+            if let posterReference = videoMedia.poster,
+                !context.resourceExists(with: posterReference, ofType: .image)
+            {
+                problems.append(
+                    unresolvedResourceProblem(
+                        resource: posterReference,
+                        expectedType: .image,
+                        source: source,
+                        range: videoMedia.originalMarkup.range,
+                        severity: .warning
+                    )
+                )
+            }
+            
+            return blockDirective
         case Comment.directiveName:
             return blockDirective
         default:

--- a/Sources/SwiftDocC/Semantics/Media/ImageMedia.swift
+++ b/Sources/SwiftDocC/Semantics/Media/ImageMedia.swift
@@ -18,8 +18,12 @@ public final class ImageMedia: Semantic, Media, AutomaticDirectiveConvertible {
     public let originalMarkup: BlockDirective
     
     /// Optional alternate text for an image.
-    @DirectiveArgumentWrapped(name: .custom("alt"), required: true)
+    @DirectiveArgumentWrapped(name: .custom("alt"))
     public private(set) var altText: String? = nil
+    
+    /// An optional caption that should be rendered alongside the image.
+    @ChildMarkup(numberOfParagraphs: .zeroOrOne)
+    public private(set) var caption: MarkupContainer
     
     @DirectiveArgumentWrapped(
         parseArgument: { bundle, argumentValue in
@@ -31,6 +35,7 @@ public final class ImageMedia: Semantic, Media, AutomaticDirectiveConvertible {
     static var keyPaths: [String : AnyKeyPath] = [
         "altText" : \ImageMedia._altText,
         "source"  : \ImageMedia._source,
+        "caption" : \ImageMedia._caption,
     ]
     
     /// Creates a new image with the given parameters.
@@ -53,5 +58,27 @@ public final class ImageMedia: Semantic, Media, AutomaticDirectiveConvertible {
     
     public override func accept<V>(_ visitor: inout V) -> V.Result where V : SemanticVisitor {
         return visitor.visitImageMedia(self)
+    }
+}
+
+extension ImageMedia: RenderableDirectiveConvertible {
+    func render(with contentCompiler: inout RenderContentCompiler) -> [RenderContent] {
+        var renderedCaption: [RenderInlineContent]?
+        if let caption = caption.first {
+            let blockContent = contentCompiler.visit(caption)
+            if case let .paragraph(paragraph) = blockContent.first as? RenderBlockContent {
+                renderedCaption = paragraph.inlineContent
+            }
+        }
+
+        guard let renderedImage = contentCompiler.visitImage(
+            source: source.path,
+            altText: altText,
+            caption: renderedCaption
+        ).first as? RenderInlineContent else {
+            return []
+        }
+
+        return [RenderBlockContent.paragraph(.init(inlineContent: [renderedImage]))]
     }
 }

--- a/Sources/SwiftDocC/Semantics/Media/VideoMedia.swift
+++ b/Sources/SwiftDocC/Semantics/Media/VideoMedia.swift
@@ -24,6 +24,14 @@ public final class VideoMedia: Semantic, Media, AutomaticDirectiveConvertible {
     )
     public private(set) var source: ResourceReference
     
+    /// Alternate text describing the video.
+    @DirectiveArgumentWrapped(name: .custom("alt"))
+    public private(set) var altText: String? = nil
+    
+    /// An optional caption that should be rendered alongside the video.
+    @ChildMarkup(numberOfParagraphs: .zeroOrOne)
+    public private(set) var caption: MarkupContainer
+    
     /// An image to be shown when the video isn't playing.
     @DirectiveArgumentWrapped(
         parseArgument: { bundle, argumentValue in
@@ -33,8 +41,10 @@ public final class VideoMedia: Semantic, Media, AutomaticDirectiveConvertible {
     public private(set) var poster: ResourceReference? = nil
     
     static var keyPaths: [String : AnyKeyPath] = [
-        "source" : \VideoMedia._source,
-        "poster" : \VideoMedia._poster,
+        "source"    : \VideoMedia._source,
+        "poster"    : \VideoMedia._poster,
+        "caption"   : \VideoMedia._caption,
+        "altText"   : \VideoMedia._altText,
     ]
     
     init(originalMarkup: BlockDirective, source: ResourceReference, poster: ResourceReference?) {
@@ -54,3 +64,48 @@ public final class VideoMedia: Semantic, Media, AutomaticDirectiveConvertible {
     }
 }
 
+extension VideoMedia: RenderableDirectiveConvertible {
+    func render(with contentCompiler: inout RenderContentCompiler) -> [RenderContent] {
+        var renderedCaption: [RenderInlineContent]?
+        if let caption = caption.first {
+            let blockContent = contentCompiler.visit(caption)
+            if case let .paragraph(paragraph) = blockContent.first as? RenderBlockContent {
+                renderedCaption = paragraph.inlineContent
+            }
+        }
+        
+        var posterReferenceIdentifier: RenderReferenceIdentifier?
+        if let poster = poster {
+            posterReferenceIdentifier = contentCompiler.resolveImage(source: poster.path)
+        }
+        
+        let unescapedVideoSource = source.path.removingPercentEncoding ?? source.path
+        let videoIdentifier = RenderReferenceIdentifier(unescapedVideoSource)
+        guard let resolvedVideos = contentCompiler.context.resolveAsset(
+            named: unescapedVideoSource,
+            in: contentCompiler.identifier,
+            withType: .video
+        ) else {
+            return []
+        }
+        
+        contentCompiler.videoReferences[unescapedVideoSource] = VideoReference(
+            identifier: videoIdentifier,
+            altText: altText,
+            videoAsset: resolvedVideos,
+            poster: posterReferenceIdentifier
+        )
+        
+        var metadata: RenderContentMetadata?
+        if let renderedCaption = renderedCaption {
+            metadata = RenderContentMetadata(abstract: renderedCaption)
+        }
+        
+        let video = RenderBlockContent.Video(
+            identifier: videoIdentifier,
+            metadata: metadata
+        )
+        
+        return [RenderBlockContent.video(video)]
+    }
+}

--- a/Sources/SwiftDocC/Semantics/ReferenceResolver.swift
+++ b/Sources/SwiftDocC/Semantics/ReferenceResolver.swift
@@ -20,8 +20,30 @@ func unresolvedReferenceProblem(reference: TopicReference, source: URL?, range: 
     return Problem(diagnostic: diagnostic, possibleSolutions: [])
 }
 
-func unresolvedResourceProblem(resource: ResourceReference, source: URL?, range: SourceRange?, severity: DiagnosticSeverity) -> Problem {
-    let diagnostic = Diagnostic(source: source, severity: severity, range: range, identifier: "org.swift.docc.unresolvedResource", summary: "Resource \(resource.path.singleQuoted) couldn't be found")
+func unresolvedResourceProblem(
+    resource: ResourceReference,
+    expectedType: DocumentationContext.AssetType? = nil,
+    source: URL?,
+    range: SourceRange?,
+    severity: DiagnosticSeverity
+) -> Problem {
+    let summary: String
+    let identifier: String
+    if let expectedType = expectedType {
+        identifier = "org.swift.docc.unresolvedResource.\(expectedType)"
+        summary = "\(expectedType) resource \(resource.path.singleQuoted) couldn't be found"
+    } else {
+        identifier = "org.swift.docc.unresolvedResource"
+        summary = "Resource \(resource.path.singleQuoted) couldn't be found"
+    }
+    
+    let diagnostic = Diagnostic(
+        source: source,
+        severity: severity,
+        range: range,
+        identifier: identifier,
+        summary: summary
+    )
     return Problem(diagnostic: diagnostic, possibleSolutions: [])
 }
 

--- a/Sources/SwiftDocC/Semantics/Technology/Volume/Volume.swift
+++ b/Sources/SwiftDocC/Semantics/Technology/Volume/Volume.swift
@@ -77,7 +77,7 @@ public final class Volume: Semantic, DirectiveConvertible, Abstracted, Redirecte
         (image, remainder) = Semantic.Analyses.HasExactlyOne<Volume, ImageMedia>(severityIfNotFound: .warning).analyze(directive, children: directive.children, source: source, for: bundle, in: context, problems: &problems)
         
         let chapters: [Chapter]
-        (chapters, remainder) = Semantic.Analyses.HasAtLeastOne<Volume, Chapter>(severityIfNotFound: .warning).analyze(directive, children: directive.children, source: source, for: bundle, in: context, problems: &problems)
+        (chapters, remainder) = Semantic.Analyses.HasAtLeastOne<Volume, Chapter>(severityIfNotFound: .warning).analyze(directive, children: remainder, source: source, for: bundle, in: context, problems: &problems)
         _ = Semantic.Analyses.HasContent<Volume>(additionalContext: "A \(Volume.directiveName.singleQuoted) directive should at least have a sentence summarizing what the reader will learn").analyze(directive, children: remainder, source: source, for: bundle, in: context, problems: &problems)
         
         let redirects: [Redirect]

--- a/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderNode.spec.json
+++ b/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderNode.spec.json
@@ -435,6 +435,9 @@
                         "$ref": "#/components/schemas/TabNavigator"
                     },
                     {
+                        "$ref": "#/components/schemas/Video"
+                    },
+                    {
                         "$ref": "#/components/schemas/Aside"
                     },
                     {
@@ -669,6 +672,26 @@
                      }
                  }
              },
+            "Video": {
+                "type": "object",
+                "required": [
+                    "type",
+                    "identifier"
+                ],
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": ["video"]
+                    },
+                    "identifier": {
+                        "type": "string",
+                        "format": "reference(VideoRenderReference)"
+                    },
+                    "metadata": {
+                        "$ref": "#/components/schemas/RenderContentMetadata"
+                    }
+                }
+            },
             "Aside": {
                 "type": "object",
                 "required": [

--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
@@ -2692,7 +2692,6 @@ Document
                 RenderBlockContent.heading(.init(level: 2, text: "Discussion", anchor: "discussion")),
                 .paragraph(.init(inlineContent: [
                     .text("Doc extension discussion. Missing: "),
-                    .image(identifier: RenderReferenceIdentifier("my-inherited-image.png"), metadata: nil),
                     .text("."),
                 ]))
             ])
@@ -2867,7 +2866,6 @@ Document
                 RenderBlockContent.heading(.init(level: 2, text: "Discussion", anchor: "discussion")),
                 .paragraph(.init(inlineContent: [
                     .text("Inherited discussion. Missing: "),
-                    .image(identifier: RenderReferenceIdentifier("my-inherited-image.png"), metadata: nil),
                     .text("."),
                 ])),
             ])

--- a/Tests/SwiftDocCTests/Semantics/DirectiveInfrastructure/DirectiveIndexTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/DirectiveInfrastructure/DirectiveIndexTests.swift
@@ -54,10 +54,12 @@ class DirectiveIndexTests: XCTestCase {
         XCTAssertEqual(
             DirectiveIndex.shared.renderableDirectives.keys.sorted(),
             [
+                "Image",
                 "Links",
                 "Row",
                 "Small",
                 "TabNavigator",
+                "Video",
             ]
         )
     }


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://97739628

## Summary

Adds support for using the `@Image` and `@Video` directives from Tutorials
in regular reference documentation. This allows authors to
insert videos into documentation and to create images that have
attached captions.

To that point, the `@Image` and `@Video` directives can now contain
inline text to form a caption.

The final change here is that the `@Video` directive now supports
alt text.

Examples:

    @Image(source: "overview-hero.png",
           alt: "An illustration of a sleeping sloth.") {
        This is a caption adding additional context for the image.
    }

    @Video(source: "sloth-smiling.mp4",
           poster: "happy-sloth-frame.png",
           alt: "A short video of a sloth jumping down from a branch.") {
        A *happy* sloth. 🦥
    }

This change is described on the Swift forums here:
https://forums.swift.org/t/supporting-more-dynamic-content-in-swift-docc-reference-documentation/59527#image-1

## Dependencies

- https://github.com/apple/swift-docc-render/pull/404
- https://github.com/apple/swift-docc-render/pull/407

## Testing

Use `@Image` and `@Video` in regular article content and confirm that work as expected.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
