### PR TITLE
Changes to the symbol page content layout

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -1145,8 +1145,8 @@ public struct RenderNodeTranslator: SemanticVisitor {
                 renderNode: &node,
                 translators: [
                     DeclarationsSectionTranslator(),
-                    ReturnsSectionTranslator(),
                     ParametersSectionTranslator(),
+                    ReturnsSectionTranslator(),
                     DiscussionSectionTranslator(),
                 ]
             )

--- a/Tests/SwiftDocCTests/Indexing/IndexingTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/IndexingTests.swift
@@ -237,7 +237,7 @@ class IndexingTests: XCTestCase {
                                       title: "MyProtocol",
                                       summary: "An abstract of a protocol using a String id value.",
                                       headings: ["Return Value", "Discussion"],
-                                      rawIndexableTextContent: "An abstract of a protocol using a String id value.  Return Value A String id value. A name of the item to find. Discussion Further discussion. Exercise links to symbols: relative MyClass and absolute MyClass. Exercise unresolved symbols: unresolved MyUnresolvedSymbol. Exercise known unresolvable symbols: know unresolvable NSCodable. Exercise external references: doc://com.test.external/ExternalPage One ordered Two ordered Three ordered One unordered Two unordered Three unordered",
+                                      rawIndexableTextContent: "An abstract of a protocol using a String id value.  A name of the item to find. Return Value A String id value. Discussion Further discussion. Exercise links to symbols: relative MyClass and absolute MyClass. Exercise unresolved symbols: unresolved MyUnresolvedSymbol. Exercise known unresolvable symbols: know unresolvable NSCodable. Exercise external references: doc://com.test.external/ExternalPage One ordered Two ordered Three ordered One unordered Two unordered Three unordered",
                                      platforms: expectedPlatformInformation),
                        indexingRecords[0])
     }


### PR DESCRIPTION
[rdar://93177278](rdar://93177278)

## Summary

This PR updates the symbol page layout so that the **Return Value** section always follows the **Parameters** section (if there is one), which results in a more logical and ergonomic flow for the reader (declaration ~> parameters ~> return value ~> discussion).

## Dependencies

N/A.

## Testing

The existing test suite has been updated to account for this change.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran the `./bin/test` script and it succeeded
- [X] Updated documentation, if necessary
