### PR TITLE
curate type-subscript symbols in automatic curation

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -1384,7 +1384,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
                             }
                         }
                         for (usr, node) in symbolIndex {
-                            guard let kind = node.symbol?.kind.identifier, kind != .module,
+                            guard let kind = node.symbol?.kind.identifier, kind.symbolGeneratesPage(),
                                   !hierarchyBasedReferences.keys.contains(where: { $0.precise == usr })
                             else { continue }
                             linkResolutionMismatches.missingPathsInHierarchyBasedLinkResolver.append(node.reference.path)

--- a/Sources/SwiftDocC/Infrastructure/Extensions/KindIdentifier+Curation.swift
+++ b/Sources/SwiftDocC/Infrastructure/Extensions/KindIdentifier+Curation.swift
@@ -1,0 +1,25 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import SymbolKit
+
+extension SymbolGraph.Symbol.KindIdentifier {
+    /// The kinds of symbols that should not generate pages in the documentation hierarchy.
+    static let noPageKinds: [SymbolGraph.Symbol.KindIdentifier] = [
+        .module,
+        .snippet,
+        .snippetGroup
+    ]
+
+    /// Indicates whether this kind of symbol should generate a page.
+    func symbolGeneratesPage() -> Bool {
+        !Self.noPageKinds.contains(self)
+    }
+}

--- a/Sources/SwiftDocC/Infrastructure/Topic Graph/AutomaticCuration.swift
+++ b/Sources/SwiftDocC/Infrastructure/Topic Graph/AutomaticCuration.swift
@@ -204,8 +204,6 @@ extension AutomaticCuration {
             case .`method`: return "Instance Methods"
             case .`property`: return "Instance Properties"
             case .`protocol`: return "Protocols"
-            case .snippet: return "Snippets"
-            case .snippetGroup: return "Snippets"
             case .`struct`: return "Structures"
             case .`subscript`: return "Subscripts"
             case .`typeMethod`: return "Type Methods"
@@ -225,9 +223,10 @@ extension AutomaticCuration {
     }
 
     /// The order of symbol kinds when grouped automatically.
+    ///
+    /// Add a symbol kind to `KindIdentifier.noPageKinds` if it should not generate a page in the
+    /// documentation hierarchy.
     static let groupKindOrder: [SymbolGraph.Symbol.KindIdentifier] = [
-        .module,
-
         .`class`,
         .`protocol`,
         .`struct`,
@@ -259,8 +258,5 @@ extension AutomaticCuration {
         .unknownExtendedType,
 
         .extension,
-
-        .snippet,
-        .snippetGroup
     ]
 }

--- a/Sources/SwiftDocC/Infrastructure/Topic Graph/AutomaticCuration.swift
+++ b/Sources/SwiftDocC/Infrastructure/Topic Graph/AutomaticCuration.swift
@@ -195,6 +195,7 @@ extension AutomaticCuration {
             case .`deinit`: return "Deinitializers"
             case .`enum`: return "Enumerations"
             case .`case`: return "Enumeration Cases"
+            case .extension: return "Extensions"
             case .`func`: return "Functions"
             case .`operator`: return "Operators"
             case .`init`: return "Initializers"
@@ -204,6 +205,7 @@ extension AutomaticCuration {
             case .`property`: return "Instance Properties"
             case .`protocol`: return "Protocols"
             case .snippet: return "Snippets"
+            case .snippetGroup: return "Snippets"
             case .`struct`: return "Structures"
             case .`subscript`: return "Subscripts"
             case .`typeMethod`: return "Type Methods"
@@ -255,5 +257,10 @@ extension AutomaticCuration {
         .extendedStructure,
         .extendedEnumeration,
         .unknownExtendedType,
+
+        .extension,
+
+        .snippet,
+        .snippetGroup
     ]
 }

--- a/Sources/SwiftDocC/Infrastructure/Topic Graph/AutomaticCuration.swift
+++ b/Sources/SwiftDocC/Infrastructure/Topic Graph/AutomaticCuration.swift
@@ -247,6 +247,7 @@ extension AutomaticCuration {
         .`typeProperty`,
         .`typeMethod`,
         .`enum`,
+        .`typeSubscript`,
         
         .extendedModule,
         .extendedClass,

--- a/Tests/SwiftDocCTests/Infrastructure/AutomaticCurationTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/AutomaticCurationTests.swift
@@ -21,7 +21,7 @@ class AutomaticCurationTests: XCTestCase {
         var availableSymbolKinds = Set(AutomaticCuration.groupKindOrder)
         availableSymbolKinds.formUnion(SymbolGraph.Symbol.KindIdentifier.allCases)
 
-        for kind in availableSymbolKinds where kind != .module {
+        for kind in availableSymbolKinds where kind.symbolGeneratesPage() {
             // TODO: Synthesize appropriate `swift.extension` symbols that get transformed into
             // the respective internal symbol kinds as defined by `ExtendedTypeFormatTransformation`
             // and remove decoder injection logic from `DocumentationContext` and `SymbolGraphLoader`
@@ -43,7 +43,7 @@ class AutomaticCurationTests: XCTestCase {
             
             XCTAssertNotNil(renderNode.topicSections.first(where: { group -> Bool in
                 return group.title == AutomaticCuration.groupTitle(for: kind)
-            }), "\(kind.identifier) was not automatically curated in a \(AutomaticCuration.groupTitle(for: kind).singleQuoted) topic group." )
+            }), "\(kind.identifier) was not automatically curated in a \(AutomaticCuration.groupTitle(for: kind).singleQuoted) topic group. Please add it to either AutomaticCuration.groupKindOrder or KindIdentifier.noPageKinds." )
         }
     }
 

--- a/Tests/SwiftDocCTests/Infrastructure/AutomaticCurationTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/AutomaticCurationTests.swift
@@ -17,15 +17,17 @@ class AutomaticCurationTests: XCTestCase {
     func testAutomaticTopics() throws {
         // Create each kind of symbol and verify it gets its own topic group automatically
         let decoder = JSONDecoder()
-        
-        for kind in AutomaticCuration.groupKindOrder where kind != .module {
+
+        var availableSymbolKinds = Set(AutomaticCuration.groupKindOrder)
+        availableSymbolKinds.formUnion(SymbolGraph.Symbol.KindIdentifier.allCases)
+
+        for kind in availableSymbolKinds where kind != .module {
             // TODO: Synthesize appropriate `swift.extension` symbols that get transformed into
             // the respective internal symbol kinds as defined by `ExtendedTypeFormatTransformation`
             // and remove decoder injection logic from `DocumentationContext` and `SymbolGraphLoader`
             if !SymbolGraph.Symbol.KindIdentifier.allCases.contains(kind) {
                 decoder.register(symbolKinds: kind)
             }
-            
             let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], codeListings: [:], configureBundle: { url in
                 let sidekitURL = url.appendingPathComponent("sidekit.symbols.json")
                 let text = try String(contentsOf: sidekitURL)

--- a/Tests/SwiftDocCTests/Test Resources/TypeSubscript.symbols.json
+++ b/Tests/SwiftDocCTests/Test Resources/TypeSubscript.symbols.json
@@ -1,0 +1,201 @@
+{
+    "metadata": {
+        "formatVersion": {
+            "major": 0,
+            "minor": 5,
+            "patch": 3
+        },
+        "generator": "x"
+    },
+    "module": {
+        "name": "ThirdOrder",
+        "platform": {
+            "architecture": "x86_64",
+            "vendor": "apple",
+            "operatingSystem": {
+                "name": "macosx",
+                "minimumVersion": {
+                    "major": 12,
+                    "minor": 4,
+                    "patch": 0
+                }
+            }
+        }
+    },
+    "symbols": [
+        {
+            "kind": {
+                "identifier": "swift.type.subscript",
+                "displayName": "Type Subscript"
+            },
+            "identifier": {
+                "precise": "s:10ThirdOrder10SomeStructVyS2icipZ",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "SomeStruct",
+                "subscript(_:)"
+            ],
+            "names": {
+                "title": "subscript(_:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "static"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "subscript"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Int",
+                        "preciseIdentifier": "s:Si"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ") -> "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Int",
+                        "preciseIdentifier": "s:Si"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "static"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "subscript"
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "internalParam",
+                    "spelling": "idx"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Int",
+                    "preciseIdentifier": "s:Si"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ") -> "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Int",
+                    "preciseIdentifier": "s:Si"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " { "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "get"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " }"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///path/to/ThirdOrder.swift",
+                "position": {
+                    "line": 14,
+                    "character": 18
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.struct",
+                "displayName": "Structure"
+            },
+            "identifier": {
+                "precise": "s:10ThirdOrder10SomeStructV",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "SomeStruct"
+            ],
+            "names": {
+                "title": "SomeStruct",
+                "navigator": [
+                    {
+                        "kind": "identifier",
+                        "spelling": "SomeStruct"
+                    }
+                ],
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "struct"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "SomeStruct"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "struct"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "SomeStruct"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///path/to/ThirdOrder.swift",
+                "position": {
+                    "line": 13,
+                    "character": 14
+                }
+            }
+        }
+    ],
+    "relationships": [
+        {
+            "kind": "memberOf",
+            "source": "s:10ThirdOrder10SomeStructVyS2icipZ",
+            "target": "s:10ThirdOrder10SomeStructV"
+        }
+    ]
+}


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://99921042

## Summary

Currently, we don't curate static subscript symbols in the automatic curation logic. In Xcode, this causes the symbol to "fall out" of curation, appearing at the top level alongside the package itself. This PR adds "type subscripts" to the automatic curation listing, so that these symbols can be properly displayed.

## Dependencies

None

## Testing

The following Swift code will trigger this bug:

```swift
public struct SomeStruct {
    public static subscript(_ idx: Int) -> Int {
        idx
    }
}
```

Steps:
1. Build documentation for a package containing the above code.
2. Ensure that the `static subscript(Int) -> Int` symbol is correctly organized underneath `SomeStruct`.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ n/a ] Updated documentation if necessary
