### PR TITLE
Add support for row- and column-span in tables

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,7 +15,7 @@
         "repositoryURL": "https://github.com/apple/swift-cmark.git",
         "state": {
           "branch": "gfm",
-          "revision": "476f7b4fcf12eba381b4aaed8987006fd8fcec9c",
+          "revision": "eb9a6a357b6816c68f4b194eaa5b67f3cd1fa5c3",
           "version": null
         }
       },
@@ -57,10 +57,10 @@
       },
       {
         "package": "swift-markdown",
-        "repositoryURL": "https://github.com/apple/swift-markdown.git",
+        "repositoryURL": "https://github.com/QuietMisdreavus/swift-markdown.git",
         "state": {
-          "branch": "main",
-          "revision": "87c9e60b73174643f1f0bdfd81d41ce379defde0",
+          "branch": "table-spans",
+          "revision": "9c1ef0b451c3738b5eec311aa9a7b8afbb336f25",
           "version": null
         }
       },

--- a/Package.resolved
+++ b/Package.resolved
@@ -57,10 +57,10 @@
       },
       {
         "package": "swift-markdown",
-        "repositoryURL": "https://github.com/QuietMisdreavus/swift-markdown.git",
+        "repositoryURL": "https://github.com/apple/swift-markdown.git",
         "state": {
-          "branch": "table-spans",
-          "revision": "9c1ef0b451c3738b5eec311aa9a7b8afbb336f25",
+          "branch": "main",
+          "revision": "395fbf23fc09e76efaecbb731edb2aebf910948b",
           "version": null
         }
       },

--- a/Package.swift
+++ b/Package.swift
@@ -123,7 +123,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     package.dependencies += [
         .package(url: "https://github.com/apple/swift-nio.git", .upToNextMinor(from: "2.31.2")),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", .upToNextMinor(from: "2.15.0")),
-        .package(name: "swift-markdown", url: "https://github.com/QuietMisdreavus/swift-markdown.git", .branch("table-spans")),
+        .package(name: "swift-markdown", url: "https://github.com/apple/swift-markdown.git", .branch("main")),
         .package(name: "CLMDB", url: "https://github.com/apple/swift-lmdb.git", .branch("main")),
         .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "1.0.1")),
         .package(name: "SymbolKit", url: "https://github.com/apple/swift-docc-symbolkit", .branch("main")),

--- a/Package.swift
+++ b/Package.swift
@@ -123,7 +123,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     package.dependencies += [
         .package(url: "https://github.com/apple/swift-nio.git", .upToNextMinor(from: "2.31.2")),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", .upToNextMinor(from: "2.15.0")),
-        .package(name: "swift-markdown", url: "https://github.com/apple/swift-markdown.git", .branch("main")),
+        .package(name: "swift-markdown", url: "https://github.com/QuietMisdreavus/swift-markdown.git", .branch("table-spans")),
         .package(name: "CLMDB", url: "https://github.com/apple/swift-lmdb.git", .branch("main")),
         .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "1.0.1")),
         .package(name: "SymbolKit", url: "https://github.com/apple/swift-docc-symbolkit", .branch("main")),

--- a/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderNode.spec.json
+++ b/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderNode.spec.json
@@ -861,8 +861,26 @@
                             }
                         }
                     },
+                    "extendedData": {
+                        "type": "object",
+                        "description": "Additional data that can be applied per-cell. Property keys have the pattern 'X_Y', where X is the numerical row index and Y is the numerical column index, both starting from zero.",
+                        "additionalProperties": {
+                            "$ref": "#/components/schemas/TableExtendedData"
+                        }
+                    },
                     "metadata": {
                         "$ref": "#/components/schemas/RenderContentMetadata"
+                    }
+                }
+            },
+            "TableExtendedData": {
+                "type": "object",
+                "properties": {
+                    "colspan": {
+                        "type": "integer"
+                    },
+                    "rowspan": {
+                        "type": "integer"
                     }
                 }
             },


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://98017880

## Summary

This PR loads the new Markdown support for row- and column- span in tables and emits it in Render JSON. For more information about the Markdown syntax, see the swift-cmark PR linked below.

## Dependencies

- https://github.com/apple/swift-cmark/pull/46 (already merged)
- https://github.com/apple/swift-markdown/pull/74
- https://github.com/apple/swift-docc-render/pull/420

## Testing

Use the following sample Markdown to test the new feature:

```markdown
| one | two | three |
| --- | --- | ----- |
| big      || small |
| ^        || small |
```

Steps:
1. Add the above Markdown to Swift-DocC's top-level article.
2. Build the above-linked Swift-DocC-Render PR and add the resulting `dist` directory to the `DOCC_HTML_DIR` environment variable.
3. `swift run docc preview Sources/SwiftDocC/SwiftDocC.docc --fallback-display-name SwiftDocC --fallback-bundle-identifier org.swift.SwiftDocC --fallback-bundle-version 1.0.0`
4. Compare the added content to the below screenshot.

<img width="897" alt="image" src="https://user-images.githubusercontent.com/5217170/190509149-c63db80d-4f75-4210-999c-b6dd7efc884f.png">

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
