### PR TITLE
chore: /documentation subpath should be driven by property

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
@@ -434,8 +434,8 @@ struct PathHierarchy {
     /// - Returns: The node to start the relative search relative to.
     private func findRoot(parentID: ResolvedIdentifier?, remaining: inout ArraySlice<PathComponent>, isAbsolute: Bool, onlyFindSymbols: Bool) throws -> Node {
         // If the first path component is "tutorials" or "documentation" then that
-        let isKnownTutorialPath = remaining.first!.full == "tutorials"
-        let isKnownDocumentationPath = remaining.first!.full == "documentation"
+        let isKnownTutorialPath = remaining.first!.full == NodeURLGenerator.Path.tutorialsFolderName
+        let isKnownDocumentationPath = remaining.first!.full == NodeURLGenerator.Path.documentationFolderName
         if isKnownDocumentationPath || isKnownTutorialPath {
             // Drop that component since it isn't represented in the path hierarchy.
             remaining.removeFirst()
@@ -626,7 +626,9 @@ extension PathHierarchy {
     static func parse(path: String) -> (components: [PathComponent], isAbsolute: Bool) {
         guard !path.isEmpty else { return ([], true) }
         var components = path.split(separator: "/", omittingEmptySubsequences: true)
-        let isAbsolute = path.first == "/" || components.first == "documentation" || components.first == "tutorials"
+        let isAbsolute = path.first == "/"
+            || String(components.first ?? "") == NodeURLGenerator.Path.documentationFolderName
+            || String(components.first ?? "") == NodeURLGenerator.Path.tutorialsFolderName
        
         if let hashIndex = components.last?.firstIndex(of: "#") {
             let last = components.removeLast()

--- a/Sources/SwiftDocC/Infrastructure/NodeURLGenerator.swift
+++ b/Sources/SwiftDocC/Infrastructure/NodeURLGenerator.swift
@@ -165,7 +165,10 @@ public struct NodeURLGenerator {
     public func urlForReference(_ reference: ResolvedTopicReference, fileSafePath safePath: String) -> URL {
         if safePath.isEmpty {
             // Return the root path for the conversion: /documentation.json
-            return baseURL.appendingPathComponent("documentation", isDirectory: false)
+            return baseURL.appendingPathComponent(
+                NodeURLGenerator.Path.documentationFolderName,
+                isDirectory: false
+            )
         } else {
             let url = baseURL.appendingPathComponent(safePath, isDirectory: false)
             return url.withFragment(reference.url.fragment)


### PR DESCRIPTION
## Summary

Cleans up all references to the `”documentation”` and `”tutorial`”’ subpaths to be driven by the property in `NodeURLGenerator`.

## Testing

This is a pure refactor and a non-functional change. Confirm that DocC continues to behave as it did before.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] ~~Added tests~~ NFC
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
