### PR TITLE
emit table column alignments into Render JSON

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/Content/RenderBlockContent.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Content/RenderBlockContent.swift
@@ -244,6 +244,9 @@ public enum RenderBlockContent: Equatable {
         /// The style of header in this table.
         public var header: HeaderType
         /// The text alignment of each column in this table.
+        ///
+        /// A `nil` value for this property is the same as all the columns being
+        /// ``RenderBlockContent/ColumnAlignment/unset``.
         public var alignments: [ColumnAlignment]?
         /// The rows in this table.
         public var rows: [TableRow]
@@ -253,12 +256,21 @@ public enum RenderBlockContent: Equatable {
         public var metadata: RenderContentMetadata?
 
         /// Creates a new table with the given data.
-        public init(header: HeaderType, alignments: [ColumnAlignment]? = nil, rows: [TableRow], extendedData: Set<TableCellExtendedData>, metadata: RenderContentMetadata? = nil) {
+        ///
+        /// - Parameters:
+        ///   - header: The style of header in this table.
+        ///   - rawAlignments: The text alignment for each column in this table. If all the
+        ///     alignments are ``RenderBlockContent/ColumnAlignment/unset``, the ``alignments``
+        ///     property will be set to `nil`.
+        ///   - rows: The cell data for this table.
+        ///   - extendedData: Any extended information that describes cells in this table.
+        ///   - metadata: Additional metadata for this table, if necessary.
+        public init(header: HeaderType, rawAlignments: [ColumnAlignment]? = nil, rows: [TableRow], extendedData: Set<TableCellExtendedData>, metadata: RenderContentMetadata? = nil) {
             self.header = header
             self.rows = rows
             self.extendedData = extendedData
             self.metadata = metadata
-            if let alignments = alignments, !alignments.allSatisfy({ $0 == .unset }) {
+            if let alignments = rawAlignments, !alignments.allSatisfy({ $0 == .unset }) {
                 self.alignments = alignments
             }
         }

--- a/Sources/SwiftDocC/Model/Rendering/Content/RenderBlockContent.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Content/RenderBlockContent.swift
@@ -618,7 +618,14 @@ extension RenderBlockContent.Table: Codable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
         self.header = try container.decode(RenderBlockContent.HeaderType.self, forKey: .header)
-        self.alignments = try container.decodeIfPresent([RenderBlockContent.ColumnAlignment].self, forKey: .alignments)
+
+        let rawAlignments = try container.decodeIfPresent([RenderBlockContent.ColumnAlignment].self, forKey: .alignments)
+        if let alignments = rawAlignments, !alignments.allSatisfy({ $0 == .unset }) {
+            self.alignments = alignments
+        } else {
+            self.alignments = nil
+        }
+
         self.rows = try container.decode([RenderBlockContent.TableRow].self, forKey: .rows)
         self.metadata = try container.decodeIfPresent(RenderContentMetadata.self, forKey: .metadata)
 

--- a/Sources/SwiftDocC/Model/Rendering/Content/RenderBlockContent.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Content/RenderBlockContent.swift
@@ -253,7 +253,7 @@ public enum RenderBlockContent: Equatable {
         public var metadata: RenderContentMetadata?
 
         /// Creates a new table with the given data.
-        public init(header: HeaderType, alignments: [ColumnAlignment]?, rows: [TableRow], extendedData: Set<TableCellExtendedData>, metadata: RenderContentMetadata? = nil) {
+        public init(header: HeaderType, alignments: [ColumnAlignment]? = nil, rows: [TableRow], extendedData: Set<TableCellExtendedData>, metadata: RenderContentMetadata? = nil) {
             self.header = header
             self.rows = rows
             self.extendedData = extendedData

--- a/Sources/SwiftDocC/Model/Rendering/Content/RenderBlockContent.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Content/RenderBlockContent.swift
@@ -240,7 +240,7 @@ public enum RenderBlockContent: Equatable {
     }
 
     /// A table that contains a list of row data.
-    public struct Table: Equatable {
+    public struct Table {
         /// The style of header in this table.
         public var header: HeaderType
         /// The text alignment of each column in this table.
@@ -574,6 +574,30 @@ public enum RenderBlockContent: Equatable {
             self.identifier = identifier
             self.metadata = metadata
         }
+    }
+}
+
+extension RenderBlockContent.Table: Equatable {
+    public static func == (lhs: RenderBlockContent.Table, rhs: RenderBlockContent.Table) -> Bool {
+        guard lhs.header == rhs.header
+                && lhs.extendedData == rhs.extendedData
+                && lhs.metadata == rhs.metadata
+                && lhs.rows == rhs.rows
+        else {
+            return false
+        }
+
+        var lhsAlignments = lhs.alignments
+        if let align = lhsAlignments, align.allSatisfy({ $0 == .unset }) {
+            lhsAlignments = nil
+        }
+
+        var rhsAlignments = rhs.alignments
+        if let align = rhsAlignments, align.allSatisfy({ $0 == .unset }) {
+            rhsAlignments = nil
+        }
+
+        return lhsAlignments == rhsAlignments
     }
 }
 

--- a/Sources/SwiftDocC/Model/Rendering/RenderContentCompiler.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderContentCompiler.swift
@@ -285,7 +285,7 @@ struct RenderContentCompiler: MarkupVisitor {
             alignments = tempAlignments
         }
         
-        return [RenderBlockContent.table(.init(header: .row, alignments: alignments, rows: [RenderBlockContent.TableRow(cells: headerCells)] + rows, extendedData: extendedData, metadata: nil))]
+        return [RenderBlockContent.table(.init(header: .row, rawAlignments: alignments, rows: [RenderBlockContent.TableRow(cells: headerCells)] + rows, extendedData: extendedData, metadata: nil))]
     }
 
     mutating func visitStrikethrough(_ strikethrough: Strikethrough) -> [RenderContent] {

--- a/Sources/SwiftDocC/Model/Rendering/RenderContentCompiler.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderContentCompiler.swift
@@ -262,8 +262,30 @@ struct RenderContentCompiler: MarkupVisitor {
             }
             rows.append(RenderBlockContent.TableRow(cells: cells))
         }
+
+        var tempAlignments = [RenderBlockContent.ColumnAlignment]()
+        for alignment in table.columnAlignments {
+            switch alignment {
+            case .left: tempAlignments.append(.left)
+            case .right: tempAlignments.append(.right)
+            case .center: tempAlignments.append(.center)
+            case nil: tempAlignments.append(.unset)
+            }
+        }
+        while tempAlignments.count < table.maxColumnCount {
+            tempAlignments.append(.unset)
+        }
+        if tempAlignments.allSatisfy({ $0 == .unset }) {
+            tempAlignments = []
+        }
+        let alignments: [RenderBlockContent.ColumnAlignment]?
+        if tempAlignments.isEmpty {
+            alignments = nil
+        } else {
+            alignments = tempAlignments
+        }
         
-        return [RenderBlockContent.table(.init(header: .row, rows: [RenderBlockContent.TableRow(cells: headerCells)] + rows, extendedData: extendedData, metadata: nil))]
+        return [RenderBlockContent.table(.init(header: .row, alignments: alignments, rows: [RenderBlockContent.TableRow(cells: headerCells)] + rows, extendedData: extendedData, metadata: nil))]
     }
 
     mutating func visitStrikethrough(_ strikethrough: Strikethrough) -> [RenderContent] {

--- a/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderNode.spec.json
+++ b/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderNode.spec.json
@@ -949,6 +949,18 @@
                             "none"
                         ]
                     },
+                    "alignments": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "enum": [
+                                "left",
+                                "right",
+                                "center",
+                                "unset"
+                            ]
+                        }
+                    },
                     "rows": {
                         "type": "array",
                         "items": {

--- a/Tests/SwiftDocCTests/Model/RenderContentMetadataTests.swift
+++ b/Tests/SwiftDocCTests/Model/RenderContentMetadataTests.swift
@@ -102,6 +102,7 @@ class RenderContentMetadataTests: XCTestCase {
                 XCTAssertEqual(t.rows[0].cells.map(renderCell), ["Column 1", "Column 2"])
                 XCTAssertEqual(t.rows[1].cells.map(renderCell), ["Cell 1", "Cell 2"])
                 XCTAssertEqual(t.rows[2].cells.map(renderCell), ["Cell 3", "Cell 4"])
+                XCTAssertNil(t.alignments)
             default: XCTFail("Unexpected element")
         }
     }
@@ -152,6 +153,7 @@ class RenderContentMetadataTests: XCTestCase {
                 for expectedData in expectedExtendedData {
                     XCTAssert(t.extendedData.contains(expectedData))
                 }
+                XCTAssertNil(t.alignments)
             default: XCTFail("Unexpected element")
         }
 

--- a/Tests/SwiftDocCTests/Model/RenderContentMetadataTests.swift
+++ b/Tests/SwiftDocCTests/Model/RenderContentMetadataTests.swift
@@ -37,7 +37,7 @@ class RenderContentMetadataTests: XCTestCase {
             RenderInlineContent.text("Content"),
         ])
         
-        let table = RenderBlockContent.table(.init(header: .both, alignments: [], rows: [], extendedData: [], metadata: metadata))
+        let table = RenderBlockContent.table(.init(header: .both, rows: [], extendedData: [], metadata: metadata))
         let data = try JSONEncoder().encode(table)
         let roundtrip = try JSONDecoder().decode(RenderBlockContent.self, from: data)
         


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://77749746

## Summary

This PR takes the table alignment info from Swift-Markdown and emits it into Render JSON, so that Markdown tables' column alignment information can be reflected in the final rendering.

## Dependencies

https://github.com/apple/swift-docc-render/pull/441

## Testing

Use the following table as test information:

```markdown
| Column One | Column Two | Column Three | Column Four |
| :--------- | ---------: | :----------: | ----------- |
| one        | two        | three        | four        |
```

Steps:
1. Add the above Markdown to `Sources/SwiftDocC/SwiftDocC.docc/SwiftDocC.md`.
2. Clone and build the Swift-DocC-Render PR.
3. `DOCC_HTML_DIR=/path/to/swift-docc-render/dist bin/preview-docs`
4. Ensure that the table's columns have the proper alignment when rendered.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ n/a ] Updated documentation if necessary
