### PR TITLE
Remove need to pass --fallback-... CLI arguments in most cases

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Workspace/DataProviderBundleDiscovery.swift
+++ b/Sources/SwiftDocC/Infrastructure/Workspace/DataProviderBundleDiscovery.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information

--- a/Sources/SwiftDocC/Infrastructure/Workspace/DataProviderBundleDiscovery.swift
+++ b/Sources/SwiftDocC/Infrastructure/Workspace/DataProviderBundleDiscovery.swift
@@ -61,7 +61,7 @@ extension DocumentationWorkspaceDataProvider where Self: FileSystemProvider {
         let info = try DocumentationBundle.Info(
             from: infoPlistData,
             bundleDiscoveryOptions: options,
-            derivedDisplayName: directory.url.lastPathComponent
+            derivedDisplayName: directory.url.deletingPathExtension().lastPathComponent
         )
         
         let markupFiles = findMarkupFiles(bundleChildren, recursive: true).map { $0.url }

--- a/Sources/SwiftDocC/Infrastructure/Workspace/DataProviderBundleDiscovery.swift
+++ b/Sources/SwiftDocC/Infrastructure/Workspace/DataProviderBundleDiscovery.swift
@@ -58,7 +58,11 @@ extension DocumentationWorkspaceDataProvider where Self: FileSystemProvider {
         } else {
             infoPlistData = nil
         }
-        let info = try DocumentationBundle.Info(from: infoPlistData, bundleDiscoveryOptions: options)
+        let info = try DocumentationBundle.Info(
+            from: infoPlistData,
+            bundleDiscoveryOptions: options,
+            derivedDisplayName: directory.url.lastPathComponent
+        )
         
         let markupFiles = findMarkupFiles(bundleChildren, recursive: true).map { $0.url }
         let miscResources = findNonMarkupFiles(bundleChildren, recursive: true).map { $0.url }

--- a/Sources/SwiftDocC/Infrastructure/Workspace/DocumentationBundle+Info.swift
+++ b/Sources/SwiftDocC/Infrastructure/Workspace/DocumentationBundle+Info.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information

--- a/Sources/SwiftDocC/Infrastructure/Workspace/DocumentationBundle+Info.swift
+++ b/Sources/SwiftDocC/Infrastructure/Workspace/DocumentationBundle+Info.swift
@@ -146,7 +146,7 @@ extension DocumentationBundle {
             }
             
             /// Helper function that decodes a value of the given type for the given key
-            /// in either the Codable container or Info.plist fallbacks or an optional fallback value.
+            /// in either the Codable container, Info.plist fallbacks or an optional fallback value.
             func decodeOrFallback<T>(
                 _ expectedType: T.Type, with key: CodingKeys,
                 fallback: T? = nil

--- a/Sources/SwiftDocC/Infrastructure/Workspace/DocumentationBundle+Info.swift
+++ b/Sources/SwiftDocC/Infrastructure/Workspace/DocumentationBundle+Info.swift
@@ -180,6 +180,12 @@ extension DocumentationBundle {
                 } ?? []
             )
             
+            // If present, we can use `Info.displayName` as a fallback
+            // for `Info.identifier`.
+            if givenKeys.contains(.displayName) {
+                givenKeys.insert(.identifier)
+            }
+            
             // If present, we can use the `derivedDisplayName`
             // as a fallback for the `Info.displayName` and `Info.identifier`.
             if derivedDisplayName != nil {
@@ -197,7 +203,7 @@ extension DocumentationBundle {
             // decode them for some reason.
             
             self.displayName = try decodeOrFallback(String.self, with: .displayName, fallback: derivedDisplayName)
-            self.identifier = try decodeOrFallback(String.self, with: .identifier, fallback: derivedDisplayName)
+            self.identifier = try decodeOrFallback(String.self, with: .identifier, fallback: self.displayName)
             self.version = try decodeOrFallbackIfPresent(String.self, with: .version)
             
             // Finally, decode the optional keys if they're present.

--- a/Sources/SwiftDocC/Infrastructure/Workspace/DocumentationBundle+Info.swift
+++ b/Sources/SwiftDocC/Infrastructure/Workspace/DocumentationBundle+Info.swift
@@ -151,15 +151,20 @@ extension DocumentationBundle {
                 _ expectedType: T.Type, with key: CodingKeys,
                 fallback: T? = nil
             ) throws -> T where T : Decodable {
-                if let bundleDiscoveryOptions = bundleDiscoveryOptions {
-                    return try values?.decodeIfPresent(T.self, forKey: key)
+                do {
+                    if let bundleDiscoveryOptions = bundleDiscoveryOptions {
+                        return try values?.decodeIfPresent(T.self, forKey: key)
                         ?? bundleDiscoveryOptions.infoPlistFallbacks.decode(T.self, forKey: key.rawValue)
-                } else if let fallback = fallback {
-                    return try values?.decodeIfPresent(T.self, forKey: key) ?? fallback
-                } else if let values = values {
-                    return try values.decode(T.self, forKey: key)
-                } else {
-                    throw DocumentationBundle.PropertyListError.keyNotFound(key.rawValue)
+                    } else if let values = values {
+                        return try values.decode(T.self, forKey: key)
+                    } else {
+                        throw DocumentationBundle.PropertyListError.keyNotFound(key.rawValue)
+                    }
+                } catch {
+                    if let fallback = fallback {
+                        return fallback
+                    }
+                    throw error
                 }
             }
             

--- a/Sources/SwiftDocC/Infrastructure/Workspace/GeneratedDataProvider.swift
+++ b/Sources/SwiftDocC/Infrastructure/Workspace/GeneratedDataProvider.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationBundleInfoTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationBundleInfoTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationBundleInfoTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationBundleInfoTests.swift
@@ -355,6 +355,32 @@ class DocumentationBundleInfoTests: XCTestCase {
         )
     }
     
+    func testDerivedDisplayNameAsFallbackWithIdentifier() {
+        let infoPlistWithoutRequiredKeys = """
+        <plist version="1.0">
+        <dict>
+        <key>CFBundleIdentifier</key>
+        <string>org.swift.docc.example</string>
+        </dict>
+        </plist>
+        """
+        
+        let infoPlistWithoutRequiredKeysData = Data(infoPlistWithoutRequiredKeys.utf8)
+        
+        XCTAssertEqual(
+            try DocumentationBundle.Info(
+                from: infoPlistWithoutRequiredKeysData,
+                bundleDiscoveryOptions: nil,
+                derivedDisplayName: "Derived Display Name"
+            ),
+            DocumentationBundle.Info(
+                displayName: "Derived Display Name",
+                identifier: "org.swift.docc.example",
+                version: nil
+            )
+        )
+    }
+    
     func testDisplayNameAsIdentifierFallback() {
         let infoPlistWithoutRequiredKeys = """
         <plist version="1.0">

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationBundleInfoTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationBundleInfoTests.swift
@@ -354,4 +354,29 @@ class DocumentationBundleInfoTests: XCTestCase {
             )
         )
     }
+    
+    func testDisplayNameAsIdentifierFallback() {
+        let infoPlistWithoutRequiredKeys = """
+        <plist version="1.0">
+        <dict>
+        <key>CFBundleDisplayName</key>
+        <string>Example</string>
+        </dict>
+        </plist>
+        """
+        
+        let infoPlistWithoutRequiredKeysData = Data(infoPlistWithoutRequiredKeys.utf8)
+        
+        XCTAssertEqual(
+            try DocumentationBundle.Info(
+                from: infoPlistWithoutRequiredKeysData,
+                bundleDiscoveryOptions: nil
+            ),
+            DocumentationBundle.Info(
+                displayName: "Example",
+                identifier: "Example",
+                version: nil
+            )
+        )
+    }
 }

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationBundleInfoTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationBundleInfoTests.swift
@@ -286,7 +286,7 @@ class DocumentationBundleInfoTests: XCTestCase {
     }
     
     func testDataCorruptedPlist() throws {
-        let valueMissingInvaildPlist = """
+        let valueMissingInvalidPlist = """
         <plist version="1.0">
         <dict>
           <key>CDDefaultCodeListingLanguage</key>
@@ -314,9 +314,9 @@ class DocumentationBundleInfoTests: XCTestCase {
         </plist>
         """
         
-        let valueMissingInvaildPlistData = Data(valueMissingInvaildPlist.utf8)
+        let valueMissingInvalidPlistData = Data(valueMissingInvalidPlist.utf8)
         XCTAssertThrowsError(
-            try DocumentationBundle.Info(from: valueMissingInvaildPlistData),
+            try DocumentationBundle.Info(from: valueMissingInvalidPlistData),
             "Info.plist decode didn't throw as expected"
         ) { error in
             XCTAssertTrue(error is DocumentationBundle.Info.Error)
@@ -329,5 +329,29 @@ class DocumentationBundleInfoTests: XCTestCase {
             XCTAssertTrue(errorTypeChecking)
             XCTAssertEqual(error.localizedDescription, "Unable to decode Info.plist file. Verify that it is correctly formed. Value missing for key inside <dict> at line 24")
         }
+    }
+    
+    func testDerivedDisplayNameAsFallback() {
+        let infoPlistWithoutRequiredKeys = """
+        <plist version="1.0">
+        <dict>
+        </dict>
+        </plist>
+        """
+        
+        let infoPlistWithoutRequiredKeysData = Data(infoPlistWithoutRequiredKeys.utf8)
+        
+        XCTAssertEqual(
+            try DocumentationBundle.Info(
+                from: infoPlistWithoutRequiredKeysData,
+                bundleDiscoveryOptions: nil,
+                derivedDisplayName: "Derived Display Name"
+            ),
+            DocumentationBundle.Info(
+                displayName: "Derived Display Name",
+                identifier: "Derived Display Name",
+                version: nil
+            )
+        )
     }
 }

--- a/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
@@ -336,49 +336,6 @@ class ConvertActionTests: XCTestCase {
         let myProtocolNode = try JSONDecoder().decode(RenderNode.self, from: myProtocolNodeData)
         XCTAssertNil(myProtocolNode.abstract)
     }
-    
-    func testConvertWithoutBundleErrorMessage() throws {
-        let myKitSymbolGraph = Bundle.module.url(forResource: "TestBundle", withExtension: "docc", subdirectory: "Test Bundles")!
-            .appendingPathComponent("mykit-iOS.symbols.json")
-        
-        XCTAssert(FileManager.default.fileExists(atPath: myKitSymbolGraph.path))
-        let symbolGraphFiles = Folder(name: "Not-a-doc-bundle", content: [
-            CopyOfFile(original: myKitSymbolGraph, newName: "MyKit.symbols.json"),
-        ])
-        
-        let outputLocation = Folder(name: "output", content: [])
-        
-        let testDataProvider = try TestFileSystem(folders: [Folder.emptyHTMLTemplateDirectory, symbolGraphFiles, outputLocation])
-        
-        var infoPlistFallbacks = [String: Any]()
-        infoPlistFallbacks["CFBundleIdentifier"] = "com.example.test"
-        
-        var action = try ConvertAction(
-            documentationBundleURL: nil,
-            outOfProcessResolver: nil,
-            analyze: false,
-            targetDirectory: outputLocation.absoluteURL,
-            htmlTemplateDirectory: Folder.emptyHTMLTemplateDirectory.absoluteURL,
-            emitDigest: false,
-            currentPlatforms: nil,
-            fileManager: testDataProvider,
-                temporaryDirectory: createTemporaryDirectory(),
-            bundleDiscoveryOptions: BundleDiscoveryOptions(
-                infoPlistFallbacks: infoPlistFallbacks,
-                additionalSymbolGraphFiles: [URL(fileURLWithPath: "/Not-a-doc-bundle/MyKit.symbols.json")]
-            )
-        )
-        let logStorage = LogHandle.LogStorage()
-        XCTAssertThrowsError(try action.perform(logHandle: .memory(logStorage))) { error in
-            XCTAssertEqual(error.localizedDescription, """
-            The information provided as command line arguments is not enough to generate a documentation bundle:
-            
-            Missing value for 'CFBundleDisplayName'.
-            Use the '--fallback-display-name' argument or add 'CFBundleDisplayName' to the bundle Info.plist.
-            
-            """)
-        }
-    }
 
     func testMoveOutputCreatesTargetFolderParent() throws {
         // Source folder to test moving
@@ -2637,7 +2594,127 @@ class ConvertActionTests: XCTestCase {
 
     }
 
+    func testConvertWithoutBundlesDerivesDisplayNameAndIdentifierFromSingleModuleSymbolGraph() throws {
+        let myKitSymbolGraph = Bundle.module.url(forResource: "TestBundle", withExtension: "docc", subdirectory: "Test Bundles")!
+            .appendingPathComponent("mykit-iOS.symbols.json")
+        
+        XCTAssert(FileManager.default.fileExists(atPath: myKitSymbolGraph.path))
+        let symbolGraphFiles = Folder(name: "Not-a-doc-bundle", content: [
+            CopyOfFile(original: myKitSymbolGraph, newName: "MyKit.symbols.json"),
+        ])
+        
+        let outputLocation = Folder(name: "output", content: [])
+        
+        let testDataProvider = try TestFileSystem(folders: [Folder.emptyHTMLTemplateDirectory, symbolGraphFiles, outputLocation])
+        
+        var action = try ConvertAction(
+            documentationBundleURL: nil,
+            outOfProcessResolver: nil,
+            analyze: false,
+            targetDirectory: outputLocation.absoluteURL,
+            htmlTemplateDirectory: Folder.emptyHTMLTemplateDirectory.absoluteURL,
+            emitDigest: false,
+            currentPlatforms: nil,
+            fileManager: testDataProvider,
+                temporaryDirectory: createTemporaryDirectory(),
+            bundleDiscoveryOptions: BundleDiscoveryOptions(
+                additionalSymbolGraphFiles: [URL(fileURLWithPath: "/Not-a-doc-bundle/MyKit.symbols.json")]
+            )
+        )
+        
+        XCTAssert(action.context.registeredBundles.isEmpty)
+        XCTAssertNoThrow(try action.perform(logHandle: .standardOutput))
+
+        XCTAssertEqual(action.context.registeredBundles.count, 1)
+        let bundle = try XCTUnwrap(action.context.registeredBundles.first, "Should have registered the generated test bundle.")
+        XCTAssertEqual(bundle.displayName, "MyKit")
+        XCTAssertEqual(bundle.identifier, "MyKit")
+    }
     
+    func testConvertWithoutBundleErrorsForMultipleModulesSymbolGraph() throws {
+        let testBundle = Bundle.module.url(forResource: "TestBundle", withExtension: "docc", subdirectory: "Test Bundles")!
+        let myKitSymbolGraph = testBundle
+            .appendingPathComponent("mykit-iOS.symbols.json")
+        let sideKitSymbolGraph = testBundle
+            .appendingPathComponent("sidekit.symbols.json")
+        
+        XCTAssert(FileManager.default.fileExists(atPath: myKitSymbolGraph.path))
+        XCTAssert(FileManager.default.fileExists(atPath: sideKitSymbolGraph.path))
+        let symbolGraphFiles = Folder(name: "Not-a-doc-bundle", content: [
+            CopyOfFile(original: myKitSymbolGraph, newName: "MyKit.symbols.json"),
+            CopyOfFile(original: sideKitSymbolGraph, newName: "SideKit.symbols.json")
+        ])
+        
+        let outputLocation = Folder(name: "output", content: [])
+        
+        let testDataProvider = try TestFileSystem(
+            folders: [Folder.emptyHTMLTemplateDirectory, symbolGraphFiles, outputLocation]
+        )
+        
+        var infoPlistFallbacks = [String: Any]()
+        infoPlistFallbacks["CFBundleIdentifier"] = "com.example.test"
+        
+        var action = try ConvertAction(
+            documentationBundleURL: nil,
+            outOfProcessResolver: nil,
+            analyze: false,
+            targetDirectory: outputLocation.absoluteURL,
+            htmlTemplateDirectory: Folder.emptyHTMLTemplateDirectory.absoluteURL,
+            emitDigest: false,
+            currentPlatforms: nil,
+            fileManager: testDataProvider,
+                temporaryDirectory: createTemporaryDirectory(),
+            bundleDiscoveryOptions: BundleDiscoveryOptions(
+                infoPlistFallbacks: infoPlistFallbacks,
+                additionalSymbolGraphFiles: [
+                    URL(fileURLWithPath: "/Not-a-doc-bundle/MyKit.symbols.json"),
+                    URL(fileURLWithPath: "/Not-a-doc-bundle/SideKit.symbols.json")
+                ]
+            )
+        )
+        
+        let logStorage = LogHandle.LogStorage()
+        XCTAssertThrowsError(try action.perform(logHandle: .memory(logStorage))) { error in
+            XCTAssertEqual(error.localizedDescription, """
+            The information provided as command line arguments is not enough to generate a documentation bundle:
+            
+            Missing value for 'CFBundleDisplayName'.
+            Use the '--fallback-display-name' argument or add 'CFBundleDisplayName' to the bundle Info.plist.
+            
+            """)
+        }
+    }
+    
+    func testConvertWithBundleDerivesDisplayNameFromBundle() throws {
+        let emptyDoccCatalog = try createTemporaryDirectory(named: "Something.docc")
+        let outputLocation = try createTemporaryDirectory(named: "output")
+
+        var infoPlistFallbacks = [String: Any]()
+        infoPlistFallbacks["CFBundleIdentifier"] = "com.example.test"
+
+        var action = try ConvertAction(
+            documentationBundleURL: emptyDoccCatalog,
+            outOfProcessResolver: nil,
+            analyze: false,
+            targetDirectory: outputLocation.absoluteURL,
+            htmlTemplateDirectory: Folder.emptyHTMLTemplateDirectory.write(inside: createTemporaryDirectory(named: "template")),
+            emitDigest: false,
+            currentPlatforms: nil,
+            temporaryDirectory: createTemporaryDirectory(),
+            bundleDiscoveryOptions: BundleDiscoveryOptions(
+                infoPlistFallbacks: infoPlistFallbacks,
+                additionalSymbolGraphFiles: []
+            )
+        )
+        XCTAssert(action.context.registeredBundles.isEmpty)
+        XCTAssertNoThrow(try action.perform(logHandle: .standardOutput))
+
+        XCTAssertEqual(action.context.registeredBundles.count, 1)
+        let bundle = try XCTUnwrap(action.context.registeredBundles.first, "Should have registered the generated test bundle.")
+        XCTAssertEqual(bundle.displayName, "Something")
+        XCTAssertEqual(bundle.identifier, "com.example.test")
+    }
+
     private func uniformlyPrintDiagnosticMessages(_ problems: [Problem]) -> String {
         return problems.sorted(by: { (lhs, rhs) -> Bool in
             guard lhs.diagnostic.identifier != rhs.diagnostic.identifier else {

--- a/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
@@ -2594,7 +2594,7 @@ class ConvertActionTests: XCTestCase {
 
     }
 
-    func testConvertWithoutBundlesDerivesDisplayNameAndIdentifierFromSingleModuleSymbolGraph() throws {
+    func testConvertWithoutBundleDerivesDisplayNameAndIdentifierFromSingleModuleSymbolGraph() throws {
         let myKitSymbolGraph = Bundle.module.url(forResource: "TestBundle", withExtension: "docc", subdirectory: "Test Bundles")!
             .appendingPathComponent("mykit-iOS.symbols.json")
         


### PR DESCRIPTION
Bug/issue #, if applicable:  https://github.com/apple/swift-docc/issues/194

## Summary

We can remove the need to pass `--fallback-...` CLI arguments in most cases. 

A suitable documentation identifier can almost always be derived from the documentation's display name and a suitable documentation display name can almost always be derived from other information in the documentation "bundle".

If a documentation bundle has no specified identifier, derive the identifier from the bundle's display name.

If a documentation bundle has no specified display name:
- and it has symbol graph files about a single module, derive the display name from the module's name
- and it has a DocC catalog, derive the display name from the catalog's filename (without the file extension)
otherwise (if the bundle has no DocC catalog and symbol graphs about multiple modules, raise the same error as today that a display is missing name and needs to be provided.

## Testing

To test this, you can create a documentation archive without providing fallbacks for the `display-name` or `bundle-identifier` and check that it succeeds and derives the `display-name` and `bundle-identifier` correctly. 

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
