### PR TITLE
Add support for defining Topics sections without topic group headings

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Symbol Graph/GeneratedDocumentationTopics.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Graph/GeneratedDocumentationTopics.swift
@@ -189,7 +189,14 @@ enum GeneratedDocumentationTopics {
         )
         
         let collectionTaskGroups = try AutomaticCuration.topics(for: temporaryCollectionNode, withTrait: nil, context: context)
-            .map({ AutomaticTaskGroupSection(title: $0.title, references: $0.references, renderPositionPreference: .bottom) })
+            .map { taskGroup in
+                AutomaticTaskGroupSection(
+                    // Force-unwrapping the title since automatically-generated task groups always have a title.
+                    title: taskGroup.title!,
+                    references: taskGroup.references,
+                    renderPositionPreference: .bottom
+                )
+            }
 
         // Add the curation task groups to the article
         collectionArticle.automaticTaskGroups = collectionTaskGroups

--- a/Sources/SwiftDocC/Infrastructure/Topic Graph/AutomaticCuration.swift
+++ b/Sources/SwiftDocC/Infrastructure/Topic Graph/AutomaticCuration.swift
@@ -38,7 +38,7 @@ public struct AutomaticCuration {
     }
     
     /// Automatic curation task group.
-    typealias TaskGroup = (title: String, references: [ResolvedTopicReference])
+    typealias TaskGroup = (title: String?, references: [ResolvedTopicReference])
     
     /// Returns a list of automatically curated Topics task groups for the given documentation node.
     /// - Parameters:

--- a/Sources/SwiftDocC/Model/Rendering/DocumentationContentRenderer.swift
+++ b/Sources/SwiftDocC/Model/Rendering/DocumentationContentRenderer.swift
@@ -446,7 +446,7 @@ public class DocumentationContentRenderer {
     
     /// A value type to store an automatically curated task group and its sorting index.
     public struct ReferenceGroup: Codable {
-        public let title: String
+        public let title: String?
         public let references: [ResolvedTopicReference]
     }
 
@@ -499,7 +499,7 @@ public class DocumentationContentRenderer {
             }
             
             resolvedTaskGroups.append(
-                ReferenceGroup(title: group.heading!.plainText, references: resolvedReferences)
+                ReferenceGroup(title: group.heading?.plainText, references: resolvedReferences)
             )
         }
         

--- a/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderNode.spec.json
+++ b/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderNode.spec.json
@@ -2547,7 +2547,6 @@
             },
             "TasksGroupSection": {
                 "required": [
-                    "title",
                     "identifiers"
                 ],
                 "type": "object",

--- a/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
@@ -1586,6 +1586,27 @@ Root
             )
         )
     }
+    
+    func testAnonymousTopicGroups() throws {
+        let navigatorIndex = try generatedNavigatorIndex(
+            for: "AnonymousTopicGroups",
+            bundleIdentifier: "org.swift.docc.example"
+        )
+        
+        // The root page curates 'My Article' once without a topic group heading, and once with.
+        
+        XCTAssertEqual(
+            navigatorIndex.navigatorTree.root.dumpTree(),
+            """
+            [Root]
+            ┗╸Swift
+              ┗╸AnonymousTopicGroups
+                ┣╸My Article
+                ┣╸My Topic Group
+                ┗╸My Article
+            """
+        )
+    }
 
     func generatedNavigatorIndex(for testBundleName: String, bundleIdentifier: String) throws -> NavigatorIndex {
         let (bundle, context) = try testBundleAndContext(named: testBundleName)

--- a/Tests/SwiftDocCTests/Infrastructure/ReferenceResolverTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/ReferenceResolverTests.swift
@@ -345,7 +345,7 @@ class ReferenceResolverTests: XCTestCase {
     }
     
     func testRelativeReferencesToExtensionSymbols() throws {
-        let (bundleURL, bundle, context) = try testBundleAndContext(copying: "BundleWithRelativePathAmbiguity") { root in
+        let (_, bundle, context) = try testBundleAndContext(copying: "BundleWithRelativePathAmbiguity") { root in
             // We don't want the external target to be part of the archive as that is not
             // officially supported yet.
             try FileManager.default.removeItem(at: root.appendingPathComponent("Dependency.symbols.json"))

--- a/Tests/SwiftDocCTests/Model/DocumentationMarkupTests.swift
+++ b/Tests/SwiftDocCTests/Model/DocumentationMarkupTests.swift
@@ -433,20 +433,6 @@ class DocumentationMarkupTests: XCTestCase {
             let model = DocumentationMarkup(markup: Document(parsing: source))
             XCTAssertNil(model.topicsSection)
         }
-
-        // Missing task group heading
-        do {
-            let source = """
-            # Title
-            My abstract __content__.
-            ## Topics
-             - <doc:link>
-            ## See Also
-             - <doc:link>
-            """
-            let model = DocumentationMarkup(markup: Document(parsing: source))
-            XCTAssertNil(model.topicsSection)
-        }
     }
     
     func testSeeAlso() throws {

--- a/Tests/SwiftDocCTests/Test Bundles/AnonymousTopicGroups.docc/AnonymousTopicGroups.md
+++ b/Tests/SwiftDocCTests/Test Bundles/AnonymousTopicGroups.docc/AnonymousTopicGroups.md
@@ -1,0 +1,17 @@
+# AnonymousTopicGroups
+
+@Metadata {
+  @TechnologyRoot
+}
+
+This page's Topics section contains topics that aren't under a topic group.
+
+## Topics
+
+- <doc:article>
+
+### My Topic Group
+
+- <doc:article>
+
+<!-- Copyright (c) 2022 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Tests/SwiftDocCTests/Test Bundles/AnonymousTopicGroups.docc/Info.plist
+++ b/Tests/SwiftDocCTests/Test Bundles/AnonymousTopicGroups.docc/Info.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleName</key>
+	<string>AnonymousTopicGroups</string>
+	<key>CFBundleDisplayName</key>
+	<string>AnonymousTopicGroups</string>
+	<key>CFBundleIdentifier</key>
+	<string>org.swift.docc.example</string>
+</dict>
+</plist>

--- a/Tests/SwiftDocCTests/Test Bundles/AnonymousTopicGroups.docc/article.md
+++ b/Tests/SwiftDocCTests/Test Bundles/AnonymousTopicGroups.docc/article.md
@@ -1,0 +1,5 @@
+# My Article
+
+This is the abstract of my article.
+
+<!-- Copyright (c) 2022 Apple Inc and the Swift Project authors. All Rights Reserved. -->


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://97739538
Forums post: https://forums.swift.org/t/relaxing-structure-requirements-for-topics-sections/60534

## Summary

Adds support for defining Topics sections without h3 headings, like so:

```md
## Topics

- ``MySymbol``
```

It's also possible to define subsequent topic groups:

```md
## Topics

- ``MySymbol``

### My topic group

- ``Another Symbol``
```

## Dependencies

- https://github.com/apple/swift-docc-render/pull/443

## Testing

Define a Topics section without topic groups like shown above. Verify that the links still render on the page, with the appropriate topic group headings if they were specified.

## Checklist

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
