### PR TITLE
Add authoring support for `@Links` directive

### DIFF
--- a/Sources/SwiftDocC/Indexing/RenderBlockContent+TextIndexing.swift
+++ b/Sources/SwiftDocC/Indexing/RenderBlockContent+TextIndexing.swift
@@ -68,6 +68,13 @@ extension RenderBlockContent: TextIndexing {
             return tabNavigator.tabs.map { tab in
                 return tab.content.rawIndexableTextContent(references: references)
             }.joined(separator: " ")
+        case .links(let links):
+            // Matches the behavior in `RenderInlineContent+TextIndexing` for a
+            // `RenderInlineContent.reference`
+            return links.items
+                .compactMap { references[$0] as? TopicRenderReference }
+                .map(\.title)
+                .joined(separator: " ")
         default:
             fatalError("unknown RenderBlockContent case in rawIndexableTextContent")
         }

--- a/Sources/SwiftDocC/Semantics/DirectiveInfrastructure/DirectiveIndex.swift
+++ b/Sources/SwiftDocC/Semantics/DirectiveInfrastructure/DirectiveIndex.swift
@@ -20,6 +20,7 @@ struct DirectiveIndex {
         Options.self,
         Small.self,
         TabNavigator.self,
+        Links.self,
     ]
     
     private static let topLevelTutorialDirectives: [AutomaticDirectiveConvertible.Type] = [

--- a/Sources/SwiftDocC/Semantics/General Purpose Analyses/HasExactlyOne.swift
+++ b/Sources/SwiftDocC/Semantics/General Purpose Analyses/HasExactlyOne.swift
@@ -219,7 +219,7 @@ extension Semantic.Analyses {
         }
     }
 
-    public struct HasExactlyOneUnorderedList<Parent: Semantic & DirectiveConvertible, ListElement: Markup>: SemanticAnalysis {
+    public struct HasExactlyOneUnorderedList<Parent: Semantic & DirectiveConvertible, ListElement>: SemanticAnalysis {
         let severityIfNotFound: DiagnosticSeverity?
 
         init(severityIfNotFound: DiagnosticSeverity?) {
@@ -276,7 +276,7 @@ extension Semantic.Analyses {
                 range: range,
                 identifier: "org.swift.docc.HasExactlyOneUnorderedList<\(Parent.self), \(ListElement.self)>.ExtraneousContent",
                 summary: "Extraneous content in \(Parent.directiveName.singleQuoted)",
-                explanation: "The \(Parent.directiveName.singleQuoted) directive must contain a single unordered list, where each item is of type \(ListElement.self)"
+                explanation: "The \(Parent.directiveName.singleQuoted) directive must contain a single unordered list of links"
             )
         }
 
@@ -287,7 +287,7 @@ extension Semantic.Analyses {
                 range: range,
                 identifier: "org.swift.docc.HasExactlyOneUnorderedList<\(Parent.self), \(ListElement.self)>.InvalidContent",
                 summary: "Missing unordered list",
-                explanation: "The \(Parent.directiveName.singleQuoted) directive must contain a single unordered list, where each item is of type \(ListElement.self)"
+                explanation: "The \(Parent.directiveName.singleQuoted) directive must contain a single unordered list of links"
             )
         }
 
@@ -298,7 +298,7 @@ extension Semantic.Analyses {
                 range: range,
                 identifier: "org.swift.docc.HasExactlyOneUnorderedList<\(Parent.self), \(ListElement.self)>.InvalidListContent",
                 summary: "Invalid content in list item",
-                explanation: "The list in \(Parent.directiveName.singleQuoted) must contain \(ListElement.self) elements only"
+                explanation: "The list in \(Parent.directiveName.singleQuoted) must only contain links"
             )
         }
     }

--- a/Sources/SwiftDocC/Semantics/Reference/Links.swift
+++ b/Sources/SwiftDocC/Semantics/Reference/Links.swift
@@ -1,0 +1,140 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+import Markdown
+
+/// A directive for authoring authoring embedded
+/// previews of documentation links (similar to how links are currently
+/// rendered in Topics sections) anywhere on the page without affecting page
+/// curation behavior.
+///
+/// `@Links` gives authors flexibility in choosing how they want to highlight
+/// documentation on the page itself versus in the navigation sidebar.
+/// It also allows for mixing and matching different visual styles of
+/// topics.
+///
+/// ```md
+/// ...
+///
+/// ### What's New in SlothCreator
+///
+/// @Links(visualStyle: compactGrid) {
+///    - <doc:get-started-preparing-sloth-food>
+///    - <doc:feeding-your-sloth-in-winter>
+///    - <doc:ordering-food-delivery>
+/// }
+///
+/// ...
+/// ```
+public final class Links: Semantic, AutomaticDirectiveConvertible, MarkupContaining {
+    public let originalMarkup: BlockDirective
+    
+    /// The inline markup contained in this 'Links' directive.
+    ///
+    /// This content should not be rendered directly, instead the individual documentation links
+    /// inside the first bulleted list should be extracted and previews of the linked
+    /// pages should be rendered.
+    @ChildMarkup(numberOfParagraphs: .zeroOrMore)    // ← Set to '.zeroOrMore' because the 'validate()'
+    public private(set) var content: MarkupContainer //   method below already handles errors for missing
+                                                     //   or extraneous content.
+    
+    /// The specified style that should be used when rendering the specified links.
+    @DirectiveArgumentWrapped
+    public private(set) var visualStyle: VisualStyle
+    
+    /// A visual style for the links in a 'Links' directive.
+    public enum VisualStyle: String, CaseIterable, DirectiveArgumentValueConvertible {
+        /// A list of the linked pages, including their full declaration and abstract.
+        case list
+        
+        /// A grid of items based on the card image for the linked pages.
+        ///
+        /// Includes each page’s title and card image but excludes their abstracts.
+        case compactGrid
+        
+        /// A grid of items based on the card image for the linked pages.
+        ///
+        /// Unlike ``compactGrid``, this style includes the abstract for each page.
+        case detailedGrid
+    }
+    
+    static var keyPaths: [String : AnyKeyPath] = [
+        "content"       : \Links._content,
+        "visualStyle"   : \Links._visualStyle,
+    ]
+    
+    override var children: [Semantic] {
+        return [content]
+    }
+    
+    var childMarkup: [Markup] {
+        return content.elements
+    }
+    
+    func validate(source: URL?, for bundle: DocumentationBundle, in context: DocumentationContext, problems: inout [Problem]) -> Bool {
+        _ = Semantic.Analyses.HasExactlyOneUnorderedList<Links, AnyLink>(
+            severityIfNotFound: .warning
+        ).analyze(
+            originalMarkup,
+            children: originalMarkup.children,
+            source: source,
+            for: bundle,
+            in: context,
+            problems: &problems
+        )
+        
+        return true
+    }
+    
+    @available(*, deprecated,
+        message: "Do not call directly. Required for 'AutomaticDirectiveConvertible'."
+    )
+    init(originalMarkup: BlockDirective) {
+        self.originalMarkup = originalMarkup
+    }
+}
+
+extension Links: RenderableDirectiveConvertible {
+    func render(with contentCompiler: inout RenderContentCompiler) -> [RenderContent] {
+        guard let firstList = originalMarkup.children.first(where: { child in
+            child is UnorderedList
+        }) else {
+            return []
+        }
+        
+        var linksExtractor = ExtractLinks(mode: .linksDirective)
+        _ = linksExtractor.visit(firstList)
+        
+        contentCompiler.context.diagnosticEngine.emit(linksExtractor.problems)
+        
+        let resolvedLinks = linksExtractor.links
+            .compactMap(\.destination)
+            .compactMap { contentCompiler.resolveTopicReference($0) }
+            .map(\.absoluteString)
+        
+        guard !resolvedLinks.isEmpty else {
+            return []
+        }
+        
+        let style: RenderBlockContent.Links.Style
+        switch visualStyle {
+        case .compactGrid:
+            style = .compactGrid
+        case .detailedGrid:
+            style = .detailedGrid
+        case .list:
+            style = .list
+        }
+        
+        let renderedLinks = RenderBlockContent.Links(style: style, items: resolvedLinks)
+        return [RenderBlockContent.links(renderedLinks)]
+    }
+}

--- a/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderNode.spec.json
+++ b/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderNode.spec.json
@@ -441,6 +441,9 @@
                         "$ref": "#/components/schemas/Small"
                     },
                     {
+                        "$ref": "#/components/schemas/Links"
+                    },
+                    {
                         "$ref": "#/components/schemas/Heading"
                     },
                     {
@@ -635,6 +638,37 @@
                     }
                 }
             },
+            "Links": {
+                 "required": [
+                     "type",
+                     "style",
+                     "items"
+                 ],
+                 "type": "object",
+                 "properties": {
+                     "type": {
+                         "type": "string",
+                         "enum": [
+                             "links"
+                         ]
+                     },
+                     "style": {
+                         "type": "string",
+                         "enum": [
+                             "list",
+                             "compactGrid",
+                             "detailedGrid"
+                         ]
+                     },
+                     "items": {
+                         "type": "array",
+                         "items": {
+                             "type": "string",
+                             "format": "reference(TopicRenderReference)"
+                         }
+                     }
+                 }
+             },
             "Aside": {
                 "type": "object",
                 "required": [

--- a/Tests/SwiftDocCTests/Semantics/DirectiveInfrastructure/DirectiveIndexTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/DirectiveInfrastructure/DirectiveIndexTests.swift
@@ -29,6 +29,7 @@ class DirectiveIndexTests: XCTestCase {
                 "Image",
                 "Intro",
                 "Justification",
+                "Links",
                 "Metadata",
                 "Options",
                 "PageImage",
@@ -53,6 +54,7 @@ class DirectiveIndexTests: XCTestCase {
         XCTAssertEqual(
             DirectiveIndex.shared.renderableDirectives.keys.sorted(),
             [
+                "Links",
                 "Row",
                 "Small",
                 "TabNavigator",

--- a/Tests/SwiftDocCTests/Semantics/Reference/LinksTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/Reference/LinksTests.swift
@@ -1,0 +1,219 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+
+import XCTest
+@testable import SwiftDocC
+import Markdown
+
+class LinksTests: XCTestCase {
+    func testMissingBasicRequirements() throws {
+        do {
+            let (renderedContent, problems, links) = try parseDirective(Links.self, in: "BookLikeContent") {
+                """
+                @Links(visualStyle: compactGrid)
+                """
+            }
+            
+            XCTAssertNotNil(links)
+            
+            XCTAssertEqual(
+                problems,
+                ["1: warning – org.swift.docc.HasExactlyOneUnorderedList<Links, AnyLink>.InvalidContent"]
+            )
+            
+            XCTAssertEqual(renderedContent, [])
+        }
+        
+        do {
+            let (renderedContent, problems, links) = try parseDirective(Links.self, in: "BookLikeContent") {
+                """
+                @Links {
+                    - <doc:MyArticle>
+                }
+                """
+            }
+            
+            XCTAssertNil(links)
+            
+            XCTAssertEqual(
+                problems,
+                [
+                    "1: warning – org.swift.docc.HasArgument.visualStyle",
+                ]
+            )
+            
+            XCTAssertEqual(renderedContent, [])
+        }
+    }
+    
+    func testInvalidBodyContent() throws {
+        do {
+            let (renderedContent, problems, links) = try parseDirective(Links.self, in: "BookLikeContent") {
+                """
+                @Links(visualStyle: compactGrid) {
+                    This is a paragraph of text in 'Links' directive.
+                
+                    And a second paragraph.
+                }
+                """
+            }
+            
+            XCTAssertNotNil(links)
+            
+            XCTAssertEqual(
+                problems,
+                [
+                    "1: warning – org.swift.docc.HasExactlyOneUnorderedList<Links, AnyLink>.InvalidContent",
+                    "2: warning – org.swift.docc.HasExactlyOneUnorderedList<Links, AnyLink>.ExtraneousContent",
+                    "4: warning – org.swift.docc.HasExactlyOneUnorderedList<Links, AnyLink>.ExtraneousContent",
+                ]
+            )
+            
+            XCTAssertEqual(renderedContent, [])
+        }
+        
+        do {
+            let (renderedContent, problems, links) = try parseDirective(Links.self, in: "BookLikeContent") {
+                """
+                @Links(visualStyle: compactGrid) {
+                    This is a paragraph of text in 'Links' directive.
+                
+                    And a second paragraph preceding a valid link:
+                
+                    - <doc:MyArticle>
+                }
+                """
+            }
+            
+            XCTAssertNotNil(links)
+            
+            XCTAssertEqual(
+                problems,
+                [
+                    "2: warning – org.swift.docc.HasExactlyOneUnorderedList<Links, AnyLink>.ExtraneousContent",
+                    "4: warning – org.swift.docc.HasExactlyOneUnorderedList<Links, AnyLink>.ExtraneousContent",
+                ]
+            )
+            
+            XCTAssertEqual(
+                renderedContent,
+                [
+                    RenderBlockContent.links(RenderBlockContent.Links(
+                        style: .compactGrid,
+                        items: ["doc://org.swift.docc.Book/documentation/BestBook/MyArticle"]
+                    ))
+                ]
+            )
+        }
+        
+        do {
+            let (renderedContent, problems, links) = try parseDirective(Links.self, in: "BookLikeContent") {
+                """
+                @Links(visualStyle: compactGrid) {
+                    - <doc:MyArticle> Link with some trailing content.
+                }
+                """
+            }
+            
+            XCTAssertNotNil(links)
+            
+            XCTAssertEqual(
+                problems,
+                [
+                    "2: warning – org.swift.docc.ExtraneousLinksDirectiveItemContent"
+                ]
+            )
+            
+            XCTAssertEqual(
+                renderedContent,
+                [
+                    RenderBlockContent.links(RenderBlockContent.Links(
+                        style: .compactGrid,
+                        items: [
+                            "doc://org.swift.docc.Book/documentation/BestBook/MyArticle",
+                        ]
+                    ))
+                ]
+            )
+        }
+    }
+    
+    func testLinkResolution() throws {
+        do {
+            let (renderedContent, problems, links) = try parseDirective(Links.self, in: "BookLikeContent") {
+                """
+                @Links(visualStyle: compactGrid) {
+                    - <doc:MyArticle>
+                    - <doc:TabNavigatorArticle>
+                    - <doc:MyBook>
+                    - <doc:UnknownArticle>
+                    - <doc:MyArticle>
+                }
+                """
+            }
+            
+            XCTAssertNotNil(links)
+            
+            XCTAssertEqual(
+                problems,
+                ["5: warning – org.swift.docc.unresolvedTopicReference"]
+            )
+            
+            XCTAssertEqual(
+                renderedContent,
+                [
+                    RenderBlockContent.links(RenderBlockContent.Links(
+                        style: .compactGrid,
+                        items: [
+                            "doc://org.swift.docc.Book/documentation/BestBook/MyArticle",
+                            "doc://org.swift.docc.Book/documentation/BestBook/TabNavigatorArticle",
+                            "doc://org.swift.docc.Book/documentation/MyBook",
+                            "doc://org.swift.docc.Book/documentation/BestBook/MyArticle",
+                        ]
+                    ))
+                ]
+            )
+        }
+        
+        do {
+            let (renderedContent, problems, links) = try parseDirective(Links.self, in: "TestBundle") {
+                """
+                @Links(visualStyle: compactGrid) {
+                    - ``MyKit/MyClass``
+                    - ``MyKit/MyClass/myFunction()``
+                    - <doc:TestTutorial>
+                    - <doc:article2>
+                }
+                """
+            }
+            
+            XCTAssertNotNil(links)
+            
+            XCTAssertEqual(problems, [])
+            
+            XCTAssertEqual(
+                renderedContent,
+                [
+                    RenderBlockContent.links(RenderBlockContent.Links(
+                        style: .compactGrid,
+                        items: [
+                            "doc://org.swift.docc.example/documentation/MyKit/MyClass",
+                            "doc://org.swift.docc.example/documentation/MyKit/MyClass/myFunction()",
+                            "doc://org.swift.docc.example/tutorials/Test-Bundle/TestTutorial",
+                            "doc://org.swift.docc.example/documentation/Test-Bundle/article2",
+                        ]
+                    ))
+                ]
+            )
+        }
+    }
+}


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://99870352

## Summary

Adds a new `@Links` directive that allows for authoring embedded previews of documentation links (similar to how links are currently rendered in Topics sections) anywhere on the page without affecting page curation behavior.

`@Links` gives authors flexibility in choosing how they want to highlight documentation on the page itself versus in the navigation sidebar. It also allows for mixing and matching different visual styles of topics.

## Example

    ...

    ### What's New in SlothCreator

    @Links(visualStyle: compactGrid) {
       - <doc:get-started-preparing-sloth-food>
       - <doc:feeding-your-sloth-in-winter>
       - <doc:ordering-food-delivery>
    }

    ...

## Details

`@Links` accepts a single `visualStyle` parameter and supports a list of Swift-DocC links as its child content:

- visualStyle: The visual style of the topic links. Accepts one of the following:

    - `list`: Matches the current default style Swift-DocC uses for
      Topics section. Includes the abstract for each page.

    - `compactGrid`: A grid of items based on the card image for each
      page. Includes each page’s title and card image but excludes their
      abstracts.

    - `detailedGrid`: A grid of items based on the card image for each
      page, includes the abstract for each page.

## Dependencies

- https://github.com/apple/swift-docc-render/pull/436

<!--

## Testing

_Describe how a reviewer can test the functionality of your PR. Provide test content to test with if
applicable._

Steps:
1. _Provide setup instructions._
2. _Explain in detail how the functionality can be tested._

-->


## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary
