### PR TITLE
Copy static assets like custom templates before writing out render nodes.

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/DocumentationConverter.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationConverter.swift
@@ -246,6 +246,9 @@ public struct DocumentationConverter: DocumentationConverterProtocol {
         let renderContext = RenderContext(documentationContext: context, bundle: bundle)
         
         try outputConsumer.consume(renderReferenceStore: renderContext.store)
+
+        // Copy images, sample files, and other static assets.
+        try outputConsumer.consume(assetsInBundle: bundle)
         
         let converter = DocumentationContextConverter(
             bundle: bundle,
@@ -327,13 +330,6 @@ public struct DocumentationConverter: DocumentationConverterProtocol {
         
         // If cancelled, return before producing outputs.
         guard !isConversionCancelled() else { return ([], []) }
-        
-        // Copy images, sample files, and other static assets.
-        do {
-            try outputConsumer.consume(assetsInBundle: bundle)
-        } catch {
-            recordProblem(from: error, in: &conversionProblems, withIdentifier: "assets")
-        }
         
         // Write various metadata
         if emitDigest {


### PR DESCRIPTION
This copies custom headers and footers into all the index.html files when using --transform-for-static-hosting and
--experimental-enable-custom-templates.

Adds a test for this as well.

Bug/issue #, if applicable: #196 

## Summary

This fixes an issue where `index.html` files in the static output didn't have custom headers and footers (aside from the root `index.html`).

Per Ethan's advice in the originating issue, I moved `outputConsumer.consume(assetsInBundle: bundle)` further up the file to where some other pregeneration work seemed to be happening.

## Dependencies

None.

## Testing

You can either observe the output of the XX test or run: `swift run docc convert --transform-for-static-hosting --experimental-enable-custom-templates SomeDoccBundle.docc` on a DocC bundle that has multiple pages of docs and a custom `header.html` file.

Steps:
1. Run the command above.
2. Verify that each page under /documentation has a custom header.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [ ] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary (not really necessary here)
