### PR TITLE
Make `plainText` publicly accessible

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/Content/RenderInlineContent.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Content/RenderInlineContent.swift
@@ -176,7 +176,7 @@ extension RenderInlineContent {
     /// more sense to use the `rawIndexableTextContent` function that does use `RenderReference`
     /// for a more accurate textual representation of `RenderInlineContent.image` and
     /// `RenderInlineContent.reference`.
-    var plainText: String {
+    public var plainText: String {
         switch self {
         case let .codeVoice(code):
             return code
@@ -213,7 +213,7 @@ extension Sequence where Element == RenderInlineContent {
     /// more sense to use the `rawIndexableTextContent` function that does use `RenderReference`
     /// for a more accurate textual representation of `RenderInlineContent.image` and
     /// `RenderInlineContent.reference`.
-    var plainText: String {
+    public var plainText: String {
         return map { $0.plainText }.joined()
     }
 }

--- a/Sources/SwiftDocC/SwiftDocC.docc/SwiftDocC/RenderingModel/RenderInlineContent.md
+++ b/Sources/SwiftDocC/SwiftDocC.docc/SwiftDocC/RenderingModel/RenderInlineContent.md
@@ -2,10 +2,6 @@
 
 ## Topics
 
-### Getting a plain text representation
-
-- ``plainText``
-
 ### Inline content types
 
 - ``codeVoice(code:)``
@@ -19,3 +15,7 @@
 - ``subscript(inlineContent:)``
 - ``superscript(inlineContent:)``
 - ``text(_:)``
+
+### Getting a plain text representation
+
+- ``plainText``

--- a/Sources/SwiftDocC/SwiftDocC.docc/SwiftDocC/RenderingModel/RenderInlineContent.md
+++ b/Sources/SwiftDocC/SwiftDocC.docc/SwiftDocC/RenderingModel/RenderInlineContent.md
@@ -1,0 +1,21 @@
+# ``SwiftDocC/RenderInlineContent``
+
+## Topics
+
+### Getting a plain text representation
+
+- ``plainText``
+
+### Inline content types
+
+- ``codeVoice(code:)``
+- ``emphasis(inlineContent:)``
+- ``image(identifier:metadata:)``
+- ``inlineHead(inlineContent:)``
+- ``newTerm(inlineContent:)``
+- ``reference(identifier:isActive:overridingTitle:overridingTitleInlineContent:)``
+- ``strikethrough(inlineContent:)``
+- ``strong(inlineContent:)``
+- ``subscript(inlineContent:)``
+- ``superscript(inlineContent:)``
+- ``text(_:)``

--- a/Sources/SwiftDocC/SwiftDocC.docc/SwiftDocC/RenderingModel/RenderInlineContent.md
+++ b/Sources/SwiftDocC/SwiftDocC.docc/SwiftDocC/RenderingModel/RenderInlineContent.md
@@ -19,3 +19,5 @@
 ### Getting a plain text representation
 
 - ``plainText``
+
+<!-- Copyright (c) 2022 Apple Inc and the Swift Project authors. All Rights Reserved. -->


### PR DESCRIPTION
## Summary

This PR contains the following changes:

- Adds the `public` modifier to `plainText` in RenderInlineContent.swift (and the related extension on `Sequence`).
- Adds a markdown extension file that organizes the symbols in `RenderInlineContent`.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] ~~Added tests~~ Not applicable
- [X] Ran the `./bin/test` script and it succeeded
- [X] Updated documentation if necessary
