### PR TITLE
change sha512Checksum back into a non-optional property

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -792,7 +792,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
                 downloadReferences[url.description] = DownloadReference(
                     identifier: downloadIdentifier,
                     renderURL: url,
-                    sha512Checksum: nil
+                    checksum: nil
                 )
             } else if let fileReference = callToAction.file {
                 let downloadIdentifier = createAndRegisterRenderReference(forMedia: fileReference, assetContext: .download)
@@ -1583,7 +1583,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
                 let downloadData = try context.dataProvider.contentsOfURL(downloadURL, in: bundle)
                 downloadReference = DownloadReference(identifier: mediaReference,
                     renderURL: downloadURL,
-                    sha512Checksum: Checksum.sha512(of: downloadData))
+                    checksum: Checksum.sha512(of: downloadData))
             } catch {
                 // It seems this is the way to error out of here.
                 return mediaReference

--- a/Sources/SwiftDocC/Model/Rendering/Tutorial/References/DownloadReference.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Tutorial/References/DownloadReference.swift
@@ -60,14 +60,14 @@ public struct DownloadReference: RenderReference, URLReference {
         case type
         case identifier
         case url
-        case sha512Checksum = "checksum"
+        case checksum
     }
     
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(type.rawValue, forKey: .type)
         try container.encode(identifier, forKey: .identifier)
-        try container.encodeIfPresent(checksum, forKey: .sha512Checksum)
+        try container.encodeIfPresent(checksum, forKey: .checksum)
         
         // Render URL
         try container.encode(renderURL(for: url), forKey: .url)
@@ -78,7 +78,7 @@ public struct DownloadReference: RenderReference, URLReference {
 
         self.identifier = try container.decode(RenderReferenceIdentifier.self, forKey: .identifier)
         self.url = try container.decode(URL.self, forKey: .url)
-        self.checksum = try container.decodeIfPresent(String.self, forKey: .sha512Checksum)
+        self.checksum = try container.decodeIfPresent(String.self, forKey: .checksum)
 
         let rawType = try container.decode(String.self, forKey: .type)
         guard let decodedType = RenderReferenceType(rawValue: rawType) else {

--- a/Sources/SwiftDocC/Model/Rendering/Tutorial/References/DownloadReference.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Tutorial/References/DownloadReference.swift
@@ -50,10 +50,15 @@ public struct DownloadReference: RenderReference, URLReference {
     ///   - identifier: An identifier for the resource's reference.
     ///   - url: The path to the resource.
     ///   - sha512Checksum: The SHA512 hash value for the resource.
-    public init(identifier: RenderReferenceIdentifier, renderURL url: URL, sha512Checksum: String?) {
+    public init(identifier: RenderReferenceIdentifier, renderURL url: URL, checksum: String?) {
         self.identifier = identifier
         self.url = url
-        self.checksum = sha512Checksum
+        self.checksum = checksum
+    }
+
+    @available(*, deprecated, message: "Use 'init(identifier:renderURL:checksum:)' instead")
+    public init(identifier: RenderReferenceIdentifier, renderURL url: URL, sha512Checksum: String) {
+        self.init(identifier: identifier, renderURL: url, checksum: sha512Checksum)
     }
     
     public func encode(to encoder: Encoder) throws {

--- a/Sources/SwiftDocC/Model/Rendering/Tutorial/References/DownloadReference.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Tutorial/References/DownloadReference.swift
@@ -32,7 +32,16 @@ public struct DownloadReference: RenderReference, URLReference {
 
     @available(*, deprecated, renamed: "checksum")
     public var sha512Checksum: String {
-        return checksum ?? ""
+        get {
+            return checksum ?? ""
+        }
+        set {
+            if newValue.isEmpty {
+                self.checksum = nil
+            } else {
+                self.checksum = newValue
+            }
+        }
     }
     
     /// Creates a new reference to a downloadable resource.

--- a/Sources/SwiftDocC/Model/Rendering/Tutorial/References/DownloadReference.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Tutorial/References/DownloadReference.swift
@@ -56,13 +56,6 @@ public struct DownloadReference: RenderReference, URLReference {
         self.checksum = sha512Checksum
     }
     
-    enum CodingKeys: String, CodingKey {
-        case type
-        case identifier
-        case url
-        case checksum
-    }
-    
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(type.rawValue, forKey: .type)
@@ -71,20 +64,6 @@ public struct DownloadReference: RenderReference, URLReference {
         
         // Render URL
         try container.encode(renderURL(for: url), forKey: .url)
-    }
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-
-        self.identifier = try container.decode(RenderReferenceIdentifier.self, forKey: .identifier)
-        self.url = try container.decode(URL.self, forKey: .url)
-        self.checksum = try container.decodeIfPresent(String.self, forKey: .checksum)
-
-        let rawType = try container.decode(String.self, forKey: .type)
-        guard let decodedType = RenderReferenceType(rawValue: rawType) else {
-            throw DecodingError.dataCorruptedError(forKey: .type, in: container, debugDescription: "Unknown type")
-        }
-        self.type = decodedType
     }
 }
 


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://103602701

## Summary

In https://github.com/apple/swift-docc/pull/435 i made the `sha512Checksum` property of `DownloadReference` optional, since Swift-DocC-Render currently doesn't use that property. However, this caused an API breakage due to the requirement for optional-unwrapping. This PR restores the original non-optional property, but continues to store and encode an optional String in the data structure and in the output JSON.

## Dependencies

None

## Testing

Ensure that no functionality changes.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ n/a ] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ n/a ] Updated documentation if necessary
