### PR TITLE
[5.8] add `@Available` directive for setting platform availability

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -804,6 +804,19 @@ public struct RenderNodeTranslator: SemanticVisitor {
                 ))
             }
         }
+
+        if let availability = article.metadata?.availability, !availability.isEmpty {
+            let renderAvailability = availability.compactMap({
+                let currentPlatform = PlatformName(metadataPlatform: $0.platform).flatMap { name in
+                    context.externalMetadata.currentPlatforms?[name.displayName]
+                }
+                return .init($0, current: currentPlatform)
+            }).sorted(by: AvailabilityRenderOrder.compare)
+
+            if !renderAvailability.isEmpty {
+                node.metadata.platformsVariants = .init(defaultValue: renderAvailability)
+            }
+        }
         
         collectedTopicReferences.append(contentsOf: contentCompiler.collectedTopicReferences)
         node.references = createTopicRenderReferences()
@@ -1193,6 +1206,19 @@ public struct RenderNodeTranslator: SemanticVisitor {
                 .filter({ !($0.unconditionallyUnavailable == true) })
                 .sorted(by: AvailabilityRenderOrder.compare)
         )
+
+        if let availability = documentationNode.metadata?.availability, !availability.isEmpty {
+            let renderAvailability = availability.compactMap({
+                let currentPlatform = PlatformName(metadataPlatform: $0.platform).flatMap { name in
+                    context.externalMetadata.currentPlatforms?[name.displayName]
+                }
+                return .init($0, current: currentPlatform)
+            }).sorted(by: AvailabilityRenderOrder.compare)
+
+            if !renderAvailability.isEmpty {
+                node.metadata.platformsVariants.defaultValue = renderAvailability
+            }
+        }
         
         node.metadata.requiredVariants = VariantCollection<Bool>(from: symbol.isRequiredVariants) ?? .init(defaultValue: false)
         node.metadata.role = contentRenderer.role(for: documentationNode.kind).rawValue

--- a/Sources/SwiftDocC/Model/Rendering/Symbol/AvailabilityRenderMetadataItem.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Symbol/AvailabilityRenderMetadataItem.swift
@@ -139,6 +139,18 @@ public struct AvailabilityRenderItem: Codable, Hashable, Equatable {
             isBeta = false
         }
     }
+
+    init?(_ availability: Metadata.Availability, current: PlatformVersion?) {
+        if availability.introduced == nil {
+            // FIXME: Deprecated/Beta markings need platform versions to display properly in Swift-DocC-Render (rdar://56897597)
+            // Fill in the appropriate values here when that's fixed (https://github.com/apple/swift-docc/issues/441)
+            return nil
+        }
+
+        let platformName = PlatformName(metadataPlatform: availability.platform)
+        name = platformName?.displayName
+        introduced = availability.introduced
+    }
     
     /// Creates a new item with the given platform name and version string.
     /// - Parameters:

--- a/Sources/SwiftDocC/Semantics/Metadata/Availability.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/Availability.swift
@@ -1,0 +1,80 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+import Markdown
+
+extension Metadata {
+    /// A directive that sets the platform availability information for a documentation page.
+    ///
+    /// `@Available` is analagous to the `@available` attribute in Swift: It allows you to specify a
+    /// platform version that the page relates to. To specify a platform and version, list the platform
+    /// name and use the `introduced` argument:
+    ///
+    /// ```markdown
+    /// @Available(macOS, introduced: "12.0")
+    /// ```
+    ///
+    /// The available platforms are `macOS`, `iOS`, `watchOS`, and `tvOS`.
+    ///
+    /// This directive is available on both articles and documentation extension files. In extension
+    /// files, the information overrides any information from the symbol itself.
+    ///
+    /// This directive is only valid within a ``Metadata`` directive:
+    ///
+    /// ```markdown
+    /// @Metadata {
+    ///     @Available(macOS, introduced: "12.0")
+    ///     @Available(iOS, introduced: "15.0")
+    /// }
+    /// ```
+    public final class Availability: Semantic, AutomaticDirectiveConvertible {
+        static public let directiveName: String = "Available"
+
+        public enum Platform: String, RawRepresentable, CaseIterable, DirectiveArgumentValueConvertible {
+            // FIXME: re-add `case any = "*"` when `isBeta` and `isDeprecated` are implemented
+            // cf. https://github.com/apple/swift-docc/issues/441
+            case macOS, iOS, watchOS, tvOS
+
+            public init?(rawValue: String) {
+                for platform in Self.allCases {
+                    if platform.rawValue.lowercased() == rawValue.lowercased() {
+                        self = platform
+                        return
+                    }
+                }
+                return nil
+            }
+        }
+
+        /// The platform that this argument's information applies to.
+        @DirectiveArgumentWrapped(name: .unnamed)
+        public var platform: Platform
+
+        /// The platform version that this page applies to.
+        @DirectiveArgumentWrapped
+        public var introduced: String
+
+        // FIXME: `isBeta` and `isDeprecated` properties/arguments
+        // cf. https://github.com/apple/swift-docc/issues/441
+
+        static var keyPaths: [String : AnyKeyPath] = [
+            "platform"     : \Availability._platform,
+            "introduced"   : \Availability._introduced,
+        ]
+
+        public let originalMarkup: Markdown.BlockDirective
+
+        @available(*, deprecated, message: "Do not call directly. Required for 'AutomaticDirectiveConvertible'.")
+        init(originalMarkup: Markdown.BlockDirective) {
+            self.originalMarkup = originalMarkup
+        }
+    }
+}

--- a/Sources/SwiftDocC/Semantics/Metadata/Metadata.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/Metadata.swift
@@ -24,6 +24,7 @@ import Markdown
 /// - ``DisplayName``
 /// - ``PageImage``
 /// - ``CallToAction``
+/// - ``Availability``
 public final class Metadata: Semantic, AutomaticDirectiveConvertible {
     public let originalMarkup: BlockDirective
     
@@ -48,6 +49,9 @@ public final class Metadata: Semantic, AutomaticDirectiveConvertible {
 
     @ChildDirective
     var callToAction: CallToAction? = nil
+
+    @ChildDirective(requirements: .zeroOrMore)
+    var availability: [Availability]
     
     static var keyPaths: [String : AnyKeyPath] = [
         "documentationOptions"  : \Metadata._documentationOptions,
@@ -56,6 +60,7 @@ public final class Metadata: Semantic, AutomaticDirectiveConvertible {
         "pageImages"            : \Metadata._pageImages,
         "customMetadata"        : \Metadata._customMetadata,
         "callToAction"          : \Metadata._callToAction,
+        "availability"          : \Metadata._availability,
     ]
     
     /// Creates a metadata object with a given markup, documentation extension, and technology root.
@@ -78,7 +83,7 @@ public final class Metadata: Semantic, AutomaticDirectiveConvertible {
     
     func validate(source: URL?, for bundle: DocumentationBundle, in context: DocumentationContext, problems: inout [Problem]) -> Bool {
         // Check that something is configured in the metadata block
-        if documentationOptions == nil && technologyRoot == nil && displayName == nil && pageImages.isEmpty && customMetadata.isEmpty {
+        if documentationOptions == nil && technologyRoot == nil && displayName == nil && pageImages.isEmpty && customMetadata.isEmpty && callToAction == nil && availability.isEmpty {
             let diagnostic = Diagnostic(
                 source: source,
                 severity: .information,
@@ -130,6 +135,44 @@ public final class Metadata: Semantic, AutomaticDirectiveConvertible {
                 )
                 
                 problems.append(Problem(diagnostic: diagnostic, possibleSolutions: [solution]))
+            }
+        }
+
+        let categorizedAvailability = Dictionary(grouping: availability, by: \.platform)
+
+        for availabilityAttrs in categorizedAvailability.values {
+            guard availabilityAttrs.count > 1 else {
+                continue
+            }
+
+            let duplicateIntroduced = availabilityAttrs.filter({ $0.introduced != nil })
+            if duplicateIntroduced.count > 1 {
+                for avail in duplicateIntroduced {
+                    let diagnostic = Diagnostic(
+                        source: avail.originalMarkup.nameLocation?.source,
+                        severity: .warning,
+                        range: avail.originalMarkup.range,
+                        identifier: "org.swift.docc.\(Metadata.Availability.self).DuplicateIntroduced",
+                        summary: "Duplicate \(Metadata.Availability.directiveName.singleQuoted) directive with 'introduced' argument",
+                        explanation: """
+                        A documentation page can only contain a single 'introduced' version for each platform.
+                        """
+                    )
+
+                    guard let range = avail.originalMarkup.range else {
+                        problems.append(Problem(diagnostic: diagnostic))
+                        continue
+                    }
+
+                    let solution = Solution(
+                        summary: "Remove extraneous \(Metadata.Availability.directiveName.singleQuoted) directive",
+                        replacements: [
+                            Replacement(range: range, replacement: "")
+                        ]
+                    )
+
+                    problems.append(Problem(diagnostic: diagnostic, possibleSolutions: [solution]))
+                }
             }
         }
         

--- a/Sources/SwiftDocC/Semantics/Symbol/PlatformName.swift
+++ b/Sources/SwiftDocC/Semantics/Symbol/PlatformName.swift
@@ -101,4 +101,14 @@ public struct PlatformName: Codable, Hashable, Equatable {
         }
         self = knowDomain
     }
+
+    /// Creates a new platform name from the given metadata availability attribute platform.
+    ///
+    /// Returns `nil` if the given platform was ``Metadata/Availability/Platform-swift.enum/any``.
+    init?(metadataPlatform platform: Metadata.Availability.Platform) {
+        // Note: This is still an optional initializer to prevent source breakage when
+        // `Availability.Platform` re-introduces the `.any` case
+        // cf. https://github.com/apple/swift-docc/issues/441
+        self = .init(operatingSystemName: platform.rawValue)
+    }
 }

--- a/Tests/SwiftDocCTests/Rendering/PlatformAvailabilityTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/PlatformAvailabilityTests.swift
@@ -31,4 +31,79 @@ class PlatformAvailabilityTests: XCTestCase {
         // The "iOS" platform in the fixture is unconditionally unavailable
         XCTAssertEqual(true, platforms.first { $0.name == "iOS" }?.unconditionallyUnavailable)
     }
+
+    /// Ensure that adding `@Available` directives in an article causes the final RenderNode to contain the appropriate availability data.
+    func testPlatformAvailabilityFromArticle() throws {
+        let (bundle, context) = try testBundleAndContext(named: "AvailabilityBundle")
+        let reference = ResolvedTopicReference(
+            bundleIdentifier: bundle.identifier,
+            path: "/documentation/AvailableArticle",
+            sourceLanguage: .swift
+        )
+        let article = try XCTUnwrap(context.entity(with: reference).semantic as? Article)
+        var translator = RenderNodeTranslator(
+            context: context,
+            bundle: bundle,
+            identifier: reference,
+            source: nil
+        )
+        let renderNode = try XCTUnwrap(translator.visitArticle(article) as? RenderNode)
+        let availability = try XCTUnwrap(renderNode.metadata.platformsVariants.defaultValue)
+        XCTAssertEqual(availability.count, 1)
+        let iosAvailability = try XCTUnwrap(availability.first)
+        XCTAssertEqual(iosAvailability.name, "iOS")
+        XCTAssertEqual(iosAvailability.introduced, "16.0")
+    }
+
+    /// Ensure that adding `@Available` directives in an extension file overrides the symbol's availability.
+    func testPlatformAvailabilityFromExtension() throws {
+        let (bundle, context) = try testBundleAndContext(named: "AvailabilityBundle")
+        let reference = ResolvedTopicReference(
+            bundleIdentifier: bundle.identifier,
+            path: "/documentation/MyKit/MyClass",
+            sourceLanguage: .swift
+        )
+        let symbol = try XCTUnwrap(context.entity(with: reference).semantic as? Symbol)
+        var translator = RenderNodeTranslator(
+            context: context,
+            bundle: bundle,
+            identifier: reference,
+            source: nil
+        )
+        let renderNode = try XCTUnwrap(translator.visitSymbol(symbol) as? RenderNode)
+        let availability = try XCTUnwrap(renderNode.metadata.platformsVariants.defaultValue)
+        XCTAssertEqual(availability.count, 1)
+        let iosAvailability = try XCTUnwrap(availability.first)
+        XCTAssertEqual(iosAvailability.name, "iOS")
+        XCTAssertEqual(iosAvailability.introduced, "16.0")
+    }
+
+    func testMultiplePlatformAvailabilityFromArticle() throws {
+        let (bundle, context) = try testBundleAndContext(named: "AvailabilityBundle")
+        let reference = ResolvedTopicReference(
+            bundleIdentifier: bundle.identifier,
+            path: "/documentation/AvailabilityBundle/ComplexAvailable",
+            sourceLanguage: .swift
+        )
+        let article = try XCTUnwrap(context.entity(with: reference).semantic as? Article)
+        var translator = RenderNodeTranslator(
+            context: context,
+            bundle: bundle,
+            identifier: reference,
+            source: nil
+        )
+        let renderNode = try XCTUnwrap(translator.visitArticle(article) as? RenderNode)
+        let availability = try XCTUnwrap(renderNode.metadata.platformsVariants.defaultValue)
+        XCTAssertEqual(availability.count, 3)
+
+        XCTAssert(availability.contains(where: { item in
+            item.name == "iOS" && item.introduced == "15.0"
+        }))
+        XCTAssert(availability.contains(where: { item in
+            item.name == "macOS" && item.introduced == "12.0"
+        }))
+        XCTAssert(availability.contains(where: { item in
+            item.name == "watchOS" && item.introduced == "7.0"
+        }))
+    }
 }

--- a/Tests/SwiftDocCTests/Semantics/DirectiveInfrastructure/DirectiveIndexTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/DirectiveInfrastructure/DirectiveIndexTests.swift
@@ -21,6 +21,7 @@ class DirectiveIndexTests: XCTestCase {
                 "AutomaticArticleSubheading",
                 "AutomaticSeeAlso",
                 "AutomaticTitleHeading",
+                "Available",
                 "CallToAction",
                 "Chapter",
                 "Choice",

--- a/Tests/SwiftDocCTests/Semantics/DirectiveInfrastructure/DirectiveMirrorTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/DirectiveInfrastructure/DirectiveMirrorTests.swift
@@ -39,7 +39,7 @@ class DirectiveMirrorTests: XCTestCase {
         XCTAssertFalse(reflectedDirective.allowsMarkup)
         XCTAssert(reflectedDirective.arguments.isEmpty)
         
-        XCTAssertEqual(reflectedDirective.childDirectives.count, 6)
+        XCTAssertEqual(reflectedDirective.childDirectives.count, 7)
         
         XCTAssertEqual(
             reflectedDirective.childDirectives["DocumentationExtension"]?.propertyLabel,

--- a/Tests/SwiftDocCTests/Semantics/MetadataAvailabilityTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/MetadataAvailabilityTests.swift
@@ -1,0 +1,124 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+import XCTest
+import Markdown
+
+@testable import SwiftDocC
+
+class MetadataAvailabilityTests: XCTestCase {
+    func testInvalidWithNoArguments() throws {
+        let source = "@Available"
+        let document = Document(parsing: source, options: .parseBlockDirectives)
+        let directive = document.child(at: 0) as? BlockDirective
+        XCTAssertNotNil(directive)
+
+        let (bundle, context) = try testBundleAndContext(named: "AvailabilityBundle")
+
+        directive.map { directive in
+            var problems = [Problem]()
+            XCTAssertEqual(Metadata.Availability.directiveName, directive.name)
+            let availability = Metadata.Availability(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+            XCTAssertNil(availability)
+        }
+    }
+
+    func testInvalidDuplicateIntroduced() throws {
+        func assertInvalidDirective(source: String) throws {
+            let document = Document(parsing: source, options: .parseBlockDirectives)
+            let directive = document.child(at: 0) as? BlockDirective
+            XCTAssertNotNil(directive)
+
+            let (bundle, context) = try testBundleAndContext(named: "AvailabilityBundle")
+
+            directive.map { directive in
+                var problems = [Problem]()
+                XCTAssertEqual(Metadata.directiveName, directive.name)
+                let _ = Metadata(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+                XCTAssertEqual(2, problems.count)
+                let diagnosticIdentifiers = Set(problems.map { $0.diagnostic.identifier })
+                XCTAssertEqual(diagnosticIdentifiers, ["org.swift.docc.\(Metadata.Availability.self).DuplicateIntroduced"])
+            }
+        }
+
+        for platform in Metadata.Availability.Platform.allCases {
+            let source = """
+            @Metadata {
+                @Available(\(platform.rawValue), introduced: \"1.0\")
+                @Available(\(platform.rawValue), introduced: \"2.0\")
+            }
+            """
+            try assertInvalidDirective(source: source)
+        }
+    }
+
+    func testValidDirective() throws {
+        // assemble all the combinations of arguments you could give
+        let validArguments: [String] = [
+            // FIXME: isBeta and isDeprecated are unused (https://github.com/apple/swift-docc/issues/441)
+//            "isBeta: true",
+//            "isDeprecated: true",
+//            "isBeta: true, isDeprecated: true",
+        ]
+        // separate those that give a version so we can test the `*` platform separately
+        var validArgumentsWithVersion = ["introduced: \"1.0\""]
+        for arg in validArguments {
+            validArgumentsWithVersion.append("introduced: \"1.0\", \(arg)")
+        }
+
+        for platform in Metadata.Availability.Platform.allCases {
+            // FIXME: Test validArguments with the `*` platform once that's introduced
+            // cf. https://github.com/apple/swift-docc/issues/441
+            for args in validArgumentsWithVersion {
+                try assertValidAvailability(source: "@Available(\(platform.rawValue), \(args))")
+            }
+        }
+
+        // also test for giving no platform
+        for args in validArguments {
+            try assertValidAvailability(source: "@Available(\(args))")
+        }
+
+        // basic validity test for giving several directives
+        // FIXME: re-add isBeta after that is implemented (https://github.com/apple/swift-docc/issues/441)
+        let source = """
+        @Metadata {
+            @Available(macOS, introduced: "11.0")
+            @Available(iOS, introduced: "15.0")
+        }
+        """
+        try assertValidMetadata(source: source)
+    }
+
+    func assertValidDirective<Directive: AutomaticDirectiveConvertible>(_ type: Directive.Type, source: String) throws {
+        let document = Document(parsing: source, options: .parseBlockDirectives)
+        let directive = document.child(at: 0) as? BlockDirective
+        XCTAssertNotNil(directive)
+
+        let (bundle, context) = try testBundleAndContext(named: "AvailabilityBundle")
+
+        directive.map { directive in
+            var problems = [Problem]()
+            XCTAssertEqual(Directive.directiveName, directive.name)
+            let converted = Directive(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+            XCTAssertNotNil(converted)
+            XCTAssert(problems.isEmpty)
+        }
+    }
+
+    func assertValidAvailability(source: String) throws {
+        try assertValidDirective(Metadata.Availability.self, source: source)
+    }
+
+    func assertValidMetadata(source: String) throws {
+        try assertValidDirective(Metadata.self, source: source)
+    }
+}

--- a/Tests/SwiftDocCTests/Test Bundles/AvailabilityBundle.docc/AvailableArticle.md
+++ b/Tests/SwiftDocCTests/Test Bundles/AvailabilityBundle.docc/AvailableArticle.md
@@ -1,0 +1,16 @@
+# Available Article
+
+@Metadata {
+    @TechnologyRoot
+    @Available(iOS, introduced: 16.0)
+}
+
+Here's a cool framework that I'm offering to the world.
+
+## Topics
+
+### Cool Articles
+
+- <doc:ComplexAvailable>
+
+<!-- Copyright (c) 2022 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Tests/SwiftDocCTests/Test Bundles/AvailabilityBundle.docc/ComplexAvailable.md
+++ b/Tests/SwiftDocCTests/Test Bundles/AvailabilityBundle.docc/ComplexAvailable.md
@@ -1,0 +1,11 @@
+# Complex Available Article
+
+@Metadata {
+    @Available(macOS, introduced: "12.0")
+    @Available(iOS, introduced: "15.0")
+    @Available(watchOS, introduced: "7.0")
+}
+
+This applies to three different platforms!
+
+<!-- Copyright (c) 2022 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Tests/SwiftDocCTests/Test Bundles/AvailabilityBundle.docc/Info.plist
+++ b/Tests/SwiftDocCTests/Test Bundles/AvailabilityBundle.docc/Info.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDisplayName</key>
+	<string>AvailabilityBundle</string>
+	<key>CFBundleIdentifier</key>
+	<string>org.swift.docc.availability</string>
+	<key>CFBundleVersion</key>
+	<string>0.1.0</string>
+</dict>
+</plist>

--- a/Tests/SwiftDocCTests/Test Bundles/AvailabilityBundle.docc/MyClass.md
+++ b/Tests/SwiftDocCTests/Test Bundles/AvailabilityBundle.docc/MyClass.md
@@ -1,0 +1,7 @@
+# ``MyKit/MyClass``
+
+@Metadata {
+    @Available(iOS, introduced: "16.0")
+}
+
+<!-- Copyright (c) 2022 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Tests/SwiftDocCTests/Test Bundles/AvailabilityBundle.docc/mykit-iOS.symbols.json
+++ b/Tests/SwiftDocCTests/Test Bundles/AvailabilityBundle.docc/mykit-iOS.symbols.json
@@ -1,0 +1,562 @@
+{
+  "metadata": {
+      "formatVersion" : {
+          "major" : 1
+      },
+      "generator" : "app/1.0"
+  },
+  "module" : {
+    "name" : "MyKit",
+    "platform" : {
+      "architecture" : "x86_64",
+      "vendor" : "apple",
+      "operatingSystem" : {
+        "name" : "ios",
+        "minimumVersion" : {
+          "major" : 13,
+          "minor" : 0,
+          "patch" : 0
+        }
+      }
+    }
+  },
+  "symbols" : [
+    {
+      "accessLevel" : "public",
+      "kind" : {
+        "identifier" : "swift.class",
+        "displayName" : "Class"
+      },
+      "names" : {
+        "title" : "MyClass",
+        "subHeading" : [
+            {
+              "kind" : "keyword",
+              "spelling" : "class"
+            },
+            {
+              "kind" : "text",
+              "spelling" : " "
+            },
+            {
+              "kind" : "identifier",
+              "spelling" : "MyClass"
+            }
+        ],
+        "navigator" : [
+            {
+              "kind" : "identifier",
+              "spelling" : "MyClassNavigator"
+            }
+        ]
+      },
+      "availability" : [
+        {
+          "domain": "macOS",
+          "introduced": {
+            "major": 10,
+            "minor": 15
+          }
+        },
+        {
+          "domain": "watchOS",
+          "introduced": {
+            "major": 6,
+            "minor": 0
+          }
+        },
+        {
+          "domain": "tvOS",
+          "introduced": {
+            "major": 13,
+            "minor": 0
+          }
+        },
+        {
+          "domain": "iOS",
+          "deprecated": {
+            "major": 13,
+            "minor": 0
+          }
+        }
+      ],
+      "pathComponents" : [
+        "MyClass"
+      ],
+      "identifier" : {
+        "precise" : "s:5MyKit0A5ClassC",
+        "interfaceLanguage": "swift"
+      },
+      "declarationFragments" : [
+        {
+          "kind" : "keyword",
+          "spelling" : "class"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " "
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "MyClass"
+        }
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "kind" : {
+        "identifier" : "swift.method",
+        "displayName" : "Instance Method"
+      },
+      "names" : {
+        "title" : "myFunction()"
+      },
+      "pathComponents" : [
+        "MyClass",
+        "myFunction()"
+      ],
+      "identifier" : {
+        "precise" : "s:5MyKit0A5ClassC10myFunctionyyF",
+        "interfaceLanguage": "swift"
+      },
+      "docComment" : {
+        "lines" : [
+          {
+            "text" : "A cool API to call."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "- Parameters:"
+          },
+          {
+            "text" : "  - name: A parameter"
+          },
+          {
+            "text" : "- Returns: Return value"
+          }
+        ]
+      },
+      "declarationFragments" : [
+        {
+          "kind" : "keyword",
+          "spelling" : "func"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " "
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "myFunction"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "("
+        },
+        {
+          "kind" : "externalParam",
+          "spelling" : "for"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " "
+        },
+        {
+          "kind" : "internalParam",
+          "spelling" : "name"
+        },
+        {
+          "kind" : "unhandledTokenKind",
+          "spelling" : "..."
+        },
+        {
+          "kind" : "text",
+          "spelling" : ")"
+        }
+      ],
+      "swiftExtension" : {
+        "extendedModule": "MyKit",
+        "constraints" : [
+          {
+            "kind" : "sameType",
+            "lhs" : "Label",
+            "rhs" : "Text"
+          },
+          {
+            "kind" : "superclass",
+            "lhs" : "Observer",
+            "rhs" : "NSObject"
+          },
+          {
+            "kind" : "conformance",
+            "lhs" : "S",
+            "rhs" : "StringProtocol"
+          }
+        ]
+      }
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "keyword",
+          "spelling" : "func"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " "
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "globalFunction"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "("
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "_"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "preciseIdentifier" : "s:10Foundation4DataV",
+          "spelling" : "Data"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ", "
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "considering"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "preciseIdentifier" : "s:Si",
+          "spelling" : "Int"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ")"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+
+        ]
+      },
+      "functionSignature" : {
+        "parameters" : [
+          {
+            "declarationFragments" : [
+              {
+                "kind" : "identifier",
+                "spelling" : "data"
+              },
+              {
+                "kind" : "text",
+                "spelling" : ": "
+              },
+              {
+                "kind" : "typeIdentifier",
+                "preciseIdentifier" : "s:10Foundation4DataV",
+                "spelling" : "Data"
+              }
+            ],
+            "name" : "data"
+          },
+          {
+            "declarationFragments" : [
+              {
+                "kind" : "identifier",
+                "spelling" : "considering"
+              },
+              {
+                "kind" : "text",
+                "spelling" : ": "
+              },
+              {
+                "kind" : "typeIdentifier",
+                "preciseIdentifier" : "s:Si",
+                "spelling" : "Int"
+              }
+            ],
+            "name" : "considering"
+          }
+        ],
+        "returns" : [
+          {
+            "kind" : "text",
+            "spelling" : "()"
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "s:5MyKit14globalFunction_11consideringy10Foundation4DataV_SitF"
+      },
+      "kind" : {
+        "displayName" : "Function",
+        "identifier" : "swift.func"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "keyword",
+            "spelling" : "func"
+          },
+          {
+            "kind" : "text",
+            "spelling" : " "
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "globalFunction"
+          },
+          {
+            "kind" : "text",
+            "spelling" : "("
+          },
+          {
+            "kind" : "typeIdentifier",
+            "preciseIdentifier" : "s:10Foundation4DataV",
+            "spelling" : "Data"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ", "
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "considering"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "preciseIdentifier" : "s:Si",
+            "spelling" : "Int"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ")"
+          },
+          {
+            "kind" : "text",
+            "spelling" : "\n"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "keyword",
+            "spelling" : "func"
+          },
+          {
+            "kind" : "text",
+            "spelling" : " "
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "globalFunction"
+          },
+          {
+            "kind" : "text",
+            "spelling" : "("
+          },
+          {
+            "kind" : "typeIdentifier",
+            "preciseIdentifier" : "s:10Foundation4DataV",
+            "spelling" : "Data"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ", "
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "considering"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "preciseIdentifier" : "s:Si",
+            "spelling" : "Int"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ")"
+          },
+          {
+            "kind" : "text",
+            "spelling" : "\n"
+          }
+        ],
+        "title" : "globalFunction(_:considering:)"
+      },
+      "pathComponents" : [
+        "globalFunction(_:considering:)"
+      ]
+    },
+    {
+      "accessLevel" : "internal",
+      "kind" : {
+        "identifier" : "swift.init",
+        "displayName" : "Initializer"
+      },
+      "names" : {
+        "title" : "init()"
+      },
+      "pathComponents" : [
+        "MyClass",
+        "init()"
+      ],
+      "identifier" : {
+        "precise" : "s:5MyKit0A5ClassCACycfc",
+        "interfaceLanguage": "swift"
+      }
+    },
+    {
+      "accessLevel" : "internal",
+      "kind" : {
+        "identifier" : "swift.init",
+        "displayName" : "Initializer"
+      },
+      "names" : {
+        "title" : "init()"
+      },
+      "pathComponents" : [
+        "MyClass",
+        "init()"
+      ],
+      "identifier" : {
+        "precise" : "s:5MyKit0A5ClassCACycfcDUPLICATE",
+        "interfaceLanguage" : "swift"
+      }
+    },
+    {
+      "accessLevel" : "public",
+      "kind" : {
+        "identifier" : "swift.protocol",
+        "displayName" : "Protocol"
+      },
+      "names" : {
+        "title" : "MyProtocol",
+        "navigator": [
+          {
+            "kind" : "identifier",
+            "spelling" : "MyProtocol"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind" : "keyword",
+            "spelling" : "protocol"
+          },
+          {
+            "kind" : "text",
+            "spelling" : " "
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "MyProtocol"
+          },
+          {
+            "kind" : "text",
+            "spelling" : " : "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "spelling" : "Hashable",
+            "preciseIdentifier" : "p:hPP"
+          }
+        ]
+      },
+      "pathComponents" : [
+        "MyProtocol"
+      ],
+      "identifier" : {
+        "precise" : "s:5MyKit0A5ProtocolP",
+        "interfaceLanguage": "swift"
+      },
+      "declarationFragments" : [
+        {
+          "kind" : "keyword",
+          "spelling" : "protocol"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " "
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "MyProtocol"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " : "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Hashable",
+          "preciseIdentifier" : "p:hPP"
+        }
+      ]
+    }
+  ],
+  "relationships" : [
+    {
+      "source" : "s:5MyKit0A5ProtocolP",
+      "target" : "s:5Foundation0A5NSCodableP",
+      "kind" : "conformsTo",
+      "targetFallback": "Foundation.NSCodable"
+    },
+    {
+      "source" : "s:5MyKit0A5ProtocolP",
+      "target" : "s:5Foundation0A5EarhartP",
+      "kind" : "conformsTo"
+    },
+    {
+      "source" : "s:5MyKit0A5ClassC",
+      "target" : "s:5MyKit0A5ProtocolP",
+      "kind" : "conformsTo",
+      "swiftConstraints" : [
+        {
+            "kind" : "conformance",
+            "lhs" : "Element",
+            "rhs" : "Equatable"
+        }
+      ]
+    },
+    {
+      "source" : "s:5MyKit0A5ClassC10myFunctionyyF",
+      "target" : "s:5MyKit0A5ClassC",
+      "kind" : "memberOf"
+    },
+    {
+      "source" : "s:5MyKit0A5ClassCACycfc",
+      "target" : "s:5MyKit0A5ClassC",
+      "kind" : "memberOf"
+    },
+    {
+      "source" : "s:5MyKit0A5ClassCACycfcDUPLICATE",
+      "target" : "s:5MyKit0A5ClassC",
+      "kind" : "memberOf"
+    }
+  ]
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift-docc/pull/440

- **Explanation**: This PR adds a new metadata directive, `@Available`, for articles and symbol extensions to specify platform availability information
- **Scope**: New directive for articles and extensions.
- **Radar**: rdar://57847232
- **Risk**: Low. Existing documentation should not be affected.
- **Testing**: New tests have been added to ensure that expected permutations of this attribute provide expected results. Existing automated tests pass.
- **Reviewer**: @ethan-kusters 