### PR TITLE
[5.8] Fix encoding & decoding inconsistencies for link destination summary variant values

### DIFF
--- a/Sources/SwiftDocC/LinkTargets/LinkDestinationSummary.swift
+++ b/Sources/SwiftDocC/LinkTargets/LinkDestinationSummary.swift
@@ -474,7 +474,7 @@ extension LinkDestinationSummary.Variant {
         try container.encodeIfPresent(relativePresentationURL, forKey: .relativePresentationURL)
         try container.encodeIfPresent(title, forKey: .title)
         try container.encodeIfPresent(abstract, forKey: .abstract)
-        try container.encodeIfPresent(language, forKey: .language)
+        try container.encodeIfPresent(language?.id, forKey: .language)
         try container.encodeIfPresent(usr, forKey: .usr)
         try container.encodeIfPresent(declarationFragments, forKey: .declarationFragments)
         try container.encodeIfPresent(taskGroups, forKey: .taskGroups)
@@ -513,7 +513,7 @@ extension LinkDestinationSummary.Variant {
         relativePresentationURL = try container.decodeIfPresent(URL.self, forKey: .relativePresentationURL)
         title = try container.decodeIfPresent(String?.self, forKey: .title)
         abstract = try container.decodeIfPresent(LinkDestinationSummary.Abstract?.self, forKey: .abstract)
-        usr = try container.decodeIfPresent(String?.self, forKey: .title)
+        usr = try container.decodeIfPresent(String?.self, forKey: .usr)
         declarationFragments = try container.decodeIfPresent(LinkDestinationSummary.DeclarationFragments?.self, forKey: .declarationFragments)
         taskGroups = try container.decodeIfPresent([LinkDestinationSummary.TaskGroup]?.self, forKey: .taskGroups)
     }

--- a/Sources/SwiftDocC/SwiftDocC.docc/Resources/LinkableEntities.json
+++ b/Sources/SwiftDocC/SwiftDocC.docc/Resources/LinkableEntities.json
@@ -88,30 +88,6 @@
                     }
                 }
             },
-            "SourceLanguage": {
-                "type": "object",
-                "required": [
-                    "name",
-                    "id"
-                ],
-                "properties": {
-                    "name": {
-                        "type": "string"
-                    },
-                    "id": {
-                        "type": "string"
-                    },
-                    "idAliases": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "linkDisambiguationID": {
-                        "type": "string"
-                    }
-                }
-            },
             "RenderNodeVariantTrait": {
                 "oneOf": [
                     {
@@ -148,7 +124,7 @@
                         "nullable": true
                     },
                     "language": {
-                        "$ref": "#/components/schemas/SourceLanguage",
+                        "type": "string",
                         "nullable": true
                     },
                     "path": {

--- a/Tests/SwiftDocCTests/LinkTargets/LinkDestinationSummaryTests.swift
+++ b/Tests/SwiftDocCTests/LinkTargets/LinkDestinationSummaryTests.swift
@@ -191,6 +191,10 @@ class ExternalLinkableTests: XCTestCase {
                 .init(text: " ", kind: .text, identifier: nil),
                 .init(text: "MyClass", kind: .identifier, identifier: nil),
             ])
+            
+            let encoded = try JSONEncoder().encode(summary)
+            let decoded = try JSONDecoder().decode(LinkDestinationSummary.self, from: encoded)
+            XCTAssertEqual(decoded, summary)
         }
         
         do {
@@ -226,6 +230,10 @@ class ExternalLinkableTests: XCTestCase {
                 .init(text: " : ", kind: .text, identifier: nil),
                 .init(text: "Hashable", kind: .typeIdentifier, identifier: nil, preciseIdentifier: "p:hPP"),
             ])
+            
+            let encoded = try JSONEncoder().encode(summary)
+            let decoded = try JSONDecoder().decode(LinkDestinationSummary.self, from: encoded)
+            XCTAssertEqual(decoded, summary)
         }
         
         do {
@@ -245,6 +253,10 @@ class ExternalLinkableTests: XCTestCase {
             XCTAssertEqual(summary.platforms, renderNode.metadata.platforms)
             XCTAssertEqual(summary.usr, "s:5MyKit0A5ClassC10myFunctionyyF")
             XCTAssertEqual(summary.declarationFragments, nil) // This symbol doesn't have a `subHeading` in the symbol graph
+            
+            let encoded = try JSONEncoder().encode(summary)
+            let decoded = try JSONDecoder().decode(LinkDestinationSummary.self, from: encoded)
+            XCTAssertEqual(decoded, summary)
         }
         
         do {
@@ -276,6 +288,10 @@ class ExternalLinkableTests: XCTestCase {
                 .init(text: ")", kind: .text, identifier: nil),
                 .init(text: "\n", kind: .text, identifier: nil),
             ])
+            
+            let encoded = try JSONEncoder().encode(summary)
+            let decoded = try JSONDecoder().decode(LinkDestinationSummary.self, from: encoded)
+            XCTAssertEqual(decoded, summary)
         }
     }
     
@@ -333,6 +349,10 @@ class ExternalLinkableTests: XCTestCase {
             XCTAssertEqual(variant.usr, nil)
             XCTAssertEqual(variant.kind, nil)
             XCTAssertEqual(variant.taskGroups, nil)
+            
+            let encoded = try JSONEncoder().encode(summary)
+            let decoded = try JSONDecoder().decode(LinkDestinationSummary.self, from: encoded)
+            XCTAssertEqual(decoded, summary)
         }
         
         // Check the Swift version of a symbol that's represented differently in different languages
@@ -412,6 +432,10 @@ class ExternalLinkableTests: XCTestCase {
                     )
                 ]
             )
+            
+            let encoded = try JSONEncoder().encode(summary)
+            let decoded = try JSONDecoder().decode(LinkDestinationSummary.self, from: encoded)
+            XCTAssertEqual(decoded, summary)
         }
     }
     


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift-docc/pull/451

- **Explanation**: This fixes two bugs in the encoding and decoding of variant values for link destination summaries (the linkable entities file).
- **Scope**: Multi source-language builds that emit linkable entities (off by default).
- **Radar**: rdar://103279313 (Structure suggestions for link resolution warnings as fixits)
- **Risk**: Low. The linkable entities data is only created when the `--emit-digest` flag is passed and variant values are only created in multi source-language builds.
- **Testing**: New test assertions have been added to ensure that encoded linkable entities with variant values can be decoded. Existing automated tests pass.
- **Reviewer**: @ethan-kusters 