### PR TITLE
Fix AvailabilityParser isDeprecated check issue

### DIFF
--- a/Tests/SwiftDocCTests/Model/AvailabilityParserTests.swift
+++ b/Tests/SwiftDocCTests/Model/AvailabilityParserTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -91,7 +91,7 @@ class AvailabilityParserTests: XCTestCase {
         
         /// Test all platforms
         let compiler = AvailabilityParser(availability)
-        XCTAssertTrue(compiler.isDeprecated())
+        XCTAssertFalse(compiler.isDeprecated())
         XCTAssertEqual(compiler.deprecationMessage(), "deprecated")
     }
 
@@ -99,6 +99,24 @@ class AvailabilityParserTests: XCTestCase {
         let json = """
         [
             {
+                "message": "deprecated",
+                "isUnconditionallyDeprecated" : true
+            }
+        ]
+        """
+        let availability = try JSONDecoder().decode(Availability.self, from: json.data(using: .utf8)!)
+        
+        /// Test all platforms
+        let compiler = AvailabilityParser(availability)
+        XCTAssertTrue(compiler.isDeprecated())
+        XCTAssertEqual(compiler.deprecationMessage(), "deprecated")
+    }
+    
+    func testDeprecatedLanguage() throws {
+        let json = """
+        [
+            {
+                "domain": "swift",
                 "message": "deprecated",
                 "isUnconditionallyDeprecated" : true
             }
@@ -129,7 +147,7 @@ class AvailabilityParserTests: XCTestCase {
         
         /// Test all platforms
         let compiler = AvailabilityParser(availability)
-        XCTAssertTrue(compiler.isDeprecated())
+        XCTAssertFalse(compiler.isDeprecated())
         XCTAssertNil(compiler.deprecationMessage())
     }
 
@@ -151,7 +169,59 @@ class AvailabilityParserTests: XCTestCase {
         
         /// Test all platforms
         let compiler = AvailabilityParser(availability)
-        XCTAssertTrue(compiler.isDeprecated())
+        XCTAssertFalse(compiler.isDeprecated())
         XCTAssertEqual(compiler.deprecationMessage(), "deprecated")
+    }
+    
+    func testDeprecatedAllPlatforms() throws {
+        let json = """
+        [
+            {
+                "domain": "iOS",
+                "isUnconditionallyUnavailable" : true
+            },
+            {
+                "domain": "iOSApplicationExtension",
+                "isUnconditionallyUnavailable" : true
+            },
+            {
+                "domain": "macOS",
+                "isUnconditionallyUnavailable" : true
+            },
+            {
+                "domain": "macOSApplicationExtension",
+                "isUnconditionallyUnavailable" : true
+            },
+            {
+                "domain": "macCatalyst",
+                "isUnconditionallyUnavailable" : true
+            },
+            {
+                "domain": "macCatalystApplicationExtension",
+                "isUnconditionallyUnavailable" : true
+            },
+            {
+                "domain": "watchOS",
+                "isUnconditionallyUnavailable" : true
+            },
+            {
+                "domain": "watchOSApplicationExtension",
+                "isUnconditionallyUnavailable" : true
+            },
+            {
+                "domain": "tvOS",
+                "isUnconditionallyUnavailable" : true
+            },
+            {
+                "domain": "tvOSApplicationExtension",
+                "isUnconditionallyUnavailable" : true
+            }
+        ]
+        """
+        let availability = try JSONDecoder().decode(Availability.self, from: json.data(using: .utf8)!)
+        
+        /// Test all platforms
+        let compiler = AvailabilityParser(availability)
+        XCTAssertTrue(compiler.isDeprecated())
     }
 }

--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -2109,7 +2109,7 @@ Document
         let renderNode = translator.visitSymbol(symbol) as! RenderNode
         
         // The reference is deprecated on all platforms
-        XCTAssertEqual((renderNode.references["doc://org.swift.docc.example/documentation/MyKit/MyClass/myFunction()"] as? TopicRenderReference)?.isDeprecated, true)
+        XCTAssertEqual((renderNode.references["doc://org.swift.docc.example/documentation/MyKit/MyClass/myFunction()"] as? TopicRenderReference)?.isDeprecated, false)
     }
 
     func testDoesNotRenderDeprecatedViolator() throws {
@@ -2157,7 +2157,7 @@ Document
         let renderNode = translator.visitSymbol(symbol) as! RenderNode
         
         // Verify that the reference is deprecated on all platforms
-        XCTAssertEqual((renderNode.references["doc://org.swift.docc.example/documentation/MyKit/MyClass/myFunction()"] as? TopicRenderReference)?.isDeprecated, true)
+        XCTAssertEqual((renderNode.references["doc://org.swift.docc.example/documentation/MyKit/MyClass/myFunction()"] as? TopicRenderReference)?.isDeprecated, false)
     }
     
     func testRenderMetadataFragments() throws {

--- a/bin/check-source
+++ b/bin/check-source
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2021 Apple Inc. and the Swift project authors
+# Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information
@@ -18,7 +18,7 @@ here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 function replace_acceptable_years() {
     # this needs to replace all acceptable forms with 'YEARS'
-    sed -e 's/20[12][78901]-20[12][89012]/YEARS/' -e 's/20[12][89012]/YEARS/'
+    sed -e 's/20[12][78901]-20[12][890123]/YEARS/' -e 's/20[12][890123]/YEARS/'
 }
 
 printf "=> Checking for unacceptable language… "


### PR DESCRIPTION
<!--
If you're opening a PR to cherry-pick a change for a release branch, use this template instead:
https://github.com/apple/swift-docc/blob/main/.github/PULL_REQUEST_TEMPLATE/CHERRY_PICK.md
-->

Bug/issue #, if applicable: 
Close #450 

## Summary

Update AvailabilityParser isDeprecated check:

1. The universalCondition could be nil or "swift"
2. Only the availability's domain set is a super set of all supported OS domains and all the origin AvailabilityItem isDeprecated conditions are satisfied will the function return true.

eg.
```swift
@available(iOS, unavailable)
public struct A { }

@available(iOS, unavailable)
@available(macOS, 10.15)
public struct B { }
```
Before the PR: A will be marked as deprecated and B will not.
After the PR: Both A and B will not be marked as deprecated

## Dependencies

None

## Testing

See AvailabilityParserTests.swift 

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
