### PR TITLE
Support legacy `- SeeAlso:` callout asides 

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -60,7 +60,7 @@
         "repositoryURL": "https://github.com/apple/swift-markdown.git",
         "state": {
           "branch": "main",
-          "revision": "d491147940587dbadfb3472354f4d0c6e063e061",
+          "revision": "4a5dd44f1fb703f853df85a928492dfd1c98aa25",
           "version": null
         }
       },

--- a/Sources/SwiftDocC/Model/Rendering/Content/RenderBlockContent.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Content/RenderBlockContent.swift
@@ -295,11 +295,9 @@ public enum RenderBlockContent: Equatable {
     
     /// A type the describes an aside style.
     public struct AsideStyle: Codable, Equatable {
-        private static let specialDisplayNames: [String: String] = [
-            "nonmutatingvariant": "Non-Mutating Variant",
-            "mutatingvariant": "Mutating Variant",
-            "todo": "To Do",
-        ]
+        private static let knownDisplayNames: [String: String] = Dictionary(
+            uniqueKeysWithValues: Markdown.Aside.Kind.allCases.map { ($0.rawValue.lowercased(), $0.displayName) }
+        )
         
         /// Returns a Boolean value indicating whether two aside styles are equal.
         ///
@@ -317,7 +315,7 @@ public enum RenderBlockContent: Equatable {
 
         /// The heading text to use when rendering this style of aside.
         public var displayName: String {
-            if let value = Self.specialDisplayNames[rawValue.lowercased()] {
+            if let value = Self.knownDisplayNames[rawValue.lowercased()] {
                 return value
             } else if rawValue.contains(where: \.isUppercase) {
                 // If any character is upper-cased, assume the content has
@@ -363,7 +361,7 @@ public enum RenderBlockContent: Equatable {
         /// Creates an aside style with the specified display name.
         /// - Parameter displayName: The heading text to use when rendering this style of aside.
         public init(displayName: String) {
-            self.rawValue = Self.specialDisplayNames.first(where: { $0.value == displayName })?.key ?? displayName
+            self.rawValue = Self.knownDisplayNames.first(where: { $0.value == displayName })?.key ?? displayName
         }
         
         /// Encodes the aside style into the specified encoder.

--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
@@ -2454,6 +2454,8 @@ Document
         .aside(.init(style: .init(rawValue: "Since"), content: [.paragraph(.init(inlineContent: [.text("The beginning of time.")]))])),
         .aside(.init(style: .init(rawValue: "Todo"), content: [.paragraph(.init(inlineContent: [.text("This needs work.")]))])),
         .aside(.init(style: .init(rawValue: "Version"), content: [.paragraph(.init(inlineContent: [.text("3.1.4")]))])),
+        .aside(.init(style: .init(rawValue: "SeeAlso"), content: [.paragraph(.init(inlineContent: [.text("This other thing.")]))])),
+        .aside(.init(style: .init(rawValue: "SeeAlso"), content: [.paragraph(.init(inlineContent: [.text("And this other thing.")]))])),
         .aside(.init(style: .init(rawValue: "Throws"), content: [.paragraph(.init(inlineContent: [.text("A serious error.")]))])),
     ]
     
@@ -2996,6 +2998,10 @@ Document
                 "content": [{"type":"paragraph", "inlineContent":[{"type":"text", "text":"This needs work."}]}]},
             {"type":"aside", "style":"note", "name":"Version",
                 "content": [{"type":"paragraph", "inlineContent":[{"type":"text", "text":"3.1.4"}]}]},
+            {"type":"aside", "style":"note", "name":"See Also",
+                "content": [{"type":"paragraph", "inlineContent":[{"type":"text", "text":"This other thing."}]}]},
+            {"type":"aside", "style":"note", "name":"See Also",
+                "content": [{"type":"paragraph", "inlineContent":[{"type":"text", "text":"And this other thing."}]}]},
             {"type":"aside", "style":"note", "name":"Throws",
                 "content": [{"type":"paragraph", "inlineContent":[{"type":"text", "text":"A serious error."}]}]}
             ]

--- a/Tests/SwiftDocCTests/Test Resources/Asides.symbols.json
+++ b/Tests/SwiftDocCTests/Test Resources/Asides.symbols.json
@@ -203,6 +203,18 @@
             "text": ""
           },
           {
+            "text": "> seealso: This other thing."
+          },
+          {
+            "text": ""
+          },
+          {
+            "text": "> SeeAlso: And this other thing."
+          },
+          {
+            "text": ""
+          },
+          {
             "text": "> Throws: A serious error."
           }
         ]
@@ -417,6 +429,18 @@
           },
           {
             "text": "- Version: 3.1.4"
+          },
+          {
+            "text": ""
+          },
+          {
+            "text": "- SeeAlso: This other thing."
+          },
+          {
+            "text": ""
+          },
+          {
+            "text": "- seealso: And this other thing."
           },
           {
             "text": ""


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://55141543

There’s a lot of existing Swift documentation content that uses
the legacy `- seealso:` style aside:

```md
- SeeAlso: This other content.
```

While Swift-DocC has always supported a number of these legacy asides
like:

```md
- Experiment: Lorem ipsum.
- Tip: Lorem ipsum

<!-- etc... -->
```

it doesn’t currently support `SeeAlso` which causes breakage
when migrating existing Swift doc comments over to Swift-DocC.

This resolves the issue.

## Dependencies

- https://github.com/apple/swift-markdown/pull/96

## Testing

Create documentation content with a SeeAlso aside and confirm it renders as expected:

```md
Hi there!

- SeeAlso: <https://swift.org/documentation/docc>
```

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
