### PR TITLE
Support `deviceFrame:` parameter in `@Image` and `@Video` directives

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/Content/RenderContentMetadata.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Content/RenderContentMetadata.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -18,6 +18,8 @@ public struct RenderContentMetadata: Equatable, Codable {
     public var title: String?
     /// An optional custom abstract.
     public var abstract: [RenderInlineContent]?
+    /// An optional identifier for the device frame that should wrap this element.
+    public var deviceFrame: String?
 }
 
 extension RenderContentMetadata {

--- a/Sources/SwiftDocC/Model/Rendering/RenderContentCompiler.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderContentCompiler.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -85,22 +85,24 @@ struct RenderContentCompiler: MarkupVisitor {
         return visitImage(
             source: image.source ?? "",
             altText: image.altText,
-            caption: nil
+            caption: nil,
+            deviceFrame: nil
         )
     }
     
     mutating func visitImage(
         source: String,
         altText: String?,
-        caption: [RenderInlineContent]?
+        caption: [RenderInlineContent]?,
+        deviceFrame: String?
     ) -> [RenderContent] {
         guard let imageIdentifier = resolveImage(source: source, altText: altText) else {
             return []
         }
         
         var metadata: RenderContentMetadata?
-        if let caption = caption {
-            metadata = RenderContentMetadata(abstract: caption)
+        if caption != nil || deviceFrame != nil {
+            metadata = RenderContentMetadata(abstract: caption, deviceFrame: deviceFrame)
         }
         
         return [RenderInlineContent.image(identifier: imageIdentifier, metadata: metadata)]

--- a/Sources/SwiftDocC/Semantics/DirectiveInfrastructure/DirectiveArgumentWrapper.swift
+++ b/Sources/SwiftDocC/Semantics/DirectiveInfrastructure/DirectiveArgumentWrapper.swift
@@ -16,6 +16,7 @@ protocol _DirectiveArgumentProtocol {
     var required: Bool { get }
     var name: _DirectiveArgumentName { get }
     var allowedValues: [String]? { get }
+    var hiddenFromDocumentation: Bool { get }
     
     var parseArgument: (_ bundle: DocumentationBundle, _ argumentValue: String) -> (Any?) { get }
     
@@ -63,6 +64,7 @@ public struct DirectiveArgumentWrapped<Value>: _DirectiveArgumentProtocol {
     let name: _DirectiveArgumentName
     let typeDisplayName: String
     let allowedValues: [String]?
+    let hiddenFromDocumentation: Bool
     
     let parseArgument: (_ bundle: DocumentationBundle, _ argumentValue: String) -> (Any?)
     
@@ -94,7 +96,8 @@ public struct DirectiveArgumentWrapped<Value>: _DirectiveArgumentProtocol {
         name: _DirectiveArgumentName,
         transform: @escaping (_ bundle: DocumentationBundle, _ argumentValue: String) -> (Value?),
         allowedValues: [String]?,
-        required: Bool?
+        required: Bool?,
+        hiddenFromDocumentation: Bool
     ) {
         self.name = name
         self.defaultValue = value
@@ -112,6 +115,7 @@ public struct DirectiveArgumentWrapped<Value>: _DirectiveArgumentProtocol {
         
         self.parseArgument = transform
         self.allowedValues = allowedValues
+        self.hiddenFromDocumentation = hiddenFromDocumentation
     }
     
     @_disfavoredOverload
@@ -120,14 +124,16 @@ public struct DirectiveArgumentWrapped<Value>: _DirectiveArgumentProtocol {
         name: _DirectiveArgumentName = .inferredFromPropertyName,
         parseArgument: @escaping (_ bundle: DocumentationBundle, _ argumentValue: String) -> (Value?),
         allowedValues: [String]? = nil,
-        required: Bool? = nil
+        required: Bool? = nil,
+        hiddenFromDocumentation: Bool = false
     ) {
         self.init(
             value: wrappedValue,
             name: name,
             transform: parseArgument,
             allowedValues: allowedValues,
-            required: required
+            required: required,
+            hiddenFromDocumentation: hiddenFromDocumentation
         )
     }
     
@@ -136,14 +142,16 @@ public struct DirectiveArgumentWrapped<Value>: _DirectiveArgumentProtocol {
         name: _DirectiveArgumentName = .inferredFromPropertyName,
         parseArgument: @escaping (_ bundle: DocumentationBundle, _ argumentValue: String) -> (Value?),
         allowedValues: [String]? = nil,
-        required: Bool? = nil
+        required: Bool? = nil,
+        hiddenFromDocumentation: Bool = false
     ) {
         self.init(
             value: nil,
             name: name,
             transform: parseArgument,
             allowedValues: allowedValues,
-            required: required
+            required: required,
+            hiddenFromDocumentation: hiddenFromDocumentation
         )
     }
     
@@ -159,20 +167,25 @@ public struct DirectiveArgumentWrapped<Value>: _DirectiveArgumentProtocol {
 }
 
 extension DirectiveArgumentWrapped where Value: DirectiveArgumentValueConvertible {
-    init(name: _DirectiveArgumentName = .inferredFromPropertyName) {
-        self.init(value: nil, name: name)
+    init(
+        name: _DirectiveArgumentName = .inferredFromPropertyName,
+        hiddenFromDocumentation: Bool = false
+    ) {
+        self.init(value: nil, name: name, hiddenFromDocumentation: hiddenFromDocumentation)
     }
     
     init(
         wrappedValue: Value,
-        name: _DirectiveArgumentName = .inferredFromPropertyName
+        name: _DirectiveArgumentName = .inferredFromPropertyName,
+        hiddenFromDocumentation: Bool = false
     ) {
-        self.init(value: wrappedValue, name: name)
+        self.init(value: wrappedValue, name: name, hiddenFromDocumentation: hiddenFromDocumentation)
     }
     
     private init(
         value: Value?,
-        name: _DirectiveArgumentName
+        name: _DirectiveArgumentName,
+        hiddenFromDocumentation: Bool
     ) {
         self.name = name
         self.defaultValue = value
@@ -188,6 +201,7 @@ extension DirectiveArgumentWrapped where Value: DirectiveArgumentValueConvertibl
         }
         self.allowedValues = Value.allowedValues()
         self.required = value == nil
+        self.hiddenFromDocumentation = hiddenFromDocumentation
     }
 }
 
@@ -197,7 +211,8 @@ extension DirectiveArgumentWrapped where Value: OptionallyWrappedDirectiveArgume
     init(
         wrappedValue: Value,
         name: _DirectiveArgumentName = .inferredFromPropertyName,
-        required: Bool = false
+        required: Bool = false,
+        hiddenFromDocumentation: Bool = false
     ) {
         let argumentValueType = Value.baseType() as! DirectiveArgumentValueConvertible.Type
         
@@ -214,5 +229,6 @@ extension DirectiveArgumentWrapped where Value: OptionallyWrappedDirectiveArgume
         }
         self.allowedValues = argumentValueType.allowedValues()
         self.required = required
+        self.hiddenFromDocumentation = hiddenFromDocumentation
     }
 }

--- a/Sources/SwiftDocC/Semantics/DirectiveInfrastructure/DirectiveMirror.swift
+++ b/Sources/SwiftDocC/Semantics/DirectiveInfrastructure/DirectiveMirror.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2022-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -155,6 +155,10 @@ extension DirectiveMirror {
             } else {
                 return name
             }
+        }
+        
+        var hiddenFromDocumentation: Bool {
+            return argument.hiddenFromDocumentation
         }
         
         let name: String

--- a/Sources/SwiftDocC/Semantics/Media/ImageMedia.swift
+++ b/Sources/SwiftDocC/Semantics/Media/ImageMedia.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -28,6 +28,14 @@ public final class ImageMedia: Semantic, Media, AutomaticDirectiveConvertible {
     @DirectiveArgumentWrapped(name: .custom("alt"))
     public private(set) var altText: String? = nil
     
+    
+    /// The name of a device frame that should wrap this image.
+    ///
+    /// This is an experimental feature – any device frame specified here
+    /// must be defined in the `theme-settings.json` file of the containing DocC catalog.
+    @DirectiveArgumentWrapped(hiddenFromDocumentation: true)
+    public private(set) var deviceFrame: String? = nil
+    
     /// An optional caption that should be rendered alongside the image.
     @ChildMarkup(numberOfParagraphs: .zeroOrOne)
     public private(set) var caption: MarkupContainer
@@ -36,6 +44,7 @@ public final class ImageMedia: Semantic, Media, AutomaticDirectiveConvertible {
         "altText" : \ImageMedia._altText,
         "source"  : \ImageMedia._source,
         "caption" : \ImageMedia._caption,
+        "deviceFrame" : \ImageMedia._deviceFrame,
     ]
     
     /// Creates a new image with the given parameters.
@@ -74,7 +83,8 @@ extension ImageMedia: RenderableDirectiveConvertible {
         guard let renderedImage = contentCompiler.visitImage(
             source: source.path,
             altText: altText,
-            caption: renderedCaption
+            caption: renderedCaption,
+            deviceFrame: deviceFrame
         ).first as? RenderInlineContent else {
             return []
         }

--- a/Sources/SwiftDocC/Semantics/Media/ImageMedia.swift
+++ b/Sources/SwiftDocC/Semantics/Media/ImageMedia.swift
@@ -60,6 +60,23 @@ public final class ImageMedia: Semantic, Media, AutomaticDirectiveConvertible {
         self.source = source
     }
     
+    func validate(source: URL?, for bundle: DocumentationBundle, in context: DocumentationContext, problems: inout [Problem]) -> Bool {
+        if !FeatureFlags.current.isExperimentalDeviceFrameSupportEnabled && deviceFrame != nil {
+            let diagnostic = Diagnostic(
+                source: source,
+                severity: .warning, range: originalMarkup.range,
+                identifier: "org.swift.docc.UnknownArgument",
+                summary: "Unknown argument 'deviceFrame' in \(Self.directiveName)."
+            )
+            
+            problems.append(.init(diagnostic: diagnostic))
+            
+            deviceFrame = nil
+        }
+        
+        return true
+    }
+    
     @available(*, deprecated, message: "Do not call directly. Required for 'AutomaticDirectiveConvertible'.")
     init(originalMarkup: BlockDirective) {
         self.originalMarkup = originalMarkup

--- a/Sources/SwiftDocC/Semantics/Media/VideoMedia.swift
+++ b/Sources/SwiftDocC/Semantics/Media/VideoMedia.swift
@@ -62,6 +62,23 @@ public final class VideoMedia: Semantic, Media, AutomaticDirectiveConvertible {
         self.source = source
     }
     
+    func validate(source: URL?, for bundle: DocumentationBundle, in context: DocumentationContext, problems: inout [Problem]) -> Bool {
+        if !FeatureFlags.current.isExperimentalDeviceFrameSupportEnabled && deviceFrame != nil {
+            let diagnostic = Diagnostic(
+                source: source,
+                severity: .warning, range: originalMarkup.range,
+                identifier: "org.swift.docc.UnknownArgument",
+                summary: "Unknown argument 'deviceFrame' in \(Self.directiveName)."
+            )
+            
+            problems.append(.init(diagnostic: diagnostic))
+            
+            deviceFrame = nil
+        }
+        
+        return true
+    }
+    
     @available(*, deprecated, message: "Do not call directly. Required for 'AutomaticDirectiveConvertible'.")
     init(originalMarkup: BlockDirective) {
         self.originalMarkup = originalMarkup

--- a/Sources/SwiftDocC/Semantics/Media/VideoMedia.swift
+++ b/Sources/SwiftDocC/Semantics/Media/VideoMedia.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -28,6 +28,13 @@ public final class VideoMedia: Semantic, Media, AutomaticDirectiveConvertible {
     @DirectiveArgumentWrapped(name: .custom("alt"))
     public private(set) var altText: String? = nil
     
+    /// The name of a device frame that should wrap this video.
+    ///
+    /// This is an experimental feature – any device frame specified here
+    /// must be defined in the `theme-settings.json` file of the containing DocC catalog.
+    @DirectiveArgumentWrapped(hiddenFromDocumentation: true)
+    public private(set) var deviceFrame: String? = nil
+    
     /// An optional caption that should be rendered alongside the video.
     @ChildMarkup(numberOfParagraphs: .zeroOrOne)
     public private(set) var caption: MarkupContainer
@@ -45,6 +52,7 @@ public final class VideoMedia: Semantic, Media, AutomaticDirectiveConvertible {
         "poster"    : \VideoMedia._poster,
         "caption"   : \VideoMedia._caption,
         "altText"   : \VideoMedia._altText,
+        "deviceFrame" : \VideoMedia._deviceFrame,
     ]
     
     init(originalMarkup: BlockDirective, source: ResourceReference, poster: ResourceReference?) {
@@ -97,8 +105,8 @@ extension VideoMedia: RenderableDirectiveConvertible {
         )
         
         var metadata: RenderContentMetadata?
-        if let renderedCaption = renderedCaption {
-            metadata = RenderContentMetadata(abstract: renderedCaption)
+        if renderedCaption != nil || deviceFrame != nil {
+            metadata = RenderContentMetadata(abstract: renderedCaption, deviceFrame: deviceFrame)
         }
         
         let video = RenderBlockContent.Video(

--- a/Sources/SwiftDocC/SwiftDocC.docc/Resources/LinkableEntities.json
+++ b/Sources/SwiftDocC/SwiftDocC.docc/Resources/LinkableEntities.json
@@ -541,6 +541,9 @@
                         "items": {
                             "$ref": "#/components/schemas/RenderInlineContent"
                         }
+                    },
+                    "deviceFrame": {
+                        "type": "string"
                     }
                 }
             }

--- a/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderNode.spec.json
+++ b/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderNode.spec.json
@@ -492,6 +492,9 @@
                         "items": {
                             "$ref": "#/components/schemas/RenderInlineContent"
                         }
+                    },
+                    "deviceFrame": {
+                        "type": "string"
                     }
                 }
             },

--- a/Sources/SwiftDocC/SwiftDocC.docc/Resources/ThemeSettings.spec.json
+++ b/Sources/SwiftDocC/SwiftDocC.docc/Resources/ThemeSettings.spec.json
@@ -810,6 +810,15 @@
                                         "description": "The CSS font-family value to be used for monospaced code-voice text in documentation."
                                     }
                                 }
+                            },
+                            "device-frames": {
+                                "type": "object",
+                                "description": "Adds new DeviceFrames. The keys are used as names for the frames.",
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/DeviceFrameAttributes"
+                                    }
+                                ]
                             }
                         }
                     },
@@ -902,6 +911,36 @@
                 "type": "string",
                 "description": "An absolute URL or relative path.",
                 "format": "uri"
+            },
+            "DeviceFrameAttributes": {
+                "type": "object",
+                "description": "A definition for a device frame",
+                "properties": {
+                    "screenTop": {
+                        "type": "number"
+                    },
+                    "screenWidth": {
+                        "type": "number"
+                    },
+                    "screenHeight": {
+                        "type": "number"
+                    },
+                    "screenLeft": {
+                        "type": "number"
+                    },
+                    "frameWidth": {
+                        "type": "number"
+                    },
+                    "frameHeight": {
+                        "type": "number"
+                    },
+                    "lightUrl": {
+                        "$ref": "#/components/schemas/URL"
+                    },
+                    "darkUrl": {
+                        "$ref": "#/components/schemas/URL"
+                    }
+                }
             }
         },
         "requestBodies": {},

--- a/Sources/SwiftDocC/Utility/FeatureFlags.swift
+++ b/Sources/SwiftDocC/Utility/FeatureFlags.swift
@@ -28,6 +28,9 @@ public struct FeatureFlags: Codable {
     @available(*, deprecated, message: "Render Index JSON is now emitted by default.")
     public var isExperimentalJSONIndexEnabled = true
     
+    /// Whether or not experimental support for device frames on images and video is enabled.
+    public var isExperimentalDeviceFrameSupportEnabled = false
+    
     /// Creates a set of feature flags with the given values.
     ///
     /// - Parameters:

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/ActionExtensions/ConvertAction+CommandInitialization.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/ActionExtensions/ConvertAction+CommandInitialization.swift
@@ -20,6 +20,8 @@ extension ConvertAction {
         var standardError = LogHandle.standardError
         let outOfProcessResolver: OutOfProcessReferenceResolver?
         
+        FeatureFlags.current.isExperimentalDeviceFrameSupportEnabled = convert.enableExperimentalDeviceFrameSupport
+        
         // If the user-provided a URL for an external link resolver, attempt to
         // initialize an `OutOfProcessReferenceResolver` with the provided URL.
         if let linkResolverURL = convert.outOfProcessLinkResolverOption.linkResolverExecutableURL {

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Convert.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Convert.swift
@@ -131,6 +131,11 @@ extension Docc {
         @Flag(help: .hidden)
         @available(*, deprecated, message: "Render Index JSON is now emitted by default.")
         public var enableExperimentalJSONIndex = false
+        
+        /// A user-provided value that is true if the user enables experimental support for
+        /// device frames.
+        @Flag(help: .hidden)
+        public var enableExperimentalDeviceFrameSupport = false
 
         /// A user-provided value that is true if experimental documentation inheritance is to be enabled.
         ///

--- a/Sources/generate-symbol-graph/main.swift
+++ b/Sources/generate-symbol-graph/main.swift
@@ -26,6 +26,12 @@ struct Directive {
     }
 }
 
+extension DirectiveMirror.ReflectedDirective {
+    var documentableArguments: [DirectiveMirror.ReflectedArgument] {
+        arguments.filter { !$0.hiddenFromDocumentation }
+    }
+}
+
 func directiveUSR(_ directiveName: String) -> String {
     "__docc_universal_symbol_reference_$\(directiveName)"
 }
@@ -129,7 +135,7 @@ let supportedDirectives: [Directive] = [
     .map { directive in
         return Directive(
             name: directive.name,
-            acceptsArguments: !directive.arguments.isEmpty,
+            acceptsArguments: !directive.documentableArguments.isEmpty,
             isLeaf: !directive.allowsMarkup && directive.childDirectives.isEmpty
         )
     }
@@ -214,7 +220,7 @@ func extractDocumentationCommentsForDirectives() throws -> [String : SymbolGraph
         
         var parametersDocumentation = [SymbolGraph.LineList.Line]()
         var createdParametersSection = false
-        for argument in indexedDirective.arguments {
+        for argument in indexedDirective.documentableArguments {
             let argumentDisplayName: String
             if argument.name.isEmpty {
                 argumentDisplayName = argument.propertyLabel
@@ -405,11 +411,11 @@ func declarationFragments(
         ]
     )
     
-    if !directive.arguments.isEmpty {
+    if !directive.documentableArguments.isEmpty {
         fragments.append("(")
     }
     
-    for (index, argument) in directive.arguments.enumerated() {
+    for (index, argument) in directive.documentableArguments.enumerated() {
         if argument.labelDisplayName.hasPrefix("_ ") {
             fragments.append("_ ")
             let adjustedLabel = argument.labelDisplayName.trimmingCharacters(in: CharacterSet(charactersIn: " _"))
@@ -439,7 +445,7 @@ func declarationFragments(
             fragments.append(.init(argument.typeDisplayName, kind: .typeIdentifier))
         }
         
-        if index < directive.arguments.count - 1 {
+        if index < directive.documentableArguments.count - 1 {
             fragments.append(", ")
         } else {
             fragments.append(")")

--- a/Tests/SwiftDocCTests/Semantics/ImageMediaTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/ImageMediaTests.swift
@@ -159,7 +159,33 @@ class ImageMediaTests: XCTestCase {
         )
     }
     
+    func testImageDirectiveDiagnosesDeviceFrameByDefault() throws {
+        let (renderedContent, problems, image) = try parseDirective(ImageMedia.self, in: "BookLikeContent") {
+            """
+            @Image(source: "figure1", deviceFrame: phone)
+            """
+        }
+        
+        XCTAssertNotNil(image)
+        
+        XCTAssertEqual(problems, ["1: warning – org.swift.docc.UnknownArgument"])
+        
+        XCTAssertEqual(
+            renderedContent,
+            [
+                RenderBlockContent.paragraph(RenderBlockContent.Paragraph(
+                    inlineContent: [.image(
+                        identifier: RenderReferenceIdentifier("figure1"),
+                        metadata: nil
+                    )]
+                ))
+            ]
+        )
+    }
+    
     func testRenderImageDirectiveWithDeviceFrame() throws {
+        enableFeatureFlag(\.isExperimentalDeviceFrameSupportEnabled)
+        
         let (renderedContent, problems, image) = try parseDirective(ImageMedia.self, in: "BookLikeContent") {
             """
             @Image(source: "figure1", deviceFrame: phone)
@@ -184,6 +210,8 @@ class ImageMediaTests: XCTestCase {
     }
     
     func testRenderImageDirectiveWithDeviceFrameAndCaption() throws {
+        enableFeatureFlag(\.isExperimentalDeviceFrameSupportEnabled)
+        
         let (renderedContent, problems, image) = try parseDirective(ImageMedia.self, in: "BookLikeContent") {
             """
             @Image(source: "figure1", deviceFrame: laptop) {

--- a/Tests/SwiftDocCTests/Semantics/ImageMediaTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/ImageMediaTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -153,6 +153,56 @@ class ImageMediaTests: XCTestCase {
                     inlineContent: [.image(
                         identifier: RenderReferenceIdentifier("figure1"),
                         metadata: RenderContentMetadata(abstract: [.text("This is my caption.")])
+                    )]
+                ))
+            ]
+        )
+    }
+    
+    func testRenderImageDirectiveWithDeviceFrame() throws {
+        let (renderedContent, problems, image) = try parseDirective(ImageMedia.self, in: "BookLikeContent") {
+            """
+            @Image(source: "figure1", deviceFrame: phone)
+            """
+        }
+        
+        XCTAssertNotNil(image)
+        
+        XCTAssertEqual(problems, [])
+        
+        XCTAssertEqual(
+            renderedContent,
+            [
+                RenderBlockContent.paragraph(RenderBlockContent.Paragraph(
+                    inlineContent: [.image(
+                        identifier: RenderReferenceIdentifier("figure1"),
+                        metadata: RenderContentMetadata(deviceFrame: "phone")
+                    )]
+                ))
+            ]
+        )
+    }
+    
+    func testRenderImageDirectiveWithDeviceFrameAndCaption() throws {
+        let (renderedContent, problems, image) = try parseDirective(ImageMedia.self, in: "BookLikeContent") {
+            """
+            @Image(source: "figure1", deviceFrame: laptop) {
+                This is my caption.
+            }
+            """
+        }
+        
+        XCTAssertNotNil(image)
+        
+        XCTAssertEqual(problems, [])
+        
+        XCTAssertEqual(
+            renderedContent,
+            [
+                RenderBlockContent.paragraph(RenderBlockContent.Paragraph(
+                    inlineContent: [.image(
+                        identifier: RenderReferenceIdentifier("figure1"),
+                        metadata: RenderContentMetadata(abstract: [.text("This is my caption.")], deviceFrame: "laptop")
                     )]
                 ))
             ]

--- a/Tests/SwiftDocCTests/Semantics/VideoMediaTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/VideoMediaTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -196,6 +196,60 @@ class VideoMediaTests: XCTestCase {
                 RenderBlockContent.video(RenderBlockContent.Video(
                     identifier: RenderReferenceIdentifier("introvideo"),
                     metadata: RenderContentMetadata(abstract: [.text("This is my caption.")])
+                ))
+            ]
+        )
+        
+        XCTAssertEqual(references.count, 2)
+        
+        let videoReference = try XCTUnwrap(references["introvideo"] as? VideoReference)
+        XCTAssertEqual(videoReference.poster, RenderReferenceIdentifier("introposter"))
+        XCTAssertEqual(videoReference.altText, "An introductory video")
+        
+        XCTAssertTrue(references.keys.contains("introposter"))
+    }
+    
+    func testRenderVideoDirectiveWithDeviceFrame() throws {
+        let (renderedContent, problems, video) = try parseDirective(VideoMedia.self, in: "TestBundle") {
+            """
+            @Video(source: "introvideo", deviceFrame: watch)
+            """
+        }
+        
+        XCTAssertNotNil(video)
+        
+        XCTAssertEqual(problems, [])
+        
+        XCTAssertEqual(
+            renderedContent,
+            [
+                RenderBlockContent.video(RenderBlockContent.Video(
+                    identifier: RenderReferenceIdentifier("introvideo"),
+                    metadata: RenderContentMetadata(deviceFrame: "watch")
+                ))
+            ]
+        )
+    }
+    
+    func testRenderVideoDirectiveWithCaptionAndDeviceFrame() throws {
+        let (renderedContent, problems, video, references) = try parseDirective(VideoMedia.self, in: "TestBundle") {
+            """
+            @Video(source: "introvideo", alt: "An introductory video", poster: "introposter", deviceFrame: laptop) {
+                This is my caption.
+            }
+            """
+        }
+        
+        XCTAssertNotNil(video)
+        
+        XCTAssertEqual(problems, [])
+        
+        XCTAssertEqual(
+            renderedContent,
+            [
+                RenderBlockContent.video(RenderBlockContent.Video(
+                    identifier: RenderReferenceIdentifier("introvideo"),
+                    metadata: RenderContentMetadata(abstract: [.text("This is my caption.")], deviceFrame: "laptop")
                 ))
             ]
         )

--- a/Tests/SwiftDocCTests/Semantics/VideoMediaTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/VideoMediaTests.swift
@@ -209,7 +209,31 @@ class VideoMediaTests: XCTestCase {
         XCTAssertTrue(references.keys.contains("introposter"))
     }
     
+    func testVideoMediaDiagnosesDeviceFrameByDefault() throws {
+        let (renderedContent, problems, video) = try parseDirective(VideoMedia.self, in: "TestBundle") {
+            """
+            @Video(source: "introvideo", deviceFrame: watch)
+            """
+        }
+        
+        XCTAssertNotNil(video)
+        
+        XCTAssertEqual(problems, ["1: warning – org.swift.docc.UnknownArgument"])
+        
+        XCTAssertEqual(
+            renderedContent,
+            [
+                RenderBlockContent.video(RenderBlockContent.Video(
+                    identifier: RenderReferenceIdentifier("introvideo"),
+                    metadata: nil
+                ))
+            ]
+        )
+    }
+    
     func testRenderVideoDirectiveWithDeviceFrame() throws {
+        enableFeatureFlag(\.isExperimentalDeviceFrameSupportEnabled)
+        
         let (renderedContent, problems, video) = try parseDirective(VideoMedia.self, in: "TestBundle") {
             """
             @Video(source: "introvideo", deviceFrame: watch)
@@ -232,6 +256,8 @@ class VideoMediaTests: XCTestCase {
     }
     
     func testRenderVideoDirectiveWithCaptionAndDeviceFrame() throws {
+        enableFeatureFlag(\.isExperimentalDeviceFrameSupportEnabled)
+        
         let (renderedContent, problems, video, references) = try parseDirective(VideoMedia.self, in: "TestBundle") {
             """
             @Video(source: "introvideo", alt: "An introductory video", poster: "introposter", deviceFrame: laptop) {

--- a/Tests/SwiftDocCUtilitiesTests/ArgumentParsing/ConvertSubcommandTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ArgumentParsing/ConvertSubcommandTests.swift
@@ -370,6 +370,27 @@ class ConvertSubcommandTests: XCTestCase {
         XCTAssertTrue(actionWithFlag.experimentalEnableCustomTemplates)
     }
     
+    func testExperimentalEnableDeviceFrameSupportFlag() throws {
+        let originalFeatureFlagsState = FeatureFlags.current
+        
+        defer {
+            FeatureFlags.current = originalFeatureFlagsState
+        }
+        
+        let commandWithoutFlag = try Docc.Convert.parse([testBundleURL.path])
+        let actionWithoutFlag = try ConvertAction(fromConvertCommand: commandWithoutFlag)
+        XCTAssertFalse(commandWithoutFlag.enableExperimentalDeviceFrameSupport)
+        XCTAssertFalse(FeatureFlags.current.isExperimentalDeviceFrameSupportEnabled)
+
+        let commandWithFlag = try Docc.Convert.parse([
+            "--enable-experimental-device-frame-support",
+            testBundleURL.path,
+        ])
+        let actionWithFlag = try ConvertAction(fromConvertCommand: commandWithFlag)
+        XCTAssertTrue(commandWithFlag.enableExperimentalDeviceFrameSupport)
+        XCTAssertTrue(FeatureFlags.current.isExperimentalDeviceFrameSupportEnabled)
+    }
+    
     func testTransformForStaticHostingFlagWithoutHTMLTemplate() throws {
         unsetenv(TemplateOption.environmentVariableKey)
         


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://102183073

## Summary

When developing UI libraries or apps,
it can be useful to show previews of how things look
when rendered on a device, like a phone or a tablet.
This new experimental feature is designed to allow authors to wrap
images and videos in a frame, making it easier to create complex assets
and maintain them overtime.

Both `@Image` and `@Video` gain a `deviceFrame` parameter that
associates them with a device frame defined in the DocC catalog’s
`theme-settings.json` file.

This change is described on the Swift forums here:
https://forums.swift.org/t/support-for-device-frames/62151

## Dependencies

DocC-Render PR TBD

## Testing

### Test that `deviceFrame` works as expected

1. Add an `@Image` or `@Video` directive to a DocC article:

    ```md
    # My Great Article
    
    This is a great one!
    
    With a lot of great content.
    
    @Image(source: "sloth", deviceFrame: phone)
    ```

2. Confirm that the emitted RenderJSON references the `"phone"` device frame

### Test that `deviceFrame` is excluded from documentation

This is an experimental feature that shouldn't be advertised in documentation yet.

1. `swift run generate-symbol-graph`
2. `bin/preview-docs DocC`
3. <http://localhost:8080/documentation/docc/image>
4. Confirm that `@Image` and `@Video` declarations don't include `deviceFrame`:

    <img width="837" alt="Screenshot 2023-01-11 at 1 57 54 PM" src="https://user-images.githubusercontent.com/6750147/211926582-8dab11d3-b70d-4628-8d22-3fe40972e1c2.png">



## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
