### PR TITLE
allow arbitrary platform strings in the `@Available` directive

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/Symbol/AvailabilitySortOrder.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Symbol/AvailabilitySortOrder.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -23,6 +23,10 @@ enum AvailabilityRenderOrder {
     /// Sort two availability render items based on their platform name.
     static func compare(lhs: AvailabilityRenderItem, rhs: AvailabilityRenderItem) -> Bool {
         guard let lhsName = lhs.name, let rhsName = rhs.name else { return false }
-        return platformsOrder[lhsName, default: Int.max] < platformsOrder[rhsName, default: Int.max]
+        if platformsOrder.keys.contains(lhsName) || platformsOrder.keys.contains(rhsName) {
+            return platformsOrder[lhsName, default: Int.max] < platformsOrder[rhsName, default: Int.max]
+        } else {
+            return lhsName < rhsName
+        }
     }
 }

--- a/Sources/SwiftDocC/Semantics/Symbol/PlatformName.swift
+++ b/Sources/SwiftDocC/Semantics/Symbol/PlatformName.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -109,6 +109,11 @@ public struct PlatformName: Codable, Hashable, Equatable {
         // Note: This is still an optional initializer to prevent source breakage when
         // `Availability.Platform` re-introduces the `.any` case
         // cf. https://github.com/apple/swift-docc/issues/441
-        self = .init(operatingSystemName: platform.rawValue)
+        if let knowDomain = Self.platformNamesIndex[platform.rawValue.lowercased()] {
+            self = knowDomain
+        } else {
+            let identifier = platform.rawValue.lowercased().replacingOccurrences(of: " ", with: "")
+            self.init(rawValue: identifier, displayName: platform.rawValue)
+        }
     }
 }

--- a/Tests/SwiftDocCTests/Rendering/PlatformAvailabilityTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/PlatformAvailabilityTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -104,6 +104,32 @@ class PlatformAvailabilityTests: XCTestCase {
         }))
         XCTAssert(availability.contains(where: { item in
             item.name == "watchOS" && item.introduced == "7.0"
+        }))
+    }
+
+    func testArbitraryPlatformAvailability() throws {
+        let (bundle, context) = try testBundleAndContext(named: "AvailabilityBundle")
+        let reference = ResolvedTopicReference(
+            bundleIdentifier: bundle.identifier,
+            path: "/documentation/AvailabilityBundle/ArbitraryPlatforms",
+            sourceLanguage: .swift
+        )
+        let article = try XCTUnwrap(context.entity(with: reference).semantic as? Article)
+        var translator = RenderNodeTranslator(
+            context: context,
+            bundle: bundle,
+            identifier: reference,
+            source: nil
+        )
+        let renderNode = try XCTUnwrap(translator.visitArticle(article) as? RenderNode)
+        let availability = try XCTUnwrap(renderNode.metadata.platformsVariants.defaultValue)
+        XCTAssertEqual(availability.count, 2)
+
+        XCTAssert(availability.contains(where: { item in
+            item.name == "SomePackage" && item.introduced == "1.0"
+        }))
+        XCTAssert(availability.contains(where: { item in
+            item.name == "My Package" && item.introduced == "2.0"
         }))
     }
 }

--- a/Tests/SwiftDocCTests/Semantics/MetadataAvailabilityTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/MetadataAvailabilityTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2022-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -49,7 +49,7 @@ class MetadataAvailabilityTests: XCTestCase {
             }
         }
 
-        for platform in Metadata.Availability.Platform.allCases {
+        for platform in Metadata.Availability.Platform.defaultCases {
             let source = """
             @Metadata {
                 @Available(\(platform.rawValue), introduced: \"1.0\")
@@ -74,12 +74,20 @@ class MetadataAvailabilityTests: XCTestCase {
             validArgumentsWithVersion.append("introduced: \"1.0\", \(arg)")
         }
 
-        for platform in Metadata.Availability.Platform.allCases {
+        var checkPlatforms = Metadata.Availability.Platform.defaultCases.map({ $0.rawValue })
+        checkPlatforms.append("Package")
+
+        for platform in checkPlatforms {
             // FIXME: Test validArguments with the `*` platform once that's introduced
             // cf. https://github.com/apple/swift-docc/issues/441
             for args in validArgumentsWithVersion {
-                try assertValidAvailability(source: "@Available(\(platform.rawValue), \(args))")
+                try assertValidAvailability(source: "@Available(\(platform), \(args))")
             }
+        }
+
+        // also check a platform with spaces in the name
+        for args in validArgumentsWithVersion {
+            try assertValidAvailability(source: "@Available(\"My Package\", \(args))")
         }
 
         // also test for giving no platform

--- a/Tests/SwiftDocCTests/Test Bundles/AvailabilityBundle.docc/ArbitraryPlatforms.md
+++ b/Tests/SwiftDocCTests/Test Bundles/AvailabilityBundle.docc/ArbitraryPlatforms.md
@@ -1,0 +1,10 @@
+# Arbitrary Platforms
+
+@Metadata {
+    @Available(SomePackage, introduced: "1.0")
+    @Available("My Package", introduced: "2.0")
+}
+
+This page applies to platforms that aren't even operating systems!
+
+<!-- Copyright (c) 2023 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Tests/SwiftDocCTests/Test Bundles/AvailabilityBundle.docc/AvailableArticle.md
+++ b/Tests/SwiftDocCTests/Test Bundles/AvailabilityBundle.docc/AvailableArticle.md
@@ -12,5 +12,6 @@ Here's a cool framework that I'm offering to the world.
 ### Cool Articles
 
 - <doc:ComplexAvailable>
+- <doc:ArbitraryPlatforms>
 
-<!-- Copyright (c) 2022 Apple Inc and the Swift Project authors. All Rights Reserved. -->
+<!-- Copyright (c) 2022-2023 Apple Inc and the Swift Project authors. All Rights Reserved. -->


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://104224866

## Summary

In https://github.com/apple/swift-docc/pull/440, the `@Available` directive was limited to four platforms: `iOS`, `macOS`, `watchOS`, `tvOS`. This PR opens up that directive to take arbitrary platform strings, which will be passed along to the rendered page.

## Dependencies

None

## Testing

Use the following metadata for testing:

```markdown
@Metadata {
    @Available("Swift DocC", introduced: "1.0")
}
```

Steps:
1. Add the above metadata to `Sources/SwiftDocC/SwiftDocC.docc/SwiftDocC/Directives.md`.
2. `bin/preview-docs`
3. Ensure that the "Directives" page is printed with an availability callout for "Swift DocC" (with the space - i'm specifically testing platforms with spaces here):

<img width="698" alt="image" src="https://user-images.githubusercontent.com/5217170/212437448-6af0bda9-e94c-4305-bc0e-9d77a8345f73.png">

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
