### PR TITLE
[5.8] Update option directive naming

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Topic Graph/AutomaticCuration.swift
+++ b/Sources/SwiftDocC/Infrastructure/Topic Graph/AutomaticCuration.swift
@@ -123,12 +123,9 @@ public struct AutomaticCuration {
         renderContext: RenderContext?,
         renderer: DocumentationContentRenderer
     ) throws -> TaskGroup? {
-        if let automaticSeeAlsoOption = node.options?.automaticSeeAlsoBehavior
-            ?? context.options?.automaticSeeAlsoBehavior
+        if (node.options?.automaticSeeAlsoEnabled ?? context.options?.automaticSeeAlsoEnabled) == false
         {
-            guard automaticSeeAlsoOption == .siblingPages else {
-                return nil
-            }
+            return nil
         }
         
         // First try getting the canonical path from a render context, default to the documentation context

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -1112,27 +1112,15 @@ public struct RenderNodeTranslator: SemanticVisitor {
     }
     
     private func shouldCreateAutomaticRoleHeading(for node: DocumentationNode) -> Bool {
-        var shouldCreateAutomaticRoleHeading = true
-        if let automaticTitleHeadingOption = node.options?.automaticTitleHeadingBehavior
-            ?? context.options?.automaticTitleHeadingBehavior
-        {
-            shouldCreateAutomaticRoleHeading = automaticTitleHeadingOption == .pageKind
-        }
-        
-        return shouldCreateAutomaticRoleHeading
+        return node.options?.automaticTitleHeadingEnabled
+            ?? context.options?.automaticTitleHeadingEnabled
+            ?? true
     }
     
     private func shouldCreateAutomaticArticleSubheading(for node: DocumentationNode) -> Bool {
-        let shouldCreateAutomaticArticleSubheading: Bool
-        if let automaticSubheadingOption = node.options?.automaticArticleSubheadingBehavior
-            ?? context.options?.automaticArticleSubheadingBehavior
-        {
-            shouldCreateAutomaticArticleSubheading = !(automaticSubheadingOption == .disabled)
-        } else {
-            shouldCreateAutomaticArticleSubheading = true
-        }
-        
-        return shouldCreateAutomaticArticleSubheading
+        return node.options?.automaticArticleSubheadingEnabled
+            ?? context.options?.automaticArticleSubheadingEnabled
+            ?? true
     }
     
     private func topicsSectionStyle(for node: DocumentationNode) -> RenderNode.TopicsSectionStyle {

--- a/Sources/SwiftDocC/Semantics/Options/AutomaticArticleSubheading.swift
+++ b/Sources/SwiftDocC/Semantics/Options/AutomaticArticleSubheading.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2022-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -19,22 +19,29 @@ import Markdown
 public class AutomaticArticleSubheading: Semantic, AutomaticDirectiveConvertible {
     public let originalMarkup: BlockDirective
     
-    /// The specified behavior for automatic subheading generation.
-    @DirectiveArgumentWrapped(name: .unnamed)
-    public private(set) var behavior: Behavior
+    // This property exist so that the generated directive documentation makes it
+    // clear that "enabled" and "disabled" are then two possible values.
     
-    /// A behavior for automatic subheading generation.
-    public enum Behavior: String, CaseIterable, DirectiveArgumentValueConvertible {
-        /// No subheading should be created for the article.
-        case disabled
-        
-        /// An overview subheading should be created containing the article's
-        /// first paragraph of content.
+    /// Whether or not DocC generates automatic second-level "Overview" subheadings.
+    @DirectiveArgumentWrapped(name: .unnamed)
+    public private(set) var enabledness: Enabledness
+    
+    /// A value that represent whether automatic subheading generation is enabled or disabled.
+    public enum Enabledness: String, CaseIterable, DirectiveArgumentValueConvertible {
+        /// An overview subheading should be automatically created for the article (the default).
         case enabled
+        
+        /// No automatic overview subheading should be created for the article.
+        case disabled
+    }
+    
+    /// Whether or not DocC generates automatic second-level "Overview" subheadings.
+    public var enabled: Bool {
+        return enabledness == .enabled
     }
     
     static var keyPaths: [String : AnyKeyPath] = [
-        "behavior"  : \AutomaticArticleSubheading._behavior,
+        "enabledness"  : \AutomaticArticleSubheading._enabledness,
     ]
     
     @available(*, deprecated, message: "Do not call directly. Required for 'AutomaticDirectiveConvertible'.")

--- a/Sources/SwiftDocC/Semantics/Options/AutomaticSeeAlso.swift
+++ b/Sources/SwiftDocC/Semantics/Options/AutomaticSeeAlso.swift
@@ -16,21 +16,29 @@ import Markdown
 public class AutomaticSeeAlso: Semantic, AutomaticDirectiveConvertible {
     public let originalMarkup: BlockDirective
     
-    /// The specified behavior for automatic See Also section generation.
-    @DirectiveArgumentWrapped(name: .unnamed)
-    public private(set) var behavior: Behavior
+    // This property exist so that the generated directive documentation makes it
+    // clear that "enabled" and "disabled" are then two possible values.
     
-    /// A behavior for automatic See Also section generation.
-    public enum Behavior: String, CaseIterable, DirectiveArgumentValueConvertible {
-        /// A See Also section will not be automatically created.
-        case disabled
+    /// Whether or not DocC generates automatic See Also sections.
+    @DirectiveArgumentWrapped(name: .unnamed)
+    public private(set) var enabledness: Enabledness
+    
+    /// A value that represent whether automatic See Also section generation is enabled or disabled.
+    public enum Enabledness: String, CaseIterable, DirectiveArgumentValueConvertible {
+        /// A See Also section should be automatically created (the default).
+        case enabled
         
-        /// A See Also section will be automatically created based on the page's siblings.
-        case siblingPages
+        /// No automatic See Also section should be created.
+        case disabled
+    }
+    
+    /// Whether or not DocC generates automatic See Also sections.
+    public var enabled: Bool {
+        return enabledness == .enabled
     }
     
     static var keyPaths: [String : AnyKeyPath] = [
-        "behavior"  : \AutomaticSeeAlso._behavior,
+        "enabledness"  : \AutomaticSeeAlso._enabledness,
     ]
     
     @available(*, deprecated, message: "Do not call directly. Required for 'AutomaticDirectiveConvertible'.")

--- a/Sources/SwiftDocC/Semantics/Options/AutomaticTitleHeading.swift
+++ b/Sources/SwiftDocC/Semantics/Options/AutomaticTitleHeading.swift
@@ -18,21 +18,29 @@ import Markdown
 public class AutomaticTitleHeading: Semantic, AutomaticDirectiveConvertible {
     public let originalMarkup: BlockDirective
     
-    /// The specified behavior for automatic title heading generation.
-    @DirectiveArgumentWrapped(name: .unnamed)
-    public private(set) var behavior: Behavior
+    // This property exist so that the generated directive documentation makes it
+    // clear that "enabled" and "disabled" are then two possible values.
     
-    /// A behavior for automatic title heading generation.
-    public enum Behavior: String, CaseIterable, DirectiveArgumentValueConvertible {
-        /// No title heading should be created for the page.
-        case disabled
+    /// Whether or not DocC generates automatic title headings.
+    @DirectiveArgumentWrapped(name: .unnamed)
+    public private(set) var enabledness: Enabledness
+    
+    /// A value that represent whether automatic title heading generation is enabled or disabled.
+    public enum Enabledness: String, CaseIterable, DirectiveArgumentValueConvertible {
+        /// A title heading should be automatically created for the page (the default).
+        case enabled
         
-        /// A title heading based on the page's kind should be automatically created.
-        case pageKind
+        /// No automatic title heading should be created for the page.
+        case disabled
+    }
+    
+    /// Whether or not DocC generates automatic title headings.
+    public var enabled: Bool {
+        return enabledness == .enabled
     }
     
     static var keyPaths: [String : AnyKeyPath] = [
-        "behavior"  : \AutomaticTitleHeading._behavior,
+        "enabledness"  : \AutomaticTitleHeading._enabledness,
     ]
     
     @available(*, deprecated, message: "Do not call directly. Required for 'AutomaticDirectiveConvertible'.")

--- a/Sources/SwiftDocC/Semantics/Options/Options.swift
+++ b/Sources/SwiftDocC/Semantics/Options/Options.swift
@@ -44,19 +44,19 @@ public class Options: Semantic, AutomaticDirectiveConvertible {
     @ChildDirective
     public private(set) var _topicsVisualStyle: TopicsVisualStyle? = nil
     
-    /// If given, the authored behavior for automatic See Also section generation.
-    public var automaticSeeAlsoBehavior: AutomaticSeeAlso.Behavior? {
-        return _automaticSeeAlso?.behavior
+    /// If given, whether or not automatic See Also section generation is enabled.
+    public var automaticSeeAlsoEnabled: Bool? {
+        return _automaticSeeAlso?.enabled
     }
     
-    /// If given, the authored behavior for automatic Title Heading generation.
-    public var automaticTitleHeadingBehavior: AutomaticTitleHeading.Behavior? {
-        return _automaticTitleHeading?.behavior
+    /// If given, whether or not automatic Title Heading generation is enabled.
+    public var automaticTitleHeadingEnabled: Bool? {
+        return _automaticTitleHeading?.enabled
     }
     
-    /// If given, the authored behavior for automatic article subheading generation.
-    public var automaticArticleSubheadingBehavior: AutomaticArticleSubheading.Behavior? {
-        return _automaticArticleSubheading?.behavior
+    /// If given, whether or not automatic article subheading generation is enabled.
+    public var automaticArticleSubheadingEnabled: Bool? {
+        return _automaticArticleSubheading?.enabled
     }
     
     /// If given, the authored style for a page's Topics section.

--- a/Sources/docc/DocCDocumentation.docc/DocC.symbols.json
+++ b/Sources/docc/DocCDocumentation.docc/DocC.symbols.json
@@ -35,6 +35,2440 @@
         },
         {
           "kind" : "typeIdentifier",
+          "spelling" : "Forums"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "(...)"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " {\n    ...\n}"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$Forums"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$Forums",
+            "spelling" : "Forums"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "Forums"
+          },
+          {
+            "kind" : "text",
+            "spelling" : "(...)"
+          }
+        ],
+        "title" : "Forums"
+      },
+      "pathComponents" : [
+        "Forums"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "PageKind"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "("
+        },
+        {
+          "kind" : "text",
+          "spelling" : "_ "
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "kind"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Kind"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ")"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "text" : "A directive that allows you to set a page's kind, which affects its default title heading and page icon."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "The `@PageKind` directive tells Swift-DocC to treat a documentation page as a particular"
+          },
+          {
+            "text" : "\"kind\". This is used to determine the page's default navigator icon, as well as the default"
+          },
+          {
+            "text" : "title heading on the page itself."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "The available page kinds are `article` and `sampleCode`."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "This directive is only valid within a `@Metadata` directive:"
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "```markdown"
+          },
+          {
+            "text" : "@Metadata {"
+          },
+          {
+            "text" : "    @PageKind(sampleCode)"
+          },
+          {
+            "text" : "}"
+          },
+          {
+            "text" : "```"
+          },
+          {
+            "text" : "- Parameters:"
+          },
+          {
+            "text" : "  - kind: The page kind to apply to the page."
+          },
+          {
+            "text" : "     **(required)**"
+          },
+          {
+            "text" : "     - term `article`: An article of free-form text; the default for standalone markdown files."
+          },
+          {
+            "text" : "     - term `sampleCode`: A page describing a \"sample code\" project."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$PageKind"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$PageKind",
+            "spelling" : "PageKind"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "PageKind"
+          },
+          {
+            "kind" : "text",
+            "spelling" : "("
+          },
+          {
+            "kind" : "text",
+            "spelling" : "_ "
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "kind"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "spelling" : "Kind"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ")"
+          }
+        ],
+        "title" : "PageKind"
+      },
+      "pathComponents" : [
+        "PageKind"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Tutorial"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "("
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "time"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Int"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "?"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ", "
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "projectFiles"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "ResourceReference"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "?"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ")"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " {\n"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "    "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "preciseIdentifier" : "__docc_universal_symbol_reference_$Intro",
+          "spelling" : "Intro"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "("
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "title"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "String"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ")"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " { ... }"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "\n"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "    "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "preciseIdentifier" : "__docc_universal_symbol_reference_$Section",
+          "spelling" : "Section"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "(...)"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " { ... }"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "\n"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "}"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "text" : "A tutorial to complete in order to gain knowledge of a ``Technology``."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "- Parameters:"
+          },
+          {
+            "text" : "  - time: The estimated time in minutes that the containing ``Tutorial`` will take."
+          },
+          {
+            "text" : "     **(optional)**"
+          },
+          {
+            "text" : "  - projectFiles: Project files to download to get started with the ``Tutorial``."
+          },
+          {
+            "text" : "     **(optional)**"
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$Tutorial"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$Tutorial",
+            "spelling" : "Tutorial"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "Tutorial"
+          },
+          {
+            "kind" : "text",
+            "spelling" : "("
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "time"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "spelling" : "Int"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ", "
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "projectFiles"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "spelling" : "ResourceReference"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ")"
+          }
+        ],
+        "title" : "Tutorial"
+      },
+      "pathComponents" : [
+        "Tutorial"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Assessments"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " {\n"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "    "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "preciseIdentifier" : "__docc_universal_symbol_reference_$MultipleChoice",
+          "spelling" : "MultipleChoice"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " { ... }"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "\n"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "}"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "text" : "A collection of questions about the concepts the documentation presents."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$Assessments"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$Assessments",
+            "spelling" : "Assessments"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "Assessments"
+          }
+        ],
+        "title" : "Assessments"
+      },
+      "pathComponents" : [
+        "Assessments"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Stack"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " {\n"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "    "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "preciseIdentifier" : "__docc_universal_symbol_reference_$ContentAndMedia",
+          "spelling" : "ContentAndMedia"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " { ... }"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "\n"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "}"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "text" : "A semantic model for a view that arranges its children in a row."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$Stack"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$Stack",
+            "spelling" : "Stack"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "Stack"
+          }
+        ],
+        "title" : "Stack"
+      },
+      "pathComponents" : [
+        "Stack"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "DisplayName"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "("
+        },
+        {
+          "kind" : "text",
+          "spelling" : "_ "
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "name"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "String"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ", "
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "style"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Style"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " = conceptual"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ")"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "text" : "A directive that controls how the documentation-extension file overrides the symbol's display name."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "The ``name`` property will override the symbol's default display name."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "When the ``style-swift.property`` property is ``Style-swift.enum\/conceptual``, the symbol's name is rendered as \"conceptual\"—same as article names or tutorial names —where applicable. The default style is ``Style-swift.enum\/conceptual``."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "When the ``style-swift.property`` property is ``Style-swift.enum\/symbol``, the symbol's name is rendered as \"symbol\"—same as article names or tutorial names —where applicable. The default style is ``Style-swift.enum\/conceptual``."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "This directive is only valid within a ``Metadata`` directive:"
+          },
+          {
+            "text" : "```"
+          },
+          {
+            "text" : "@Metadata {"
+          },
+          {
+            "text" : "   @DisplayName(\"Custom Symbol Name\", style: conceptual)"
+          },
+          {
+            "text" : "}"
+          },
+          {
+            "text" : "```"
+          },
+          {
+            "text" : "- Parameters:"
+          },
+          {
+            "text" : "  - name: The custom display name for this symbol."
+          },
+          {
+            "text" : "     **(required)**"
+          },
+          {
+            "text" : "  - style: The style of the display name for this symbol."
+          },
+          {
+            "text" : "     **(optional)**"
+          },
+          {
+            "text" : "     "
+          },
+          {
+            "text" : "     Defaults to ``Style-swift.enum\/conceptual``."
+          },
+          {
+            "text" : "     - term `symbol`: Completely override any in-source content with the content from the documentation-extension."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$DisplayName"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$DisplayName",
+            "spelling" : "DisplayName"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "DisplayName"
+          },
+          {
+            "kind" : "text",
+            "spelling" : "("
+          },
+          {
+            "kind" : "text",
+            "spelling" : "_ "
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "name"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "spelling" : "String"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ", "
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "style"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "spelling" : "Style"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ")"
+          }
+        ],
+        "title" : "DisplayName"
+      },
+      "pathComponents" : [
+        "DisplayName"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Step"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " {\n    ...\n}"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$Step"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$Step",
+            "spelling" : "Step"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "Step"
+          }
+        ],
+        "title" : "Step"
+      },
+      "pathComponents" : [
+        "Step"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "TechnologyRoot"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "text" : "A directive to set this page as a documentation root-level node."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "This directive is only valid within a top-level ``Metadata`` directive:"
+          },
+          {
+            "text" : "```"
+          },
+          {
+            "text" : "@Metadata {"
+          },
+          {
+            "text" : "   @TechnologyRoot"
+          },
+          {
+            "text" : "}"
+          },
+          {
+            "text" : "```"
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$TechnologyRoot"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$TechnologyRoot",
+            "spelling" : "TechnologyRoot"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "TechnologyRoot"
+          }
+        ],
+        "title" : "TechnologyRoot"
+      },
+      "pathComponents" : [
+        "TechnologyRoot"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Section"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "(...)"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " {\n    ...\n}"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$Section"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$Section",
+            "spelling" : "Section"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "Section"
+          },
+          {
+            "kind" : "text",
+            "spelling" : "(...)"
+          }
+        ],
+        "title" : "Section"
+      },
+      "pathComponents" : [
+        "Section"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Links"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "("
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "visualStyle"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "VisualStyle"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ")"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " {\n    ...\n}"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "text" : "A directive for authoring authoring embedded"
+          },
+          {
+            "text" : "previews of documentation links (similar to how links are currently"
+          },
+          {
+            "text" : "rendered in Topics sections) anywhere on the page without affecting page"
+          },
+          {
+            "text" : "curation behavior."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "`@Links` gives authors flexibility in choosing how they want to highlight"
+          },
+          {
+            "text" : "documentation on the page itself versus in the navigation sidebar."
+          },
+          {
+            "text" : "It also allows for mixing and matching different visual styles of"
+          },
+          {
+            "text" : "topics."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "```md"
+          },
+          {
+            "text" : "..."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "### What's New in SlothCreator"
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "@Links(visualStyle: compactGrid) {"
+          },
+          {
+            "text" : "   - <doc:get-started-preparing-sloth-food>"
+          },
+          {
+            "text" : "   - <doc:feeding-your-sloth-in-winter>"
+          },
+          {
+            "text" : "   - <doc:ordering-food-delivery>"
+          },
+          {
+            "text" : "}"
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "..."
+          },
+          {
+            "text" : "```"
+          },
+          {
+            "text" : "- Parameters:"
+          },
+          {
+            "text" : "  - visualStyle: The specified style that should be used when rendering the specified links."
+          },
+          {
+            "text" : "     **(required)**"
+          },
+          {
+            "text" : "     - term `list`: A list of the linked pages, including their full declaration and abstract."
+          },
+          {
+            "text" : "     - term `compactGrid`: A grid of items based on the card image for the linked pages."
+          },
+          {
+            "text" : "        "
+          },
+          {
+            "text" : "        Includes each page’s title and card image but excludes their abstracts."
+          },
+          {
+            "text" : "     - term `detailedGrid`: A grid of items based on the card image for the linked pages."
+          },
+          {
+            "text" : "        "
+          },
+          {
+            "text" : "        Unlike ``compactGrid``, this style includes the abstract for each page."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$Links"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$Links",
+            "spelling" : "Links"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "Links"
+          },
+          {
+            "kind" : "text",
+            "spelling" : "("
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "visualStyle"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "spelling" : "VisualStyle"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ")"
+          }
+        ],
+        "title" : "Links"
+      },
+      "pathComponents" : [
+        "Links"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Tab"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "("
+        },
+        {
+          "kind" : "text",
+          "spelling" : "_ "
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "title"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "String"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ")"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " {\n    ...\n}"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "text" : "A container directive that holds general markup content describing an individual"
+          },
+          {
+            "text" : "tab within a tab-based layout."
+          },
+          {
+            "text" : "- Parameters:"
+          },
+          {
+            "text" : "  - title: The title that should identify the content in this tab when rendered."
+          },
+          {
+            "text" : "     **(required)**"
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$Tab"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$Tab",
+            "spelling" : "Tab"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "Tab"
+          },
+          {
+            "kind" : "text",
+            "spelling" : "("
+          },
+          {
+            "kind" : "text",
+            "spelling" : "_ "
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "title"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "spelling" : "String"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ")"
+          }
+        ],
+        "title" : "Tab"
+      },
+      "pathComponents" : [
+        "Tab"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "AutomaticSeeAlso"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "("
+        },
+        {
+          "kind" : "text",
+          "spelling" : "_ "
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "enabledness"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Enabledness"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ")"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "text" : "A directive for specifying Swift-DocC's automatic behavior when generating a page's"
+          },
+          {
+            "text" : "See Also section."
+          },
+          {
+            "text" : "- Parameters:"
+          },
+          {
+            "text" : "  - enabledness: Whether or not DocC generates automatic See Also sections."
+          },
+          {
+            "text" : "     **(required)**"
+          },
+          {
+            "text" : "     - term `enabled`: A See Also section should be automatically created (the default)."
+          },
+          {
+            "text" : "     - term `disabled`: No automatic See Also section should be created."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$AutomaticSeeAlso"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$AutomaticSeeAlso",
+            "spelling" : "AutomaticSeeAlso"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "AutomaticSeeAlso"
+          },
+          {
+            "kind" : "text",
+            "spelling" : "("
+          },
+          {
+            "kind" : "text",
+            "spelling" : "_ "
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "enabledness"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "spelling" : "Enabledness"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ")"
+          }
+        ],
+        "title" : "AutomaticSeeAlso"
+      },
+      "pathComponents" : [
+        "AutomaticSeeAlso"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "AutomaticArticleSubheading"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "("
+        },
+        {
+          "kind" : "text",
+          "spelling" : "_ "
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "enabledness"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Enabledness"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ")"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "text" : "A directive that modifies Swift-DocC's default behavior for automatic subheading generation on"
+          },
+          {
+            "text" : "article pages."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "By default, articles receive a second-level \"Overview\" heading unless the author explicitly writes"
+          },
+          {
+            "text" : "some other H2 heading below the abstract. This allows for opting out of that behavior."
+          },
+          {
+            "text" : "- Parameters:"
+          },
+          {
+            "text" : "  - enabledness: Whether or not DocC generates automatic second-level \"Overview\" subheadings."
+          },
+          {
+            "text" : "     **(required)**"
+          },
+          {
+            "text" : "     - term `enabled`: An overview subheading should be automatically created for the article (the default)."
+          },
+          {
+            "text" : "     - term `disabled`: No automatic overview subheading should be created for the article."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$AutomaticArticleSubheading"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$AutomaticArticleSubheading",
+            "spelling" : "AutomaticArticleSubheading"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "AutomaticArticleSubheading"
+          },
+          {
+            "kind" : "text",
+            "spelling" : "("
+          },
+          {
+            "kind" : "text",
+            "spelling" : "_ "
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "enabledness"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "spelling" : "Enabledness"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ")"
+          }
+        ],
+        "title" : "AutomaticArticleSubheading"
+      },
+      "pathComponents" : [
+        "AutomaticArticleSubheading"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "CallToAction"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "("
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "url"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "URL"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "?"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ", "
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "file"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "ResourceReference"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "?"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ", "
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "purpose"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Purpose"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "?"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ", "
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "label"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "String"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "?"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ")"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "text" : "A directive that adds a prominent button or link to a page's header."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "A \"Call to Action\" has two main components: a link or file path, and the link text to display."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "The link path can be specified in one of two ways:"
+          },
+          {
+            "text" : "- The `url` parameter specifies a URL that will be used verbatim. Use this when you're linking"
+          },
+          {
+            "text" : "  to an external page or externally-hosted file."
+          },
+          {
+            "text" : "- The `path` parameter specifies the path to a file hosted within your documentation catalog."
+          },
+          {
+            "text" : "  Use this if you're linking to a downloadable file that you're managing alongside your"
+          },
+          {
+            "text" : "  articles and tutorials."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "The link text can also be specified in one of two ways:"
+          },
+          {
+            "text" : "- The `purpose` parameter can be used to use a default button label. There are two valid values:"
+          },
+          {
+            "text" : "  - `download` indicates that the link is to a downloadable file. The button will be labeled \"Download\"."
+          },
+          {
+            "text" : "  - `link` indicates that the link is to an external webpage. The button will be labeled \"Visit\"."
+          },
+          {
+            "text" : "- The `label` parameter specifies the literal text to use as the button label."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "`@CallToAction` requires one of `url` or `path`, and one of `purpose` or `label`. Specifying both"
+          },
+          {
+            "text" : "`purpose` and `label` is allowed, but the `label` will override the default label provided by"
+          },
+          {
+            "text" : "`purpose`."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "This directive is only valid within a ``Metadata`` directive:"
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "```markdown"
+          },
+          {
+            "text" : "@Metadata {"
+          },
+          {
+            "text" : "    @CallToAction(url: \"https:\/\/example.com\/sample.zip\", purpose: download)"
+          },
+          {
+            "text" : "}"
+          },
+          {
+            "text" : "```"
+          },
+          {
+            "text" : "- Parameters:"
+          },
+          {
+            "text" : "  - url: The location of the associated link, as a fixed URL."
+          },
+          {
+            "text" : "     **(optional)**"
+          },
+          {
+            "text" : "  - file: The location of the associated link, as a reference to a file in this documentation bundle."
+          },
+          {
+            "text" : "     **(optional)**"
+          },
+          {
+            "text" : "  - purpose: The purpose of this Call to Action, which provides a default button label."
+          },
+          {
+            "text" : "     **(optional)**"
+          },
+          {
+            "text" : "     - term `download`: References a link to download an associated asset, like a sample project."
+          },
+          {
+            "text" : "     - term `link`: References a link to view external content, like a source code repository."
+          },
+          {
+            "text" : "  - label: Text to use as the button label, which may override the default provided by a"
+          },
+          {
+            "text" : "     given `purpose`."
+          },
+          {
+            "text" : "     **(optional)**"
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$CallToAction"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$CallToAction",
+            "spelling" : "CallToAction"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "CallToAction"
+          },
+          {
+            "kind" : "text",
+            "spelling" : "("
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "url"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "spelling" : "URL"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ", "
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "file"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "spelling" : "ResourceReference"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ", "
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "purpose"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "spelling" : "Purpose"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ", "
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "label"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "spelling" : "String"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ")"
+          }
+        ],
+        "title" : "CallToAction"
+      },
+      "pathComponents" : [
+        "CallToAction"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Comment"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " {\n    ...\n}"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$Comment"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$Comment",
+            "spelling" : "Comment"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "Comment"
+          }
+        ],
+        "title" : "Comment"
+      },
+      "pathComponents" : [
+        "Comment"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Options"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "("
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "scope"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Scope"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " = local"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ")"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " {\n    ...\n}"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "text" : "Use Option directives to adjust DocC's default behaviors when rendering a page."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "- Parameters:"
+          },
+          {
+            "text" : "  - scope: Whether the options in this Options directive should apply locally to the page"
+          },
+          {
+            "text" : "     or globally to the DocC catalog."
+          },
+          {
+            "text" : "     **(optional)**"
+          },
+          {
+            "text" : "     - term `local`: The directive should only affect the current page."
+          },
+          {
+            "text" : "     - term `global`: The directive should affect all pages in the current DocC catalog."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "## Topics"
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "### Adjusting Automatic Behaviors"
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "- ``AutomaticSeeAlso``"
+          },
+          {
+            "text" : "- ``AutomaticTitleHeading``"
+          },
+          {
+            "text" : "- ``AutomaticArticleSubheading``"
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "### Adjusting Visual Style"
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "- ``TopicsVisualStyle``"
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$Options"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$Options",
+            "spelling" : "Options"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "Options"
+          },
+          {
+            "kind" : "text",
+            "spelling" : "("
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "scope"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "spelling" : "Scope"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ")"
+          }
+        ],
+        "title" : "Options"
+      },
+      "pathComponents" : [
+        "Options"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Volume"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "(...)"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " {\n    ...\n}"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$Volume"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$Volume",
+            "spelling" : "Volume"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "Volume"
+          },
+          {
+            "kind" : "text",
+            "spelling" : "(...)"
+          }
+        ],
+        "title" : "Volume"
+      },
+      "pathComponents" : [
+        "Volume"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Choice"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "("
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "isCorrect"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Bool"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ")"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " {\n"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "    ...\n\n"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "    "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "preciseIdentifier" : "__docc_universal_symbol_reference_$Justification",
+          "spelling" : "Justification"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "("
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "reaction"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "String"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "?"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ")"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " { ... }"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "\n"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "}"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "text" : "One of possibly many choices in a ``MultipleChoice`` question."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "- Parameters:"
+          },
+          {
+            "text" : "  - isCorrect: `true` if this choice is a correct one; there can be multiple correct choices."
+          },
+          {
+            "text" : "     **(required)**"
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$Choice"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$Choice",
+            "spelling" : "Choice"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "Choice"
+          },
+          {
+            "kind" : "text",
+            "spelling" : "("
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "isCorrect"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "spelling" : "Bool"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ")"
+          }
+        ],
+        "title" : "Choice"
+      },
+      "pathComponents" : [
+        "Choice"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Metadata"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " {\n    ...\n}"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "text" : "A directive that contains various metadata about a page."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "This directive acts as a container for metadata and configuration without any arguments of its own."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "## Topics"
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "### Child Directives"
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "- ``DocumentationExtension``"
+          },
+          {
+            "text" : "- ``TechnologyRoot``"
+          },
+          {
+            "text" : "- ``DisplayName``"
+          },
+          {
+            "text" : "- ``PageImage``"
+          },
+          {
+            "text" : "- ``CallToAction``"
+          },
+          {
+            "text" : "- ``Availability``"
+          },
+          {
+            "text" : "- ``PageKind``"
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$Metadata"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$Metadata",
+            "spelling" : "Metadata"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "Metadata"
+          }
+        ],
+        "title" : "Metadata"
+      },
+      "pathComponents" : [
+        "Metadata"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
           "spelling" : "Chapter"
         },
         {
@@ -249,140 +2683,11 @@
         },
         {
           "kind" : "typeIdentifier",
-          "spelling" : "AutomaticArticleSubheading"
+          "spelling" : "Videos"
         },
         {
           "kind" : "text",
-          "spelling" : "("
-        },
-        {
-          "kind" : "text",
-          "spelling" : "_ "
-        },
-        {
-          "kind" : "identifier",
-          "spelling" : "behavior"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ": "
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "Behavior"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ")"
-        }
-      ],
-      "docComment" : {
-        "lines" : [
-          {
-            "text" : "A directive that modifies Swift-DocC's default behavior for automatic subheading generation on"
-          },
-          {
-            "text" : "article pages."
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "By default, articles receive a second-level \"Overview\" heading unless the author explicitly writes"
-          },
-          {
-            "text" : "some other H2 heading below the abstract. This allows for opting out of that behavior."
-          },
-          {
-            "text" : "- Parameters:"
-          },
-          {
-            "text" : "  - behavior: The specified behavior for automatic subheading generation."
-          },
-          {
-            "text" : "     **(required)**"
-          },
-          {
-            "text" : "     - term `disabled`: No subheading should be created for the article."
-          },
-          {
-            "text" : "     - term `enabled`: An overview subheading should be created containing the article's"
-          },
-          {
-            "text" : "        first paragraph of content."
-          }
-        ]
-      },
-      "identifier" : {
-        "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$AutomaticArticleSubheading"
-      },
-      "kind" : {
-        "displayName" : "Directive",
-        "identifier" : "class"
-      },
-      "names" : {
-        "navigator" : [
-          {
-            "kind" : "attribute",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$AutomaticArticleSubheading",
-            "spelling" : "AutomaticArticleSubheading"
-          }
-        ],
-        "subHeading" : [
-          {
-            "kind" : "identifier",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "AutomaticArticleSubheading"
-          },
-          {
-            "kind" : "text",
-            "spelling" : "("
-          },
-          {
-            "kind" : "text",
-            "spelling" : "_ "
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "behavior"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ": "
-          },
-          {
-            "kind" : "typeIdentifier",
-            "spelling" : "Behavior"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ")"
-          }
-        ],
-        "title" : "AutomaticArticleSubheading"
-      },
-      "pathComponents" : [
-        "AutomaticArticleSubheading"
-      ]
-    },
-    {
-      "accessLevel" : "public",
-      "declarationFragments" : [
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "MultipleChoice"
+          "spelling" : "(...)"
         },
         {
           "kind" : "text",
@@ -391,7 +2696,7 @@
       ],
       "identifier" : {
         "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$MultipleChoice"
+        "precise" : "__docc_universal_symbol_reference_$Videos"
       },
       "kind" : {
         "displayName" : "Directive",
@@ -405,8 +2710,8 @@
           },
           {
             "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$MultipleChoice",
-            "spelling" : "MultipleChoice"
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$Videos",
+            "spelling" : "Videos"
           }
         ],
         "subHeading" : [
@@ -416,13 +2721,17 @@
           },
           {
             "kind" : "identifier",
-            "spelling" : "MultipleChoice"
+            "spelling" : "Videos"
+          },
+          {
+            "kind" : "text",
+            "spelling" : "(...)"
           }
         ],
-        "title" : "MultipleChoice"
+        "title" : "Videos"
       },
       "pathComponents" : [
-        "MultipleChoice"
+        "Videos"
       ]
     },
     {
@@ -434,19 +2743,15 @@
         },
         {
           "kind" : "typeIdentifier",
-          "spelling" : "AutomaticSeeAlso"
+          "spelling" : "XcodeRequirement"
         },
         {
           "kind" : "text",
           "spelling" : "("
         },
         {
-          "kind" : "text",
-          "spelling" : "_ "
-        },
-        {
           "kind" : "identifier",
-          "spelling" : "behavior"
+          "spelling" : "title"
         },
         {
           "kind" : "text",
@@ -454,7 +2759,23 @@
         },
         {
           "kind" : "typeIdentifier",
-          "spelling" : "Behavior"
+          "spelling" : "String"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ", "
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "destination"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "URL"
         },
         {
           "kind" : "text",
@@ -464,31 +2785,31 @@
       "docComment" : {
         "lines" : [
           {
-            "text" : "A directive for specifying Swift-DocC's automatic behavior when generating a page's"
+            "text" : "An informal Xcode requirement for completing an instructional ``Tutorial``."
           },
           {
-            "text" : "See Also section."
+            "text" : ""
           },
           {
             "text" : "- Parameters:"
           },
           {
-            "text" : "  - behavior: The specified behavior for automatic See Also section generation."
+            "text" : "  - title: Human readable title."
           },
           {
             "text" : "     **(required)**"
           },
           {
-            "text" : "     - term `disabled`: A See Also section will not be automatically created."
+            "text" : "  - destination: Domain where requirement applies."
           },
           {
-            "text" : "     - term `siblingPages`: A See Also section will be automatically created based on the page's siblings."
+            "text" : "     **(required)**"
           }
         ]
       },
       "identifier" : {
         "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$AutomaticSeeAlso"
+        "precise" : "__docc_universal_symbol_reference_$XcodeRequirement"
       },
       "kind" : {
         "displayName" : "Directive",
@@ -502,8 +2823,8 @@
           },
           {
             "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$AutomaticSeeAlso",
-            "spelling" : "AutomaticSeeAlso"
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$XcodeRequirement",
+            "spelling" : "XcodeRequirement"
           }
         ],
         "subHeading" : [
@@ -513,19 +2834,15 @@
           },
           {
             "kind" : "identifier",
-            "spelling" : "AutomaticSeeAlso"
+            "spelling" : "XcodeRequirement"
           },
           {
             "kind" : "text",
             "spelling" : "("
           },
           {
-            "kind" : "text",
-            "spelling" : "_ "
-          },
-          {
             "kind" : "identifier",
-            "spelling" : "behavior"
+            "spelling" : "title"
           },
           {
             "kind" : "text",
@@ -533,17 +2850,33 @@
           },
           {
             "kind" : "typeIdentifier",
-            "spelling" : "Behavior"
+            "spelling" : "String"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ", "
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "destination"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "spelling" : "URL"
           },
           {
             "kind" : "text",
             "spelling" : ")"
           }
         ],
-        "title" : "AutomaticSeeAlso"
+        "title" : "XcodeRequirement"
       },
       "pathComponents" : [
-        "AutomaticSeeAlso"
+        "XcodeRequirement"
       ]
     },
     {
@@ -555,7 +2888,7 @@
         },
         {
           "kind" : "typeIdentifier",
-          "spelling" : "TopicsVisualStyle"
+          "spelling" : "Available"
         },
         {
           "kind" : "text",
@@ -567,7 +2900,7 @@
         },
         {
           "kind" : "identifier",
-          "spelling" : "style"
+          "spelling" : "platform"
         },
         {
           "kind" : "text",
@@ -575,59 +2908,32 @@
         },
         {
           "kind" : "typeIdentifier",
-          "spelling" : "Style"
+          "spelling" : "Platform"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ", "
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "introduced"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "String"
         },
         {
           "kind" : "text",
           "spelling" : ")"
         }
       ],
-      "docComment" : {
-        "lines" : [
-          {
-            "text" : "A directive for specifying the style that should be used when rendering a page's"
-          },
-          {
-            "text" : "Topics section."
-          },
-          {
-            "text" : "- Parameters:"
-          },
-          {
-            "text" : "  - style: The specified style that should be used when rendering a page's Topics section."
-          },
-          {
-            "text" : "     **(required)**"
-          },
-          {
-            "text" : "     - term `list`: A list of the page's topics, including their full declaration and abstract."
-          },
-          {
-            "text" : "     - term `compactGrid`: A grid of items based on the card image for each page."
-          },
-          {
-            "text" : "        "
-          },
-          {
-            "text" : "        Includes each page’s title and card image but excludes their abstracts."
-          },
-          {
-            "text" : "     - term `detailedGrid`: A grid of items based on the card image for each page."
-          },
-          {
-            "text" : "        "
-          },
-          {
-            "text" : "        Unlike ``compactGrid``, this style includes the abstract for each page."
-          },
-          {
-            "text" : "     - term `hidden`: Do not show child pages anywhere on the page."
-          }
-        ]
-      },
       "identifier" : {
         "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$TopicsVisualStyle"
+        "precise" : "__docc_universal_symbol_reference_$Available"
       },
       "kind" : {
         "displayName" : "Directive",
@@ -641,8 +2947,8 @@
           },
           {
             "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$TopicsVisualStyle",
-            "spelling" : "TopicsVisualStyle"
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$Available",
+            "spelling" : "Available"
           }
         ],
         "subHeading" : [
@@ -652,7 +2958,7 @@
           },
           {
             "kind" : "identifier",
-            "spelling" : "TopicsVisualStyle"
+            "spelling" : "Available"
           },
           {
             "kind" : "text",
@@ -664,7 +2970,7 @@
           },
           {
             "kind" : "identifier",
-            "spelling" : "style"
+            "spelling" : "platform"
           },
           {
             "kind" : "text",
@@ -672,17 +2978,585 @@
           },
           {
             "kind" : "typeIdentifier",
-            "spelling" : "Style"
+            "spelling" : "Platform"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ", "
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "introduced"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "spelling" : "String"
           },
           {
             "kind" : "text",
             "spelling" : ")"
           }
         ],
-        "title" : "TopicsVisualStyle"
+        "title" : "Available"
       },
       "pathComponents" : [
-        "TopicsVisualStyle"
+        "Available"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Column"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "("
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "size"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Int"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " = 1"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ")"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " {\n    ...\n}"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "text" : "A container directive that holds general markup content describing a column"
+          },
+          {
+            "text" : "with a row in a grid-based layout."
+          },
+          {
+            "text" : "- Parameters:"
+          },
+          {
+            "text" : "  - size: The size of this column."
+          },
+          {
+            "text" : "     **(optional)**"
+          },
+          {
+            "text" : "     "
+          },
+          {
+            "text" : "     Specify a value greater than `1` to make this column span multiple columns"
+          },
+          {
+            "text" : "     in the parent ``Row``."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$Column"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$Column",
+            "spelling" : "Column"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "Column"
+          },
+          {
+            "kind" : "text",
+            "spelling" : "("
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "size"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "spelling" : "Int"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ")"
+          }
+        ],
+        "title" : "Column"
+      },
+      "pathComponents" : [
+        "Column"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "SampleCode"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "(...)"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " {\n    ...\n}"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$SampleCode"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$SampleCode",
+            "spelling" : "SampleCode"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "SampleCode"
+          },
+          {
+            "kind" : "text",
+            "spelling" : "(...)"
+          }
+        ],
+        "title" : "SampleCode"
+      },
+      "pathComponents" : [
+        "SampleCode"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "TabNavigator"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " {\n"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "    "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "preciseIdentifier" : "__docc_universal_symbol_reference_$Tab",
+          "spelling" : "Tab"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "("
+        },
+        {
+          "kind" : "text",
+          "spelling" : "_ "
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "title"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "String"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ")"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " { ... }"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "\n"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "}"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "text" : "A container directive that arranges content into a tab-based layout."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "Create a new tab navigator by writing a `@TabNavigator` directive that contains child"
+          },
+          {
+            "text" : "`@Tab` directives."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "```md"
+          },
+          {
+            "text" : "@TabNavigator {"
+          },
+          {
+            "text" : "   @Tab(\"Powers\") {"
+          },
+          {
+            "text" : "      ![A diagram with the five sloth power types.](sloth-powers)"
+          },
+          {
+            "text" : "   }"
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "   @Tab(\"Excerise routines\") {"
+          },
+          {
+            "text" : "      ![A sloth relaxing and enjoying a good book.](sloth-exercise)"
+          },
+          {
+            "text" : "   }"
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "   @Tab(\"Hats\") {"
+          },
+          {
+            "text" : "      ![A sloth discovering newfound confidence after donning a fedora.](sloth-hats)"
+          },
+          {
+            "text" : "   }"
+          },
+          {
+            "text" : "}"
+          },
+          {
+            "text" : "```"
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "## Topics"
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "- ``Tab``"
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$TabNavigator"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$TabNavigator",
+            "spelling" : "TabNavigator"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "TabNavigator"
+          }
+        ],
+        "title" : "TabNavigator"
+      },
+      "pathComponents" : [
+        "TabNavigator"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Downloads"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "(...)"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " {\n    ...\n}"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$Downloads"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$Downloads",
+            "spelling" : "Downloads"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "Downloads"
+          },
+          {
+            "kind" : "text",
+            "spelling" : "(...)"
+          }
+        ],
+        "title" : "Downloads"
+      },
+      "pathComponents" : [
+        "Downloads"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Image"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "("
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "source"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "ResourceReference"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ", "
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "alt"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "String"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "?"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ")"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " {\n    ...\n}"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$Image"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$Image",
+            "spelling" : "Image"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "Image"
+          },
+          {
+            "kind" : "text",
+            "spelling" : "("
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "source"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "spelling" : "ResourceReference"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ", "
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "alt"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "spelling" : "String"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ")"
+          }
+        ],
+        "title" : "Image"
+      },
+      "pathComponents" : [
+        "Image"
       ]
     },
     {
@@ -813,173 +3687,6 @@
         },
         {
           "kind" : "typeIdentifier",
-          "spelling" : "Justification"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "("
-        },
-        {
-          "kind" : "identifier",
-          "spelling" : "reaction"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ": "
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "String"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "?"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ")"
-        },
-        {
-          "kind" : "text",
-          "spelling" : " {\n    ...\n}"
-        }
-      ],
-      "docComment" : {
-        "lines" : [
-          {
-            "text" : "A short justification as to whether a ``Choice`` is correct for a question."
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "- Parameters:"
-          },
-          {
-            "text" : "  - reaction: The reaction to the reader selecting the containing ``Choice``. Defaults to nil."
-          },
-          {
-            "text" : "     **(optional)**"
-          }
-        ]
-      },
-      "identifier" : {
-        "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$Justification"
-      },
-      "kind" : {
-        "displayName" : "Directive",
-        "identifier" : "class"
-      },
-      "names" : {
-        "navigator" : [
-          {
-            "kind" : "attribute",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$Justification",
-            "spelling" : "Justification"
-          }
-        ],
-        "subHeading" : [
-          {
-            "kind" : "identifier",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "Justification"
-          },
-          {
-            "kind" : "text",
-            "spelling" : "("
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "reaction"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ": "
-          },
-          {
-            "kind" : "typeIdentifier",
-            "spelling" : "String"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ")"
-          }
-        ],
-        "title" : "Justification"
-      },
-      "pathComponents" : [
-        "Justification"
-      ]
-    },
-    {
-      "accessLevel" : "public",
-      "declarationFragments" : [
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "Step"
-        },
-        {
-          "kind" : "text",
-          "spelling" : " {\n    ...\n}"
-        }
-      ],
-      "identifier" : {
-        "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$Step"
-      },
-      "kind" : {
-        "displayName" : "Directive",
-        "identifier" : "class"
-      },
-      "names" : {
-        "navigator" : [
-          {
-            "kind" : "attribute",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$Step",
-            "spelling" : "Step"
-          }
-        ],
-        "subHeading" : [
-          {
-            "kind" : "identifier",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "Step"
-          }
-        ],
-        "title" : "Step"
-      },
-      "pathComponents" : [
-        "Step"
-      ]
-    },
-    {
-      "accessLevel" : "public",
-      "declarationFragments" : [
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
           "spelling" : "Resources"
         },
         {
@@ -1021,871 +3728,6 @@
       },
       "pathComponents" : [
         "Resources"
-      ]
-    },
-    {
-      "accessLevel" : "public",
-      "declarationFragments" : [
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "Forums"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "(...)"
-        },
-        {
-          "kind" : "text",
-          "spelling" : " {\n    ...\n}"
-        }
-      ],
-      "identifier" : {
-        "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$Forums"
-      },
-      "kind" : {
-        "displayName" : "Directive",
-        "identifier" : "class"
-      },
-      "names" : {
-        "navigator" : [
-          {
-            "kind" : "attribute",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$Forums",
-            "spelling" : "Forums"
-          }
-        ],
-        "subHeading" : [
-          {
-            "kind" : "identifier",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "Forums"
-          },
-          {
-            "kind" : "text",
-            "spelling" : "(...)"
-          }
-        ],
-        "title" : "Forums"
-      },
-      "pathComponents" : [
-        "Forums"
-      ]
-    },
-    {
-      "accessLevel" : "public",
-      "declarationFragments" : [
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "SampleCode"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "(...)"
-        },
-        {
-          "kind" : "text",
-          "spelling" : " {\n    ...\n}"
-        }
-      ],
-      "identifier" : {
-        "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$SampleCode"
-      },
-      "kind" : {
-        "displayName" : "Directive",
-        "identifier" : "class"
-      },
-      "names" : {
-        "navigator" : [
-          {
-            "kind" : "attribute",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$SampleCode",
-            "spelling" : "SampleCode"
-          }
-        ],
-        "subHeading" : [
-          {
-            "kind" : "identifier",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "SampleCode"
-          },
-          {
-            "kind" : "text",
-            "spelling" : "(...)"
-          }
-        ],
-        "title" : "SampleCode"
-      },
-      "pathComponents" : [
-        "SampleCode"
-      ]
-    },
-    {
-      "accessLevel" : "public",
-      "declarationFragments" : [
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "ContentAndMedia"
-        },
-        {
-          "kind" : "text",
-          "spelling" : " {\n    ...\n}"
-        }
-      ],
-      "identifier" : {
-        "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$ContentAndMedia"
-      },
-      "kind" : {
-        "displayName" : "Directive",
-        "identifier" : "class"
-      },
-      "names" : {
-        "navigator" : [
-          {
-            "kind" : "attribute",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$ContentAndMedia",
-            "spelling" : "ContentAndMedia"
-          }
-        ],
-        "subHeading" : [
-          {
-            "kind" : "identifier",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "ContentAndMedia"
-          }
-        ],
-        "title" : "ContentAndMedia"
-      },
-      "pathComponents" : [
-        "ContentAndMedia"
-      ]
-    },
-    {
-      "accessLevel" : "public",
-      "declarationFragments" : [
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "Downloads"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "(...)"
-        },
-        {
-          "kind" : "text",
-          "spelling" : " {\n    ...\n}"
-        }
-      ],
-      "identifier" : {
-        "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$Downloads"
-      },
-      "kind" : {
-        "displayName" : "Directive",
-        "identifier" : "class"
-      },
-      "names" : {
-        "navigator" : [
-          {
-            "kind" : "attribute",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$Downloads",
-            "spelling" : "Downloads"
-          }
-        ],
-        "subHeading" : [
-          {
-            "kind" : "identifier",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "Downloads"
-          },
-          {
-            "kind" : "text",
-            "spelling" : "(...)"
-          }
-        ],
-        "title" : "Downloads"
-      },
-      "pathComponents" : [
-        "Downloads"
-      ]
-    },
-    {
-      "accessLevel" : "public",
-      "declarationFragments" : [
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "Section"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "(...)"
-        },
-        {
-          "kind" : "text",
-          "spelling" : " {\n    ...\n}"
-        }
-      ],
-      "identifier" : {
-        "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$Section"
-      },
-      "kind" : {
-        "displayName" : "Directive",
-        "identifier" : "class"
-      },
-      "names" : {
-        "navigator" : [
-          {
-            "kind" : "attribute",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$Section",
-            "spelling" : "Section"
-          }
-        ],
-        "subHeading" : [
-          {
-            "kind" : "identifier",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "Section"
-          },
-          {
-            "kind" : "text",
-            "spelling" : "(...)"
-          }
-        ],
-        "title" : "Section"
-      },
-      "pathComponents" : [
-        "Section"
-      ]
-    },
-    {
-      "accessLevel" : "public",
-      "declarationFragments" : [
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "Stack"
-        },
-        {
-          "kind" : "text",
-          "spelling" : " {\n"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "    "
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "preciseIdentifier" : "__docc_universal_symbol_reference_$ContentAndMedia",
-          "spelling" : "ContentAndMedia"
-        },
-        {
-          "kind" : "text",
-          "spelling" : " { ... }"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "\n"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "}"
-        }
-      ],
-      "docComment" : {
-        "lines" : [
-          {
-            "text" : "A semantic model for a view that arranges its children in a row."
-          }
-        ]
-      },
-      "identifier" : {
-        "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$Stack"
-      },
-      "kind" : {
-        "displayName" : "Directive",
-        "identifier" : "class"
-      },
-      "names" : {
-        "navigator" : [
-          {
-            "kind" : "attribute",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$Stack",
-            "spelling" : "Stack"
-          }
-        ],
-        "subHeading" : [
-          {
-            "kind" : "identifier",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "Stack"
-          }
-        ],
-        "title" : "Stack"
-      },
-      "pathComponents" : [
-        "Stack"
-      ]
-    },
-    {
-      "accessLevel" : "public",
-      "declarationFragments" : [
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "AutomaticTitleHeading"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "("
-        },
-        {
-          "kind" : "text",
-          "spelling" : "_ "
-        },
-        {
-          "kind" : "identifier",
-          "spelling" : "behavior"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ": "
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "Behavior"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ")"
-        }
-      ],
-      "docComment" : {
-        "lines" : [
-          {
-            "text" : "A directive for specifying Swift-DocC's automatic behavior when generating a page's"
-          },
-          {
-            "text" : "title heading."
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "A title heading is also known as a page eyebrow or kicker."
-          },
-          {
-            "text" : "- Parameters:"
-          },
-          {
-            "text" : "  - behavior: The specified behavior for automatic title heading generation."
-          },
-          {
-            "text" : "     **(required)**"
-          },
-          {
-            "text" : "     - term `disabled`: No title heading should be created for the page."
-          },
-          {
-            "text" : "     - term `pageKind`: A title heading based on the page's kind should be automatically created."
-          }
-        ]
-      },
-      "identifier" : {
-        "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$AutomaticTitleHeading"
-      },
-      "kind" : {
-        "displayName" : "Directive",
-        "identifier" : "class"
-      },
-      "names" : {
-        "navigator" : [
-          {
-            "kind" : "attribute",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$AutomaticTitleHeading",
-            "spelling" : "AutomaticTitleHeading"
-          }
-        ],
-        "subHeading" : [
-          {
-            "kind" : "identifier",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "AutomaticTitleHeading"
-          },
-          {
-            "kind" : "text",
-            "spelling" : "("
-          },
-          {
-            "kind" : "text",
-            "spelling" : "_ "
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "behavior"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ": "
-          },
-          {
-            "kind" : "typeIdentifier",
-            "spelling" : "Behavior"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ")"
-          }
-        ],
-        "title" : "AutomaticTitleHeading"
-      },
-      "pathComponents" : [
-        "AutomaticTitleHeading"
-      ]
-    },
-    {
-      "accessLevel" : "public",
-      "declarationFragments" : [
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "DisplayName"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "("
-        },
-        {
-          "kind" : "text",
-          "spelling" : "_ "
-        },
-        {
-          "kind" : "identifier",
-          "spelling" : "name"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ": "
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "String"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ", "
-        },
-        {
-          "kind" : "identifier",
-          "spelling" : "style"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ": "
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "Style"
-        },
-        {
-          "kind" : "text",
-          "spelling" : " = conceptual"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ")"
-        }
-      ],
-      "docComment" : {
-        "lines" : [
-          {
-            "text" : "A directive that controls how the documentation-extension file overrides the symbol's display name."
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "The ``name`` property will override the symbol's default display name."
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "When the ``style-swift.property`` property is ``Style-swift.enum\/conceptual``, the symbol's name is rendered as \"conceptual\"—same as article names or tutorial names —where applicable. The default style is ``Style-swift.enum\/conceptual``."
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "When the ``style-swift.property`` property is ``Style-swift.enum\/symbol``, the symbol's name is rendered as \"symbol\"—same as article names or tutorial names —where applicable. The default style is ``Style-swift.enum\/conceptual``."
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "This directive is only valid within a ``Metadata`` directive:"
-          },
-          {
-            "text" : "```"
-          },
-          {
-            "text" : "@Metadata {"
-          },
-          {
-            "text" : "   @DisplayName(\"Custom Symbol Name\", style: conceptual)"
-          },
-          {
-            "text" : "}"
-          },
-          {
-            "text" : "```"
-          },
-          {
-            "text" : "- Parameters:"
-          },
-          {
-            "text" : "  - name: The custom display name for this symbol."
-          },
-          {
-            "text" : "     **(required)**"
-          },
-          {
-            "text" : "  - style: The style of the display name for this symbol."
-          },
-          {
-            "text" : "     **(optional)**"
-          },
-          {
-            "text" : "     "
-          },
-          {
-            "text" : "     Defaults to ``Style-swift.enum\/conceptual``."
-          },
-          {
-            "text" : "     - term `symbol`: Completely override any in-source content with the content from the documentation-extension."
-          }
-        ]
-      },
-      "identifier" : {
-        "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$DisplayName"
-      },
-      "kind" : {
-        "displayName" : "Directive",
-        "identifier" : "class"
-      },
-      "names" : {
-        "navigator" : [
-          {
-            "kind" : "attribute",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$DisplayName",
-            "spelling" : "DisplayName"
-          }
-        ],
-        "subHeading" : [
-          {
-            "kind" : "identifier",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "DisplayName"
-          },
-          {
-            "kind" : "text",
-            "spelling" : "("
-          },
-          {
-            "kind" : "text",
-            "spelling" : "_ "
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "name"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ": "
-          },
-          {
-            "kind" : "typeIdentifier",
-            "spelling" : "String"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ", "
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "style"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ": "
-          },
-          {
-            "kind" : "typeIdentifier",
-            "spelling" : "Style"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ")"
-          }
-        ],
-        "title" : "DisplayName"
-      },
-      "pathComponents" : [
-        "DisplayName"
-      ]
-    },
-    {
-      "accessLevel" : "public",
-      "declarationFragments" : [
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "Options"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "("
-        },
-        {
-          "kind" : "identifier",
-          "spelling" : "scope"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ": "
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "Scope"
-        },
-        {
-          "kind" : "text",
-          "spelling" : " = local"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ")"
-        },
-        {
-          "kind" : "text",
-          "spelling" : " {\n    ...\n}"
-        }
-      ],
-      "docComment" : {
-        "lines" : [
-          {
-            "text" : "Use Option directives to adjust DocC's default behaviors when rendering a page."
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "- Parameters:"
-          },
-          {
-            "text" : "  - scope: Whether the options in this Options directive should apply locally to the page"
-          },
-          {
-            "text" : "     or globally to the DocC catalog."
-          },
-          {
-            "text" : "     **(optional)**"
-          },
-          {
-            "text" : "     - term `local`: The directive should only affect the current page."
-          },
-          {
-            "text" : "     - term `global`: The directive should affect all pages in the current DocC catalog."
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "## Topics"
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "### Adjusting Automatic Behaviors"
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "- ``AutomaticSeeAlso``"
-          },
-          {
-            "text" : "- ``AutomaticTitleHeading``"
-          },
-          {
-            "text" : "- ``AutomaticArticleSubheading``"
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "### Adjusting Visual Style"
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "- ``TopicsVisualStyle``"
-          }
-        ]
-      },
-      "identifier" : {
-        "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$Options"
-      },
-      "kind" : {
-        "displayName" : "Directive",
-        "identifier" : "class"
-      },
-      "names" : {
-        "navigator" : [
-          {
-            "kind" : "attribute",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$Options",
-            "spelling" : "Options"
-          }
-        ],
-        "subHeading" : [
-          {
-            "kind" : "identifier",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "Options"
-          },
-          {
-            "kind" : "text",
-            "spelling" : "("
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "scope"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ": "
-          },
-          {
-            "kind" : "typeIdentifier",
-            "spelling" : "Scope"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ")"
-          }
-        ],
-        "title" : "Options"
-      },
-      "pathComponents" : [
-        "Options"
       ]
     },
     {
@@ -2038,6 +3880,870 @@
       },
       "pathComponents" : [
         "DocumentationExtension"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "PageImage"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "("
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "purpose"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Purpose"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ", "
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "source"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "ResourceReference"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ", "
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "alt"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "String"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "?"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ")"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$PageImage"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$PageImage",
+            "spelling" : "PageImage"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "PageImage"
+          },
+          {
+            "kind" : "text",
+            "spelling" : "("
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "purpose"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "spelling" : "Purpose"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ", "
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "source"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "spelling" : "ResourceReference"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ", "
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "alt"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "spelling" : "String"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ")"
+          }
+        ],
+        "title" : "PageImage"
+      },
+      "pathComponents" : [
+        "PageImage"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "TopicsVisualStyle"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "("
+        },
+        {
+          "kind" : "text",
+          "spelling" : "_ "
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "style"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Style"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ")"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "text" : "A directive for specifying the style that should be used when rendering a page's"
+          },
+          {
+            "text" : "Topics section."
+          },
+          {
+            "text" : "- Parameters:"
+          },
+          {
+            "text" : "  - style: The specified style that should be used when rendering a page's Topics section."
+          },
+          {
+            "text" : "     **(required)**"
+          },
+          {
+            "text" : "     - term `list`: A list of the page's topics, including their full declaration and abstract."
+          },
+          {
+            "text" : "     - term `compactGrid`: A grid of items based on the card image for each page."
+          },
+          {
+            "text" : "        "
+          },
+          {
+            "text" : "        Includes each page’s title and card image but excludes their abstracts."
+          },
+          {
+            "text" : "     - term `detailedGrid`: A grid of items based on the card image for each page."
+          },
+          {
+            "text" : "        "
+          },
+          {
+            "text" : "        Unlike ``compactGrid``, this style includes the abstract for each page."
+          },
+          {
+            "text" : "     - term `hidden`: Do not show child pages anywhere on the page."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$TopicsVisualStyle"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$TopicsVisualStyle",
+            "spelling" : "TopicsVisualStyle"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "TopicsVisualStyle"
+          },
+          {
+            "kind" : "text",
+            "spelling" : "("
+          },
+          {
+            "kind" : "text",
+            "spelling" : "_ "
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "style"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "spelling" : "Style"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ")"
+          }
+        ],
+        "title" : "TopicsVisualStyle"
+      },
+      "pathComponents" : [
+        "TopicsVisualStyle"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Intro"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "("
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "title"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "String"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ")"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " {\n    ...\n}"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "text" : "An introductory section for instructional pages."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "- Parameters:"
+          },
+          {
+            "text" : "  - title: The title of the containing ``Tutorial``."
+          },
+          {
+            "text" : "     **(required)**"
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$Intro"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$Intro",
+            "spelling" : "Intro"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "Intro"
+          },
+          {
+            "kind" : "text",
+            "spelling" : "("
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "title"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "spelling" : "String"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ")"
+          }
+        ],
+        "title" : "Intro"
+      },
+      "pathComponents" : [
+        "Intro"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "AutomaticTitleHeading"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "("
+        },
+        {
+          "kind" : "text",
+          "spelling" : "_ "
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "enabledness"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Enabledness"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ")"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "text" : "A directive for specifying Swift-DocC's automatic behavior when generating a page's"
+          },
+          {
+            "text" : "title heading."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "A title heading is also known as a page eyebrow or kicker."
+          },
+          {
+            "text" : "- Parameters:"
+          },
+          {
+            "text" : "  - enabledness: Whether or not DocC generates automatic title headings."
+          },
+          {
+            "text" : "     **(required)**"
+          },
+          {
+            "text" : "     - term `enabled`: A title heading should be automatically created for the page (the default)."
+          },
+          {
+            "text" : "     - term `disabled`: No automatic title heading should be created for the page."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$AutomaticTitleHeading"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$AutomaticTitleHeading",
+            "spelling" : "AutomaticTitleHeading"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "AutomaticTitleHeading"
+          },
+          {
+            "kind" : "text",
+            "spelling" : "("
+          },
+          {
+            "kind" : "text",
+            "spelling" : "_ "
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "enabledness"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "spelling" : "Enabledness"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ")"
+          }
+        ],
+        "title" : "AutomaticTitleHeading"
+      },
+      "pathComponents" : [
+        "AutomaticTitleHeading"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Justification"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "("
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "reaction"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "String"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "?"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ")"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " {\n    ...\n}"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "text" : "A short justification as to whether a ``Choice`` is correct for a question."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "- Parameters:"
+          },
+          {
+            "text" : "  - reaction: The reaction to the reader selecting the containing ``Choice``. Defaults to nil."
+          },
+          {
+            "text" : "     **(optional)**"
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$Justification"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$Justification",
+            "spelling" : "Justification"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "Justification"
+          },
+          {
+            "kind" : "text",
+            "spelling" : "("
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "reaction"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "spelling" : "String"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ")"
+          }
+        ],
+        "title" : "Justification"
+      },
+      "pathComponents" : [
+        "Justification"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Code"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "(...)"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " {\n    ...\n}"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$Code"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$Code",
+            "spelling" : "Code"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "Code"
+          },
+          {
+            "kind" : "text",
+            "spelling" : "(...)"
+          }
+        ],
+        "title" : "Code"
+      },
+      "pathComponents" : [
+        "Code"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "TutorialReference"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "("
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "tutorial"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "TopicReference"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ")"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "text" : "A reference to a ``Tutorial`` or ``TutorialArticle`` by `URL`."
+          },
+          {
+            "text" : "- Parameters:"
+          },
+          {
+            "text" : "  - tutorial: The tutorial page or tutorial article to which this refers."
+          },
+          {
+            "text" : "     **(required)**"
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$TutorialReference"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$TutorialReference",
+            "spelling" : "TutorialReference"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "TutorialReference"
+          },
+          {
+            "kind" : "text",
+            "spelling" : "("
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "tutorial"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "spelling" : "TopicReference"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ")"
+          }
+        ],
+        "title" : "TutorialReference"
+      },
+      "pathComponents" : [
+        "TutorialReference"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "MultipleChoice"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " {\n    ...\n}"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$MultipleChoice"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$MultipleChoice",
+            "spelling" : "MultipleChoice"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "MultipleChoice"
+          }
+        ],
+        "title" : "MultipleChoice"
+      },
+      "pathComponents" : [
+        "MultipleChoice"
       ]
     },
     {
@@ -2378,1499 +5084,6 @@
         },
         {
           "kind" : "typeIdentifier",
-          "spelling" : "Links"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "("
-        },
-        {
-          "kind" : "identifier",
-          "spelling" : "visualStyle"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ": "
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "VisualStyle"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ")"
-        },
-        {
-          "kind" : "text",
-          "spelling" : " {\n    ...\n}"
-        }
-      ],
-      "docComment" : {
-        "lines" : [
-          {
-            "text" : "A directive for authoring authoring embedded"
-          },
-          {
-            "text" : "previews of documentation links (similar to how links are currently"
-          },
-          {
-            "text" : "rendered in Topics sections) anywhere on the page without affecting page"
-          },
-          {
-            "text" : "curation behavior."
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "`@Links` gives authors flexibility in choosing how they want to highlight"
-          },
-          {
-            "text" : "documentation on the page itself versus in the navigation sidebar."
-          },
-          {
-            "text" : "It also allows for mixing and matching different visual styles of"
-          },
-          {
-            "text" : "topics."
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "```md"
-          },
-          {
-            "text" : "..."
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "### What's New in SlothCreator"
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "@Links(visualStyle: compactGrid) {"
-          },
-          {
-            "text" : "   - <doc:get-started-preparing-sloth-food>"
-          },
-          {
-            "text" : "   - <doc:feeding-your-sloth-in-winter>"
-          },
-          {
-            "text" : "   - <doc:ordering-food-delivery>"
-          },
-          {
-            "text" : "}"
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "..."
-          },
-          {
-            "text" : "```"
-          },
-          {
-            "text" : "- Parameters:"
-          },
-          {
-            "text" : "  - visualStyle: The specified style that should be used when rendering the specified links."
-          },
-          {
-            "text" : "     **(required)**"
-          },
-          {
-            "text" : "     - term `list`: A list of the linked pages, including their full declaration and abstract."
-          },
-          {
-            "text" : "     - term `compactGrid`: A grid of items based on the card image for the linked pages."
-          },
-          {
-            "text" : "        "
-          },
-          {
-            "text" : "        Includes each page’s title and card image but excludes their abstracts."
-          },
-          {
-            "text" : "     - term `detailedGrid`: A grid of items based on the card image for the linked pages."
-          },
-          {
-            "text" : "        "
-          },
-          {
-            "text" : "        Unlike ``compactGrid``, this style includes the abstract for each page."
-          }
-        ]
-      },
-      "identifier" : {
-        "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$Links"
-      },
-      "kind" : {
-        "displayName" : "Directive",
-        "identifier" : "class"
-      },
-      "names" : {
-        "navigator" : [
-          {
-            "kind" : "attribute",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$Links",
-            "spelling" : "Links"
-          }
-        ],
-        "subHeading" : [
-          {
-            "kind" : "identifier",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "Links"
-          },
-          {
-            "kind" : "text",
-            "spelling" : "("
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "visualStyle"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ": "
-          },
-          {
-            "kind" : "typeIdentifier",
-            "spelling" : "VisualStyle"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ")"
-          }
-        ],
-        "title" : "Links"
-      },
-      "pathComponents" : [
-        "Links"
-      ]
-    },
-    {
-      "accessLevel" : "public",
-      "declarationFragments" : [
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "Metadata"
-        },
-        {
-          "kind" : "text",
-          "spelling" : " {\n    ...\n}"
-        }
-      ],
-      "docComment" : {
-        "lines" : [
-          {
-            "text" : "A directive that contains various metadata about a page."
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "This directive acts as a container for metadata and configuration without any arguments of its own."
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "## Topics"
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "### Child Directives"
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "- ``DocumentationExtension``"
-          },
-          {
-            "text" : "- ``TechnologyRoot``"
-          },
-          {
-            "text" : "- ``DisplayName``"
-          },
-          {
-            "text" : "- ``PageImage``"
-          },
-          {
-            "text" : "- ``CallToAction``"
-          }
-        ]
-      },
-      "identifier" : {
-        "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$Metadata"
-      },
-      "kind" : {
-        "displayName" : "Directive",
-        "identifier" : "class"
-      },
-      "names" : {
-        "navigator" : [
-          {
-            "kind" : "attribute",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$Metadata",
-            "spelling" : "Metadata"
-          }
-        ],
-        "subHeading" : [
-          {
-            "kind" : "identifier",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "Metadata"
-          }
-        ],
-        "title" : "Metadata"
-      },
-      "pathComponents" : [
-        "Metadata"
-      ]
-    },
-    {
-      "accessLevel" : "public",
-      "declarationFragments" : [
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "Intro"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "("
-        },
-        {
-          "kind" : "identifier",
-          "spelling" : "title"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ": "
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "String"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ")"
-        },
-        {
-          "kind" : "text",
-          "spelling" : " {\n    ...\n}"
-        }
-      ],
-      "docComment" : {
-        "lines" : [
-          {
-            "text" : "An introductory section for instructional pages."
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "- Parameters:"
-          },
-          {
-            "text" : "  - title: The title of the containing ``Tutorial``."
-          },
-          {
-            "text" : "     **(required)**"
-          }
-        ]
-      },
-      "identifier" : {
-        "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$Intro"
-      },
-      "kind" : {
-        "displayName" : "Directive",
-        "identifier" : "class"
-      },
-      "names" : {
-        "navigator" : [
-          {
-            "kind" : "attribute",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$Intro",
-            "spelling" : "Intro"
-          }
-        ],
-        "subHeading" : [
-          {
-            "kind" : "identifier",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "Intro"
-          },
-          {
-            "kind" : "text",
-            "spelling" : "("
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "title"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ": "
-          },
-          {
-            "kind" : "typeIdentifier",
-            "spelling" : "String"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ")"
-          }
-        ],
-        "title" : "Intro"
-      },
-      "pathComponents" : [
-        "Intro"
-      ]
-    },
-    {
-      "accessLevel" : "public",
-      "declarationFragments" : [
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "Code"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "(...)"
-        },
-        {
-          "kind" : "text",
-          "spelling" : " {\n    ...\n}"
-        }
-      ],
-      "identifier" : {
-        "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$Code"
-      },
-      "kind" : {
-        "displayName" : "Directive",
-        "identifier" : "class"
-      },
-      "names" : {
-        "navigator" : [
-          {
-            "kind" : "attribute",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$Code",
-            "spelling" : "Code"
-          }
-        ],
-        "subHeading" : [
-          {
-            "kind" : "identifier",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "Code"
-          },
-          {
-            "kind" : "text",
-            "spelling" : "(...)"
-          }
-        ],
-        "title" : "Code"
-      },
-      "pathComponents" : [
-        "Code"
-      ]
-    },
-    {
-      "accessLevel" : "public",
-      "declarationFragments" : [
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "TabNavigator"
-        },
-        {
-          "kind" : "text",
-          "spelling" : " {\n"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "    "
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "preciseIdentifier" : "__docc_universal_symbol_reference_$Tab",
-          "spelling" : "Tab"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "("
-        },
-        {
-          "kind" : "text",
-          "spelling" : "_ "
-        },
-        {
-          "kind" : "identifier",
-          "spelling" : "title"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ": "
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "String"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ")"
-        },
-        {
-          "kind" : "text",
-          "spelling" : " { ... }"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "\n"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "}"
-        }
-      ],
-      "docComment" : {
-        "lines" : [
-          {
-            "text" : "A container directive that arranges content into a tab-based layout."
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "Create a new tab navigator by writing a `@TabNavigator` directive that contains child"
-          },
-          {
-            "text" : "`@Tab` directives."
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "```md"
-          },
-          {
-            "text" : "@TabNavigator {"
-          },
-          {
-            "text" : "   @Tab(\"Powers\") {"
-          },
-          {
-            "text" : "      ![A diagram with the five sloth power types.](sloth-powers)"
-          },
-          {
-            "text" : "   }"
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "   @Tab(\"Excerise routines\") {"
-          },
-          {
-            "text" : "      ![A sloth relaxing and enjoying a good book.](sloth-exercise)"
-          },
-          {
-            "text" : "   }"
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "   @Tab(\"Hats\") {"
-          },
-          {
-            "text" : "      ![A sloth discovering newfound confidence after donning a fedora.](sloth-hats)"
-          },
-          {
-            "text" : "   }"
-          },
-          {
-            "text" : "}"
-          },
-          {
-            "text" : "```"
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "## Topics"
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "- ``Tab``"
-          }
-        ]
-      },
-      "identifier" : {
-        "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$TabNavigator"
-      },
-      "kind" : {
-        "displayName" : "Directive",
-        "identifier" : "class"
-      },
-      "names" : {
-        "navigator" : [
-          {
-            "kind" : "attribute",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$TabNavigator",
-            "spelling" : "TabNavigator"
-          }
-        ],
-        "subHeading" : [
-          {
-            "kind" : "identifier",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "TabNavigator"
-          }
-        ],
-        "title" : "TabNavigator"
-      },
-      "pathComponents" : [
-        "TabNavigator"
-      ]
-    },
-    {
-      "accessLevel" : "public",
-      "declarationFragments" : [
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "CallToAction"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "("
-        },
-        {
-          "kind" : "identifier",
-          "spelling" : "url"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ": "
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "URL"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "?"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ", "
-        },
-        {
-          "kind" : "identifier",
-          "spelling" : "file"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ": "
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "ResourceReference"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "?"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ", "
-        },
-        {
-          "kind" : "identifier",
-          "spelling" : "purpose"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ": "
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "Purpose"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "?"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ", "
-        },
-        {
-          "kind" : "identifier",
-          "spelling" : "label"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ": "
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "String"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "?"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ")"
-        }
-      ],
-      "docComment" : {
-        "lines" : [
-          {
-            "text" : "A directive that adds a prominent button or link to a page's header."
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "A \"Call to Action\" has two main components: a link or file path, and the link text to display."
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "The link path can be specified in one of two ways:"
-          },
-          {
-            "text" : "- The `url` parameter specifies a URL that will be used verbatim. Use this when you're linking"
-          },
-          {
-            "text" : "  to an external page or externally-hosted file."
-          },
-          {
-            "text" : "- The `path` parameter specifies the path to a file hosted within your documentation catalog."
-          },
-          {
-            "text" : "  Use this if you're linking to a downloadable file that you're managing alongside your"
-          },
-          {
-            "text" : "  articles and tutorials."
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "The link text can also be specified in one of two ways:"
-          },
-          {
-            "text" : "- The `purpose` parameter can be used to use a default button label. There are two valid values:"
-          },
-          {
-            "text" : "  - `download` indicates that the link is to a downloadable file. The button will be labeled \"Download\"."
-          },
-          {
-            "text" : "  - `link` indicates that the link is to an external webpage. The button will be labeled \"Visit\"."
-          },
-          {
-            "text" : "- The `label` parameter specifies the literal text to use as the button label."
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "`@CallToAction` requires one of `url` or `path`, and one of `purpose` or `label`. Specifying both"
-          },
-          {
-            "text" : "`purpose` and `label` is allowed, but the `label` will override the default label provided by"
-          },
-          {
-            "text" : "`purpose`."
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "This directive is only valid within a ``Metadata`` directive:"
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "```markdown"
-          },
-          {
-            "text" : "@Metadata {"
-          },
-          {
-            "text" : "    @CallToAction(url: \"https:\/\/example.com\/sample.zip\", purpose: download)"
-          },
-          {
-            "text" : "}"
-          },
-          {
-            "text" : "```"
-          },
-          {
-            "text" : "- Parameters:"
-          },
-          {
-            "text" : "  - url: The location of the associated link, as a fixed URL."
-          },
-          {
-            "text" : "     **(optional)**"
-          },
-          {
-            "text" : "  - file: The location of the associated link, as a reference to a file in this documentation bundle."
-          },
-          {
-            "text" : "     **(optional)**"
-          },
-          {
-            "text" : "  - purpose: The purpose of this Call to Action, which provides a default button label."
-          },
-          {
-            "text" : "     **(optional)**"
-          },
-          {
-            "text" : "     - term `download`: References a link to download an associated asset, like a sample project."
-          },
-          {
-            "text" : "     - term `link`: References a link to view external content, like a source code repository."
-          },
-          {
-            "text" : "  - label: Text to use as the button label, which may override ``purpose-swift.property``."
-          },
-          {
-            "text" : "     **(optional)**"
-          }
-        ]
-      },
-      "identifier" : {
-        "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$CallToAction"
-      },
-      "kind" : {
-        "displayName" : "Directive",
-        "identifier" : "class"
-      },
-      "names" : {
-        "navigator" : [
-          {
-            "kind" : "attribute",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$CallToAction",
-            "spelling" : "CallToAction"
-          }
-        ],
-        "subHeading" : [
-          {
-            "kind" : "identifier",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "CallToAction"
-          },
-          {
-            "kind" : "text",
-            "spelling" : "("
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "url"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ": "
-          },
-          {
-            "kind" : "typeIdentifier",
-            "spelling" : "URL"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ", "
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "file"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ": "
-          },
-          {
-            "kind" : "typeIdentifier",
-            "spelling" : "ResourceReference"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ", "
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "purpose"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ": "
-          },
-          {
-            "kind" : "typeIdentifier",
-            "spelling" : "Purpose"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ", "
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "label"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ": "
-          },
-          {
-            "kind" : "typeIdentifier",
-            "spelling" : "String"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ")"
-          }
-        ],
-        "title" : "CallToAction"
-      },
-      "pathComponents" : [
-        "CallToAction"
-      ]
-    },
-    {
-      "accessLevel" : "public",
-      "declarationFragments" : [
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "TechnologyRoot"
-        }
-      ],
-      "docComment" : {
-        "lines" : [
-          {
-            "text" : "A directive to set this page as a documentation root-level node."
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "This directive is only valid within a top-level ``Metadata`` directive:"
-          },
-          {
-            "text" : "```"
-          },
-          {
-            "text" : "@Metadata {"
-          },
-          {
-            "text" : "   @TechnologyRoot"
-          },
-          {
-            "text" : "}"
-          },
-          {
-            "text" : "```"
-          }
-        ]
-      },
-      "identifier" : {
-        "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$TechnologyRoot"
-      },
-      "kind" : {
-        "displayName" : "Directive",
-        "identifier" : "class"
-      },
-      "names" : {
-        "navigator" : [
-          {
-            "kind" : "attribute",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$TechnologyRoot",
-            "spelling" : "TechnologyRoot"
-          }
-        ],
-        "subHeading" : [
-          {
-            "kind" : "identifier",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "TechnologyRoot"
-          }
-        ],
-        "title" : "TechnologyRoot"
-      },
-      "pathComponents" : [
-        "TechnologyRoot"
-      ]
-    },
-    {
-      "accessLevel" : "public",
-      "declarationFragments" : [
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "PageImage"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "("
-        },
-        {
-          "kind" : "identifier",
-          "spelling" : "purpose"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ": "
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "Purpose"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ", "
-        },
-        {
-          "kind" : "identifier",
-          "spelling" : "source"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ": "
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "ResourceReference"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ", "
-        },
-        {
-          "kind" : "identifier",
-          "spelling" : "alt"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ": "
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "String"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "?"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ")"
-        }
-      ],
-      "identifier" : {
-        "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$PageImage"
-      },
-      "kind" : {
-        "displayName" : "Directive",
-        "identifier" : "class"
-      },
-      "names" : {
-        "navigator" : [
-          {
-            "kind" : "attribute",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$PageImage",
-            "spelling" : "PageImage"
-          }
-        ],
-        "subHeading" : [
-          {
-            "kind" : "identifier",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "PageImage"
-          },
-          {
-            "kind" : "text",
-            "spelling" : "("
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "purpose"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ": "
-          },
-          {
-            "kind" : "typeIdentifier",
-            "spelling" : "Purpose"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ", "
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "source"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ": "
-          },
-          {
-            "kind" : "typeIdentifier",
-            "spelling" : "ResourceReference"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ", "
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "alt"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ": "
-          },
-          {
-            "kind" : "typeIdentifier",
-            "spelling" : "String"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ")"
-          }
-        ],
-        "title" : "PageImage"
-      },
-      "pathComponents" : [
-        "PageImage"
-      ]
-    },
-    {
-      "accessLevel" : "public",
-      "declarationFragments" : [
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "Volume"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "(...)"
-        },
-        {
-          "kind" : "text",
-          "spelling" : " {\n    ...\n}"
-        }
-      ],
-      "identifier" : {
-        "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$Volume"
-      },
-      "kind" : {
-        "displayName" : "Directive",
-        "identifier" : "class"
-      },
-      "names" : {
-        "navigator" : [
-          {
-            "kind" : "attribute",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$Volume",
-            "spelling" : "Volume"
-          }
-        ],
-        "subHeading" : [
-          {
-            "kind" : "identifier",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "Volume"
-          },
-          {
-            "kind" : "text",
-            "spelling" : "(...)"
-          }
-        ],
-        "title" : "Volume"
-      },
-      "pathComponents" : [
-        "Volume"
-      ]
-    },
-    {
-      "accessLevel" : "public",
-      "declarationFragments" : [
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "Column"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "("
-        },
-        {
-          "kind" : "identifier",
-          "spelling" : "size"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ": "
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "Int"
-        },
-        {
-          "kind" : "text",
-          "spelling" : " = 1"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ")"
-        },
-        {
-          "kind" : "text",
-          "spelling" : " {\n    ...\n}"
-        }
-      ],
-      "docComment" : {
-        "lines" : [
-          {
-            "text" : "A container directive that holds general markup content describing a column"
-          },
-          {
-            "text" : "with a row in a grid-based layout."
-          },
-          {
-            "text" : "- Parameters:"
-          },
-          {
-            "text" : "  - size: The size of this column."
-          },
-          {
-            "text" : "     **(optional)**"
-          },
-          {
-            "text" : "     "
-          },
-          {
-            "text" : "     Specify a value greater than `1` to make this column span multiple columns"
-          },
-          {
-            "text" : "     in the parent ``Row``."
-          }
-        ]
-      },
-      "identifier" : {
-        "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$Column"
-      },
-      "kind" : {
-        "displayName" : "Directive",
-        "identifier" : "class"
-      },
-      "names" : {
-        "navigator" : [
-          {
-            "kind" : "attribute",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$Column",
-            "spelling" : "Column"
-          }
-        ],
-        "subHeading" : [
-          {
-            "kind" : "identifier",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "Column"
-          },
-          {
-            "kind" : "text",
-            "spelling" : "("
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "size"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ": "
-          },
-          {
-            "kind" : "typeIdentifier",
-            "spelling" : "Int"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ")"
-          }
-        ],
-        "title" : "Column"
-      },
-      "pathComponents" : [
-        "Column"
-      ]
-    },
-    {
-      "accessLevel" : "public",
-      "declarationFragments" : [
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "Tutorials"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "(...)"
-        },
-        {
-          "kind" : "text",
-          "spelling" : " {\n    ...\n}"
-        }
-      ],
-      "identifier" : {
-        "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$Tutorials"
-      },
-      "kind" : {
-        "displayName" : "Directive",
-        "identifier" : "class"
-      },
-      "names" : {
-        "navigator" : [
-          {
-            "kind" : "attribute",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$Tutorials",
-            "spelling" : "Tutorials"
-          }
-        ],
-        "subHeading" : [
-          {
-            "kind" : "identifier",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "Tutorials"
-          },
-          {
-            "kind" : "text",
-            "spelling" : "(...)"
-          }
-        ],
-        "title" : "Tutorials"
-      },
-      "pathComponents" : [
-        "Tutorials"
-      ]
-    },
-    {
-      "accessLevel" : "public",
-      "declarationFragments" : [
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "Steps"
-        },
-        {
-          "kind" : "text",
-          "spelling" : " {\n    ...\n}"
-        }
-      ],
-      "identifier" : {
-        "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$Steps"
-      },
-      "kind" : {
-        "displayName" : "Directive",
-        "identifier" : "class"
-      },
-      "names" : {
-        "navigator" : [
-          {
-            "kind" : "attribute",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$Steps",
-            "spelling" : "Steps"
-          }
-        ],
-        "subHeading" : [
-          {
-            "kind" : "identifier",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "Steps"
-          }
-        ],
-        "title" : "Steps"
-      },
-      "pathComponents" : [
-        "Steps"
-      ]
-    },
-    {
-      "accessLevel" : "public",
-      "declarationFragments" : [
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
           "spelling" : "Video"
         },
         {
@@ -4035,297 +5248,7 @@
         },
         {
           "kind" : "typeIdentifier",
-          "spelling" : "Assessments"
-        },
-        {
-          "kind" : "text",
-          "spelling" : " {\n"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "    "
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "preciseIdentifier" : "__docc_universal_symbol_reference_$MultipleChoice",
-          "spelling" : "MultipleChoice"
-        },
-        {
-          "kind" : "text",
-          "spelling" : " { ... }"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "\n"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "}"
-        }
-      ],
-      "docComment" : {
-        "lines" : [
-          {
-            "text" : "A collection of questions about the concepts the documentation presents."
-          }
-        ]
-      },
-      "identifier" : {
-        "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$Assessments"
-      },
-      "kind" : {
-        "displayName" : "Directive",
-        "identifier" : "class"
-      },
-      "names" : {
-        "navigator" : [
-          {
-            "kind" : "attribute",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$Assessments",
-            "spelling" : "Assessments"
-          }
-        ],
-        "subHeading" : [
-          {
-            "kind" : "identifier",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "Assessments"
-          }
-        ],
-        "title" : "Assessments"
-      },
-      "pathComponents" : [
-        "Assessments"
-      ]
-    },
-    {
-      "accessLevel" : "public",
-      "declarationFragments" : [
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "TutorialReference"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "("
-        },
-        {
-          "kind" : "identifier",
-          "spelling" : "tutorial"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ": "
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "TopicReference"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ")"
-        }
-      ],
-      "docComment" : {
-        "lines" : [
-          {
-            "text" : "A reference to a ``Tutorial`` or ``TutorialArticle`` by `URL`."
-          },
-          {
-            "text" : "- Parameters:"
-          },
-          {
-            "text" : "  - tutorial: The tutorial page or tutorial article to which this refers."
-          },
-          {
-            "text" : "     **(required)**"
-          }
-        ]
-      },
-      "identifier" : {
-        "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$TutorialReference"
-      },
-      "kind" : {
-        "displayName" : "Directive",
-        "identifier" : "class"
-      },
-      "names" : {
-        "navigator" : [
-          {
-            "kind" : "attribute",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$TutorialReference",
-            "spelling" : "TutorialReference"
-          }
-        ],
-        "subHeading" : [
-          {
-            "kind" : "identifier",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "TutorialReference"
-          },
-          {
-            "kind" : "text",
-            "spelling" : "("
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "tutorial"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ": "
-          },
-          {
-            "kind" : "typeIdentifier",
-            "spelling" : "TopicReference"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ")"
-          }
-        ],
-        "title" : "TutorialReference"
-      },
-      "pathComponents" : [
-        "TutorialReference"
-      ]
-    },
-    {
-      "accessLevel" : "public",
-      "declarationFragments" : [
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "Tutorial"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "("
-        },
-        {
-          "kind" : "identifier",
-          "spelling" : "time"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ": "
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "Int"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "?"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ", "
-        },
-        {
-          "kind" : "identifier",
-          "spelling" : "projectFiles"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ": "
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "ResourceReference"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "?"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ")"
-        },
-        {
-          "kind" : "text",
-          "spelling" : " {\n"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "    "
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "preciseIdentifier" : "__docc_universal_symbol_reference_$Intro",
-          "spelling" : "Intro"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "("
-        },
-        {
-          "kind" : "identifier",
-          "spelling" : "title"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ": "
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "String"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ")"
-        },
-        {
-          "kind" : "text",
-          "spelling" : " { ... }"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "\n"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "    "
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "preciseIdentifier" : "__docc_universal_symbol_reference_$Section",
-          "spelling" : "Section"
+          "spelling" : "Tutorials"
         },
         {
           "kind" : "text",
@@ -4333,292 +5256,12 @@
         },
         {
           "kind" : "text",
-          "spelling" : " { ... }"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "\n"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "}"
-        }
-      ],
-      "docComment" : {
-        "lines" : [
-          {
-            "text" : "A tutorial to complete in order to gain knowledge of a ``Technology``."
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "- Parameters:"
-          },
-          {
-            "text" : "  - time: The estimated time in minutes that the containing ``Tutorial`` will take."
-          },
-          {
-            "text" : "     **(optional)**"
-          },
-          {
-            "text" : "  - projectFiles: Project files to download to get started with the ``Tutorial``."
-          },
-          {
-            "text" : "     **(optional)**"
-          }
-        ]
-      },
-      "identifier" : {
-        "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$Tutorial"
-      },
-      "kind" : {
-        "displayName" : "Directive",
-        "identifier" : "class"
-      },
-      "names" : {
-        "navigator" : [
-          {
-            "kind" : "attribute",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$Tutorial",
-            "spelling" : "Tutorial"
-          }
-        ],
-        "subHeading" : [
-          {
-            "kind" : "identifier",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "Tutorial"
-          },
-          {
-            "kind" : "text",
-            "spelling" : "("
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "time"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ": "
-          },
-          {
-            "kind" : "typeIdentifier",
-            "spelling" : "Int"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ", "
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "projectFiles"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ": "
-          },
-          {
-            "kind" : "typeIdentifier",
-            "spelling" : "ResourceReference"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ")"
-          }
-        ],
-        "title" : "Tutorial"
-      },
-      "pathComponents" : [
-        "Tutorial"
-      ]
-    },
-    {
-      "accessLevel" : "public",
-      "declarationFragments" : [
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "Tab"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "("
-        },
-        {
-          "kind" : "text",
-          "spelling" : "_ "
-        },
-        {
-          "kind" : "identifier",
-          "spelling" : "title"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ": "
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "String"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ")"
-        },
-        {
-          "kind" : "text",
-          "spelling" : " {\n    ...\n}"
-        }
-      ],
-      "docComment" : {
-        "lines" : [
-          {
-            "text" : "A container directive that holds general markup content describing an individual"
-          },
-          {
-            "text" : "tab within a tab-based layout."
-          },
-          {
-            "text" : "- Parameters:"
-          },
-          {
-            "text" : "  - title: The title that should identify the content in this tab when rendered."
-          },
-          {
-            "text" : "     **(required)**"
-          }
-        ]
-      },
-      "identifier" : {
-        "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$Tab"
-      },
-      "kind" : {
-        "displayName" : "Directive",
-        "identifier" : "class"
-      },
-      "names" : {
-        "navigator" : [
-          {
-            "kind" : "attribute",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$Tab",
-            "spelling" : "Tab"
-          }
-        ],
-        "subHeading" : [
-          {
-            "kind" : "identifier",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "Tab"
-          },
-          {
-            "kind" : "text",
-            "spelling" : "("
-          },
-          {
-            "kind" : "text",
-            "spelling" : "_ "
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "title"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ": "
-          },
-          {
-            "kind" : "typeIdentifier",
-            "spelling" : "String"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ")"
-          }
-        ],
-        "title" : "Tab"
-      },
-      "pathComponents" : [
-        "Tab"
-      ]
-    },
-    {
-      "accessLevel" : "public",
-      "declarationFragments" : [
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "Image"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "("
-        },
-        {
-          "kind" : "identifier",
-          "spelling" : "source"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ": "
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "ResourceReference"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ", "
-        },
-        {
-          "kind" : "identifier",
-          "spelling" : "alt"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ": "
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "String"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "?"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ")"
-        },
-        {
-          "kind" : "text",
           "spelling" : " {\n    ...\n}"
         }
       ],
       "identifier" : {
         "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$Image"
+        "precise" : "__docc_universal_symbol_reference_$Tutorials"
       },
       "kind" : {
         "displayName" : "Directive",
@@ -4632,8 +5275,8 @@
           },
           {
             "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$Image",
-            "spelling" : "Image"
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$Tutorials",
+            "spelling" : "Tutorials"
           }
         ],
         "subHeading" : [
@@ -4643,325 +5286,17 @@
           },
           {
             "kind" : "identifier",
-            "spelling" : "Image"
-          },
-          {
-            "kind" : "text",
-            "spelling" : "("
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "source"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ": "
-          },
-          {
-            "kind" : "typeIdentifier",
-            "spelling" : "ResourceReference"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ", "
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "alt"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ": "
-          },
-          {
-            "kind" : "typeIdentifier",
-            "spelling" : "String"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ")"
-          }
-        ],
-        "title" : "Image"
-      },
-      "pathComponents" : [
-        "Image"
-      ]
-    },
-    {
-      "accessLevel" : "public",
-      "declarationFragments" : [
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "Choice"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "("
-        },
-        {
-          "kind" : "identifier",
-          "spelling" : "isCorrect"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ": "
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "Bool"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ")"
-        },
-        {
-          "kind" : "text",
-          "spelling" : " {\n"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "    ...\n\n"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "    "
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "preciseIdentifier" : "__docc_universal_symbol_reference_$Justification",
-          "spelling" : "Justification"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "("
-        },
-        {
-          "kind" : "identifier",
-          "spelling" : "reaction"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ": "
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "String"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "?"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ")"
-        },
-        {
-          "kind" : "text",
-          "spelling" : " { ... }"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "\n"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "}"
-        }
-      ],
-      "docComment" : {
-        "lines" : [
-          {
-            "text" : "One of possibly many choices in a ``MultipleChoice`` question."
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "- Parameters:"
-          },
-          {
-            "text" : "  - isCorrect: `true` if this choice is a correct one; there can be multiple correct choices."
-          },
-          {
-            "text" : "     **(required)**"
-          }
-        ]
-      },
-      "identifier" : {
-        "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$Choice"
-      },
-      "kind" : {
-        "displayName" : "Directive",
-        "identifier" : "class"
-      },
-      "names" : {
-        "navigator" : [
-          {
-            "kind" : "attribute",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$Choice",
-            "spelling" : "Choice"
-          }
-        ],
-        "subHeading" : [
-          {
-            "kind" : "identifier",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "Choice"
-          },
-          {
-            "kind" : "text",
-            "spelling" : "("
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "isCorrect"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ": "
-          },
-          {
-            "kind" : "typeIdentifier",
-            "spelling" : "Bool"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ")"
-          }
-        ],
-        "title" : "Choice"
-      },
-      "pathComponents" : [
-        "Choice"
-      ]
-    },
-    {
-      "accessLevel" : "public",
-      "declarationFragments" : [
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "Comment"
-        },
-        {
-          "kind" : "text",
-          "spelling" : " {\n    ...\n}"
-        }
-      ],
-      "identifier" : {
-        "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$Comment"
-      },
-      "kind" : {
-        "displayName" : "Directive",
-        "identifier" : "class"
-      },
-      "names" : {
-        "navigator" : [
-          {
-            "kind" : "attribute",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$Comment",
-            "spelling" : "Comment"
-          }
-        ],
-        "subHeading" : [
-          {
-            "kind" : "identifier",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "Comment"
-          }
-        ],
-        "title" : "Comment"
-      },
-      "pathComponents" : [
-        "Comment"
-      ]
-    },
-    {
-      "accessLevel" : "public",
-      "declarationFragments" : [
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "Videos"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "(...)"
-        },
-        {
-          "kind" : "text",
-          "spelling" : " {\n    ...\n}"
-        }
-      ],
-      "identifier" : {
-        "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$Videos"
-      },
-      "kind" : {
-        "displayName" : "Directive",
-        "identifier" : "class"
-      },
-      "names" : {
-        "navigator" : [
-          {
-            "kind" : "attribute",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$Videos",
-            "spelling" : "Videos"
-          }
-        ],
-        "subHeading" : [
-          {
-            "kind" : "identifier",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "Videos"
+            "spelling" : "Tutorials"
           },
           {
             "kind" : "text",
             "spelling" : "(...)"
           }
         ],
-        "title" : "Videos"
+        "title" : "Tutorials"
       },
       "pathComponents" : [
-        "Videos"
+        "Tutorials"
       ]
     },
     {
@@ -4973,73 +5308,16 @@
         },
         {
           "kind" : "typeIdentifier",
-          "spelling" : "XcodeRequirement"
+          "spelling" : "Steps"
         },
         {
           "kind" : "text",
-          "spelling" : "("
-        },
-        {
-          "kind" : "identifier",
-          "spelling" : "title"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ": "
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "String"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ", "
-        },
-        {
-          "kind" : "identifier",
-          "spelling" : "destination"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ": "
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "URL"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ")"
+          "spelling" : " {\n    ...\n}"
         }
       ],
-      "docComment" : {
-        "lines" : [
-          {
-            "text" : "An informal Xcode requirement for completing an instructional ``Tutorial``."
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "- Parameters:"
-          },
-          {
-            "text" : "  - title: Human readable title."
-          },
-          {
-            "text" : "     **(required)**"
-          },
-          {
-            "text" : "  - destination: Domain where requirement applies."
-          },
-          {
-            "text" : "     **(required)**"
-          }
-        ]
-      },
       "identifier" : {
         "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$XcodeRequirement"
+        "precise" : "__docc_universal_symbol_reference_$Steps"
       },
       "kind" : {
         "displayName" : "Directive",
@@ -5053,8 +5331,8 @@
           },
           {
             "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$XcodeRequirement",
-            "spelling" : "XcodeRequirement"
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$Steps",
+            "spelling" : "Steps"
           }
         ],
         "subHeading" : [
@@ -5064,49 +5342,65 @@
           },
           {
             "kind" : "identifier",
-            "spelling" : "XcodeRequirement"
-          },
-          {
-            "kind" : "text",
-            "spelling" : "("
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "title"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ": "
-          },
-          {
-            "kind" : "typeIdentifier",
-            "spelling" : "String"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ", "
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "destination"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ": "
-          },
-          {
-            "kind" : "typeIdentifier",
-            "spelling" : "URL"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ")"
+            "spelling" : "Steps"
           }
         ],
-        "title" : "XcodeRequirement"
+        "title" : "Steps"
       },
       "pathComponents" : [
-        "XcodeRequirement"
+        "Steps"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "ContentAndMedia"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " {\n    ...\n}"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$ContentAndMedia"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$ContentAndMedia",
+            "spelling" : "ContentAndMedia"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "ContentAndMedia"
+          }
+        ],
+        "title" : "ContentAndMedia"
+      },
+      "pathComponents" : [
+        "ContentAndMedia"
       ]
     }
   ]

--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
@@ -1839,7 +1839,7 @@ Document
             # Article 2
             
             @Options {
-                @AutomaticTitleHeading(pageKind)
+                @AutomaticTitleHeading(enabled)
             }
 
             This is article 2.

--- a/Tests/SwiftDocCTests/Semantics/ArticleTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/ArticleTests.swift
@@ -179,7 +179,7 @@ class ArticleTests: XCTestCase {
         This is an abstract.
         
         @Options {
-            @AutomaticSeeAlso(siblingPages)
+            @AutomaticSeeAlso(enabled)
         }
 
         Here's an overview.
@@ -206,6 +206,6 @@ class ArticleTests: XCTestCase {
             9
         )
         
-        XCTAssertEqual(article?.options[.local]?.automaticSeeAlsoBehavior, .disabled)
+        XCTAssertEqual(article?.options[.local]?.automaticSeeAlsoEnabled, false)
     }
 }

--- a/Tests/SwiftDocCTests/Semantics/Options/OptionsTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/Options/OptionsTests.swift
@@ -27,8 +27,8 @@ class OptionsTests: XCTestCase {
         XCTAssertTrue(problems.isEmpty)
         let unwrappedOptions = try XCTUnwrap(options)
         
-        XCTAssertNil(unwrappedOptions.automaticTitleHeadingBehavior)
-        XCTAssertNil(unwrappedOptions.automaticSeeAlsoBehavior)
+        XCTAssertNil(unwrappedOptions.automaticTitleHeadingEnabled)
+        XCTAssertNil(unwrappedOptions.automaticSeeAlsoEnabled)
         XCTAssertNil(unwrappedOptions.topicsVisualStyle)
         XCTAssertEqual(unwrappedOptions.scope, .local)
     }
@@ -90,20 +90,20 @@ class OptionsTests: XCTestCase {
             }
             
             XCTAssertTrue(problems.isEmpty)
-            XCTAssertEqual(options?.automaticSeeAlsoBehavior, .disabled)
+            XCTAssertEqual(options?.automaticSeeAlsoEnabled, false)
         }
         
         do {
             let (problems, options) = try parseDirective(Options.self) {
                 """
                 @Options {
-                    @AutomaticSeeAlso(siblingPages)
+                    @AutomaticSeeAlso(enabled)
                 }
                 """
             }
             
             XCTAssertTrue(problems.isEmpty)
-            XCTAssertEqual(options?.automaticSeeAlsoBehavior, .siblingPages)
+            XCTAssertEqual(options?.automaticSeeAlsoEnabled, true)
         }
         
         do {
@@ -117,7 +117,7 @@ class OptionsTests: XCTestCase {
             
             
             XCTAssertNotNil(options)
-            XCTAssertNil(options?.automaticSeeAlsoBehavior)
+            XCTAssertNil(options?.automaticSeeAlsoEnabled)
             
             XCTAssertEqual(
                 problems,
@@ -214,20 +214,20 @@ class OptionsTests: XCTestCase {
             }
             
             XCTAssertTrue(problems.isEmpty)
-            XCTAssertEqual(options?.automaticTitleHeadingBehavior, .disabled)
+            XCTAssertEqual(options?.automaticTitleHeadingEnabled, false)
         }
         
         do {
             let (problems, options) = try parseDirective(Options.self) {
                 """
                 @Options {
-                    @AutomaticTitleHeading(pageKind)
+                    @AutomaticTitleHeading(enabled)
                 }
                 """
             }
             
             XCTAssertTrue(problems.isEmpty)
-            XCTAssertEqual(options?.automaticTitleHeadingBehavior, .pageKind)
+            XCTAssertEqual(options?.automaticTitleHeadingEnabled, true)
         }
         
         do {
@@ -241,7 +241,7 @@ class OptionsTests: XCTestCase {
             
             
             XCTAssertNotNil(options)
-            XCTAssertNil(options?.automaticTitleHeadingBehavior)
+            XCTAssertNil(options?.automaticTitleHeadingEnabled)
             
             XCTAssertEqual(
                 problems,
@@ -256,7 +256,7 @@ class OptionsTests: XCTestCase {
         let (problems, options) = try parseDirective(Options.self) {
             """
             @Options {
-                @AutomaticTitleHeading(pageKind)
+                @AutomaticTitleHeading(enabled)
                 @AutomaticSeeAlso(disabled)
                 @TopicsVisualStyle(detailedGrid)
                 @AutomaticArticleSubheading(enabled)
@@ -265,17 +265,17 @@ class OptionsTests: XCTestCase {
         }
         
         XCTAssertTrue(problems.isEmpty)
-        XCTAssertEqual(options?.automaticTitleHeadingBehavior, .pageKind)
-        XCTAssertEqual(options?.automaticSeeAlsoBehavior, .disabled)
+        XCTAssertEqual(options?.automaticTitleHeadingEnabled, true)
+        XCTAssertEqual(options?.automaticSeeAlsoEnabled, false)
         XCTAssertEqual(options?.topicsVisualStyle, .detailedGrid)
-        XCTAssertEqual(options?.automaticArticleSubheadingBehavior, .enabled)
+        XCTAssertEqual(options?.automaticArticleSubheadingEnabled, true)
     }
     
     func testUnsupportedChild() throws {
         let (problems, options) = try parseDirective(Options.self) {
             """
             @Options {
-                @AutomaticTitleHeading(pageKind)
+                @AutomaticTitleHeading(enabled)
                 @Row {
                     @Column {
                         Hi!
@@ -285,7 +285,7 @@ class OptionsTests: XCTestCase {
             """
         }
         
-        XCTAssertEqual(options?.automaticTitleHeadingBehavior, .pageKind)
+        XCTAssertEqual(options?.automaticTitleHeadingEnabled, true)
         XCTAssertEqual(
             problems,
             [
@@ -306,7 +306,7 @@ class OptionsTests: XCTestCase {
             
             XCTAssertTrue(problems.isEmpty)
             let unwrappedOptions = try XCTUnwrap(options)
-            XCTAssertNil(unwrappedOptions.automaticArticleSubheadingBehavior)
+            XCTAssertNil(unwrappedOptions.automaticArticleSubheadingEnabled)
         }
         
         do {
@@ -320,7 +320,7 @@ class OptionsTests: XCTestCase {
             
             XCTAssertEqual(problems, ["2: warning – org.swift.docc.HasArgument.unlabeled.ConversionFailed"])
             let unwrappedOptions = try XCTUnwrap(options)
-            XCTAssertNil(unwrappedOptions.automaticArticleSubheadingBehavior)
+            XCTAssertNil(unwrappedOptions.automaticArticleSubheadingEnabled)
         }
         
         do {
@@ -334,7 +334,7 @@ class OptionsTests: XCTestCase {
             
             XCTAssertTrue(problems.isEmpty)
             let unwrappedOptions = try XCTUnwrap(options)
-            XCTAssertEqual(unwrappedOptions.automaticArticleSubheadingBehavior, .disabled)
+            XCTAssertEqual(unwrappedOptions.automaticArticleSubheadingEnabled, false)
         }
         
         do {
@@ -348,7 +348,7 @@ class OptionsTests: XCTestCase {
             
             XCTAssertTrue(problems.isEmpty)
             let unwrappedOptions = try XCTUnwrap(options)
-            XCTAssertEqual(unwrappedOptions.automaticArticleSubheadingBehavior, .enabled)
+            XCTAssertEqual(unwrappedOptions.automaticArticleSubheadingEnabled, true)
         }
     }
 }


### PR DESCRIPTION
Squash of https://github.com/apple/swift-docc/pull/448

- **Explanation**: This updates the naming convention of "option directives" to match the Forum discussions.
- **Scope**: Documentation using `@Option` directives to disabled various default behaviors. 
- **Radar**: rdar://104437275 
- **Risk**: Low. The syntax to disable default behaviors remain the same. Only redundantly writing out the directives to enable the behavior that's already on by default changed.
- **Testing**: Updated tests to use new directive argument names. Existing automated tests pass.
- **Reviewer**: @ethan-kusters 