### PR TITLE
make CallToAction `url` arguments encode verbatim in Render JSON

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/References/ExternalLocationReference.swift
+++ b/Sources/SwiftDocC/Model/Rendering/References/ExternalLocationReference.swift
@@ -20,7 +20,7 @@ import Foundation
 /// ``DownloadReference``, but with the `url` set to the text given in the `@CallToAction`'s `url`
 /// argument.
 public struct ExternalLocationReference: RenderReference, URLReference {
-    public static var baseURL: URL = .init(string: "/\(DownloadReference.locationName)/")!
+    public static var baseURL: URL = DownloadReference.baseURL
 
     public private(set) var type: RenderReferenceType = .download
 

--- a/Sources/SwiftDocC/Model/Rendering/References/ExternalLocationReference.swift
+++ b/Sources/SwiftDocC/Model/Rendering/References/ExternalLocationReference.swift
@@ -22,7 +22,7 @@ import Foundation
 public struct ExternalLocationReference: RenderReference, URLReference {
     public static var baseURL: URL = .init(string: "/\(DownloadReference.locationName)/")!
 
-    public var type: RenderReferenceType = .download
+    public private(set) var type: RenderReferenceType = .download
 
     public var identifier: RenderReferenceIdentifier
 
@@ -40,6 +40,7 @@ public struct ExternalLocationReference: RenderReference, URLReference {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
         self.identifier = try container.decode(RenderReferenceIdentifier.self, forKey: .identifier)
+        self.type = try container.decode(RenderReferenceType.self, forKey: .type)
     }
 
     public func encode(to encoder: Encoder) throws {

--- a/Sources/SwiftDocC/Model/Rendering/References/ExternalLocationReference.swift
+++ b/Sources/SwiftDocC/Model/Rendering/References/ExternalLocationReference.swift
@@ -10,7 +10,7 @@
 
 import Foundation
 
-/// A specialized ``DownloadReference`` used for ``CallToAction`` directives.
+/// A specialized ``DownloadReference`` used for references to external links.
 ///
 /// `@CallToAction` directives can link either to a local file or to a URL, whether relative or
 /// absolute. Directives that use the `file` argument will create a ``DownloadReference`` and copy

--- a/Sources/SwiftDocC/Model/Rendering/References/ExternalLocationReference.swift
+++ b/Sources/SwiftDocC/Model/Rendering/References/ExternalLocationReference.swift
@@ -16,10 +16,10 @@ import Foundation
 /// absolute. Directives that use the `file` argument will create a ``DownloadReference`` and copy
 /// the file from the catalog into the resulting archive.
 ///
-/// A `CallToActionReference` is intended to encode to Render JSON compatible with a
+/// An `ExternalLocationReference` is intended to encode to Render JSON compatible with a
 /// ``DownloadReference``, but with the `url` set to the text given in the `@CallToAction`'s `url`
 /// argument.
-public struct CallToActionReference: RenderReference, URLReference {
+public struct ExternalLocationReference: RenderReference, URLReference {
     public static var baseURL: URL = .init(string: "/\(DownloadReference.locationName)/")!
 
     public var type: RenderReferenceType = .download

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -789,7 +789,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
                         isActive: true,
                         overridingTitle: callToAction.buttonLabel,
                         overridingTitleInlineContent: nil))
-                callToActionReferences[url.description] = ExternalLocationReference(identifier: downloadIdentifier)
+                externalLocationReferences[url.description] = ExternalLocationReference(identifier: downloadIdentifier)
             } else if let fileReference = callToAction.file {
                 let downloadIdentifier = createAndRegisterRenderReference(forMedia: fileReference, assetContext: .download)
                 node.sampleDownload = .init(action: .reference(
@@ -826,7 +826,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
         addReferences(videoReferences, to: &node)
         addReferences(linkReferences, to: &node)
         addReferences(downloadReferences, to: &node)
-        addReferences(callToActionReferences, to: &node)
+        addReferences(externalLocationReferences, to: &node)
         // See Also can contain external links, we need to separately transfer
         // link references from the content compiler
         addReferences(contentCompiler.linkReferences, to: &node)
@@ -1623,7 +1623,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
     var linkReferences: [String: LinkReference] = [:]
     var requirementReferences: [String: XcodeRequirementReference] = [:]
     var downloadReferences: [String: DownloadReference] = [:]
-    var callToActionReferences: [String: ExternalLocationReference] = [:]
+    var externalLocationReferences: [String: ExternalLocationReference] = [:]
     
     private var bundleAvailability: [BundleModuleIdentifier: [AvailabilityRenderItem]] = [:]
     

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -789,11 +789,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
                         isActive: true,
                         overridingTitle: callToAction.buttonLabel,
                         overridingTitleInlineContent: nil))
-                downloadReferences[url.description] = DownloadReference(
-                    identifier: downloadIdentifier,
-                    renderURL: url,
-                    checksum: nil
-                )
+                callToActionReferences[url.description] = CallToActionReference(identifier: downloadIdentifier)
             } else if let fileReference = callToAction.file {
                 let downloadIdentifier = createAndRegisterRenderReference(forMedia: fileReference, assetContext: .download)
                 node.sampleDownload = .init(action: .reference(
@@ -830,6 +826,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
         addReferences(videoReferences, to: &node)
         addReferences(linkReferences, to: &node)
         addReferences(downloadReferences, to: &node)
+        addReferences(callToActionReferences, to: &node)
         // See Also can contain external links, we need to separately transfer
         // link references from the content compiler
         addReferences(contentCompiler.linkReferences, to: &node)
@@ -1626,6 +1623,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
     var linkReferences: [String: LinkReference] = [:]
     var requirementReferences: [String: XcodeRequirementReference] = [:]
     var downloadReferences: [String: DownloadReference] = [:]
+    var callToActionReferences: [String: CallToActionReference] = [:]
     
     private var bundleAvailability: [BundleModuleIdentifier: [AvailabilityRenderItem]] = [:]
     

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -789,7 +789,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
                         isActive: true,
                         overridingTitle: callToAction.buttonLabel,
                         overridingTitleInlineContent: nil))
-                callToActionReferences[url.description] = CallToActionReference(identifier: downloadIdentifier)
+                callToActionReferences[url.description] = ExternalLocationReference(identifier: downloadIdentifier)
             } else if let fileReference = callToAction.file {
                 let downloadIdentifier = createAndRegisterRenderReference(forMedia: fileReference, assetContext: .download)
                 node.sampleDownload = .init(action: .reference(
@@ -1623,7 +1623,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
     var linkReferences: [String: LinkReference] = [:]
     var requirementReferences: [String: XcodeRequirementReference] = [:]
     var downloadReferences: [String: DownloadReference] = [:]
-    var callToActionReferences: [String: CallToActionReference] = [:]
+    var callToActionReferences: [String: ExternalLocationReference] = [:]
     
     private var bundleAvailability: [BundleModuleIdentifier: [AvailabilityRenderItem]] = [:]
     

--- a/Tests/SwiftDocCTests/Rendering/SampleDownloadTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/SampleDownloadTests.swift
@@ -185,7 +185,7 @@ class SampleDownloadTests: XCTestCase {
         XCTAssertEqual(ident.identifier, "files/ExternalSample.zip")
 
         // Ensure that the encoded URL still references the entered URL
-        let downloadReference = try XCTUnwrap(renderNode.references[ident.identifier] as? CallToActionReference)
+        let downloadReference = try XCTUnwrap(renderNode.references[ident.identifier] as? ExternalLocationReference)
 
         let encoder = JSONEncoder()
         let decoder = JSONDecoder()

--- a/Tests/SwiftDocCTests/Rendering/SampleDownloadTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/SampleDownloadTests.swift
@@ -161,5 +161,38 @@ class SampleDownloadTests: XCTestCase {
 
         XCTAssertEqual(origIdent, decodedIdent)
     }
-    
+
+    func testSampleDownloadRelativeURL() throws {
+        let (bundle, context) = try testBundleAndContext(named: "SampleBundle")
+        let reference = ResolvedTopicReference(
+            bundleIdentifier: bundle.identifier,
+            path: "/documentation/SampleBundle/RelativeURLSample",
+            sourceLanguage: .swift
+        )
+        let article = try XCTUnwrap(context.entity(with: reference).semantic as? Article)
+        var translator = RenderNodeTranslator(
+            context: context,
+            bundle: bundle,
+            identifier: reference,
+            source: nil
+        )
+        let renderNode = try XCTUnwrap(translator.visitArticle(article) as? RenderNode)
+        let sampleCodeDownload = try XCTUnwrap(renderNode.sampleDownload)
+        guard case .reference(identifier: let ident, isActive: true, overridingTitle: "Download", overridingTitleInlineContent: nil) = sampleCodeDownload.action else {
+            XCTFail("Unexpected action in callToAction")
+            return
+        }
+        XCTAssertEqual(ident.identifier, "files/ExternalSample.zip")
+
+        // Ensure that the encoded URL still references the entered URL
+        let downloadReference = try XCTUnwrap(renderNode.references[ident.identifier] as? CallToActionReference)
+
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+
+        let encodedReference = try encoder.encode(downloadReference)
+        let decodedReference = try decoder.decode(DownloadReference.self, from: encodedReference)
+
+        XCTAssertEqual(decodedReference.url.description, "files/ExternalSample.zip")
+    }
 }

--- a/Tests/SwiftDocCTests/Rendering/SampleDownloadTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/SampleDownloadTests.swift
@@ -222,6 +222,7 @@ class SampleDownloadTests: XCTestCase {
         let downloadReference = try XCTUnwrap(renderNode.references[ident.identifier] as? ExternalLocationReference)
 
         let encoder = JSONEncoder()
+        encoder.outputFormatting.insert(.sortedKeys)
         let decoder = JSONDecoder()
 
         let encodedReference = try encoder.encode(downloadReference)

--- a/Tests/SwiftDocCTests/Rendering/SampleDownloadTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/SampleDownloadTests.swift
@@ -195,4 +195,68 @@ class SampleDownloadTests: XCTestCase {
 
         XCTAssertEqual(decodedReference.url.description, "files/ExternalSample.zip")
     }
+
+    func testExternalLocationRoundtrip() throws {
+        let (bundle, context) = try testBundleAndContext(named: "SampleBundle")
+        let reference = ResolvedTopicReference(
+            bundleIdentifier: bundle.identifier,
+            path: "/documentation/SampleBundle/RelativeURLSample",
+            sourceLanguage: .swift
+        )
+        let article = try XCTUnwrap(context.entity(with: reference).semantic as? Article)
+        var translator = RenderNodeTranslator(
+            context: context,
+            bundle: bundle,
+            identifier: reference,
+            source: nil
+        )
+        let renderNode = try XCTUnwrap(translator.visitArticle(article) as? RenderNode)
+        let sampleCodeDownload = try XCTUnwrap(renderNode.sampleDownload)
+        guard case .reference(identifier: let ident, isActive: true, overridingTitle: "Download", overridingTitleInlineContent: nil) = sampleCodeDownload.action else {
+            XCTFail("Unexpected action in callToAction")
+            return
+        }
+        XCTAssertEqual(ident.identifier, "files/ExternalSample.zip")
+
+        // Make sure that the ExternalLocationReference we get can round-trip as itself as well as through a DownloadReference
+        let downloadReference = try XCTUnwrap(renderNode.references[ident.identifier] as? ExternalLocationReference)
+
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+
+        let encodedReference = try encoder.encode(downloadReference)
+
+        // ExternalLocationReference -> ExternalLocationReference
+        // The encoded JSON should be the same before and after re-encoding.
+        do {
+            let decodedReference = try decoder.decode(ExternalLocationReference.self, from: encodedReference)
+            let reEncodedReference = try encoder.encode(decodedReference)
+
+            let firstJson = String(data: encodedReference, encoding: .utf8)
+            let finalJson = String(data: reEncodedReference, encoding: .utf8)
+
+            XCTAssertEqual(firstJson, finalJson)
+        }
+
+        // ExternalLocationReference -> DownloadReference -> ExternalLocationReference
+        // The reference identifier should be the same all throughout, and the final ExternalLocationReference
+        // should encode to the same JSON as the initial reference.
+        do {
+            let decodedReference = try decoder.decode(DownloadReference.self, from: encodedReference)
+
+            XCTAssertEqual(decodedReference.identifier, downloadReference.identifier)
+
+            let encodedDownload = try encoder.encode(decodedReference)
+            let reDecodedReference = try decoder.decode(ExternalLocationReference.self, from: encodedDownload)
+
+            XCTAssertEqual(reDecodedReference.identifier, downloadReference.identifier)
+
+            let reEncodedReference = try encoder.encode(reDecodedReference)
+
+            let firstJson = String(data: encodedReference, encoding: .utf8)
+            let finalJson = String(data: reEncodedReference, encoding: .utf8)
+
+            XCTAssertEqual(firstJson, finalJson)
+        }
+    }
 }

--- a/Tests/SwiftDocCTests/Test Bundles/SampleBundle.docc/RelativeURLSample.md
+++ b/Tests/SwiftDocCTests/Test Bundles/SampleBundle.docc/RelativeURLSample.md
@@ -1,0 +1,9 @@
+# Relative URL Sample
+
+@Metadata {
+    @CallToAction(url: "files/ExternalSample.zip", purpose: download)
+}
+
+This sample references a file on the web server.
+
+<!-- Copyright (c) 2023 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Tests/SwiftDocCTests/Test Bundles/SampleBundle.docc/SomeSample.md
+++ b/Tests/SwiftDocCTests/Test Bundles/SampleBundle.docc/SomeSample.md
@@ -12,5 +12,6 @@ This is a great framework, I tell you what.
 
 - <doc:MySample>
 - <doc:MyLocalSample>
+- <doc:RelativeURLSample>
 
-<!-- Copyright (c) 2022 Apple Inc and the Swift Project authors. All Rights Reserved. -->
+<!-- Copyright (c) 2022-2023 Apple Inc and the Swift Project authors. All Rights Reserved. -->


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://104558809

## Summary

The `url` argument of the `@CallToAction` directive was meant to be copied in verbatim as the `href` attribute of the resulting button. However, due to using the `DownloadReference` type to store this information, URLs that did not include a protocol and domain (i.e. those meant to reference items outside the documentation catalog/archive but ultimately stored on the same server) would be rewritten to be `/downloads/<filename>`. This PR introduces a `CallToActionReference`, compatible with `DownloadReference`, that bypasses the latter's `renderURL` logic, so that the path written into the `url` argument will be copied verbatim.

## Dependencies

None

## Testing

Use the following directive to test:

```markdown
@Metadata {
    @CallToAction(url: "/files/Sample.zip", purpose: download)
}
```

Steps:
1. Add the above metadata to `Sources/SwiftDocC/SwiftDocC.docc/SwiftDocC/Directives.md`.
2. Run `bin/preview-docs`.
3. Navigate to the "Directives" article in the preview.
4. Ensure that the "Download" button links to `http://localhost:8080/files/Sample.zip` (and not `http://localhost:8080/downloads/Sample.zip`).

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ n/a ] Updated documentation if necessary
