### PR TITLE
Support resolving external content with topic images

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -223,6 +223,10 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
     /// unresolvable asset references using a fallback resolver (if one is set for the reference's bundle identifier.)
     public var fallbackAssetResolvers = [BundleIdentifier: FallbackAssetResolver]()
     
+    // This protocol only exist to workaround a limitation. It should be removed when it's no longer needed.
+    // FIXME: https://github.com/apple/swift-docc/issues/468
+    public var _externalAssetResolvers = [BundleIdentifier: _ExternalAssetResolver]()
+    
     /// All the symbol references that have been resolved from external sources.
     ///
     /// This is tracked to exclude external symbols from the build output. Information about external references is still included for the local pages that makes the external reference.
@@ -2655,6 +2659,13 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
             return externallyResolvedAsset
         }
         
+        if let externalAssetResolver = _externalAssetResolvers[bundleIdentifier],
+           let externallyResolvedAsset = externalAssetResolver.resolveExternalAsset(named: name, bundleIdentifier: bundleIdentifier) {
+            assetManagers[bundleIdentifier, default: DataAssetManager()]
+                .register(dataAsset: externallyResolvedAsset, forName: name)
+            return externallyResolvedAsset
+        }
+        
         // If no fallbackAssetResolver is set, try to treat it as external media link
         if let externalMediaLink = URL(string: name),
            externalMediaLink.isAbsoluteWebURL {
@@ -2679,7 +2690,13 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
     /// - Returns: The best matching storage key if it was found, otherwise `nil`.
     public func identifier(forAssetName name: String, in parent: ResolvedTopicReference) -> String? {
         let bundleIdentifier = parent.bundleIdentifier
-        return assetManagers[bundleIdentifier]?.bestKey(forAssetName: name)
+        if let assetManager = assetManagers[bundleIdentifier] {
+            return assetManager.bestKey(forAssetName: name)
+        } else {
+            return nil != _externalAssetResolvers[bundleIdentifier]?.resolveExternalAsset(named: name, bundleIdentifier: parent.bundleIdentifier)
+                ? name
+                : nil
+        }
     }
 
     /// Attempt to resolve an unresolved code listing.

--- a/Sources/SwiftDocC/Infrastructure/External Data/ExternalAssetResolver.swift
+++ b/Sources/SwiftDocC/Infrastructure/External Data/ExternalAssetResolver.swift
@@ -1,0 +1,22 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2023 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+
+/// An asset resolver that can be used to resolve assets that couldn't be resolved locally.
+public protocol _ExternalAssetResolver {
+    // This protocol only exist so that externally resolved media references can be returned separately from the external
+    // content that is known to reference them. See details in OutOfProcessReferenceResolver.addImagesAndCacheMediaReferences(to:from:)
+    // We should remove it when that's no longer necessary.
+    // FIXME: https://github.com/apple/swift-docc/issues/468
+    
+    /// Attempts to resolve an asset that couldn't be resolved externally given its name and the bundle it's apart of.
+    func resolveExternalAsset(named assetName: String, bundleIdentifier: String) -> DataAsset?
+}

--- a/Sources/SwiftDocC/Infrastructure/External Data/OutOfProcessReferenceResolver.swift
+++ b/Sources/SwiftDocC/Infrastructure/External Data/OutOfProcessReferenceResolver.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -172,7 +172,7 @@ public class OutOfProcessReferenceResolver: ExternalReferenceResolver, FallbackR
             name = .conceptual(title: resolvedInformation.title)
         }
         
-        return DocumentationNode(
+        var node = DocumentationNode(
             reference: reference,
             kind: resolvedInformation.kind,
             sourceLanguage: resolvedInformation.language,
@@ -182,6 +182,10 @@ public class OutOfProcessReferenceResolver: ExternalReferenceResolver, FallbackR
             semantic: maybeSymbol,
             platformNames: resolvedInformation.platformNames
         )
+        
+        addImagesAndCacheMediaReferences(to: &node, from: resolvedInformation)
+        
+        return node
     }
     
     /// Returns the web URL for the external topic.
@@ -247,7 +251,7 @@ public class OutOfProcessReferenceResolver: ExternalReferenceResolver, FallbackR
             variants: resolvedInformation.variants
         )! // This entity was resolved from a symbol USR and is known to be a symbol.
         
-        return DocumentationNode(
+        var node = DocumentationNode(
             reference: reference,
             kind: resolvedInformation.kind,
             sourceLanguage: resolvedInformation.language,
@@ -257,6 +261,50 @@ public class OutOfProcessReferenceResolver: ExternalReferenceResolver, FallbackR
             semantic: symbol,
             platformNames: resolvedInformation.platformNames
         )
+        
+        addImagesAndCacheMediaReferences(to: &node, from: resolvedInformation)
+        
+        return node
+    }
+    
+    private func addImagesAndCacheMediaReferences(to node: inout DocumentationNode, from resolvedInformation: ResolvedInformation) {
+        // Because DocC renders external content in the local context, external media also needs to be added to the local context.
+        // If the external content was treated as pre-rendered then this wouldn't be necessary. (rdar://78718811)
+        // FIXME: https://github.com/apple/swift-docc/issues/468
+        
+        // `@PageImage` directives isn't meant to be created in code like this but it's the only way to associate topic images
+        // with a render node.
+        
+        if let topicImages = resolvedInformation.topicImages, !topicImages.isEmpty {
+            let metadata = node.metadata ?? Metadata(originalMarkup: BlockDirective(name: "Metadata", children: []), documentationExtension: nil, technologyRoot: nil, displayName: nil)
+            
+            metadata.pageImages = topicImages.map { topicImage in
+                let purpose: PageImage.Purpose
+                switch topicImage.type {
+                case .card: purpose = .card
+                case .icon: purpose = .icon
+                }
+                
+                return PageImage._make(
+                    originalMarkup: BlockDirective(name: "PageImage", children: []),
+                    purpose: purpose,
+                    source: ResourceReference(bundleIdentifier: node.reference.bundleIdentifier, path: topicImage.identifier.identifier),
+                    alt: (resolvedInformation.references?.first(where: { $0.identifier == topicImage.identifier }) as? ImageReference)?.altText
+                )
+            }
+            
+            node.metadata = metadata
+        }
+        
+        // Since the DocumentationNode doesn't have any media references, the external media references can't be returned with the node.
+        // Instead they are added to the cache so that they are returned from later requests.
+        
+        for reference in (resolvedInformation.references ?? []) {
+            guard let mediaReference = reference as? MediaReference else { continue }
+            
+            assetCache[.init(assetName: mediaReference.identifier.identifier, bundleIdentifier: node.reference.bundleIdentifier)] = mediaReference.asset
+        }
+        
     }
     
     /// Returns the web URL for the external symbol.
@@ -397,6 +445,14 @@ public class OutOfProcessReferenceResolver: ExternalReferenceResolver, FallbackR
         
         // Fall back to the `language` property if `availableLanguages` is empty.
         return [resolvedInformation.language]
+    }
+}
+
+extension OutOfProcessReferenceResolver: _ExternalAssetResolver {
+    public func resolveExternalAsset(named assetName: String, bundleIdentifier: String) -> DataAsset? {
+        // We don't want to make additional requests for these external assets.
+        // If they were already resolved, return them from the cache.
+        return assetCache[AssetReference(assetName: assetName, bundleIdentifier: bundleIdentifier)]
     }
 }
 
@@ -689,6 +745,10 @@ extension OutOfProcessReferenceResolver {
     
     /// A type used to transfer information about a resolved reference to DocC from from a reference resolver in another executable.
     public struct ResolvedInformation: Codable {
+        // This type is duplicating the information from LinkDestinationSummary with some minor differences.
+        // Changes generally need to be made in both places. It would be good to replace this with LinkDestinationSummary.
+        // FIXME: https://github.com/apple/swift-docc/issues/468
+        
         /// Information about the resolved kind.
         public let kind: DocumentationNode.Kind
         /// Information about the resolved URL.
@@ -719,8 +779,14 @@ extension OutOfProcessReferenceResolver {
             return platforms.map { platforms in Set(platforms.compactMap { $0.name }) }
         }
         
+        /// Images that are used to represent the summarized element.
+        public var topicImages: [TopicImage]?
+                
+        /// References used in the content of the summarized element.
+        public var references: [RenderReference]?
+        
         /// The variants of content (kind, url, title, abstract, language, declaration) for this resolver information.
-        public let variants: [Variant]?
+        public var variants: [Variant]?
         
         /// Creates a new resolved information value with all its values.
         ///
@@ -743,6 +809,8 @@ extension OutOfProcessReferenceResolver {
             availableLanguages: Set<SourceLanguage>,
             platforms: [PlatformAvailability]?,
             declarationFragments: DeclarationFragments?,
+            topicImages: [TopicImage]?,
+            references: [RenderReference]?,
             variants: [Variant]? = nil
         ) {
             self.kind = kind
@@ -753,6 +821,8 @@ extension OutOfProcessReferenceResolver {
             self.availableLanguages = availableLanguages
             self.platforms = platforms
             self.declarationFragments = declarationFragments
+            self.topicImages = topicImages
+            self.references = references
             self.variants = variants
         }
         
@@ -889,3 +959,55 @@ extension OutOfProcessReferenceResolver {
         )
     }
 }
+
+extension OutOfProcessReferenceResolver.ResolvedInformation {
+    enum CodingKeys: CodingKey {
+        case kind
+        case url
+        case title
+        case abstract
+        case language
+        case availableLanguages
+        case platforms
+        case declarationFragments
+        case topicImages
+        case references
+        case variants
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        
+        kind = try container.decode(DocumentationNode.Kind.self, forKey: .kind)
+        url = try container.decode(URL.self, forKey: .url)
+        title = try container.decode(String.self, forKey: .title)
+        abstract = try container.decode(String.self, forKey: .abstract)
+        language = try container.decode(SourceLanguage.self, forKey: .language)
+        availableLanguages = try container.decode(Set<SourceLanguage>.self, forKey: .availableLanguages)
+        platforms = try container.decodeIfPresent([OutOfProcessReferenceResolver.ResolvedInformation.PlatformAvailability].self, forKey: .platforms)
+        declarationFragments = try container.decodeIfPresent(OutOfProcessReferenceResolver.ResolvedInformation.DeclarationFragments.self, forKey: .declarationFragments)
+        topicImages = try container.decodeIfPresent([TopicImage].self, forKey: .topicImages)
+        references = try container.decodeIfPresent([CodableRenderReference].self, forKey: .references).map { decodedReferences in
+            decodedReferences.map(\.reference)
+        }
+        variants = try container.decodeIfPresent([OutOfProcessReferenceResolver.ResolvedInformation.Variant].self, forKey: .variants)
+        
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        
+        try container.encode(self.kind, forKey: .kind)
+        try container.encode(self.url, forKey: .url)
+        try container.encode(self.title, forKey: .title)
+        try container.encode(self.abstract, forKey: .abstract)
+        try container.encode(self.language, forKey: .language)
+        try container.encode(self.availableLanguages, forKey: .availableLanguages)
+        try container.encodeIfPresent(self.platforms, forKey: .platforms)
+        try container.encodeIfPresent(self.declarationFragments, forKey: .declarationFragments)
+        try container.encodeIfPresent(self.topicImages, forKey: .topicImages)
+        try container.encodeIfPresent(references?.map { CodableRenderReference($0) }, forKey: .references)
+        try container.encodeIfPresent(self.variants, forKey: .variants)
+    }
+}
+

--- a/Sources/SwiftDocC/Model/Rendering/References/FileReference.swift
+++ b/Sources/SwiftDocC/Model/Rendering/References/FileReference.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -13,7 +13,7 @@ import Foundation
 /// A reference to a file resource.
 ///
 /// File resources are used, for example, to display the contents of a source code file in a Tutorial's step.
-public struct FileReference: RenderReference {
+public struct FileReference: RenderReference, Equatable {
     /// The type of this file reference.
     ///
     /// This value is always `.file`.
@@ -71,7 +71,7 @@ public struct FileReference: RenderReference {
 ///
 /// This is not a reference to a specific file, but rather to a type of file. Use a file type reference together with a file reference to display an icon for that file type
 /// alongside the content of that file. For example, a property list file icon alongside the content of a specific property list file.
-public struct FileTypeReference: RenderReference {
+public struct FileTypeReference: RenderReference, Equatable {
     public var type: RenderReferenceType = .fileType
     
     /// The identifier of this reference.

--- a/Sources/SwiftDocC/Model/Rendering/References/LinkReference.swift
+++ b/Sources/SwiftDocC/Model/Rendering/References/LinkReference.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -9,7 +9,7 @@
 */
 
 /// A reference to a URL.
-public struct LinkReference: RenderReference {
+public struct LinkReference: RenderReference, Equatable {
     /// The type of this link reference.
     ///
     /// This value is always `.link`.

--- a/Sources/SwiftDocC/Model/Rendering/References/TopicRenderReference.swift
+++ b/Sources/SwiftDocC/Model/Rendering/References/TopicRenderReference.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -9,7 +9,7 @@
 */
 
 /// A reference to another page of documentation in the current context.
-public struct TopicRenderReference: RenderReference, VariantContainer {
+public struct TopicRenderReference: RenderReference, VariantContainer, Equatable {
     /// The type of this reference.
     ///
     /// This value is always `.topic`.

--- a/Sources/SwiftDocC/Model/Rendering/References/UnresolvedReference.swift
+++ b/Sources/SwiftDocC/Model/Rendering/References/UnresolvedReference.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -9,7 +9,7 @@
 */
 
 /// A reference to another page which cannot be resolved.
-public struct UnresolvedRenderReference: RenderReference {
+public struct UnresolvedRenderReference: RenderReference, Equatable {
     /// The type of this unresolvable reference.
     ///
     /// This value is always `.unresolvable`.

--- a/Sources/SwiftDocC/Model/Rendering/References/VideoReference.swift
+++ b/Sources/SwiftDocC/Model/Rendering/References/VideoReference.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -11,7 +11,7 @@
 import Foundation
 
 /// A reference to a video.
-public struct VideoReference: MediaReference, URLReference {
+public struct VideoReference: MediaReference, URLReference, Equatable {
     /// The type of this video reference.
     ///
     /// This value is always `.video`.

--- a/Sources/SwiftDocC/Model/Rendering/RenderNode.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNode.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -121,7 +121,9 @@ public struct RenderNode: VariantContainer {
     /// The kind of this documentation node.
     public var kind: Kind
         
-    /// The values of the references used in documentation node. These can be references to other nodes, media, and more.
+    /// The references used in the render node. These can be references to other nodes, media, and more.
+    ///
+    /// The key for each reference is the ``RenderReferenceIdentifier/identifier`` of the reference's ``RenderReference/identifier``.
     public var references: [String: RenderReference] = [:]
         
     /// Hierarchy information about the context in which this documentation node is placed.

--- a/Sources/SwiftDocC/Model/Rendering/Symbol/PlistDetailsRenderSection.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Symbol/PlistDetailsRenderSection.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -11,7 +11,7 @@
 import Foundation
 
 /// A title style for a property list key or an entitlement key.
-public enum TitleStyle: String, Codable {
+public enum TitleStyle: String, Codable, Equatable {
     // Render links to the symbol using the "raw" name, for example, "com.apple.enableDataAccess".
     case symbol
     // Render links to the symbol using a special "IDE title" name, for example, "Enables Data Access".

--- a/Sources/SwiftDocC/Model/Rendering/Tutorial/LineHighlighter.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Tutorial/LineHighlighter.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -61,7 +61,7 @@ public struct LineHighlighter {
     /**
      A single line's highlight.
      */
-    public struct Highlight: Codable {
+    public struct Highlight: Codable, Equatable {
         /// The line to highlight.
         public let line: Int
         

--- a/Sources/SwiftDocC/Model/Rendering/Tutorial/References/DownloadReference.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Tutorial/References/DownloadReference.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -11,7 +11,7 @@
 import Foundation
 
 /// A reference to a resource that can be downloaded.
-public struct DownloadReference: RenderReference, URLReference {
+public struct DownloadReference: RenderReference, URLReference, Equatable {
     /// The name you use for the directory that contains download items.
     ///
     /// This is the name of the directory within the generated build folder

--- a/Sources/SwiftDocC/Model/Rendering/Tutorial/References/XcodeRequirementReference.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Tutorial/References/XcodeRequirementReference.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -11,7 +11,7 @@
 import Foundation
 
 /// A reference to a version of Xcode that users of your documentation must use.
-public struct XcodeRequirementReference: RenderReference {
+public struct XcodeRequirementReference: RenderReference, Equatable {
     public var type: RenderReferenceType = .xcodeRequirement
     
     public let identifier: RenderReferenceIdentifier

--- a/Sources/SwiftDocC/Model/Rendering/Variants/VariantCollection+Symbol.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Variants/VariantCollection+Symbol.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -56,7 +56,7 @@ public extension VariantCollection {
 
         let defaultValue = documentationDataVariants.removeDefaultValueForRendering().flatMap(transform)
 
-        let variants = documentationDataVariants.allValues.compactMap { trait, value -> Variant<Value>? in
+        let variants = documentationDataVariants.allValues.compactMap { trait, value -> Variant? in
             Self.createVariant(trait: trait, value: transform(trait, value))
         }
 
@@ -77,7 +77,7 @@ public extension VariantCollection {
         
         let defaultValue = transform(documentationDataVariants.removeDefaultValueForRendering())
         
-        let variants = documentationDataVariants.allValues.compactMap { trait, value -> Variant<Value>? in
+        let variants = documentationDataVariants.allValues.compactMap { trait, value -> Variant? in
             Self.createVariant(trait: trait, value: transform((trait, value)))
         }
         
@@ -147,7 +147,7 @@ public extension VariantCollection {
         let defaultValue = transform(trait1, defaultValue1, defaultValue2.map(\.variant))
         
         let variants = zipPairsByKey(documentationDataVariants1.allValues, optionalPairs2: documentationDataVariants2.allValues)
-            .compactMap { (trait, values) -> Variant<Value>? in
+            .compactMap { (trait, values) -> Variant? in
                 let (value1, value2) = values
                 return Self.createVariant(trait: trait, value: transform(trait, value1, value2))
             }
@@ -179,7 +179,7 @@ public extension VariantCollection {
         let defaultValue = transform(trait1, defaultValue1, defaultValue2.map(\.variant))
         
         let variants = zipPairsByKey(documentationDataVariants1.allValues, optionalPairs2: documentationDataVariants2.allValues)
-            .compactMap { (trait, values) -> Variant<Value>? in
+            .compactMap { (trait, values) -> Variant? in
                 let (value1, value2) = values
                 guard let patchValue = transform(trait, value1, value2) else { return nil }
                 return Self.createVariant(trait: trait, value: patchValue)
@@ -211,7 +211,7 @@ public extension VariantCollection {
         let defaultValue = transform(trait1, defaultValue1, defaultValue2)
         
         let variants = zipPairsByKey(documentationDataVariants1.allValues, documentationDataVariants2.allValues)
-            .compactMap { (trait, values) -> Variant<Value>? in
+            .compactMap { (trait, values) -> Variant? in
                 let (value1, value2) = values
                 return Self.createVariant(trait: trait, value: transform(trait, value1, value2))
             }
@@ -248,7 +248,7 @@ public extension VariantCollection {
             documentationDataVariants1.allValues,
             documentationDataVariants2.allValues,
             documentationDataVariants3.allValues
-        ).compactMap { (trait, values) -> Variant<Value>? in
+        ).compactMap { (trait, values) -> Variant? in
             let (value1, value2, value3) = values
             return Self.createVariant(trait: trait, value: transform(trait, value1, value2, value3))
         }
@@ -272,7 +272,7 @@ public extension VariantCollection {
            return nil
         }
         
-        let variants = documentationDataVariants.allValues.compactMap { trait, value -> Variant<Value>? in
+        let variants = documentationDataVariants.allValues.compactMap { trait, value -> Variant? in
             Self.createVariant(trait: trait, value: transform(trait, value))
         }
         
@@ -285,7 +285,7 @@ public extension VariantCollection {
     private static func createVariant(
         trait: DocumentationDataVariantsTrait,
         value: Value
-    ) -> Variant<Value>? {
+    ) -> Variant? {
         guard let interfaceLanguage = trait.interfaceLanguage else { return nil }
         
         return Variant(traits: [.interfaceLanguage(interfaceLanguage)], patch: [

--- a/Sources/SwiftDocC/Model/Rendering/Variants/VariantCollection+Variant.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Variants/VariantCollection+Variant.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2022-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -12,7 +12,7 @@ import Foundation
 
 public extension VariantCollection {
     /// A variant for a render node value.
-    struct Variant<Value: Codable> {
+    struct Variant {
         /// The traits associated with the override.
         public var traits: [RenderNode.Variant.Trait]
         
@@ -32,11 +32,20 @@ public extension VariantCollection {
         /// Returns a new variant collection containing the traits of this variant collection with the values transformed by the given closure.
         public func mapPatch<TransformedValue>(
             _ transform: (Value) -> TransformedValue
-        ) -> VariantCollection<TransformedValue>.Variant<TransformedValue> {
-            VariantCollection<TransformedValue>.Variant<TransformedValue>(
+        ) -> VariantCollection<TransformedValue>.Variant {
+            VariantCollection<TransformedValue>.Variant(
                 traits: traits,
                 patch: patch.map { patchOperation in patchOperation.map(transform) }
             )
         }
+    }
+}
+
+extension VariantCollection.Variant: Equatable where Value: Equatable {
+    public static func == (lhs: VariantCollection<Value>.Variant, rhs: VariantCollection<Value>.Variant) -> Bool {
+        guard lhs.traits == rhs.traits else { return false }
+        guard lhs.patch == rhs.patch else { return false }
+        
+        return true
     }
 }

--- a/Sources/SwiftDocC/Model/Rendering/Variants/VariantCollection.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Variants/VariantCollection.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -27,14 +27,14 @@ public struct VariantCollection<Value: Codable>: Codable {
     /// Trait-specific overrides for the default value.
     ///
     /// Clients should decide whether the `defaultValue` or a value in ``variants`` is appropriate in their context.
-    public var variants: [Variant<Value>]
+    public var variants: [Variant]
     
     /// Creates a variant collection given a default value and an array of trait-specific overrides.
     ///
     /// - Parameters:
     ///   - defaultValue: The default value of the variant.
     ///   - variantOverrides: The trait-specific overrides for the value.
-    public init(defaultValue: Value, variants: [Variant<Value>] = []) {
+    public init(defaultValue: Value, variants: [Variant] = []) {
         self.defaultValue = defaultValue
         self.variants = variants
     }
@@ -102,5 +102,14 @@ public struct VariantCollection<Value: Codable>: Codable {
                 variant.mapPatch(transform)
             }
         )
+    }
+}
+
+extension VariantCollection: Equatable where Value: Equatable {
+    public static func == (lhs: VariantCollection<Value>, rhs: VariantCollection<Value>) -> Bool {
+        guard lhs.defaultValue == rhs.defaultValue else { return false }
+        guard lhs.variants == rhs.variants else { return false }
+        
+        return true
     }
 }

--- a/Sources/SwiftDocC/Model/Rendering/Variants/VariantPatchOperation.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Variants/VariantPatchOperation.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -76,3 +76,6 @@ extension VariantCollection.Variant where Value: RangeReplaceableCollection {
         return result
     }
 }
+
+// The synthesized implementation is sufficient for this conformance.
+extension VariantPatchOperation: Equatable where Value: Equatable {}

--- a/Sources/SwiftDocC/Semantics/Metadata/PageImage.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/PageImage.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2022-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -43,5 +43,31 @@ public final class PageImage: Semantic, AutomaticDirectiveConvertible {
     @available(*, deprecated, message: "Do not call directly. Required for 'AutomaticDirectiveConvertible'.")
     init(originalMarkup: BlockDirective) {
         self.originalMarkup = originalMarkup
+    }
+
+    /// Don't use this outside of ``OutOfProcessReferenceResolver/entity(with:)`` .
+    ///
+    /// Directives aren't meant to be created from non-markup but the out-of-process resolver needs to create a ``PageImage`` to associate topic
+    /// images with external pages. This is because DocC renderers external content in the local context. (rdar://78718811)
+    /// https://github.com/apple/swift-docc/issues/468
+    ///
+    /// This is intentionally defined as an underscore prefixed static function instead of an initializer to make it less likely that it's used in other places.
+    static func _make(originalMarkup: BlockDirective, purpose: Purpose, source: ResourceReference, alt: String?) -> PageImage {
+        // FIXME: https://github.com/apple/swift-docc/issues/468
+        return PageImage(
+            originalMarkup:  originalMarkup,
+            purpose: purpose,
+            source: source,
+            alt: alt
+        )
+    }
+    
+    // This initializer only exist to be called by `_make` above.
+    private init(originalMarkup: BlockDirective, purpose: Purpose, source: ResourceReference, alt: String?) {
+        self.originalMarkup = originalMarkup
+        super.init()
+        self.purpose = purpose
+        self.source = source
+        self.alt = alt
     }
 }

--- a/Sources/SwiftDocC/SwiftDocC.docc/Resources/LinkableEntities.json
+++ b/Sources/SwiftDocC/SwiftDocC.docc/Resources/LinkableEntities.json
@@ -2,7 +2,7 @@
     "openapi": "3.0.0",
     "info": {
         "description": "Specification of the DocC linkable-entities.json digest file.",
-        "version": "0.2.0",
+        "version": "0.3.0",
         "title": "Linkable Entities"
     },
     "paths": { },
@@ -72,6 +72,18 @@
                         "type": "array",
                         "items": {
                             "$ref": "#/components/schemas/DeclarationToken"
+                        }
+                    },
+                    "topicImages": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/TopicImage"
+                        }
+                    },
+                    "references": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "$ref": "#/components/schemas/RenderReference"
                         }
                     },
                     "redirects": {
@@ -524,6 +536,481 @@
                     },
                     "preciseIdentifier": {
                         "type": "string"
+                    }
+                }
+            },
+            "TopicImage": {
+                "type": "object",
+                "required": [
+                    "type",
+                    "identifier"
+                ],
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": ["icon", "card"]
+                    },
+                    "reference": {
+                        "type": "string",
+                        "format": "reference(ImageRenderReference)"
+                    }
+                }
+            },
+            "RenderReference": {
+                "oneOf": [
+                    {
+                        "$ref": "#/components/schemas/ImageRenderReference"
+                    },
+                    {
+                        "$ref": "#/components/schemas/VideoRenderReference"
+                    },
+                    {
+                        "$ref": "#/components/schemas/FileRenderReference"
+                    },
+                    {
+                        "$ref": "#/components/schemas/FileTypeRenderReference"
+                    },
+                    {
+                        "$ref": "#/components/schemas/XcodeRequirementRenderReference"
+                    },
+                    {
+                        "$ref": "#/components/schemas/TopicRenderReference"
+                    },
+                    {
+                        "$ref": "#/components/schemas/DownloadRenderReference"
+                    },
+                    {
+                        "$ref": "#/components/schemas/UnresolvableRenderReference"
+                    },
+                    {
+                        "$ref": "#/components/schemas/LinkRenderReference"
+                    }
+                ]
+            },
+            "LinkRenderReference": {
+                "type": "object",
+                "required": [
+                    "type",
+                    "identifier",
+                    "url"
+                ],
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": ["link"]
+                    },
+                    "identifier": {
+                        "type": "string"
+                    },
+                    "title": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "titleInlineContent": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/RenderInlineContent"
+                        }
+                    },
+                    "url": {
+                        "type": "string"
+                    }
+                }
+            },
+            "ImageRenderReference": {
+                "type": "object",
+                "required": [
+                    "type",
+                    "identifier",
+                    "variants"
+                ],
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": ["image"]
+                    },
+                    "alt": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "identifier": {
+                        "type": "string"
+                    },
+                    "variants": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/RenderReferenceVariant"
+                        }
+                    }
+                }
+            },
+            "RenderReferenceVariant": {
+                "type": "object",
+                "required": [
+                    "url",
+                    "traits"
+                ],
+                "properties": {
+                    "url": {
+                        "type": "string"
+                    },
+                    "svgID": {
+                        "type": "string",
+                        "description": "The ID attribute for the image that should be rendered in the SVG file represented by this variant."
+                    },
+                    "traits": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/RenderReferenceVariantTrait"
+                        }
+                    }
+                }
+            },
+            "RenderReferenceVariantTrait": {
+                "type": "string",
+                "enum": ["1x", "2x", "3x", "light", "dark"]
+            },
+            "VideoRenderReference": {
+                "type": "object",
+                "required": [
+                    "type",
+                    "identifier",
+                    "variants"
+                ],
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": ["video"]
+                    },
+                    "alt": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "identifier": {
+                        "type": "string"
+                    },
+                    "poster": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "variants": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/RenderReferenceVariant"
+                        }
+                    }
+                }
+            },
+            "FileRenderReference": {
+                "type": "object",
+                "required": [
+                    "type",
+                    "identifier",
+                    "fileName",
+                    "fileType",
+                    "syntax",
+                    "content"
+                ],
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": ["file"]
+                    },
+                    "fileName": {
+                        "type": "string"
+                    },
+                    "fileType": {
+                        "type": "string"
+                    },
+                    "identifier": {
+                        "type": "string"
+                    },
+                    "syntax": {
+                        "type": "string"
+                    },
+                    "content": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "highlights": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/FileRenderReferenceHighlight"
+                        }
+                    }
+                }
+            },
+            "FileRenderReferenceHighlight": {
+                "type": "object",
+                "required": [
+                    "line"
+                ],
+                "properties": {
+                    "line": {
+                        "type": "integer"
+                    },
+                    "start": {
+                        "type": "integer"
+                    },
+                    "length": {
+                        "type": "integer"
+                    }
+                }
+            },
+            "FileTypeRenderReference": {
+                "type": "object",
+                "required": [
+                    "type",
+                    "identifier",
+                    "displayName",
+                    "iconBase64"
+                ],
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": ["fileType"]
+                    },
+                    "identifier": {
+                        "type": "string"
+                    },
+                    "displayName": {
+                        "type": "string"
+                    },
+                    "iconBase64": {
+                        "type": "string"
+                    }
+                }
+            },
+            "XcodeRequirementRenderReference": {
+                "type": "object",
+                "required": [
+                    "type",
+                    "identifier",
+                    "title",
+                    "url"
+                ],
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": ["xcodeRequirement"]
+                    },
+                    "identifier": {
+                        "type": "string"
+                    },
+                    "title": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    }
+                }
+            },
+            "TopicRenderReference": {
+                "type": "object",
+                "required": [
+                    "title",
+                    "type",
+                    "kind",
+                    "identifier",
+                    "url"
+                ],
+                "properties": {
+                    "title": {
+                        "type": "string"
+                    },
+                    "abstract": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/RenderInlineContent"
+                        }
+                    },
+                    "type": {
+                        "type": "string",
+                        "enum": ["topic", "section"]
+                    },
+                    "identifier": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "kind": {
+                        "type": "string",
+                        "enum": [
+                            "article",
+                            "project",
+                            "section",
+                            "overview",
+                            "symbol",
+                            "root"
+                        ]
+                    },
+                    "required": {
+                        "type": "boolean"
+                    },
+                    "defaultImplementations": {
+                        "type": "number"
+                    },
+                    "fragments": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/DeclarationToken"
+                        }
+                    },
+                    "images": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/TopicImage"
+                        }
+                    },
+                    "navigatorTitle": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/DeclarationToken"
+                        }
+                    },
+                    "role": {
+                        "$ref": "#/components/schemas/DocumentationRole"
+                    },
+                    "conformance": {
+                        "$ref" : "#/components/schemas/ConformanceSection"
+                    },
+                    "estimatedTime": {
+                        "type": "string"
+                    },
+                    "beta": {
+                        "type": "boolean",
+                        "format": "true"
+                    },
+                    "deprecated": {
+                        "type": "boolean",
+                        "format": "true"
+                    },
+                    "titleStyle": {
+                        "type": "string",
+                        "enum": ["title", "symbol"]
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "ideTitle": {
+                        "type": "string"
+                    },
+                    "tags": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/SymbolTag"
+                        }
+                    }
+                }
+            },
+            "DownloadRenderReference": {
+                "type": "object",
+                "required": [
+                    "type",
+                    "identifier",
+                    "url"
+                ],
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": ["download"]
+                    },
+                    "identifier": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "checksum": {
+                        "type": "string"
+                    }
+                }
+            },
+            "UnresolvableRenderReference": {
+                "type": "object",
+                "required": [
+                    "type",
+                    "title",
+                    "identifier"
+                ],
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": ["unresolvable"]
+                    },
+                    "title": {
+                        "type": "string"
+                    },
+                    "identifier": {
+                        "type": "string"
+                    }
+                }
+            },
+            "SymbolTag": {
+                "type": "object",
+                "required": [
+                    "type",
+                    "text"
+                ],
+                "properties": {
+                    "type": {
+                        "type": "string"
+                    },
+                    "text": {
+                        "type": "string"
+                    }
+                }
+            },
+            "DocumentationRole": {
+                "type": "string",
+                "enum" : [
+                    "symbol",
+                    "containerSymbol",
+                    "restRequestSymbol",
+                    "dictionarySymbol",
+                    "pseudoSymbol",
+                    "pseudoCollection",
+                    "collection",
+                    "collectionGroup",
+                    "article",
+                    "sampleCode",
+                    "overview",
+                    "table",
+                    "codeListing",
+                    "link",
+                    "project",
+                    "subsection",
+                    "task"
+                ]
+            },
+            "ConformanceSection": {
+                "type": "object",
+                "required": [
+                    "constraints",
+                    "availabilityPrefix",
+                    "conformancePrefix"
+                ],
+                "properties": {
+                    "constraints": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/RenderInlineContent"
+                        }
+                    },
+                    "availabilityPrefix": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/RenderInlineContent"
+                        }
+                    },
+                    "conformancePrefix": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/RenderInlineContent"
+                        }
                     }
                 }
             },

--- a/Sources/SwiftDocCUtilities/Action/Actions/Convert/ConvertAction.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Convert/ConvertAction.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -305,6 +305,7 @@ public struct ConvertAction: Action, RecreatingContext {
         if let outOfProcessResolver = outOfProcessResolver {
             context.externalReferenceResolvers[outOfProcessResolver.bundleIdentifier] = outOfProcessResolver
             context.externalSymbolResolver = outOfProcessResolver
+            context._externalAssetResolvers[outOfProcessResolver.bundleIdentifier] = outOfProcessResolver
         }
         
         let temporaryFolder = try createTempFolder(

--- a/Tests/SwiftDocCTests/DocumentationService/ConvertService/ConvertServiceTests.swift
+++ b/Tests/SwiftDocCTests/DocumentationService/ConvertService/ConvertServiceTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -995,7 +995,9 @@ class ConvertServiceTests: XCTestCase {
                                 language: .init(name: "Swift", id: "swift"),
                                 availableLanguages: [],
                                 platforms: [],
-                                declarationFragments: nil
+                                declarationFragments: nil,
+                                topicImages: nil,
+                                references: nil
                             )
                         
                         let payloadData = OutOfProcessReferenceResolver.Response
@@ -1019,7 +1021,9 @@ class ConvertServiceTests: XCTestCase {
                                 language: .init(name: "Swift", id: "swift"),
                                 availableLanguages: [],
                                 platforms: [],
-                                declarationFragments: nil
+                                declarationFragments: nil,
+                                topicImages: nil,
+                                references: nil
                             )
                         
                         let payloadData = OutOfProcessReferenceResolver.Response
@@ -1056,7 +1060,9 @@ class ConvertServiceTests: XCTestCase {
                                 language: .init(name: "Swift", id: "swift"),
                                 availableLanguages: [],
                                 platforms: [],
-                                declarationFragments: nil
+                                declarationFragments: nil,
+                                topicImages: nil,
+                                references: nil
                             )
                         
                         return DocumentationServer.Message(
@@ -1258,7 +1264,9 @@ class ConvertServiceTests: XCTestCase {
                                 language: .init(name: "Swift", id: "swift"),
                                 availableLanguages: [],
                                 platforms: [],
-                                declarationFragments: nil
+                                declarationFragments: nil,
+                                topicImages: nil,
+                                references: nil
                             )
                         
                         let payloadData = OutOfProcessReferenceResolver.Response

--- a/Tests/SwiftDocCTests/Rendering/Variants/VariantCollection+VariantTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/Variants/VariantCollection+VariantTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2022-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -13,7 +13,7 @@ import XCTest
 @testable import SwiftDocC
 
 class VariantCollection_VariantTests: XCTestCase {
-    let testVariant = VariantCollection<String>.Variant<String>(
+    let testVariant = VariantCollection<String>.Variant(
         traits: [.interfaceLanguage("a")],
         patch: [
             .replace(value: "replace"),

--- a/Tests/SwiftDocCTests/Rendering/Variants/VariantPatchOperationTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/Variants/VariantPatchOperationTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -20,7 +20,7 @@ class VariantPatchOperationTests: XCTestCase {
         ])
         XCTAssertEqual(addVariant.applyingPatchTo(original), [1, 2, 3, 4, 5, 6])
         
-        let removeVariant = VariantCollection<[Int]>.Variant<[Int]>(traits: [], patch: [
+        let removeVariant = VariantCollection<[Int]>.Variant(traits: [], patch: [
             .remove
         ])
         XCTAssertEqual(removeVariant.applyingPatchTo(original), [])
@@ -62,7 +62,7 @@ class VariantPatchOperationTests: XCTestCase {
             "MNOPQR",
         ]
         for (index, expectedValue) in expectedValues.enumerated() {
-            let stringVariant = VariantCollection<String>.Variant<String>(traits: [], patch: Array(stringPatches.prefix(index)))
+            let stringVariant = VariantCollection<String>.Variant(traits: [], patch: Array(stringPatches.prefix(index)))
             XCTAssertEqual(stringVariant.applyingPatchTo("A"), expectedValue)
         }
     }

--- a/Tests/SwiftDocCTests/XCTestCase+LoadingTestData.swift
+++ b/Tests/SwiftDocCTests/XCTestCase+LoadingTestData.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -20,6 +20,8 @@ extension XCTestCase {
                     codeListings: [String : AttributedCodeListing] = [:],
                     externalResolvers: [String: ExternalReferenceResolver] = [:],
                     externalSymbolResolver: ExternalSymbolResolver? = nil,
+                    fallbackAssetResolvers: [String: FallbackAssetResolver] = [:],
+                    _externalAssetResolvers: [String: _ExternalAssetResolver] = [:],
                     diagnosticFilterLevel: DiagnosticSeverity = .hint,
                     configureContext: ((DocumentationContext) throws -> Void)? = nil,
                     decoder: JSONDecoder = JSONDecoder()) throws -> (URL, DocumentationBundle, DocumentationContext) {
@@ -27,6 +29,8 @@ extension XCTestCase {
         let context = try DocumentationContext(dataProvider: workspace, diagnosticEngine: DiagnosticEngine(filterLevel: diagnosticFilterLevel))
         context.externalReferenceResolvers = externalResolvers
         context.externalSymbolResolver = externalSymbolResolver
+        context.fallbackAssetResolvers = fallbackAssetResolvers
+        context._externalAssetResolvers = _externalAssetResolvers
         context.externalMetadata.diagnosticLevel = diagnosticFilterLevel
         context.decoder = decoder
         try configureContext?(context)
@@ -45,6 +49,8 @@ extension XCTestCase {
                               codeListings: [String : AttributedCodeListing] = [:],
                               externalResolvers: [BundleIdentifier : ExternalReferenceResolver] = [:],
                               externalSymbolResolver: ExternalSymbolResolver? = nil,
+                              fallbackAssetResolvers: [BundleIdentifier : FallbackAssetResolver] = [:],
+                              _externalAssetResolvers: [BundleIdentifier : _ExternalAssetResolver] = [:],
                               configureBundle: ((URL) throws -> Void)? = nil,
                               decoder: JSONDecoder = JSONDecoder()) throws -> (URL, DocumentationBundle, DocumentationContext) {
         let sourceURL = try XCTUnwrap(Bundle.module.url(
@@ -66,7 +72,15 @@ extension XCTestCase {
         // Do any additional setup to the custom bundle - adding, modifying files, etc
         try configureBundle?(bundleURL)
         
-        return try loadBundle(from: bundleURL, codeListings: codeListings, externalResolvers: externalResolvers, externalSymbolResolver: externalSymbolResolver, decoder: decoder)
+        return try loadBundle(
+            from: bundleURL,
+            codeListings: codeListings,
+            externalResolvers: externalResolvers,
+            externalSymbolResolver: externalSymbolResolver,
+            fallbackAssetResolvers: fallbackAssetResolvers,
+            _externalAssetResolvers: _externalAssetResolvers,
+            decoder: decoder
+        )
     }
     
     func testBundleAndContext(named name: String, codeListings: [String : AttributedCodeListing] = [:], externalResolvers: [String: ExternalReferenceResolver] = [:]) throws -> (DocumentationBundle, DocumentationContext) {

--- a/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -1065,6 +1065,8 @@ class ConvertActionTests: XCTestCase {
                         usr: "TestBed",
                         availableLanguages: [.swift],
                         platforms: nil,
+                        topicImages: nil,
+                        references: nil,
                         redirects: nil
                     ),
                 ]
@@ -1081,6 +1083,8 @@ class ConvertActionTests: XCTestCase {
                         usr: "s:7TestBed1AV",
                         availableLanguages: [.swift],
                         platforms: nil,
+                        topicImages: nil,
+                        references: nil,
                         redirects: nil
                     ),
                 ]
@@ -1096,6 +1100,8 @@ class ConvertActionTests: XCTestCase {
                         taskGroups: [],
                         availableLanguages: [.swift],
                         platforms: nil,
+                        topicImages: nil,
+                        references: nil,
                         redirects: nil
                     ),
                 ]
@@ -1262,6 +1268,8 @@ class ConvertActionTests: XCTestCase {
                         taskGroups: [.init(title: nil, identifiers: [reference.withFragment("Section-Name").absoluteString])],
                         availableLanguages: [.swift],
                         platforms: nil,
+                        topicImages: nil,
+                        references: nil,
                         redirects: nil
                     ),
                     LinkDestinationSummary(
@@ -1274,6 +1282,8 @@ class ConvertActionTests: XCTestCase {
                         taskGroups: [],
                         availableLanguages: [.swift],
                         platforms: nil,
+                        topicImages: nil,
+                        references: nil,
                         redirects: nil
                     ),
                 ]
@@ -1289,6 +1299,8 @@ class ConvertActionTests: XCTestCase {
                         taskGroups: [.init(title: nil, identifiers: [reference.appendingPath("Volume-1").absoluteString])],
                         availableLanguages: [.swift],
                         platforms: nil,
+                        topicImages: nil,
+                        references: nil,
                         redirects: nil
                     ),
                 ]
@@ -2825,6 +2837,8 @@ private extension LinkDestinationSummary {
         usr: String? = nil,
         availableLanguages: Set<SourceLanguage>,
         platforms: [PlatformAvailability]?,
+        topicImages: [TopicImage]?,
+        references: [RenderReference]?,
         redirects: [URL]?
     ) {
         self.init(
@@ -2840,6 +2854,8 @@ private extension LinkDestinationSummary {
             usr: usr,
             declarationFragments: nil,
             redirects: redirects,
+            topicImages: topicImages,
+            references: references,
             variants: []
         )
     }

--- a/Tests/SwiftDocCUtilitiesTests/OutOfProcessReferenceResolverTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/OutOfProcessReferenceResolverTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -73,6 +73,8 @@ class OutOfProcessReferenceResolverTests: XCTestCase {
             declarationFragments: .init(declarationFragments: [
                 .init(kind: .text, spelling: "declaration fragment", preciseIdentifier: nil)
             ]),
+            topicImages: nil,
+            references: nil,
             variants: [
                 .init(
                     traits: [.interfaceLanguage("com.test.another-language.id")],
@@ -216,6 +218,9 @@ class OutOfProcessReferenceResolverTests: XCTestCase {
         makeResolver: (OutOfProcessReferenceResolver.ResolvedInformation) throws
             -> OutOfProcessReferenceResolver
     ) throws {
+        let lightCardImageURL = try XCTUnwrap(URL(string: "https://com.test.example/some-image-name.jpg"))
+        let darkCardImageURL = try XCTUnwrap(URL(string: "https://com.test.example/some-image-name-dark.jpg"))
+        
         let testMetadata = OutOfProcessReferenceResolver.ResolvedInformation(
             kind: .init(name: "Kind Name", id: "com.test.kind.id", isSymbol: true),
             url: URL(string: "/relative/path/to/symbol")!,
@@ -234,6 +239,30 @@ class OutOfProcessReferenceResolverTests: XCTestCase {
             declarationFragments: .init(declarationFragments: [
                 .init(kind: .text, spelling: "declaration fragment", preciseIdentifier: nil)
             ]),
+            topicImages: [
+                TopicImage(
+                    type: .card,
+                    identifier: RenderReferenceIdentifier("external-card")
+                ),
+            ],
+            references: [
+                ImageReference(
+                    identifier: RenderReferenceIdentifier("external-card"),
+                    altText: "External card alt text",
+                    imageAsset:
+                        DataAsset(
+                            variants: [
+                                DataTraitCollection(userInterfaceStyle: .light, displayScale: .double): lightCardImageURL,
+                                DataTraitCollection(userInterfaceStyle: .dark, displayScale: .double): darkCardImageURL,
+                            ],
+                            metadata: [
+                                lightCardImageURL : DataAsset.Metadata(svgID: nil),
+                                darkCardImageURL : DataAsset.Metadata(svgID: nil),
+                            ],
+                            context: .display
+                        )
+                    ),
+            ],
             variants: [
                 .init(
                     traits: [.interfaceLanguage("com.test.another-language.id")],
@@ -297,6 +326,26 @@ class OutOfProcessReferenceResolverTests: XCTestCase {
         XCTAssertEqual(symbol.titleVariants[variantTrait], "Resolved Variant Title")
         XCTAssertEqual(symbol.abstractVariants[variantTrait]?.plainText, "Resolved variant abstract for this topic.")
         XCTAssertEqual(symbol.subHeadingVariants[variantTrait], [.init(kind: .text, spelling: "variant declaration fragment", preciseIdentifier: nil)])
+        
+        XCTAssertEqual(symbolNode.metadata?.pageImages.count, 1)
+        let pageImage = try XCTUnwrap(symbolNode.metadata?.pageImages.first)
+        XCTAssertEqual(pageImage.purpose, .card)
+        XCTAssertEqual(pageImage.source, ResourceReference(bundleIdentifier: "com.externally.resolved.symbol", path: "external-card"))
+        XCTAssertEqual(pageImage.alt, "External card alt text")
+        
+        let asset = try XCTUnwrap(resolver.resolve(assetNamed: pageImage.source.path, bundleIdentifier: pageImage.source.bundleIdentifier))
+        
+        XCTAssertEqual(asset, DataAsset(
+            variants: [
+                DataTraitCollection(userInterfaceStyle: .light, displayScale: .double): lightCardImageURL,
+                DataTraitCollection(userInterfaceStyle: .dark, displayScale: .double): darkCardImageURL,
+            ],
+            metadata: [
+                lightCardImageURL : DataAsset.Metadata(svgID: nil),
+                darkCardImageURL : DataAsset.Metadata(svgID: nil),
+            ],
+            context: .display
+        ))
     }
     
     func testResolvingSymbolProcess() throws {
@@ -511,7 +560,9 @@ class OutOfProcessReferenceResolverTests: XCTestCase {
                 language: .init(name: "Language Name", id: "com.test.language.id"),
                 availableLanguages: [],
                 platforms: nil,
-                declarationFragments: nil
+                declarationFragments: nil,
+                topicImages: nil,
+                references: nil
             )
             let message = OutOfProcessReferenceResolver.Response.resolvedInformation(testMetadata)
             
@@ -553,6 +604,8 @@ class OutOfProcessReferenceResolverTests: XCTestCase {
                 declarationFragments: .init(declarationFragments: [
                     .init(kind: .text, spelling: "declaration fragment", preciseIdentifier: nil)
                 ]),
+                topicImages: nil,
+                references: nil,
                 variants: [
                     .init(
                         traits: [.interfaceLanguage("com.test.other-language.id")],

--- a/bin/test-data-external-resolver
+++ b/bin/test-data-external-resolver
@@ -62,6 +62,38 @@ RESPONSE='{
         "name" : "Platform Name"
       }
     ],
+    "topicImages": [
+      {
+        "type": "card",
+        "identifier": "some-external-card-image-identifier"
+      }
+    ],
+    "references": [
+      {
+        "type": "image",
+        "identifier": "some-external-card-image-identifier",
+        "variants": [
+          {
+            "url": "http:\/\/example.com\/some-image-1x.jpg",
+            "traits": [
+              "1x"
+            ]
+          },
+          {
+            "url": "http:\/\/example.com\/some-image-1x-dark.jpg",
+            "traits": [
+              "1x", "dark"
+            ]
+          },
+          {
+            "url": "http:\/\/example.com\/some-image-2x.jpg",
+            "traits": [
+              "2x"
+            ]
+          }
+        ]
+      }
+    ],
     "title" : "Resolved Title",
     "url" : "doc:\/\/com.test.bundle\/resolved/path\/",
     "variants" : [


### PR DESCRIPTION
<!--
If you're opening a PR to cherry-pick a change for a release branch, use this template instead:
https://github.com/apple/swift-docc/blob/main/.github/PULL_REQUEST_TEMPLATE/CHERRY_PICK.md
-->

Bug/issue #, if applicable: rdar://100501774

## Summary

This adds support for writing topic image information to linkable-entities.json and for resolving external content with topic images.

The code for processing the external images and their image references is running up against the limitations outlined in https://github.com/apple/swift-docc/issues/468.

## Dependencies

None

## Testing

This can be tested using `bin/test-data-external-resolver` as an external resolver:

1. Update `bin/test-data-external-resolver` to use real image URLs instead of example.com URLs.
2. Set `DOCC_LINK_RESOLVER_EXECUTABLE` to the test-data-external-resolver` path
3. Set `DOCC_HTML_DIR` to swift-docc-render-artifact checkout path (`/path/to/swift-docc-render-artifact/dist`)
4. With any documentation with an article:
- Set the topic style to either `compactGrid` or `detailedGrid`
- Curate an external reference with the `com.test.bundle` bundle identifier. 

For example, with the SomeSample.md file in SampleBundle.docc:
```md
# SomeSample

@Metadata {
    @TechnologyRoot
}

This is a great framework, I tell you what.

@Options {
    @TopicsVisualStyle(compactGrid)
}

## Topics

### Examples

- <doc://com.test.bundle/something>
```

5. Build the documentation
```
swift run docc preview ./Tests/SwiftDocCTests/Test\ Bundles/SampleBundle.docc
```

6.  Preview the page with the curated external reference

<img width="833" alt="Screenshot 2023-01-26 at 5 35 20 PM" src="https://user-images.githubusercontent.com/1228143/214991123-f3a8544e-5d94-44e0-8646-2b6e64eb3b03.png">



## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
