### PR TITLE
Create .spi.yml

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,4 @@
+version: 1
+builder:
+  configs:
+    - documentation_targets: [SwiftDocC, SwiftDocCUtilities]


### PR DESCRIPTION
As discussed with @franklinsch , this will ensure SPI documentation is updated without any particular workarounds in place in SPI.

We initially added custom support to host documentation on SPI without a `.spi.yml` file but this is becoming a bit tricky to maintain and has broken in a couple of instances.