### PR TITLE
Add default values for optional parameters to ResolvedInformation init

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/External Data/OutOfProcessReferenceResolver.swift
+++ b/Sources/SwiftDocC/Infrastructure/External Data/OutOfProcessReferenceResolver.swift
@@ -806,10 +806,10 @@ extension OutOfProcessReferenceResolver {
             abstract: String,
             language: SourceLanguage,
             availableLanguages: Set<SourceLanguage>,
-            platforms: [PlatformAvailability]?,
-            declarationFragments: DeclarationFragments?,
-            topicImages: [TopicImage]?,
-            references: [RenderReference]?,
+            platforms: [PlatformAvailability]? = nil,
+            declarationFragments: DeclarationFragments? = nil,
+            topicImages: [TopicImage]? = nil,
+            references: [RenderReference]? = nil,
             variants: [Variant]? = nil
         ) {
             self.kind = kind


### PR DESCRIPTION
<!--
If you're opening a PR to cherry-pick a change for a release branch, use this template instead:
https://github.com/apple/swift-docc/blob/main/.github/PULL_REQUEST_TEMPLATE/CHERRY_PICK.md
-->

Bug/issue #, if applicable: rdar://105148636

## Summary

This adds default values for the optional arguments to the public `OutOfProcessReferenceResolver.ResolvedInformation` initializer to avoid breaking the public API.

## Dependencies

n/a

## Testing

n/a

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary
