### PR TITLE
set reference roles with PageKind directive

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/DocumentationContentRenderer.swift
+++ b/Sources/SwiftDocC/Model/Rendering/DocumentationContentRenderer.swift
@@ -127,6 +127,12 @@ public class DocumentationContentRenderer {
 
     /// Returns a metadata role for an article, depending if it's a collection, technology, or a free form article.
     func roleForArticle(_ article: Article, nodeKind: DocumentationNode.Kind) -> RenderMetadata.Role {
+        // If the article has a `@PageKind` directive, use the kind from there
+        // before checking anything else.
+        if let pageKind = article.metadata?.pageKind {
+            return pageKind.kind.renderRole
+        }
+
         // We create generated nodes with a semantic Article because they
         // can have doc extensions and the only way to tell them apart from
         // api collections or other articles is by their node kind.
@@ -135,10 +141,6 @@ public class DocumentationContentRenderer {
         default: break
         }
 
-        if let pageKind = article.metadata?.pageKind {
-            return pageKind.kind.renderRole
-        }
-        
         if article.topics?.taskGroups.isEmpty == false {
             // The documentation includes a "Topics" section, it's a collection or a group
             let isTechnologyRoot = article.metadata?.technologyRoot != nil

--- a/Sources/SwiftDocC/Model/Rendering/DocumentationContentRenderer.swift
+++ b/Sources/SwiftDocC/Model/Rendering/DocumentationContentRenderer.swift
@@ -134,6 +134,10 @@ public class DocumentationContentRenderer {
         case .collectionGroup: return role(for: nodeKind)
         default: break
         }
+
+        if let pageKind = article.metadata?.pageKind {
+            return pageKind.kind.renderRole
+        }
         
         if article.topics?.taskGroups.isEmpty == false {
             // The documentation includes a "Topics" section, it's a collection or a group

--- a/Tests/SwiftDocCTests/Rendering/PageKindTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/PageKindTests.swift
@@ -74,6 +74,27 @@ class PageKindTests: XCTestCase {
         XCTAssertEqual(renderNode.metadata.roleHeading, "Article")
     }
 
+    func testPageKindReference() throws {
+        let (bundle, context) = try testBundleAndContext(named: "SampleBundle")
+        let reference = ResolvedTopicReference(
+            bundleIdentifier: bundle.identifier,
+            path: "/documentation/SomeSample",
+            sourceLanguage: .swift
+        )
+        let article = try XCTUnwrap(context.entity(with: reference).semantic as? Article)
+        var translator = RenderNodeTranslator(
+            context: context,
+            bundle: bundle,
+            identifier: reference,
+            source: nil
+        )
+        let renderNode = try XCTUnwrap(translator.visitArticle(article) as? RenderNode)
+
+        let sampleReference = try XCTUnwrap(renderNode.references["doc://org.swift.docc.sample/documentation/SampleBundle/MyLocalSample"] as? TopicRenderReference)
+
+        XCTAssertEqual(sampleReference.role, RenderMetadata.Role.sampleCode.rawValue)
+    }
+
     func testValidMetadataWithOnlyPageKind() throws {
         let source = """
         @Metadata {


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://104980714

## Summary

When the `@PageKind` directive was added, it set the page's `role` on the page itself, but not for any references to that page. That led to situations where a page marked as `@PageKind(sampleCode)` would still get an article's icon in a page that curated it. This PR addresses this by setting the `TopicRenderReference`'s `role` with the role for the selected page kind.

## Dependencies

None

## Testing

Use the following markdown for testing:

```markdown
@Metadata {
    @PageKind(sampleCode)
}
```

Steps:
1. Add the above directive to `Sources/SwiftDocC/SwiftDocC.docc/SwiftDocC/Directives.md`
2. `bin/preview-docs`
3. Ensure that the reference to the "Directives" page in the Swift-DocC top-level page uses the sample code icon (a pair of curly braces in Swift-DocC-Render) instead of the article icon (a page with a folded corner).

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ n/a ] Updated documentation if necessary
