### PR TITLE
emit ExternalLocationReferences into assets digest

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/References/AssetReferences.swift
+++ b/Sources/SwiftDocC/Model/Rendering/References/AssetReferences.swift
@@ -13,7 +13,7 @@ import Foundation
 public extension RenderNode {
     /// All image, video, file, and download references of this node, grouped by their type.
     var assetReferences: [RenderReferenceType: [RenderReference]] {
-        let assetTypes = [RenderReferenceType.image, .video, .file, .download]
+        let assetTypes = [RenderReferenceType.image, .video, .file, .download, .externalLocation]
         return .init(grouping: references.values.lazy.filter({ assetTypes.contains($0.type) }), by: { $0.type })
     }    
 }

--- a/Sources/SwiftDocC/Model/Rendering/References/ExternalLocationReference.swift
+++ b/Sources/SwiftDocC/Model/Rendering/References/ExternalLocationReference.swift
@@ -22,7 +22,7 @@ import Foundation
 public struct ExternalLocationReference: RenderReference, URLReference {
     public static var baseURL: URL = DownloadReference.baseURL
 
-    public private(set) var type: RenderReferenceType = .download
+    public private(set) var type: RenderReferenceType = .externalLocation
 
     public var identifier: RenderReferenceIdentifier
 

--- a/Sources/SwiftDocC/Model/Rendering/References/RenderReference.swift
+++ b/Sources/SwiftDocC/Model/Rendering/References/RenderReference.swift
@@ -26,7 +26,7 @@ public protocol RenderReference: Codable {
 
 /// The type of a reference.
 public enum RenderReferenceType: String, Codable, Equatable {
-    case image, video, file, fileType, xcodeRequirement, topic, section, download, link
+    case image, video, file, fileType, xcodeRequirement, topic, section, download, link, externalLocation
     case unresolvable
 }
 

--- a/Sources/SwiftDocC/Model/Rendering/RenderNode/CodableRenderReference.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNode/CodableRenderReference.swift
@@ -43,6 +43,8 @@ struct CodableRenderReference: Codable {
             reference = try UnresolvedRenderReference(from: decoder)
         case .link:
             reference = try LinkReference(from: decoder)
+        case .externalLocation:
+            reference = try ExternalLocationReference(from: decoder)
         }
     }
     

--- a/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderNode.spec.json
+++ b/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderNode.spec.json
@@ -1816,7 +1816,7 @@
                 "properties": {
                     "type": {
                         "type": "string",
-                        "enum": ["download"]
+                        "enum": ["download", "externalLocation"]
                     },
                     "identifier": {
                         "type": "string"

--- a/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
@@ -1272,17 +1272,20 @@ class ConvertActionTests: XCTestCase {
             XCTFail("Can't find assets.json in output")
             return
         }
-        XCTAssertEqual(resultAssets.downloads.count, 2)
+        XCTAssertEqual(resultAssets.downloads.count, 1)
 
         XCTAssert(resultAssets.downloads.contains(where: {
-            guard case let .download(download) = $0 else { return false }
-            return download.identifier.identifier == "project.zip"
+            $0.identifier.identifier == "project.zip"
         }))
-        XCTAssert(resultAssets.downloads.contains(where: {
-            // Because ExternalLocationReferences encode to JSON compatible with DownloadReference,
-            // it will also decode into .download here; the data will still be the same
-            guard case let .download(reference) = $0 else { return false }
-            return reference.identifier.identifier == "https://example.com/sample.zip"
+
+        guard let externalAssets: Digest.ExternalAssets = contentsOfJSONFile(url: result.outputs[0].appendingPathComponent("external-assets.json")) else {
+            XCTFail("Can't find external-assets.json in output")
+            return
+        }
+        XCTAssertEqual(externalAssets.externalLocations.count, 1)
+
+        XCTAssert(externalAssets.externalLocations.contains(where: {
+            $0.identifier.identifier == "https://example.com/sample.zip"
         }))
     }
 

--- a/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
@@ -31,6 +31,10 @@ class ConvertActionTests: XCTestCase {
         withExtension: "symbols.json",
         subdirectory: "Test Resources"
     )!
+
+    let projectZipFile = Bundle.module.url(
+        forResource: "TestBundle", withExtension: "docc", subdirectory: "Test Bundles")!
+        .appendingPathComponent("project.zip")
     
     /// A symbol graph file that has missing symbols.
     let incompleteSymbolGraphFile = TextFile(name: "TechnologyX.symbols.json", utf8Content: """
@@ -1157,6 +1161,129 @@ class ConvertActionTests: XCTestCase {
             return
         }
         XCTAssertEqual(resultAssets.images.map({ $0.identifier.identifier }).sorted(), images.map({ $0.identifier.identifier }).sorted())
+    }
+
+    func testDownloadMetadataIsWritenToOutputFolder() throws {
+        let bundle = Folder(name: "unit-test.docc", content: [
+            CopyOfFile(original: projectZipFile),
+            CopyOfFile(original: imageFile, newName: "referenced-tutorials-image.png"),
+
+            TextFile(name: "MyTechnology.tutorial", utf8Content: """
+            @Tutorial(time: 10, projectFiles: project.zip) {
+              @Intro(title: "TechologyX") {}
+
+              @Section(title: "Section") {
+                @Steps {}
+              }
+
+              @Assessments {
+                @MultipleChoice {
+                  text
+                  @Choice(isCorrect: true) {
+                    text
+                    @Justification(reaction: "reaction text") {}
+                  }
+
+                  @Choice(isCorrect: false) {
+                    text
+                    @Justification(reaction: "reaction text") {}
+                  }
+                }
+              }
+            }
+            """),
+
+            TextFile(name: "TechnologyX.tutorial", utf8Content: """
+            @Tutorials(name: TechnologyX) {
+               @Intro(title: "Technology X") {
+                  Learn about some stuff in Technology X.
+               }
+
+               @Volume(name: "Volume 1") {
+                  This volume contains Chapter 1.
+
+                  @Image(source: referenced-tutorials-image.png, alt: "Some alt text")
+
+                  @Chapter(name: "Chapter 1") {
+                     In this chapter, you'll learn about Tutorial 1.
+
+                     @Image(source: referenced-tutorials-image.png, alt: "Some alt text")
+                     @TutorialReference(tutorial: "doc:MyTechnology")
+                  }
+               }
+            }
+            """),
+
+            TextFile(name: "MySample.md", utf8Content: """
+            # My Sample
+
+            @Metadata {
+                @CallToAction(url: "https://example.com/sample.zip", purpose: download)
+            }
+
+            This is a page with a download button.
+            """),
+
+            TextFile(name: "TestBundle.md", utf8Content: """
+            # ``TestBundle``
+
+            This is a test.
+
+            ## Topics
+
+            ### Pages
+
+            - <doc:TechnologyX>
+            - <doc:MySample>
+            """),
+
+            // A symbol graph
+            CopyOfFile(original: Bundle.module.url(forResource: "TopLevelCuration.symbols", withExtension: "json", subdirectory: "Test Resources")!),
+
+            InfoPlist(displayName: "TestBundle", identifier: "com.test.example"),
+        ])
+
+        let testDataProvider = try TestFileSystem(folders: [bundle, Folder.emptyHTMLTemplateDirectory])
+        let targetDirectory = URL(fileURLWithPath: testDataProvider.currentDirectoryPath)
+            .appendingPathComponent("target", isDirectory: true)
+
+        var action = try ConvertAction(
+            documentationBundleURL: bundle.absoluteURL,
+            outOfProcessResolver: nil,
+            analyze: false,
+            targetDirectory: targetDirectory,
+            htmlTemplateDirectory: Folder.emptyHTMLTemplateDirectory.absoluteURL,
+            emitDigest: true,
+            currentPlatforms: nil,
+            dataProvider: testDataProvider,
+            fileManager: testDataProvider,
+            temporaryDirectory: createTemporaryDirectory())
+        let result = try action.perform(logHandle: .standardOutput)
+
+        func contentsOfJSONFile<Result: Decodable>(url: URL) -> Result? {
+            guard let data = testDataProvider.contents(atPath: url.path) else {
+                return nil
+            }
+            return try? JSONDecoder().decode(Result.self, from: data)
+        }
+
+        // Verify downloads
+        guard let resultAssets: Digest.Assets = contentsOfJSONFile(url: result.outputs[0].appendingPathComponent("assets.json")) else {
+            XCTFail("Can't find assets.json in output")
+            return
+        }
+        XCTAssertEqual(resultAssets.downloads.count, 2)
+
+        XCTAssert(resultAssets.downloads.contains(where: {
+            guard case let .download(download) = $0 else { return false }
+            return download.identifier.identifier == "project.zip"
+        }))
+        XCTAssert(resultAssets.downloads.contains(where: {
+            // Because ExternalLocationReferences encode to JSON compatible with DownloadReference,
+            // it will also decode into .download here; the data will still be the same
+            guard case let .download(reference) = $0 else { return false }
+            return reference.identifier.identifier == "https://example.com/sample.zip"
+        }))
     }
 
     func testMetadataIsWrittenToOutputFolder() throws {


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://105226975

## Summary

The implementation of `ExternalLocationReference` in #467 meant that there were now two types sourcing `download` references: Both that and the original `DownloadReference`. This broke the code that emitted the `assets.json` digest, since it expected to be able to cast the list of references directly to `[DownloadReference]`. This PR provides some wrapper code in the assets digest to allow both `DownloadReference` and `ExternalLocationReference` to be encoded to the assets digest.

## Dependencies

None

## Testing

Steps:
1. Use a doc catalog where an article uses the `@CallToAction(url:)` directive to link to an externally-located resource. (The Swift-DocC catalog can be used by adding such a directive to any article.)
2. Run `docc convert MyCatalog.docc --emit-digest`.
3. Inspect the `assets.json` in the rendered archive; ensure that it includes the link added in the `@CallToAction` directive.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ n/a ] Updated documentation if necessary
