### PR TITLE
Try finding full path component before the parsed path component name

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
@@ -378,13 +378,13 @@ struct PathHierarchy {
     /// - Returns: The child disambiguation tree and path component.
     private func findChildTree(node: inout Node, remaining: ArraySlice<PathComponent>) throws -> (DisambiguationTree, PathComponent) {
         var pathComponent = remaining.first!
-        if let match = node.children[pathComponent.name] {
-            return (match, pathComponent)
-        } else if let match = node.children[pathComponent.full] {
+        if let match = node.children[pathComponent.full] {
             // The path component parsing may treat dash separated words as disambiguation information.
             // If the parsed name didn't match, also try the original.
             pathComponent.kind = nil
             pathComponent.hash = nil
+            return (match, pathComponent)
+        } else if let match = node.children[pathComponent.name] {
             return (match, pathComponent)
         } else {
             if node.name == pathComponent.name || node.name == pathComponent.full, let parent = node.parent {


### PR DESCRIPTION
<!--
If you're opening a PR to cherry-pick a change for a release branch, use this template instead:
https://github.com/apple/swift-docc/blob/main/.github/PULL_REQUEST_TEMPLATE/CHERRY_PICK.md
-->

Bug/issue #, if applicable: rdar://101212257

## Summary

This fixes an issue in the hierarchy based link resolver where articles with file names that resemble a disambiguated symbol name—for a symbol that exist in the local context—would fail to resolve.

## Dependencies

n/a

## Testing

In any documentation project a DocC catalog and at least one symbol. 

1. Enable the hierarchy based link resolver
```
defaults write -g DocCUseHierarchyBasedLinkResolver -bool true
```
2. Add an article with a file name that's follows this pattern: `NameOfSymbol-abcd.md`
3. Add a link to `<doc:NameOfSymbol-abcd>`

The link should resolve to the added article

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
