### PR TITLE
[ConvertService] Add baseline support for standalone articles and tutorials

### DIFF
--- a/Sources/SwiftDocC/DocumentationService/Convert/ConvertService+DataProvider.swift
+++ b/Sources/SwiftDocC/DocumentationService/Convert/ConvertService+DataProvider.swift
@@ -24,10 +24,23 @@ extension ConvertService {
             info: DocumentationBundle.Info,
             symbolGraphs: [Data],
             markupFiles: [Data],
+            tutorialFiles: [Data],
             miscResourceURLs: [URL]
         ) {
-            let symbolGraphURLs = symbolGraphs.map { registerFile(contents: $0, isMarkupFile: false) }
-            let markupFileURLs = markupFiles.map { registerFile(contents: $0, isMarkupFile: true) }
+            let symbolGraphURLs = symbolGraphs.map { registerFile(contents: $0, pathExtension: nil) }
+            let markupFileURLs = markupFiles.map { markupFile in
+                registerFile(
+                    contents: markupFile,
+                    pathExtension:
+                        DocumentationBundleFileTypes.referenceFileExtension
+                )
+            } + tutorialFiles.map { tutorialFile in
+                registerFile(
+                    contents: tutorialFile,
+                    pathExtension:
+                        DocumentationBundleFileTypes.tutorialFileExtension
+                )
+            }
             
             bundles.append(
                 DocumentationBundle(
@@ -39,8 +52,8 @@ extension ConvertService {
             )
         }
         
-        private mutating func registerFile(contents: Data, isMarkupFile: Bool) -> URL {
-            let url = Self.createURL(isMarkupFile: isMarkupFile)
+        private mutating func registerFile(contents: Data, pathExtension: String?) -> URL {
+            let url = Self.createURL(pathExtension: pathExtension)
             files[url] = contents
             return url
         }
@@ -50,11 +63,11 @@ extension ConvertService {
         /// The URL this function generates for a resource is not derived from the resource itself, because it doesn't need to be. The
         /// ``DocumentationWorkspaceDataProvider`` model revolves around retrieving resources by their URL. In our use
         /// case, our resources are not file URLs so we generate a URL for each resource.
-        static private func createURL(isMarkupFile: Bool) -> URL {
+        static private func createURL(pathExtension: String? = nil) -> URL {
             var url = URL(string: "docc-service:/\(UUID().uuidString)")!
             
-            if isMarkupFile {
-                url.appendPathExtension(DocumentationBundleFileTypes.referenceFileExtension)
+            if let pathExtension = pathExtension {
+                url.appendPathExtension(pathExtension)
             }
             
             return url

--- a/Sources/SwiftDocC/DocumentationService/Convert/ConvertService.swift
+++ b/Sources/SwiftDocC/DocumentationService/Convert/ConvertService.swift
@@ -136,6 +136,7 @@ public struct ConvertService: DocumentationService {
                     info: request.bundleInfo,
                     symbolGraphs: request.symbolGraphs,
                     markupFiles: request.markupFiles,
+                    tutorialFiles: request.tutorialFiles,
                     miscResourceURLs: request.miscResourceURLs
                 )
                 
@@ -144,6 +145,10 @@ public struct ConvertService: DocumentationService {
             
             let context = try DocumentationContext(dataProvider: workspace)
             context.knownDisambiguatedSymbolPathComponents = request.knownDisambiguatedSymbolPathComponents
+            
+            // Enable support for generating documentation for standalone articles and tutorials.
+            context.allowsRegisteringArticlesWithoutTechnologyRoot = true
+            context.allowsRegisteringUncuratedTutorials = true
             
             if let linkResolvingServer = linkResolvingServer {
                 let resolver = try OutOfProcessReferenceResolver(

--- a/Sources/SwiftDocC/DocumentationService/Models/Services/Convert/ConvertRequest.swift
+++ b/Sources/SwiftDocC/DocumentationService/Models/Services/Convert/ConvertRequest.swift
@@ -105,11 +105,15 @@ public struct ConvertRequest: Codable {
     /// - ``DocumentationBundle/symbolGraphURLs``
     public var symbolGraphs: [Data]
     
-    /// The markup file data included in the documentation bundle to convert.
+    /// The article and documentation extension file data included in the documentation bundle to convert.
     ///
     /// ## See Also
     /// - ``DocumentationBundle/markupURLs``
     public var markupFiles: [Data]
+    
+    
+    /// The tutorial file data included in the documentation bundle to convert.
+    public var tutorialFiles: [Data]
     
     /// The on-disk resources in the documentation bundle to convert.
     ///
@@ -153,6 +157,7 @@ public struct ConvertRequest: Codable {
         self.symbolGraphs = symbolGraphs
         self.knownDisambiguatedSymbolPathComponents = knownDisambiguatedSymbolPathComponents
         self.markupFiles = markupFiles
+        self.tutorialFiles = []
         self.miscResourceURLs = miscResourceURLs
         self.featureFlags = FeatureFlags()
         
@@ -174,7 +179,8 @@ public struct ConvertRequest: Codable {
     ///   - symbolGraphs: The symbols graph data included in the documentation bundle to convert.
     ///   - knownDisambiguatedSymbolPathComponents: The mapping of external symbol identifiers to
     ///   known disambiguated symbol path components.
-    ///   - markupFiles: The markup file data included in the documentation bundle to convert.
+    ///   - markupFiles: The article and documentation extension file data included in the documentation bundle to convert.
+    ///   - tutorialFiles: The tutorial file data included in the documentation bundle to convert.
     ///   - miscResourceURLs: The on-disk resources in the documentation bundle to convert.
     public init(
         bundleInfo: DocumentationBundle.Info,
@@ -186,6 +192,7 @@ public struct ConvertRequest: Codable {
         symbolGraphs: [Data],
         knownDisambiguatedSymbolPathComponents: [String: [String]]? = nil,
         markupFiles: [Data],
+        tutorialFiles: [Data] = [],
         miscResourceURLs: [URL]
     ) {
         self.externalIDsToConvert = externalIDsToConvert
@@ -195,6 +202,7 @@ public struct ConvertRequest: Codable {
         self.symbolGraphs = symbolGraphs
         self.knownDisambiguatedSymbolPathComponents = knownDisambiguatedSymbolPathComponents
         self.markupFiles = markupFiles
+        self.tutorialFiles = tutorialFiles
         self.miscResourceURLs = miscResourceURLs
         self.bundleInfo = bundleInfo
         self.featureFlags = featureFlags

--- a/Sources/SwiftDocC/Infrastructure/DocumentationBundleFileTypes.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationBundleFileTypes.swift
@@ -21,7 +21,7 @@ public enum DocumentationBundleFileTypes {
         return url.pathExtension.lowercased() == referenceFileExtension
     }
     
-    private static let tutorialFileExtension = "tutorial"
+    static let tutorialFileExtension = "tutorial"
     /// Checks if a file is a tutorial file.
     /// - Parameter url: The file to check.
     /// - Returns: Whether or not the file at `url` is a tutorial file.

--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -139,6 +139,19 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
             }
         }
     }
+    
+    /// Controls whether bundle registration should allow registering articles when no technology root is defined.
+    ///
+    /// Set this property to `true` to enable registering documentation for standalone articles,
+    /// for example when using ``ConvertService``.
+    var allowsRegisteringArticlesWithoutTechnologyRoot: Bool = false
+    
+    /// Controls whether tutorials that aren't curated in a tutorials overview page are registered and translated.
+    ///
+    /// Set this property to `true` to enable registering documentation for standalone tutorials,
+    /// for example when ``ConvertService``.
+    var allowsRegisteringUncuratedTutorials: Bool = false
+    
     /// The set of all manually curated references if `shouldStoreManuallyCuratedReferences` was true at the time of processing and has remained `true` since.. Nil if curation has not been processed yet.
     public private(set) var manuallyCuratedReferences: Set<ResolvedTopicReference>?
 
@@ -2133,7 +2146,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
         
         // Articles that will be automatically curated can be resolved but they need to be pre registered before resolving links.
         let rootNodeForAutomaticCuration = soleRootModuleReference.flatMap(topicGraph.nodeWithReference(_:))
-        if rootNodeForAutomaticCuration != nil {
+        if allowsRegisteringArticlesWithoutTechnologyRoot || rootNodeForAutomaticCuration != nil {
             otherArticles = registerArticles(otherArticles, in: bundle)
             try shouldContinueRegistration()
         }

--- a/Sources/SwiftDocC/Infrastructure/Workspace/DefaultAvailability.swift
+++ b/Sources/SwiftDocC/Infrastructure/Workspace/DefaultAvailability.swift
@@ -44,12 +44,12 @@ public struct DefaultAvailability: Codable, Equatable {
         /// A string representation of the version for this platform.
         public var platformVersion: String
 
-        /// Create a new module availability with a given platform name and platform version.
+        /// Creates a new module availability with a given platform name and platform version.
         ///
         /// - Parameters:
         ///   - platformName: A platform name, such as "iOS" or "macOS"; see ``PlatformName``.
         ///   - platformVersion: A 2- or 3-component version string, such as `"13.0"` or `"13.1.2"`
-        init(platformName: PlatformName, platformVersion: String) {
+        public init(platformName: PlatformName, platformVersion: String) {
             self.platformName = platformName
             self.platformVersion = platformVersion
         }
@@ -70,7 +70,9 @@ public struct DefaultAvailability: Codable, Equatable {
     /// For example: "ModuleName" -> ["macOS 10.15", "iOS 13.0"]
     var modules: [String: [ModuleAvailability]]
 
-    init(with modules: [String: [ModuleAvailability]]) {
+    /// Creates a default availability module.
+    /// - Parameter modules: A map of modules and the default platform availability for symbols in that module.
+    public init(with modules: [String: [ModuleAvailability]]) {
         self.modules = modules.mapValues { platformAvailabilities -> [DefaultAvailability.ModuleAvailability] in
             // If a module doesn't contain default introduced availability for macCatalyst,
             // infer it from iOS. Their platform versions are always the same.

--- a/Sources/SwiftDocC/Infrastructure/Workspace/DocumentationBundle+Info.swift
+++ b/Sources/SwiftDocC/Infrastructure/Workspace/DocumentationBundle+Info.swift
@@ -78,6 +78,31 @@ extension DocumentationBundle {
             }
         }
         
+        
+        /// Creates a new documentation bundle information value.
+        /// - Parameters:
+        ///   - displayName: The display name of the bundle.
+        ///   - identifier:  The unique identifier of the bundle.
+        ///   - version: The version of the bundle.
+        ///   - defaultCodeListingLanguage: The default language identifier for code listings in the bundle.
+        ///   - defaultAvailability: The default availability for the various modules in the bundle.
+        ///   - defaultModuleKind: The default kind for the various modules in the bundle.
+        public init(
+            displayName: String,
+            identifier: String,
+            version: String?,
+            defaultCodeListingLanguage: String?,
+            defaultAvailability: DefaultAvailability?,
+            defaultModuleKind: String?
+        ) {
+            self.displayName = displayName
+            self.identifier = identifier
+            self.version = version
+            self.defaultCodeListingLanguage = defaultCodeListingLanguage
+            self.defaultAvailability = defaultAvailability
+            self.defaultModuleKind = defaultModuleKind
+        }
+        
         /// Creates documentation bundle information from the given Info.plist data, falling back to the values
         /// in the given bundle discovery options if necessary.
         init(

--- a/Tests/SwiftDocCTests/DocumentationService/ConvertService/ConvertServiceTests.swift
+++ b/Tests/SwiftDocCTests/DocumentationService/ConvertService/ConvertServiceTests.swift
@@ -524,6 +524,145 @@ class ConvertServiceTests: XCTestCase {
         }
     }
     
+    func testConvertSingleArticlePage() throws {
+        let articleFile = Bundle.module.url(
+            forResource: "StandaloneArticle",
+            withExtension: "md",
+            subdirectory: "Test Resources"
+        )!
+        
+        let article = try Data(contentsOf: articleFile)
+        
+        let request = ConvertRequest(
+            bundleInfo: testBundleInfo,
+            externalIDsToConvert: nil,
+            documentPathsToConvert: nil,
+            symbolGraphs: [],
+            knownDisambiguatedSymbolPathComponents: nil,
+            markupFiles: [article],
+            miscResourceURLs: []
+        )
+        
+        try processAndAssert(request: request) { message in
+            XCTAssertEqual(message.type, "convert-response")
+            XCTAssertEqual(message.identifier, "test-identifier-response")
+            
+            let response = try JSONDecoder().decode(
+                ConvertResponse.self, from: XCTUnwrap(message.payload)
+            )
+            
+            XCTAssertEqual(response.renderNodes.count, 1)
+            let data = try XCTUnwrap(response.renderNodes.first)
+            let renderNode = try JSONDecoder().decode(RenderNode.self, from: data)
+            
+            XCTAssertEqual(
+                renderNode.metadata.externalID,
+                nil
+            )
+            
+            XCTAssertEqual(renderNode.kind, .article)
+            
+            XCTAssertEqual(renderNode.abstract?.count, 1)
+            
+            XCTAssertEqual(
+                renderNode.abstract?.first,
+                .text("An article abstract.")
+            )
+        }
+    }
+    
+    func testConvertSingleTutorial() throws {
+        let tutorialFile = Bundle.module.url(
+            forResource: "StandaloneTutorial",
+            withExtension: "tutorial",
+            subdirectory: "Test Resources"
+        )!
+        
+        let tutorial = try Data(contentsOf: tutorialFile)
+        
+        let request = ConvertRequest(
+            bundleInfo: testBundleInfo,
+            externalIDsToConvert: nil,
+            documentPathsToConvert: nil,
+            symbolGraphs: [],
+            knownDisambiguatedSymbolPathComponents: nil,
+            markupFiles: [],
+            tutorialFiles: [tutorial],
+            miscResourceURLs: []
+        )
+        
+        try processAndAssert(request: request) { message in
+            XCTAssertEqual(message.type, "convert-response")
+            XCTAssertEqual(message.identifier, "test-identifier-response")
+            
+            let response = try JSONDecoder().decode(
+                ConvertResponse.self, from: XCTUnwrap(message.payload)
+            )
+            
+            XCTAssertEqual(response.renderNodes.count, 1)
+            let data = try XCTUnwrap(response.renderNodes.first)
+            let renderNode = try JSONDecoder().decode(RenderNode.self, from: data)
+            
+            XCTAssertEqual(
+                renderNode.metadata.externalID,
+                nil
+            )
+            
+            XCTAssertEqual(renderNode.kind, .tutorial)
+            
+            XCTAssertEqual(
+                renderNode.metadata.title,
+                "Standalone Tutorial"
+            )
+        }
+    }
+    
+    func testConvertSingleTutorialOverview() throws {
+        let tutorialOverviewFile = Bundle.module.url(
+            forResource: "StandaloneTutorialOverview",
+            withExtension: "tutorial",
+            subdirectory: "Test Resources"
+        )!
+        
+        let tutorialOverview = try Data(contentsOf: tutorialOverviewFile)
+        
+        let request = ConvertRequest(
+            bundleInfo: testBundleInfo,
+            externalIDsToConvert: nil,
+            documentPathsToConvert: nil,
+            symbolGraphs: [],
+            knownDisambiguatedSymbolPathComponents: nil,
+            markupFiles: [],
+            tutorialFiles: [tutorialOverview],
+            miscResourceURLs: []
+        )
+        
+        try processAndAssert(request: request) { message in
+            XCTAssertEqual(message.type, "convert-response")
+            XCTAssertEqual(message.identifier, "test-identifier-response")
+            
+            let response = try JSONDecoder().decode(
+                ConvertResponse.self, from: XCTUnwrap(message.payload)
+            )
+            
+            XCTAssertEqual(response.renderNodes.count, 1)
+            let data = try XCTUnwrap(response.renderNodes.first)
+            let renderNode = try JSONDecoder().decode(RenderNode.self, from: data)
+            
+            XCTAssertEqual(
+                renderNode.metadata.externalID,
+                nil
+            )
+            
+            XCTAssertEqual(renderNode.kind, .overview)
+            
+            XCTAssertEqual(
+                renderNode.metadata.title,
+                "Standalone Tutorial Overview"
+            )
+        }
+    }
+    
     func processAndAssertResponseContents(
         expectedRenderNodePaths: [String],
         includesRenderReferenceStore: Bool,

--- a/Tests/SwiftDocCTests/Test Resources/StandaloneArticle.md
+++ b/Tests/SwiftDocCTests/Test Resources/StandaloneArticle.md
@@ -1,0 +1,7 @@
+# My Article
+
+An article abstract.
+
+This is an overview of the article.
+
+<!-- Copyright (c) 2023 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Tests/SwiftDocCTests/Test Resources/StandaloneTutorial.tutorial
+++ b/Tests/SwiftDocCTests/Test Resources/StandaloneTutorial.tutorial
@@ -1,0 +1,8 @@
+@Tutorial {
+   @Intro(title: "Standalone Tutorial") {
+
+      This is the tutorial abstract.
+   }
+}
+
+<!-- Copyright (c) 2023 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Tests/SwiftDocCTests/Test Resources/StandaloneTutorialOverview.tutorial
+++ b/Tests/SwiftDocCTests/Test Resources/StandaloneTutorialOverview.tutorial
@@ -1,0 +1,6 @@
+@Tutorials(name: "Standalone Tutorial Overview") {
+   @Intro(title: "Standalone Tutorial Overview") {
+   }
+}
+
+<!-- Copyright (c) 2023 Apple Inc and the Swift Project authors. All Rights Reserved. -->


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://105374582

## Summary

Adds baseline support for ConvertService to generate documentation for single articles without a top-level root page and for un-curated tutorials.

## Dependencies

None.

## Testing

In a client that uses `ConvertService`, verify that passing a standalone article or a tutorial results in DocC returning a render node.

## Checklist

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
