### PR TITLE
documentation update to clarify CLI option

### DIFF
--- a/Sources/docc/DocCDocumentation.docc/distributing-documentation-to-other-developers.md
+++ b/Sources/docc/DocCDocumentation.docc/distributing-documentation-to-other-developers.md
@@ -61,7 +61,7 @@ service configuration flags like so:
 docc convert […] \
     --source-service github \
     --source-service-base-url https://github.com/<org>/<repo>/blob/<branch> \
-    --checkout-path <path to local checkout>
+    --checkout-path <absolute path to local checkout>
 ```
 
 **GitLab**
@@ -69,7 +69,7 @@ docc convert […] \
 docc convert […] \
     --source-service gitlab \
     --source-service-base-url https://gitlab.com/<org>/<repo>/-/tree/<branch> \
-    --checkout-path <path to local checkout>
+    --checkout-path <absolute path to local checkout>
 ```
 
 **BitBucket**
@@ -77,8 +77,11 @@ docc convert […] \
 docc convert […] \
     --source-service bitbucket \
     --source-service-base-url https://bitbucket.org/<org>/<repo>/src/<branch> \
-    --checkout-path <path to local checkout>
+    --checkout-path <absolute path to local checkout>
 ```
+
+The option `--checkout-path` expects an absolute path to where the package 
+resides, not a relative path.
 
 These arguments can also be provided to `swift package generate-documentation`
 if you're using the SwiftPM DocC Plugin or via the `OTHER_DOCC_FLAGS` build

--- a/Sources/docc/DocCDocumentation.docc/distributing-documentation-to-other-developers.md
+++ b/Sources/docc/DocCDocumentation.docc/distributing-documentation-to-other-developers.md
@@ -80,8 +80,8 @@ docc convert […] \
     --checkout-path <absolute path to local checkout>
 ```
 
-The option `--checkout-path` expects an absolute path to where the package 
-resides, not a relative path.
+> Note: The option `--checkout-path` expects an absolute path to where the package 
+is checked out, not a relative path.
 
 These arguments can also be provided to `swift package generate-documentation`
 if you're using the SwiftPM DocC Plugin or via the `OTHER_DOCC_FLAGS` build


### PR DESCRIPTION
- related to https://github.com/apple/swift-docc/issues/490, updates the documentation to identify that --checkout-path requires an absolute oath, not a relative path.

Bug/issue #, if applicable: https://github.com/apple/swift-docc/issues/490

## Summary

Updates DocC documentation to make it more explicit how to use `--checkout-path` when linking source to hosted git repositories.

## Dependencies

none.

## Testing

Visual inspection only.

Steps:
1. Render updated DocC documentation
2. View article update for Distributing Documentation to Other Developers

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests - Not done - I haven't spotted tests for documentation content to add into
- [X] Ran the `./bin/test` script and it succeeded
- [X] Updated documentation if necessary
