### PR TITLE
Include suggested solution messages in main diagnostic message when writing diagnostics to console

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Diagnostics/Diagnostic.swift
+++ b/Sources/SwiftDocC/Infrastructure/Diagnostics/Diagnostic.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -97,30 +97,11 @@ public extension Diagnostic {
     }
 
     var localizedDescription: String {
-        var result = ""
-
-        if let range = range, let url = self.source {
-            result += "\(url.path):\(range.lowerBound.line):\(range.lowerBound.column): "
-        } else if let url = self.source {
-            result += "\(url.path): "
-        }
-        
-        result += "\(severity): \(localizedSummary)"
-
-        if let explanation = localizedExplanation {
-            result += "\n\(explanation)"
-        }
-
-        if !notes.isEmpty {
-            result += "\n"
-            result += notes.map { $0.description }.joined(separator: "\n")
-        }
-
-        return result
+        return DiagnosticConsoleWriter.formattedDescriptionFor(self)
     }
 
     var errorDescription: String {
-        return localizedDescription
+        return DiagnosticConsoleWriter.formattedDescriptionFor(self)
     }
 }
 

--- a/Sources/SwiftDocC/Infrastructure/Diagnostics/Problem.swift
+++ b/Sources/SwiftDocC/Infrastructure/Diagnostics/Problem.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -31,23 +31,11 @@ public struct Problem {
 
 extension Problem {
     var localizedDescription: String {
-        return formattedLocalizedDescription(withOptions: [])
+        return DiagnosticConsoleWriter.formattedDescriptionFor(self)
     }
 
     func formattedLocalizedDescription(withOptions options: DiagnosticFormattingOptions = []) -> String {
-        let description = diagnostic.localizedDescription
-
-        guard let source = diagnostic.source, options.contains(.showFixits) else {
-            return description
-        }
-
-        let fixitString = possibleSolutions.reduce("", { string, solution -> String in
-            return solution.replacements.reduce(string, {
-                $0 + "\n\(source.path):\($1.range.lowerBound.line):\($1.range.lowerBound.column)-\($1.range.upperBound.line):\($1.range.upperBound.column): fixit: \($1.replacement)"
-            })
-        })
-
-        return description + fixitString
+        return DiagnosticConsoleWriter.formattedDescriptionFor(self, options: options)
     }
 }
 

--- a/Sources/SwiftDocC/Infrastructure/External Data/OutOfProcessReferenceResolver.swift
+++ b/Sources/SwiftDocC/Infrastructure/External Data/OutOfProcessReferenceResolver.swift
@@ -123,7 +123,7 @@ public class OutOfProcessReferenceResolver: ExternalReferenceResolver, FallbackR
             do {
                 guard let unresolvedTopicURL = unresolvedReference.topicURL.components.url else {
                     // Return the unresolved reference if the underlying URL is not valid
-                    return .failure(unresolvedReference, TopicReferenceResolutionError("URL \(unresolvedReference.topicURL.absoluteString.singleQuoted) is not valid."))
+                    return .failure(unresolvedReference, TopicReferenceResolutionErrorInfo("URL \(unresolvedReference.topicURL.absoluteString.singleQuoted) is not valid."))
                 }
                 let metadata = try resolveInformationForTopicURL(unresolvedTopicURL)
                 // Don't do anything with this URL. The external URL will be resolved during conversion to render nodes
@@ -136,7 +136,7 @@ public class OutOfProcessReferenceResolver: ExternalReferenceResolver, FallbackR
                     )
                 )
             } catch let error {
-                return .failure(unresolvedReference, TopicReferenceResolutionError(error))
+                return .failure(unresolvedReference, TopicReferenceResolutionErrorInfo(error))
             }
         }
     }

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/DocumentationCacheBasedLinkResolver.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/DocumentationCacheBasedLinkResolver.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2022-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -129,7 +129,7 @@ final class DocumentationCacheBasedLinkResolver {
         // Ensure we are resolving either relative links or "doc:" scheme links
         guard unresolvedReference.topicURL.url.scheme == nil || ResolvedTopicReference.urlHasResolvedTopicScheme(unresolvedReference.topicURL.url) else {
             // Not resolvable in the topic graph
-            return .failure(unresolvedReference, TopicReferenceResolutionError("Reference URL \(unresolvedReference.description.singleQuoted) doesn't have \"doc:\" scheme."))
+            return .failure(unresolvedReference, TopicReferenceResolutionErrorInfo("Reference URL \(unresolvedReference.description.singleQuoted) doesn't have \"doc:\" scheme."))
         }
         
         // Fall back on the parent's bundle identifier for relative paths
@@ -267,7 +267,7 @@ final class DocumentationCacheBasedLinkResolver {
                 // Return the successful or failed externally resolved reference.
                 return resolvedExternalReference
             } else if !context.registeredBundles.contains(where: { $0.identifier == bundleID }) {
-                return .failure(unresolvedReference, TopicReferenceResolutionError("No external resolver registered for \(bundleID.singleQuoted)."))
+                return .failure(unresolvedReference, TopicReferenceResolutionErrorInfo("No external resolver registered for \(bundleID.singleQuoted)."))
             }
         }
         
@@ -295,7 +295,7 @@ final class DocumentationCacheBasedLinkResolver {
         // Give up: there is no local or external document for this reference.
         
         // External references which failed to resolve will already have returned a more specific error message.
-        return .failure(unresolvedReference, TopicReferenceResolutionError("No local documentation matches this reference."))
+        return .failure(unresolvedReference, TopicReferenceResolutionErrorInfo("No local documentation matches this reference."))
     }
     
     

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
@@ -930,19 +930,19 @@ extension PathHierarchy.Error {
             let disambiguations = remaining[0].full.dropFirst(remaining[0].name.count)
             let replacementRange = SourceLocation(line: 0, column: validPrefix.count, source: nil)..<SourceLocation(line: 0, column: validPrefix.count + disambiguations.count, source: nil)
             
-            let solutions = collisions.sorted(by: {
+            let solutions: [Solution] = collisions.sorted(by: {
                 $0.node.fullNameOfValue(context: context) + $0.disambiguation
                     < $1.node.fullNameOfValue(context: context) + $1.disambiguation
-            }).map { collision in
+            }).map { (node: PathHierarchy.Node, disambiguation: String) -> Solution in
                 let replacementOperationDescription: String
                 if disambiguations.isEmpty {
-                    replacementOperationDescription = "Insert \(collision.disambiguation.singleQuoted)"
+                    replacementOperationDescription = "Insert \(disambiguation.singleQuoted)"
                 } else {
                     // Drop the leading "-" from the current disambiguation since it's not part of the suggested disambiguation.
-                    replacementOperationDescription = "Replace \(disambiguations.dropFirst().singleQuoted) with \(collision.disambiguation.singleQuoted)"
+                    replacementOperationDescription = "Replace \(disambiguations.dropFirst().singleQuoted) with \(disambiguation.singleQuoted)"
                 }
-                return Solution(summary: "\(replacementOperationDescription) to refer to \(collision.node.fullNameOfValue(context: context).singleQuoted)", replacements: [
-                    Replacement(range: replacementRange, replacement: "-" + collision.disambiguation)
+                return Solution(summary: "\(replacementOperationDescription) to refer to \(node.fullNameOfValue(context: context).singleQuoted)", replacements: [
+                    Replacement(range: replacementRange, replacement: "-" + disambiguation)
                 ])
             }
             

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
@@ -910,7 +910,7 @@ extension PathHierarchy.Error {
                 $0.node.fullNameOfValue(context: context) + $0.disambiguation
                     < $1.node.fullNameOfValue(context: context) + $1.disambiguation
             }).map { collision in
-                Solution(summary: "Insert disambiguation suffix for \(collision.node.fullNameOfValue(context: context).singleQuoted)", replacements: [
+                Solution(summary: "Insert \(collision.disambiguation.singleQuoted) to refer to \(collision.node.fullNameOfValue(context: context).singleQuoted)", replacements: [
                     Replacement(range: replacementRange, replacement: "-" + collision.disambiguation)
                 ])
             }

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2022-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -841,14 +841,14 @@ extension PathHierarchy.Error {
     ///
     /// - Note: `Replacement`s produced by this function use `SourceLocation`s relative to the `originalReference`, i.e. the beginning
     /// of the _body_ of the original reference.
-    func asTopicReferenceResolutionError(context: DocumentationContext, originalReference: String) -> TopicReferenceResolutionError {
+    func asTopicReferenceResolutionErrorInfo(context: DocumentationContext, originalReference: String) -> TopicReferenceResolutionErrorInfo {
         switch self {
         case .notFound(availableChildren: let availableChildren):
-            return TopicReferenceResolutionError("No local documentation matches this reference.", note: availabilityNote(category: "top-level elements", candidates: availableChildren))
+            return TopicReferenceResolutionErrorInfo("No local documentation matches this reference.", note: availabilityNote(category: "top-level elements", candidates: availableChildren))
         case .unfindableMatch:
-            return TopicReferenceResolutionError("No local documentation matches this reference.")
+            return TopicReferenceResolutionErrorInfo("No local documentation matches this reference.")
         case .nonSymbolMatchForSymbolLink:
-            return TopicReferenceResolutionError("Symbol links can only resolve symbols.", solutions: [
+            return TopicReferenceResolutionErrorInfo("Symbol links can only resolve symbols.", solutions: [
                 Solution(summary: "Use a '<doc:>' style reference.", replacements: [
                     // the SourceRange points to the opening double-backtick
                     Replacement(range: SourceLocation(line: 0, column: -2, source: nil)..<SourceLocation(line: 0, column: 0, source: nil), replacement: "<doc:"),
@@ -891,7 +891,7 @@ extension PathHierarchy.Error {
                 return "Reference at \(partialResult.pathWithoutDisambiguation().singleQuoted) can't resolve \(remainingSubpath.singleQuoted). \(suggestion)"
             }
             
-            return TopicReferenceResolutionError(message, note: availabilityNote(category: "children", candidates: availableChildren), solutions: solutions)
+            return TopicReferenceResolutionErrorInfo(message, note: availabilityNote(category: "children", candidates: availableChildren), solutions: solutions)
             
         case .lookupCollision(partialResult: let partialResult, remainingSubpath: let remainingSubpath, collisions: let collisions):
             let unprocessedSuffix = remainingSubpath.suffix(from: remainingSubpath.firstIndex(of: "/") ?? remainingSubpath.endIndex)
@@ -915,7 +915,7 @@ extension PathHierarchy.Error {
                 ])
             }
             
-            return TopicReferenceResolutionError("Reference is ambiguous after \(partialResult.pathWithoutDisambiguation().singleQuoted).", solutions: solutions)
+            return TopicReferenceResolutionErrorInfo("Reference is ambiguous after \(partialResult.pathWithoutDisambiguation().singleQuoted).", solutions: solutions)
         }
     }
     

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchyBasedLinkResolver.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchyBasedLinkResolver.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2022-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -207,7 +207,7 @@ final class PathHierarchyBasedLinkResolver {
                 // Return the successful or failed externally resolved reference.
                 return resolvedExternalReference
             } else if !context.registeredBundles.contains(where: { $0.identifier == bundleID }) {
-                return .failure(unresolvedReference, TopicReferenceResolutionError("No external resolver registered for \(bundleID.singleQuoted)."))
+                return .failure(unresolvedReference, TopicReferenceResolutionErrorInfo("No external resolver registered for \(bundleID.singleQuoted)."))
             }
         }
         
@@ -227,7 +227,7 @@ final class PathHierarchyBasedLinkResolver {
                     originalReferenceString += "#" + fragment
                 }
                 
-                return .failure(unresolvedReference, error.asTopicReferenceResolutionError(context: context, originalReference: originalReferenceString))
+                return .failure(unresolvedReference, error.asTopicReferenceResolutionErrorInfo(context: context, originalReference: originalReferenceString))
             }
         } catch {
             fatalError("Only SymbolPathTree.Error errors are raised from the symbol link resolution code above.")

--- a/Sources/SwiftDocC/Model/Identifier.swift
+++ b/Sources/SwiftDocC/Model/Identifier.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -55,7 +55,7 @@ public enum TopicReferenceResolutionResult: Hashable, CustomStringConvertible {
     /// A topic reference that has successfully been resolved to known documentation.
     case success(ResolvedTopicReference)
     /// A topic reference that has failed to resolve to known documentation and an error message with information about why the reference failed to resolve.
-    case failure(UnresolvedTopicReference, TopicReferenceResolutionError)
+    case failure(UnresolvedTopicReference, TopicReferenceResolutionErrorInfo)
     
     public var description: String {
         switch self {
@@ -68,40 +68,32 @@ public enum TopicReferenceResolutionResult: Hashable, CustomStringConvertible {
 }
 
 /// The error causing the failure in the resolution of a ``TopicReference``.
-public struct TopicReferenceResolutionError: DescribedError, Hashable {
-    public let errorDescription: String
-    public let recoverySuggestion: String?
-    public let failureReason: String?
-    public let helpAnchor: String?
-    private let solutions: [Solution]
+public struct TopicReferenceResolutionErrorInfo: Hashable {
+    public var message: String
+    public var note: String?
+    public var solutions: [Solution]
     
-    init(_ message: String, note: String? = nil, solutions: [Solution] = []) {
-        self.errorDescription = message
-        self.recoverySuggestion = note
-        self.failureReason = nil
-        self.helpAnchor = nil
+    public init(_ message: String, note: String? = nil, solutions: [Solution] = []) {
+        self.message = message
+        self.note = note
         self.solutions = solutions
     }
 }
 
-extension TopicReferenceResolutionError {
+extension TopicReferenceResolutionErrorInfo {
     init(_ error: Error, solutions: [Solution] = []) {
         if let describedError = error as? DescribedError {
-            self.errorDescription = describedError.errorDescription
-            self.recoverySuggestion = describedError.recoverySuggestion
-            self.failureReason = describedError.failureReason
-            self.helpAnchor = describedError.helpAnchor
+            self.message = describedError.errorDescription
+            self.note = describedError.recoverySuggestion
         } else {
-            self.errorDescription = error.localizedDescription
-            self.recoverySuggestion = nil
-            self.failureReason = nil
-            self.helpAnchor = nil
+            self.message = error.localizedDescription
+            self.note = nil
         }
         self.solutions = solutions
     }
 }
 
-extension TopicReferenceResolutionError {
+extension TopicReferenceResolutionErrorInfo {
     /// Extracts any `Solution`s from this error, if available.
     ///
     /// The error can provide `Solution`s if appropriate. Since the absolute location of

--- a/Sources/SwiftDocC/Semantics/MarkupReferenceResolver.swift
+++ b/Sources/SwiftDocC/Semantics/MarkupReferenceResolver.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -65,7 +65,7 @@ struct MarkupReferenceResolver: MarkupRewriter {
             
         case .failure(let unresolved, let error):
             if let callback = problemForUnresolvedReference,
-               let problem = callback(unresolved, source, range, fromSymbolLink, error.localizedDescription) {
+               let problem = callback(unresolved, source, range, fromSymbolLink, error.message) {
                 problems.append(problem)
                 return nil
             }

--- a/Sources/SwiftDocC/Semantics/ReferenceResolver.swift
+++ b/Sources/SwiftDocC/Semantics/ReferenceResolver.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -11,21 +11,21 @@
 import Foundation
 import Markdown
 
-func unresolvedReferenceProblem(reference: TopicReference, source: URL?, range: SourceRange?, severity: DiagnosticSeverity, uncuratedArticleMatch: URL?, underlyingError: TopicReferenceResolutionError, fromSymbolLink: Bool) -> Problem {
+func unresolvedReferenceProblem(reference: TopicReference, source: URL?, range: SourceRange?, severity: DiagnosticSeverity, uncuratedArticleMatch: URL?, underlyingError: TopicReferenceResolutionErrorInfo, fromSymbolLink: Bool) -> Problem {
     var notes = uncuratedArticleMatch.map {
         [DiagnosticNote(source: $0, range: SourceLocation(line: 1, column: 1, source: nil)..<SourceLocation(line: 1, column: 1, source: nil), message: "This article was found but is not available for linking because it's uncurated")]
     } ?? []
     
     if let source = source,
        let range = range,
-       let note = underlyingError.recoverySuggestion ?? underlyingError.failureReason ?? underlyingError.helpAnchor {
+       let note = underlyingError.note {
         notes.append(DiagnosticNote(source: source, range: range, message: note))
     }
     
     var solutions: [Solution] = []
     
     if let range = range {
-        // FIXME: The replacements currently only support DocC's predomentantly used custom link formats.
+        // FIXME: The replacements currently only support DocC's predominantly used custom link formats.
         // We should also support the regular markdown link syntax ([doc:my/reference](doc:my/reference), or
         // [custom title](doc:my/reference)), however don't have the necessary information yet.
         // https://github.com/apple/swift-docc/issues/470
@@ -37,7 +37,7 @@ func unresolvedReferenceProblem(reference: TopicReference, source: URL?, range: 
         solutions.append(contentsOf: underlyingError.solutions(referenceSourceRange: innerRange))
     }
     
-    let diagnostic = Diagnostic(source: source, severity: severity, range: range, identifier: "org.swift.docc.unresolvedTopicReference", summary: "Topic reference \(reference.description.singleQuoted) couldn't be resolved. \(underlyingError.localizedDescription)", notes: notes)
+    let diagnostic = Diagnostic(source: source, severity: severity, range: range, identifier: "org.swift.docc.unresolvedTopicReference", summary: "Topic reference \(reference.description.singleQuoted) couldn't be resolved. \(underlyingError.message)", notes: notes)
     return Problem(diagnostic: diagnostic, possibleSolutions: solutions)
 }
 

--- a/Tests/SwiftDocCTests/Diagnostics/DiagnosticConsoleWriterTests.swift
+++ b/Tests/SwiftDocCTests/Diagnostics/DiagnosticConsoleWriterTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -62,24 +62,70 @@ class DiagnosticConsoleWriterTests: XCTestCase {
         let range = SourceLocation(line: 1, column: 8, source: source)..<SourceLocation(line: 10, column: 21, source: source)
         let identifier = "org.swift.docc.test-identifier"
         let summary = "Test diagnostic summary"
+        let solutionSummary = "Test solution summary"
         let explanation = "Test diagnostic explanation."
         let expectedLocation = "/path/to/file.md:1:8"
         
         let replacementRange = SourceLocation(line: 1, column: 8, source: source)..<SourceLocation(line: 1, column: 24, source: source)
         let replacement = Replacement(range: replacementRange, replacement: "Replacement text")
-        let solution = Solution(summary: "", replacements: [replacement])
-        let diagnostic = Diagnostic(source: source, severity: .error, range: range, identifier: identifier, summary: summary, explanation: explanation)
-        let problem = Problem(diagnostic: diagnostic, possibleSolutions: [solution])
         
-        let logger = Logger()
-        let consumer = DiagnosticConsoleWriter(logger, formattingOptions: [.showFixits])
-        consumer.receive([problem])
-        XCTAssertEqual(logger.output, """
-            \(expectedLocation): error: \(summary)
+        do {
+            let solution = Solution(summary: solutionSummary, replacements: [replacement])
+            let diagnostic = Diagnostic(source: source, severity: .error, range: range, identifier: identifier, summary: summary, explanation: explanation)
+            let problem = Problem(diagnostic: diagnostic, possibleSolutions: [solution])
+            
+            let logger = Logger()
+            let consumer = DiagnosticConsoleWriter(logger, formattingOptions: [.showFixits])
+            consumer.receive([problem])
+            XCTAssertEqual(logger.output, """
+            \(expectedLocation): error: \(summary). \(solutionSummary).
             \(explanation)
             \(source):1:8-1:24: fixit: Replacement text
             
             """)
+        }
+        
+        do {
+            let firstSolutionSummary = "Test first solution summary!"  // end with punctuation
+            let secondSolutionSummary = "Test second solution summary" // end without punctuation
+            let firstSolution = Solution(summary: firstSolutionSummary, replacements: [replacement])
+            let secondSolution = Solution(summary: secondSolutionSummary, replacements: [])
+            
+            let diagnostic = Diagnostic(source: source, severity: .error, range: range, identifier: identifier, summary: summary, explanation: explanation)
+            let problem = Problem(diagnostic: diagnostic, possibleSolutions: [firstSolution, secondSolution])
+            
+            let logger = Logger()
+            let consumer = DiagnosticConsoleWriter(logger, formattingOptions: [.showFixits])
+            consumer.receive([problem])
+            XCTAssertEqual(logger.output, """
+            \(expectedLocation): error: \(summary). \(firstSolutionSummary) \(secondSolutionSummary).
+            \(explanation)
+            
+            """)
+        }
+        
+        do {
+            let firstInsertRange = SourceLocation(line: 1, column: 8, source: source)..<SourceLocation(line: 1, column: 8, source: source)
+            let secondInsertRange = SourceLocation(line: 1, column: 14, source: source)..<SourceLocation(line: 1, column: 14, source: source)
+            let firstReplacement = Replacement(range: firstInsertRange, replacement: "ABC")
+            let secondReplacement = Replacement(range: secondInsertRange, replacement: "abc")
+            
+            let solution = Solution(summary: solutionSummary, replacements: [firstReplacement, secondReplacement])
+            
+            let diagnostic = Diagnostic(source: source, severity: .error, range: range, identifier: identifier, summary: summary, explanation: explanation)
+            let problem = Problem(diagnostic: diagnostic, possibleSolutions: [solution])
+            
+            let logger = Logger()
+            let consumer = DiagnosticConsoleWriter(logger, formattingOptions: [.showFixits])
+            consumer.receive([problem])
+            XCTAssertEqual(logger.output, """
+            \(expectedLocation): error: \(summary). \(solutionSummary).
+            \(explanation)
+            \(source):1:8-1:8: fixit: ABC
+            \(source):1:14-1:14: fixit: abc
+            
+            """)
+        }
     }
     
     func testDoesNotEmitFixits() {

--- a/Tests/SwiftDocCTests/Diagnostics/DiagnosticConsoleWriterTests.swift
+++ b/Tests/SwiftDocCTests/Diagnostics/DiagnosticConsoleWriterTests.swift
@@ -33,7 +33,7 @@ class DiagnosticConsoleWriterTests: XCTestCase {
         }
     }
 
-    func testRecieveProblem() {
+    func testReceiveProblem() {
         let problem = Problem(diagnostic: Diagnostic(source: nil, severity: .warning, range: nil, identifier: "org.swift.docc.tests", summary: "Test diagnostic"), possibleSolutions: [])
 
         let logger = Logger()
@@ -43,7 +43,7 @@ class DiagnosticConsoleWriterTests: XCTestCase {
         XCTAssertEqual(logger.output, "warning: Test diagnostic\n")
     }
 
-    func testRecieveMultipleProblems() {
+    func testReceiveMultipleProblems() {
         let problem = Problem(diagnostic: Diagnostic(source: nil, severity: .warning, range: nil, identifier: "org.swift.docc.tests", summary: "Test diagnostic"), possibleSolutions: [])
 
         let logger = Logger()

--- a/Tests/SwiftDocCTests/Diagnostics/ProblemTests.swift
+++ b/Tests/SwiftDocCTests/Diagnostics/ProblemTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -40,17 +40,18 @@ class ProblemTests: XCTestCase {
         let range = SourceLocation(line: 1, column: 8, source: source)..<SourceLocation(line: 10, column: 21, source: source)
         let identifier = "org.swift.docc.test-identifier"
         let summary = "Test diagnostic summary"
+        let solutionSummary = "Test solution summary"
         let explanation = "Test diagnostic explanation."
         let expectedLocation = "/path/to/file.md:1:8"
 
         let replacementRange = SourceLocation(line: 1, column: 8, source: source)..<SourceLocation(line: 1, column: 24, source: source)
         let replacement = Replacement(range: replacementRange, replacement: "Replacement text")
-        let solution = Solution(summary: "", replacements: [replacement])
+        let solution = Solution(summary: solutionSummary, replacements: [replacement])
         let diagnostic = Diagnostic(source: source, severity: .error, range: range, identifier: identifier, summary: summary, explanation: explanation)
         let problem = Problem(diagnostic: diagnostic, possibleSolutions: [solution])
 
         XCTAssertEqual(problem.formattedLocalizedDescription(withOptions: [.showFixits]), """
-        \(expectedLocation): error: \(summary)
+        \(expectedLocation): error: \(summary). \(solutionSummary).
         \(explanation)
         \(source):1:8-1:24: fixit: Replacement text
         """)

--- a/Tests/SwiftDocCTests/Infrastructure/ExternalReferenceResolverTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/ExternalReferenceResolverTests.swift
@@ -700,7 +700,7 @@ Document @1:1-1:35
                 guard reference.description == "doc://com.external.testbundle/resolvable" else {
                     switch reference {
                     case .unresolved(let unresolved):
-                        return .failure(unresolved, TopicReferenceResolutionError("Unit test: External resolve error."))
+                        return .failure(unresolved, TopicReferenceResolutionErrorInfo("Unit test: External resolve error."))
                     case .resolved(let resolvedResult):
                         return resolvedResult
                     }
@@ -758,11 +758,11 @@ Document @1:1-1:35
         // Expected failed externally resolved reference.
         XCTAssertEqual(
             context.externallyResolvedLinks[ValidatedURL(parsingExact: "doc://com.external.testbundle/not-resolvable-1")!],
-            TopicReferenceResolutionResult.failure(UnresolvedTopicReference(topicURL: ValidatedURL(parsingExact: "doc://com.external.testbundle/not-resolvable-1")!), TopicReferenceResolutionError("Unit test: External resolve error."))
+            TopicReferenceResolutionResult.failure(UnresolvedTopicReference(topicURL: ValidatedURL(parsingExact: "doc://com.external.testbundle/not-resolvable-1")!), TopicReferenceResolutionErrorInfo("Unit test: External resolve error."))
         )
         XCTAssertEqual(
             context.externallyResolvedLinks[ValidatedURL(parsingExact: "doc://com.external.testbundle/not-resolvable-2")!],
-            TopicReferenceResolutionResult.failure(UnresolvedTopicReference(topicURL: ValidatedURL(parsingExact: "doc://com.external.testbundle/not-resolvable-2")!), TopicReferenceResolutionError("Unit test: External resolve error."))
+            TopicReferenceResolutionResult.failure(UnresolvedTopicReference(topicURL: ValidatedURL(parsingExact: "doc://com.external.testbundle/not-resolvable-2")!), TopicReferenceResolutionErrorInfo("Unit test: External resolve error."))
         )
         
         // Expected successful externally resolved reference.

--- a/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
@@ -299,8 +299,8 @@ class PathHierarchyTests: XCTestCase {
         Reference is ambiguous after '/MixedFramework/CollisionsWithDifferentKinds'.
         """) { error in
             XCTAssertEqual(error.solutions, [
-                .init(summary: "Insert 'enum.case' to refer to 'case something'", replacements: ["-enum.case"]),
-                .init(summary: "Insert 'property' to refer to 'var something: String { get }'", replacements: ["-property"]),
+                .init(summary: "Insert 'enum.case' to refer to 'case something'", replacements: [("-enum.case", 54, 54)]),
+                .init(summary: "Insert 'property' to refer to 'var something: String { get }'", replacements: [("-property", 54, 54)]),
             ])
         }
         
@@ -320,9 +320,9 @@ class PathHierarchyTests: XCTestCase {
         ])
         try assertPathRaisesErrorMessage("/MixedFramework/CollisionsWithEscapedKeywords/init()", in: tree, context: context, expectedErrorMessage: "Reference is ambiguous after '/MixedFramework/CollisionsWithEscapedKeywords'.") { error in
             XCTAssertEqual(error.solutions, [
-                .init(summary: "Insert 'method' to refer to 'func `init`()'", replacements: ["-method"]),
-                .init(summary: "Insert 'init' to refer to 'init()'", replacements: ["-init"]),
-                .init(summary: "Insert 'type.method' to refer to 'static func `init`()'", replacements: ["-type.method"]),
+                .init(summary: "Insert 'method' to refer to 'func `init`()'", replacements: [("-method", 52, 52)]),
+                .init(summary: "Insert 'init' to refer to 'init()'", replacements: [("-init", 52, 52)]),
+                .init(summary: "Insert 'type.method' to refer to 'static func `init`()'", replacements: [("-type.method", 52, 52)]),
             ])
         }
         
@@ -333,9 +333,9 @@ class PathHierarchyTests: XCTestCase {
         ])
         try assertPathRaisesErrorMessage("/MixedFramework/CollisionsWithEscapedKeywords/subscript()", in: tree, context: context, expectedErrorMessage: "Reference is ambiguous after '/MixedFramework/CollisionsWithEscapedKeywords'.") { error in
             XCTAssertEqual(error.solutions, [
-                .init(summary: "Insert 'method' to refer to 'func `subscript`()'", replacements: ["-method"]),
-                .init(summary: "Insert 'type.method' to refer to 'static func `subscript`()'", replacements: ["-type.method"]),
-                .init(summary: "Insert 'subscript' to refer to 'subscript() -> Int { get }'", replacements: ["-subscript"]),
+                .init(summary: "Insert 'method' to refer to 'func `subscript`()'", replacements: [("-method", 57, 57)]),
+                .init(summary: "Insert 'type.method' to refer to 'static func `subscript`()'", replacements: [("-type.method", 57, 57)]),
+                .init(summary: "Insert 'subscript' to refer to 'subscript() -> Int { get }'", replacements: [("-subscript", 57, 57)]),
             ])
         }
         
@@ -352,8 +352,18 @@ class PathHierarchyTests: XCTestCase {
                                          context: context,
                                          expectedErrorMessage: "Reference is ambiguous after '/MixedFramework/CollisionsWithDifferentFunctionArguments'.") { error in
             XCTAssertEqual(error.solutions, [
-                .init(summary: "Insert '1cyvp' to refer to 'func something(argument: Int) -> Int'", replacements: ["-1cyvp"]),
-                .init(summary: "Insert '2vke2' to refer to 'func something(argument: String) -> Int'", replacements: ["-2vke2"]),
+                .init(summary: "Insert '1cyvp' to refer to 'func something(argument: Int) -> Int'", replacements: [("-1cyvp", 77, 77)]),
+                .init(summary: "Insert '2vke2' to refer to 'func something(argument: String) -> Int'", replacements: [("-2vke2", 77, 77)]),
+            ])
+        }
+        
+        try assertPathRaisesErrorMessage("/MixedFramework/CollisionsWithDifferentFunctionArguments/something(argument:)-method",
+                                         in: tree,
+                                         context: context,
+                                         expectedErrorMessage: "Reference is ambiguous after '/MixedFramework/CollisionsWithDifferentFunctionArguments'.") { error in
+            XCTAssertEqual(error.solutions, [
+                .init(summary: "Replace 'method' with '1cyvp' to refer to 'func something(argument: Int) -> Int'", replacements: [("-1cyvp", 77, 84)]),
+                .init(summary: "Replace 'method' with '2vke2' to refer to 'func something(argument: String) -> Int'", replacements: [("-2vke2", 77, 84)]),
             ])
         }
         
@@ -367,8 +377,15 @@ class PathHierarchyTests: XCTestCase {
         ])
         try assertPathRaisesErrorMessage("/MixedFramework/CollisionsWithDifferentSubscriptArguments/subscript(_:)", in: tree, context: context, expectedErrorMessage: "Reference is ambiguous after '/MixedFramework/CollisionsWithDifferentSubscriptArguments'.") { error in
             XCTAssertEqual(error.solutions, [
-                .init(summary: "Insert '4fd0l' to refer to 'subscript(something: Int) -> Int { get }'", replacements: ["-4fd0l"]),
-                .init(summary: "Insert '757cj' to refer to 'subscript(somethingElse: String) -> Int { get }'", replacements: ["-757cj"]),
+                .init(summary: "Insert '4fd0l' to refer to 'subscript(something: Int) -> Int { get }'", replacements: [("-4fd0l", 71, 71)]),
+                .init(summary: "Insert '757cj' to refer to 'subscript(somethingElse: String) -> Int { get }'", replacements: [("-757cj", 71, 71)]),
+            ])
+        }
+        
+        try assertPathRaisesErrorMessage("/MixedFramework/CollisionsWithDifferentSubscriptArguments/subscript(_:)-subscript", in: tree, context: context, expectedErrorMessage: "Reference is ambiguous after '/MixedFramework/CollisionsWithDifferentSubscriptArguments'.") { error in
+            XCTAssertEqual(error.solutions, [
+                .init(summary: "Replace 'subscript' with '4fd0l' to refer to 'subscript(something: Int) -> Int { get }'", replacements: [("-4fd0l", 71, 81)]),
+                .init(summary: "Replace 'subscript' with '757cj' to refer to 'subscript(somethingElse: String) -> Int { get }'", replacements: [("-757cj", 71, 81)]),
             ])
         }
         
@@ -878,8 +895,8 @@ class PathHierarchyTests: XCTestCase {
         ])
         try assertPathRaisesErrorMessage("/SideKit/SideProtocol/func()", in: tree, context: context, expectedErrorMessage: "Reference is ambiguous after '/SideKit/SideProtocol'.") { error in
             XCTAssertEqual(error.solutions, [
-                .init(summary: "Insert '2dxqn' to refer to 'func1()'", replacements: ["-2dxqn"]),
-                .init(summary: "Insert '6ijsi' to refer to 'func1()'", replacements: ["-6ijsi"]),
+                .init(summary: "Insert '2dxqn' to refer to 'func1()'", replacements: [("-2dxqn", 28, 28)]),
+                .init(summary: "Insert '6ijsi' to refer to 'func1()'", replacements: [("-6ijsi", 28, 28)]),
             ])
         } // This test data have the same declaration for both symbols.
         
@@ -924,9 +941,9 @@ class PathHierarchyTests: XCTestCase {
         ])
         try assertPathRaisesErrorMessage("MixedLanguageFramework/Foo", in: tree, context: context, expectedErrorMessage: "Reference is ambiguous after '/MixedLanguageFramework'.") { error in
             XCTAssertEqual(error.solutions, [
-                .init(summary: "Insert 'struct' to refer to 'struct Foo'", replacements: ["-struct"]),
-                .init(summary: "Insert 'enum' to refer to 'typedef enum Foo : NSString { ... } Foo;'", replacements: ["-enum"]),
-                .init(summary: "Insert 'typealias' to refer to 'typedef enum Foo : NSString { ... } Foo;'", replacements: ["-typealias"]),
+                .init(summary: "Insert 'struct' to refer to 'struct Foo'", replacements: [("-struct", 26, 26)]),
+                .init(summary: "Insert 'enum' to refer to 'typedef enum Foo : NSString { ... } Foo;'", replacements: [("-enum", 26, 26)]),
+                .init(summary: "Insert 'typealias' to refer to 'typedef enum Foo : NSString { ... } Foo;'", replacements: [("-typealias", 26, 26)]),
             ])
         } // The 'enum' and 'typealias' symbols have multi-line declarations that are presented on a single line
         
@@ -1363,12 +1380,23 @@ extension PathHierarchy {
 private extension TopicReferenceResolutionErrorInfo {
     var solutions: [SimplifiedSolution] {
         self.solutions(referenceSourceRange: SourceLocation(line: 0, column: 0, source: nil)..<SourceLocation(line: 0, column: 0, source: nil)).map { solution in
-            SimplifiedSolution(summary: solution.summary, replacements: solution.replacements.map(\.replacement))
+            SimplifiedSolution(summary: solution.summary, replacements: solution.replacements.map {
+                (
+                    $0.replacement,
+                    start: $0.range.lowerBound.column,
+                    end: $0.range.upperBound.column
+                )
+            })
         }
     }
 }
 
 private struct SimplifiedSolution: Equatable {
     let summary: String
-    let replacements: [String]
+    let replacements: [(String, start: Int, end: Int)]
+    
+    static func == (lhs: SimplifiedSolution, rhs: SimplifiedSolution) -> Bool {
+        return lhs.summary == rhs.summary
+            && lhs.replacements.elementsEqual(rhs.replacements, by: ==)
+    }
 }

--- a/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
@@ -299,8 +299,8 @@ class PathHierarchyTests: XCTestCase {
         Reference is ambiguous after '/MixedFramework/CollisionsWithDifferentKinds'.
         """) { error in
             XCTAssertEqual(error.solutions, [
-                .init(summary: "Insert disambiguation suffix for 'case something'", replacements: ["-enum.case"]),
-                .init(summary: "Insert disambiguation suffix for 'var something: String { get }'", replacements: ["-property"]),
+                .init(summary: "Insert 'enum.case' to refer to 'case something'", replacements: ["-enum.case"]),
+                .init(summary: "Insert 'property' to refer to 'var something: String { get }'", replacements: ["-property"]),
             ])
         }
         
@@ -320,9 +320,9 @@ class PathHierarchyTests: XCTestCase {
         ])
         try assertPathRaisesErrorMessage("/MixedFramework/CollisionsWithEscapedKeywords/init()", in: tree, context: context, expectedErrorMessage: "Reference is ambiguous after '/MixedFramework/CollisionsWithEscapedKeywords'.") { error in
             XCTAssertEqual(error.solutions, [
-                .init(summary: "Insert disambiguation suffix for 'func `init`()'", replacements: ["-method"]),
-                .init(summary: "Insert disambiguation suffix for 'init()'", replacements: ["-init"]),
-                .init(summary: "Insert disambiguation suffix for 'static func `init`()'", replacements: ["-type.method"]),
+                .init(summary: "Insert 'method' to refer to 'func `init`()'", replacements: ["-method"]),
+                .init(summary: "Insert 'init' to refer to 'init()'", replacements: ["-init"]),
+                .init(summary: "Insert 'type.method' to refer to 'static func `init`()'", replacements: ["-type.method"]),
             ])
         }
         
@@ -333,9 +333,9 @@ class PathHierarchyTests: XCTestCase {
         ])
         try assertPathRaisesErrorMessage("/MixedFramework/CollisionsWithEscapedKeywords/subscript()", in: tree, context: context, expectedErrorMessage: "Reference is ambiguous after '/MixedFramework/CollisionsWithEscapedKeywords'.") { error in
             XCTAssertEqual(error.solutions, [
-                .init(summary: "Insert disambiguation suffix for 'func `subscript`()'", replacements: ["-method"]),
-                .init(summary: "Insert disambiguation suffix for 'static func `subscript`()'", replacements: ["-type.method"]),
-                .init(summary: "Insert disambiguation suffix for 'subscript() -> Int { get }'", replacements: ["-subscript"]),
+                .init(summary: "Insert 'method' to refer to 'func `subscript`()'", replacements: ["-method"]),
+                .init(summary: "Insert 'type.method' to refer to 'static func `subscript`()'", replacements: ["-type.method"]),
+                .init(summary: "Insert 'subscript' to refer to 'subscript() -> Int { get }'", replacements: ["-subscript"]),
             ])
         }
         
@@ -352,8 +352,8 @@ class PathHierarchyTests: XCTestCase {
                                          context: context,
                                          expectedErrorMessage: "Reference is ambiguous after '/MixedFramework/CollisionsWithDifferentFunctionArguments'.") { error in
             XCTAssertEqual(error.solutions, [
-                .init(summary: "Insert disambiguation suffix for 'func something(argument: Int) -> Int'", replacements: ["-1cyvp"]),
-                .init(summary: "Insert disambiguation suffix for 'func something(argument: String) -> Int'", replacements: ["-2vke2"]),
+                .init(summary: "Insert '1cyvp' to refer to 'func something(argument: Int) -> Int'", replacements: ["-1cyvp"]),
+                .init(summary: "Insert '2vke2' to refer to 'func something(argument: String) -> Int'", replacements: ["-2vke2"]),
             ])
         }
         
@@ -367,8 +367,8 @@ class PathHierarchyTests: XCTestCase {
         ])
         try assertPathRaisesErrorMessage("/MixedFramework/CollisionsWithDifferentSubscriptArguments/subscript(_:)", in: tree, context: context, expectedErrorMessage: "Reference is ambiguous after '/MixedFramework/CollisionsWithDifferentSubscriptArguments'.") { error in
             XCTAssertEqual(error.solutions, [
-                .init(summary: "Insert disambiguation suffix for 'subscript(something: Int) -> Int { get }'", replacements: ["-4fd0l"]),
-                .init(summary: "Insert disambiguation suffix for 'subscript(somethingElse: String) -> Int { get }'", replacements: ["-757cj"]),
+                .init(summary: "Insert '4fd0l' to refer to 'subscript(something: Int) -> Int { get }'", replacements: ["-4fd0l"]),
+                .init(summary: "Insert '757cj' to refer to 'subscript(somethingElse: String) -> Int { get }'", replacements: ["-757cj"]),
             ])
         }
         
@@ -878,8 +878,8 @@ class PathHierarchyTests: XCTestCase {
         ])
         try assertPathRaisesErrorMessage("/SideKit/SideProtocol/func()", in: tree, context: context, expectedErrorMessage: "Reference is ambiguous after '/SideKit/SideProtocol'.") { error in
             XCTAssertEqual(error.solutions, [
-                .init(summary: "Insert disambiguation suffix for 'func1()'", replacements: ["-2dxqn"]),
-                .init(summary: "Insert disambiguation suffix for 'func1()'", replacements: ["-6ijsi"]),
+                .init(summary: "Insert '2dxqn' to refer to 'func1()'", replacements: ["-2dxqn"]),
+                .init(summary: "Insert '6ijsi' to refer to 'func1()'", replacements: ["-6ijsi"]),
             ])
         } // This test data have the same declaration for both symbols.
         
@@ -924,9 +924,9 @@ class PathHierarchyTests: XCTestCase {
         ])
         try assertPathRaisesErrorMessage("MixedLanguageFramework/Foo", in: tree, context: context, expectedErrorMessage: "Reference is ambiguous after '/MixedLanguageFramework'.") { error in
             XCTAssertEqual(error.solutions, [
-                .init(summary: "Insert disambiguation suffix for 'struct Foo'", replacements: ["-struct"]),
-                .init(summary: "Insert disambiguation suffix for 'typedef enum Foo : NSString { ... } Foo;'", replacements: ["-enum"]),
-                .init(summary: "Insert disambiguation suffix for 'typedef enum Foo : NSString { ... } Foo;'", replacements: ["-typealias"]),
+                .init(summary: "Insert 'struct' to refer to 'struct Foo'", replacements: ["-struct"]),
+                .init(summary: "Insert 'enum' to refer to 'typedef enum Foo : NSString { ... } Foo;'", replacements: ["-enum"]),
+                .init(summary: "Insert 'typealias' to refer to 'typedef enum Foo : NSString { ... } Foo;'", replacements: ["-typealias"]),
             ])
         } // The 'enum' and 'typealias' symbols have multi-line declarations that are presented on a single line
         

--- a/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2022-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -1333,11 +1333,11 @@ class PathHierarchyTests: XCTestCase {
         }
     }
     
-    private func assertPathRaisesErrorMessage(_ path: String, in tree: PathHierarchy, context: DocumentationContext, expectedErrorMessage: String, file: StaticString = #file, line: UInt = #line, _ additionalAssertion: (TopicReferenceResolutionError) -> Void = { _ in }) throws {
+    private func assertPathRaisesErrorMessage(_ path: String, in tree: PathHierarchy, context: DocumentationContext, expectedErrorMessage: String, file: StaticString = #file, line: UInt = #line, _ additionalAssertion: (TopicReferenceResolutionErrorInfo) -> Void = { _ in }) throws {
         XCTAssertThrowsError(try tree.findSymbol(path: path), "Finding path \(path) didn't raise an error.",file: file,line: line) { untypedError in
             let error = untypedError as! PathHierarchy.Error
-            let referenceError = error.asTopicReferenceResolutionError(context: context, originalReference: path)
-            XCTAssertEqual(referenceError.localizedDescription, expectedErrorMessage, file: file, line: line)
+            let referenceError = error.asTopicReferenceResolutionErrorInfo(context: context, originalReference: path)
+            XCTAssertEqual(referenceError.message, expectedErrorMessage, file: file, line: line)
             additionalAssertion(referenceError)
         }
     }
@@ -1360,7 +1360,7 @@ extension PathHierarchy {
     }
 }
 
-private extension TopicReferenceResolutionError {
+private extension TopicReferenceResolutionErrorInfo {
     var solutions: [SimplifiedSolution] {
         self.solutions(referenceSourceRange: SourceLocation(line: 0, column: 0, source: nil)..<SourceLocation(line: 0, column: 0, source: nil)).map { solution in
             SimplifiedSolution(summary: solution.summary, replacements: solution.replacements.map(\.replacement))

--- a/Tests/SwiftDocCTests/Semantics/SymbolTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/SymbolTests.swift
@@ -630,8 +630,8 @@ class SymbolTests: XCTestCase {
             XCTAssertEqual(problem.possibleSolutions.count, 2)
             XCTAssert(problem.possibleSolutions.map(\.replacements.count).allSatisfy { $0 == 1 })
             XCTAssertEqual(problem.possibleSolutions.map { [$0.summary, $0.replacements.first!.replacement] }, [
-                ["Insert '33vaw' to refer to 'init()'", "-33vaw"],
-                ["Insert '3743d' to refer to 'init()'", "-3743d"],
+                ["Replace 'swift.init' with '33vaw' to refer to 'init()'", "-33vaw"],
+                ["Replace 'swift.init' with '3743d' to refer to 'init()'", "-3743d"],
             ])
             XCTAssertEqual(try problem.possibleSolutions.first!.applyTo(contentsOf: url.appendingPathComponent("documentation/myclass.md")), """
             # ``MyKit/MyClass``
@@ -676,8 +676,8 @@ class SymbolTests: XCTestCase {
             XCTAssertEqual(problem.possibleSolutions.count, 2)
             XCTAssert(problem.possibleSolutions.map(\.replacements.count).allSatisfy { $0 == 1 })
             XCTAssertEqual(problem.possibleSolutions.map { [$0.summary, $0.replacements.first!.replacement] }, [
-                ["Insert '33vaw' to refer to 'init()'", "-33vaw"],
-                ["Insert '3743d' to refer to 'init()'", "-3743d"],
+                ["Replace 'swift.init' with '33vaw' to refer to 'init()'", "-33vaw"],
+                ["Replace 'swift.init' with '3743d' to refer to 'init()'", "-3743d"],
             ])
             XCTAssertEqual(try problem.possibleSolutions.first!.applyTo(contentsOf: url.appendingPathComponent("documentation/myclass.md")), """
             # ``MyKit/MyClass``
@@ -722,7 +722,7 @@ class SymbolTests: XCTestCase {
             XCTAssertEqual(problem.possibleSolutions.count, 1)
             XCTAssert(problem.possibleSolutions.map(\.replacements.count).allSatisfy { $0 == 1 })
             XCTAssertEqual(problem.possibleSolutions.map { [$0.summary, $0.replacements.first!.replacement] }, [
-                ["Correct reference to myFunction().", "myFunction()"],
+                ["Replace 'otherFunction()' with 'myFunction()'.", "myFunction()"],
             ])
             XCTAssertEqual(try problem.possibleSolutions.first!.applyTo(contentsOf: url.appendingPathComponent("documentation/myclass.md")), """
             # ``MyKit/MyClass``
@@ -767,7 +767,7 @@ class SymbolTests: XCTestCase {
             XCTAssertEqual(problem.possibleSolutions.count, 1)
             XCTAssert(problem.possibleSolutions.map(\.replacements.count).allSatisfy { $0 == 1 })
             XCTAssertEqual(problem.possibleSolutions.map { [$0.summary, $0.replacements.first!.replacement] }, [
-                ["Correct reference to /MyKit/MyClass.", "MyClass"],
+                ["Replace 'MyClas' with 'MyClass'.", "MyClass"],
             ])
             XCTAssertEqual(try problem.possibleSolutions.first!.applyTo(contentsOf: url.appendingPathComponent("documentation/myclass.md")), """
             # ``MyKit/MyClass``
@@ -812,7 +812,7 @@ class SymbolTests: XCTestCase {
             XCTAssertEqual(problem.possibleSolutions.count, 1)
             XCTAssert(problem.possibleSolutions.map(\.replacements.count).allSatisfy { $0 == 1 })
             XCTAssertEqual(problem.possibleSolutions.map { [$0.summary, $0.replacements.first!.replacement] }, [
-                ["Correct reference to MyKit/MyClass/myFunction().", "MyClass"],
+                ["Replace 'MyClas' with 'MyClass'.", "MyClass"],
             ])
             XCTAssertEqual(try problem.possibleSolutions.first!.applyTo(contentsOf: url.appendingPathComponent("documentation/myclass.md")), """
             # ``MyKit/MyClass``
@@ -857,7 +857,7 @@ class SymbolTests: XCTestCase {
             XCTAssertEqual(problem.possibleSolutions.count, 1)
             XCTAssert(problem.possibleSolutions.map(\.replacements.count).allSatisfy { $0 == 1 })
             XCTAssertEqual(problem.possibleSolutions.map { [$0.summary, $0.replacements.first!.replacement] }, [
-                ["Correct reference to MyKit/MyClass/myFunction().", "MyClass"],
+                ["Replace 'MyClas' with 'MyClass'.", "MyClass"],
             ])
             XCTAssertEqual(try problem.possibleSolutions.first!.applyTo(contentsOf: url.appendingPathComponent("documentation/myclass.md")), """
             # ``MyKit/MyClass``
@@ -902,7 +902,7 @@ class SymbolTests: XCTestCase {
             XCTAssertEqual(problem.possibleSolutions.count, 1)
             XCTAssert(problem.possibleSolutions.map(\.replacements.count).allSatisfy { $0 == 1 })
             XCTAssertEqual(problem.possibleSolutions.map { [$0.summary, $0.replacements.first!.replacement] }, [
-                ["Correct reference to MyKit/MyClass/myFunction().", "MyClass"],
+                ["Replace 'MyClas' with 'MyClass'.", "MyClass"],
             ])
             XCTAssertEqual(try problem.possibleSolutions.first!.applyTo(contentsOf: url.appendingPathComponent("documentation/myclass.md")), """
             # ``MyKit/MyClass``
@@ -993,7 +993,7 @@ class SymbolTests: XCTestCase {
             XCTAssertEqual(problem.possibleSolutions.count, 1)
             XCTAssert(problem.possibleSolutions.map(\.replacements.count).allSatisfy { $0 == 1 })
             XCTAssertEqual(problem.possibleSolutions.map { [$0.summary, $0.replacements.first!.replacement] }, [
-                ["Correct reference to Unresolvable-curation.", "Unresolvable-curation"],
+                ["Replace 'UnresolvableSymbolLinkInMyClassOverview' with 'Unresolvable-curation'.", "Unresolvable-curation"],
             ])
             XCTAssertEqual(try problem.possibleSolutions.first!.applyTo(docComment), """
             A cool API to call.
@@ -1018,7 +1018,7 @@ class SymbolTests: XCTestCase {
             XCTAssertEqual(problem.possibleSolutions.count, 1)
             XCTAssert(problem.possibleSolutions.map(\.replacements.count).allSatisfy { $0 == 1 })
             XCTAssertEqual(problem.possibleSolutions.map { [$0.summary, $0.replacements.first!.replacement] }, [
-                ["Correct reference to Unresolvable-curation.", "Unresolvable-curation"],
+                ["Replace 'UnresolvableClassInMyClassTopicCuration' with 'Unresolvable-curation'.", "Unresolvable-curation"],
             ])
             XCTAssertEqual(try problem.possibleSolutions.first!.applyTo(docComment), """
             A cool API to call.
@@ -1044,8 +1044,8 @@ class SymbolTests: XCTestCase {
             XCTAssertEqual(problem.possibleSolutions.count, 2)
             XCTAssert(problem.possibleSolutions.map(\.replacements.count).allSatisfy { $0 == 1 })
             XCTAssertEqual(problem.possibleSolutions.map { [$0.summary, $0.replacements.first!.replacement] }, [
-                ["Correct reference to MyClass/init().", "init()"],
-                ["Correct reference to MyClass/myFunction().", "myFunction()"],
+                ["Replace 'unresolvablePropertyInMyClassTopicCuration' with 'init()'.", "init()"],
+                ["Replace 'unresolvablePropertyInMyClassTopicCuration' with 'myFunction()'.", "myFunction()"],
             ])
             XCTAssertEqual(try problem.possibleSolutions.first!.applyTo(docComment), """
             A cool API to call.

--- a/Tests/SwiftDocCTests/Semantics/SymbolTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/SymbolTests.swift
@@ -584,8 +584,8 @@ class SymbolTests: XCTestCase {
             XCTAssertEqual(problem.possibleSolutions.count, 2)
             XCTAssert(problem.possibleSolutions.map(\.replacements.count).allSatisfy { $0 == 1 })
             XCTAssertEqual(problem.possibleSolutions.map { [$0.summary, $0.replacements.first!.replacement] }, [
-                ["Insert disambiguation suffix for 'init()'", "-33vaw"],
-                ["Insert disambiguation suffix for 'init()'", "-3743d"],
+                ["Insert '33vaw' to refer to 'init()'", "-33vaw"],
+                ["Insert '3743d' to refer to 'init()'", "-3743d"],
             ])
             XCTAssertEqual(try problem.possibleSolutions.first!.applyTo(contentsOf: url.appendingPathComponent("documentation/myclass.md")), """
             # ``MyKit/MyClass``
@@ -630,8 +630,8 @@ class SymbolTests: XCTestCase {
             XCTAssertEqual(problem.possibleSolutions.count, 2)
             XCTAssert(problem.possibleSolutions.map(\.replacements.count).allSatisfy { $0 == 1 })
             XCTAssertEqual(problem.possibleSolutions.map { [$0.summary, $0.replacements.first!.replacement] }, [
-                ["Insert disambiguation suffix for 'init()'", "-33vaw"],
-                ["Insert disambiguation suffix for 'init()'", "-3743d"],
+                ["Insert '33vaw' to refer to 'init()'", "-33vaw"],
+                ["Insert '3743d' to refer to 'init()'", "-3743d"],
             ])
             XCTAssertEqual(try problem.possibleSolutions.first!.applyTo(contentsOf: url.appendingPathComponent("documentation/myclass.md")), """
             # ``MyKit/MyClass``
@@ -676,8 +676,8 @@ class SymbolTests: XCTestCase {
             XCTAssertEqual(problem.possibleSolutions.count, 2)
             XCTAssert(problem.possibleSolutions.map(\.replacements.count).allSatisfy { $0 == 1 })
             XCTAssertEqual(problem.possibleSolutions.map { [$0.summary, $0.replacements.first!.replacement] }, [
-                ["Insert disambiguation suffix for 'init()'", "-33vaw"],
-                ["Insert disambiguation suffix for 'init()'", "-3743d"],
+                ["Insert '33vaw' to refer to 'init()'", "-33vaw"],
+                ["Insert '3743d' to refer to 'init()'", "-3743d"],
             ])
             XCTAssertEqual(try problem.possibleSolutions.first!.applyTo(contentsOf: url.appendingPathComponent("documentation/myclass.md")), """
             # ``MyKit/MyClass``

--- a/Tests/SwiftDocCUtilitiesTests/ArgumentParsing/ConvertSubcommandTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ArgumentParsing/ConvertSubcommandTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -378,7 +378,7 @@ class ConvertSubcommandTests: XCTestCase {
         }
         
         let commandWithoutFlag = try Docc.Convert.parse([testBundleURL.path])
-        let actionWithoutFlag = try ConvertAction(fromConvertCommand: commandWithoutFlag)
+        _ = try ConvertAction(fromConvertCommand: commandWithoutFlag)
         XCTAssertFalse(commandWithoutFlag.enableExperimentalDeviceFrameSupport)
         XCTAssertFalse(FeatureFlags.current.isExperimentalDeviceFrameSupportEnabled)
 
@@ -386,7 +386,7 @@ class ConvertSubcommandTests: XCTestCase {
             "--enable-experimental-device-frame-support",
             testBundleURL.path,
         ])
-        let actionWithFlag = try ConvertAction(fromConvertCommand: commandWithFlag)
+        _ = try ConvertAction(fromConvertCommand: commandWithFlag)
         XCTAssertTrue(commandWithFlag.enableExperimentalDeviceFrameSupport)
         XCTAssertTrue(FeatureFlags.current.isExperimentalDeviceFrameSupportEnabled)
     }

--- a/Tests/SwiftDocCUtilitiesTests/OutOfProcessReferenceResolverTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/OutOfProcessReferenceResolverTests.swift
@@ -452,7 +452,7 @@ class OutOfProcessReferenceResolverTests: XCTestCase {
             XCTFail("Encountered an unexpected type of error.")
             return
         }
-        XCTAssertEqual(error.localizedDescription, "Some error message.")
+        XCTAssertEqual(error.message, "Some error message.")
     }
     
     func testForwardsResolverErrorsProcess() throws {


### PR DESCRIPTION
<!--
If you're opening a PR to cherry-pick a change for a release branch, use this template instead:
https://github.com/apple/swift-docc/blob/main/.github/PULL_REQUEST_TEMPLATE/CHERRY_PICK.md
-->

Bug/issue #, if applicable: https://github.com/apple/swift-docc/issues/478 <rdar://105985393>

## Summary

This works around a limitation that the messages of suggested solutions aren't written to console by including them in the main diagnostic message. It also updates the new link resolution suggestions to describe their replacement so that a reader can identify which described solution corresponds to which "fixit".

I will make more changes in this area but wanted to open this PR first so that we don't regress — by displaying less information to the developer — with the more structured diagnostics.

## Dependencies

None

## Testing

This can be tested with any diagnostic with solutions. This describes how to test it with a link resolution diagnostic.

In any documentation project with some symbols requiring disambiguation. 

1. Enable the hierarchy based link resolver
```
defaults write -g DocCUseHierarchyBasedLinkResolver -bool true
```
2. Find a link with disambiguation and remove the disambiguation.

3. Build documentation for the project and pass the `--emit-fixits` flag to DocC in the build.

The descriptions about which disambiguation to add to refer to which symbol should be included in the error message. 

Here's one example from TestBundle.docc

```
/path/to/swift-docc/Tests/SwiftDocCTests/Test Bundles/TestBundle.docc/documentation/myprotocol.md:11:41: warning: Topic reference 'MyUnresolvedSymbol' couldn't be resolved. Reference at '/MyKit/MyProtocol' can't resolve 'MyUnresolvedSymbol'. No similar pages. Replace 'MyUnresolvedSymbol' with 'Discussion'.
/path/to/swift-docc/Tests/SwiftDocCTests/Test Bundles/TestBundle.docc/documentation/myprotocol.md:11:41: note: Available children: Discussion.
/path/to/swift-docc/Tests/SwiftDocCTests/Test Bundles/TestBundle.docc/documentation/myprotocol.md:11:43-11:61: fixit: Discussion
```

Note the "Replace 'MyUnresolvedSymbol' with 'Discussion'." part of the warning message.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
