### PR TITLE
[ConvertService] Set metadata.remoteSource

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -1297,12 +1297,22 @@ public struct RenderNodeTranslator: SemanticVisitor {
             )
         )
         
+        var sourceRepository = sourceRepository
+        
         if shouldEmitSymbolSourceFileURIs {
             node.metadata.sourceFileURIVariants = VariantCollection<String?>(
                 from: symbol.locationVariants
             ) { _, location in
                 location.uri
             } ?? .init(defaultValue: nil)
+            
+            // If a source repository is not set, set the device's
+            // filesystem as the source repository. This causes
+            // the `metadata.remoteSource` property to link to the
+            // file's location on disk.
+            if sourceRepository == nil {
+                sourceRepository = .localFilesystem()
+            }
         }
         
         if let sourceRepository = sourceRepository {

--- a/Sources/SwiftDocC/SourceRepository/SourceRepository.swift
+++ b/Sources/SwiftDocC/SourceRepository/SourceRepository.swift
@@ -89,4 +89,16 @@ public extension SourceRepository {
             formatLineNumber: { line in "lines-\(line)" }
         )
     }
+    
+    /// Creates a source repository hosted by the device's filesystem.
+    ///
+    /// Use this source repository to format `file://` links to files on the
+    /// device where documentation is being presented.
+    static func localFilesystem() -> SourceRepository {
+        SourceRepository(
+            checkoutPath: "",
+            sourceServiceBaseURL: URL(fileURLWithPath: "/"),
+            formatLineNumber: { line in "L\(line)" }
+        )
+    }
 }

--- a/Tests/SwiftDocCTests/SourceRepository/SourceRepositoryTests.swift
+++ b/Tests/SwiftDocCTests/SourceRepository/SourceRepositoryTests.swift
@@ -83,4 +83,12 @@ class SourceRepositoryTests: XCTestCase {
             URL(string: "https://example.com/source/file#lines-5")!
         )
     }
+    
+    func testLocalFileSystemFormatting() {
+        XCTAssertEqual(
+            SourceRepository.localFilesystem()
+                .format(sourceFileURL: URL(string: "file:///path/to/file")!, lineNumber: 5),
+            URL(string: "file:///path/to/file#L5")!
+        )
+    }
 }


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://104049149

## Summary

When using ConvertService to generate documentation, makes DocC set the symbol's declaration file path and line to the `metadata.remoteSource` property.

## Dependencies

None.

## Testing

Generate documentation for a symbol using the `ConvertService` API and verify that the `metadata.remoteSource` property is set to the symbol declaration's local path and line number.

## Checklist

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
