### PR TITLE
add experimental Doxygen support

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -60,7 +60,7 @@
         "repositoryURL": "https://github.com/apple/swift-markdown.git",
         "state": {
           "branch": "main",
-          "revision": "4a5dd44f1fb703f853df85a928492dfd1c98aa25",
+          "revision": "4cbd46eab22cbeef307095d17958b6ed23b5f38f",
           "version": null
         }
       },

--- a/Sources/SwiftDocC/Model/DocumentationNode.swift
+++ b/Sources/SwiftDocC/Model/DocumentationNode.swift
@@ -422,7 +422,12 @@ public struct DocumentationNode {
             ]
         } else if let symbol = documentedSymbol, let docComment = symbol.docComment {
             let docCommentString = docComment.lines.map { $0.text }.joined(separator: "\n")
-            let docCommentMarkup = Document(parsing: docCommentString, options: [.parseBlockDirectives, .parseSymbolLinks])
+
+            var documentOptions: ParseOptions = [.parseBlockDirectives, .parseSymbolLinks]
+            if FeatureFlags.current.isExperimentalDoxygenSupportEnabled {
+                documentOptions.insert(.parseMinimalDoxygen)
+            }
+            let docCommentMarkup = Document(parsing: docCommentString, options: documentOptions)
             
             let docCommentDirectives = docCommentMarkup.children.compactMap({ $0 as? BlockDirective })
             if !docCommentDirectives.isEmpty {

--- a/Sources/SwiftDocC/Model/Semantics/Parameter.swift
+++ b/Sources/SwiftDocC/Model/Semantics/Parameter.swift
@@ -25,4 +25,12 @@ public struct Parameter {
         self.name = name
         self.contents = contents
     }
+
+    /// Initialize a value to describe documentation about a symbol's parameter via a Doxygen `\param` command.
+    ///
+    /// - Parameter doxygenParameter: A parsed Doxygen `\param` command.
+    public init(_ doxygenParameter: DoxygenParameter) {
+        self.name = doxygenParameter.name
+        self.contents = Array(doxygenParameter.children)
+    }
 }

--- a/Sources/SwiftDocC/Model/Semantics/Return.swift
+++ b/Sources/SwiftDocC/Model/Semantics/Return.swift
@@ -20,4 +20,11 @@ public struct Return {
     public init(contents: [Markup]) {
         self.contents = contents
     }
+
+    /// Initialize a value to describe documentation about a symbol's return value.
+    ///
+    /// - Parameter doxygenReturns: A parsed Doxygen `\returns` command.
+    public init(_ doxygenReturns: DoxygenReturns) {
+        self.contents = Array(doxygenReturns.children)
+    }
 }

--- a/Sources/SwiftDocC/Utility/FeatureFlags.swift
+++ b/Sources/SwiftDocC/Utility/FeatureFlags.swift
@@ -30,6 +30,9 @@ public struct FeatureFlags: Codable {
     
     /// Whether or not experimental support for device frames on images and video is enabled.
     public var isExperimentalDeviceFrameSupportEnabled = false
+
+    /// Whether or not experimental support for parsing Doxygen commands is enabled.
+    public var isExperimentalDoxygenSupportEnabled = false
     
     /// Creates a set of feature flags with the given values.
     ///

--- a/Sources/SwiftDocC/Utility/MarkupExtensions/ListItemExtractor.swift
+++ b/Sources/SwiftDocC/Utility/MarkupExtensions/ListItemExtractor.swift
@@ -407,4 +407,14 @@ struct TaggedListItemExtractor: MarkupRewriter {
         // No match; leave this list item alone.
         return listItem
     }
+
+    mutating func visitDoxygenParameter(_ doxygenParam: DoxygenParameter) -> Markup? {
+        parameters.append(Parameter(doxygenParam))
+        return nil
+    }
+
+    mutating func visitDoxygenReturns(_ doxygenReturns: DoxygenReturns) -> Markup? {
+        returns.append(Return(doxygenReturns))
+        return nil
+    }
 }

--- a/Sources/SwiftDocCUtilities/Action/Actions/Convert/ConvertAction.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Convert/ConvertAction.swift
@@ -35,7 +35,6 @@ public struct ConvertAction: Action, RecreatingContext {
     let inheritDocs: Bool
     let treatWarningsAsErrors: Bool
     let experimentalEnableCustomTemplates: Bool
-    let experimentalParseDoxygenCommands: Bool
     let buildLMDBIndex: Bool
     let documentationCoverageOptions: DocumentationCoverageOptions
     let diagnosticLevel: DiagnosticSeverity
@@ -106,8 +105,7 @@ public struct ConvertAction: Action, RecreatingContext {
         experimentalEnableCustomTemplates: Bool = false,
         transformForStaticHosting: Bool = false,
         hostingBasePath: String? = nil,
-        sourceRepository: SourceRepository? = nil,
-        experimentalParseDoxygenCommands: Bool = false
+        sourceRepository: SourceRepository? = nil
     ) throws
     {
         self.rootURL = documentationBundleURL
@@ -125,7 +123,6 @@ public struct ConvertAction: Action, RecreatingContext {
         self.transformForStaticHosting = transformForStaticHosting
         self.hostingBasePath = hostingBasePath
         self.sourceRepository = sourceRepository
-        self.experimentalParseDoxygenCommands = experimentalParseDoxygenCommands
         
         let filterLevel: DiagnosticSeverity
         if analyze {

--- a/Sources/SwiftDocCUtilities/Action/Actions/Convert/ConvertAction.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Convert/ConvertAction.swift
@@ -35,6 +35,7 @@ public struct ConvertAction: Action, RecreatingContext {
     let inheritDocs: Bool
     let treatWarningsAsErrors: Bool
     let experimentalEnableCustomTemplates: Bool
+    let experimentalParseDoxygenCommands: Bool
     let buildLMDBIndex: Bool
     let documentationCoverageOptions: DocumentationCoverageOptions
     let diagnosticLevel: DiagnosticSeverity
@@ -105,7 +106,8 @@ public struct ConvertAction: Action, RecreatingContext {
         experimentalEnableCustomTemplates: Bool = false,
         transformForStaticHosting: Bool = false,
         hostingBasePath: String? = nil,
-        sourceRepository: SourceRepository? = nil
+        sourceRepository: SourceRepository? = nil,
+        experimentalParseDoxygenCommands: Bool = false
     ) throws
     {
         self.rootURL = documentationBundleURL
@@ -123,6 +125,7 @@ public struct ConvertAction: Action, RecreatingContext {
         self.transformForStaticHosting = transformForStaticHosting
         self.hostingBasePath = hostingBasePath
         self.sourceRepository = sourceRepository
+        self.experimentalParseDoxygenCommands = experimentalParseDoxygenCommands
         
         let filterLevel: DiagnosticSeverity
         if analyze {

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/ActionExtensions/ConvertAction+CommandInitialization.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/ActionExtensions/ConvertAction+CommandInitialization.swift
@@ -86,8 +86,7 @@ extension ConvertAction {
             experimentalEnableCustomTemplates: convert.experimentalEnableCustomTemplates,
             transformForStaticHosting: convert.transformForStaticHosting,
             hostingBasePath: convert.hostingBasePath,
-            sourceRepository: SourceRepository(from: convert.sourceRepositoryArguments),
-            experimentalParseDoxygenCommands: convert.experimentalParseDoxygenCommands
+            sourceRepository: SourceRepository(from: convert.sourceRepositoryArguments)
         )
     }
 }

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/ActionExtensions/ConvertAction+CommandInitialization.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/ActionExtensions/ConvertAction+CommandInitialization.swift
@@ -21,6 +21,7 @@ extension ConvertAction {
         let outOfProcessResolver: OutOfProcessReferenceResolver?
         
         FeatureFlags.current.isExperimentalDeviceFrameSupportEnabled = convert.enableExperimentalDeviceFrameSupport
+        FeatureFlags.current.isExperimentalDoxygenSupportEnabled = convert.experimentalParseDoxygenCommands
         
         // If the user-provided a URL for an external link resolver, attempt to
         // initialize an `OutOfProcessReferenceResolver` with the provided URL.
@@ -85,7 +86,8 @@ extension ConvertAction {
             experimentalEnableCustomTemplates: convert.experimentalEnableCustomTemplates,
             transformForStaticHosting: convert.transformForStaticHosting,
             hostingBasePath: convert.hostingBasePath,
-            sourceRepository: SourceRepository(from: convert.sourceRepositoryArguments)
+            sourceRepository: SourceRepository(from: convert.sourceRepositoryArguments),
+            experimentalParseDoxygenCommands: convert.experimentalParseDoxygenCommands
         )
     }
 }

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Convert.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Convert.swift
@@ -170,7 +170,7 @@ extension Docc {
         /// A user-provided value that is true if experimental Doxygen support should be enabled.
         ///
         /// Defaults to false.
-        @Flag(help: "Parse a limited set of Doxygen commands as equivalent DocC markup")
+        @Flag(help: .hidden)
         public var experimentalParseDoxygenCommands = false
 
         // MARK: - Info.plist fallbacks

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Convert.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Convert.swift
@@ -167,6 +167,12 @@ extension Docc {
         @OptionGroup()
         public var sourceRepositoryArguments: SourceRepositoryArguments
 
+        /// A user-provided value that is true if experimental Doxygen support should be enabled.
+        ///
+        /// Defaults to false.
+        @Flag(help: "Parse a limited set of Doxygen commands as equivalent DocC markup")
+        public var experimentalParseDoxygenCommands = false
+
         // MARK: - Info.plist fallbacks
         
         /// A user-provided fallback display name for the documentation bundle.

--- a/Tests/SwiftDocCTests/Test Resources/DeckKit-Objective-C.symbols.json
+++ b/Tests/SwiftDocCTests/Test Resources/DeckKit-Objective-C.symbols.json
@@ -1637,7 +1637,7 @@
                 "line" : 49
               }
             },
-            "text" : "\\param suit The suit of the card."
+            "text" : "@param suit The suit of the card."
           },
           {
             "range" : {

--- a/Tests/SwiftDocCTests/Test Resources/DeckKit-Objective-C.symbols.json
+++ b/Tests/SwiftDocCTests/Test Resources/DeckKit-Objective-C.symbols.json
@@ -1591,14 +1591,66 @@
             "range" : {
               "end" : {
                 "character" : 68,
-                "line" : 56
+                "line" : 46
               },
               "start" : {
                 "character" : 4,
-                "line" : 56
+                "line" : 46
               }
             },
             "text" : "Allocate and initialize a new card with the given rank and suit."
+          },
+          {
+            "range" : {
+              "end" : {
+                "character" : 3,
+                "line" : 47
+              },
+              "start" : {
+                "character" : 3,
+                "line" : 47
+              }
+            },
+            "text" : ""
+          },
+          {
+            "range" : {
+              "end" : {
+                "character" : 37,
+                "line" : 48
+              },
+              "start" : {
+                "character" : 4,
+                "line" : 48
+              }
+            },
+            "text" : "\\param rank The rank of the card."
+          },
+          {
+            "range" : {
+              "end" : {
+                "character" : 37,
+                "line" : 49
+              },
+              "start" : {
+                "character" : 4,
+                "line" : 49
+              }
+            },
+            "text" : "\\param suit The suit of the card."
+          },
+          {
+            "range" : {
+              "end" : {
+                "character" : 54,
+                "line" : 50
+              },
+              "start" : {
+                "character" : 4,
+                "line" : 50
+              }
+            },
+            "text" : "\\returns A new card with the given configuration. "
           }
         ]
       },

--- a/Tests/SwiftDocCUtilitiesTests/ArgumentParsing/ConvertSubcommandTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ArgumentParsing/ConvertSubcommandTests.swift
@@ -399,18 +399,16 @@ class ConvertSubcommandTests: XCTestCase {
         }
 
         let commandWithoutFlag = try Docc.Convert.parse([testBundleURL.path])
-        let actionWithoutFlag = try ConvertAction(fromConvertCommand: commandWithoutFlag)
+        let _ = try ConvertAction(fromConvertCommand: commandWithoutFlag)
         XCTAssertFalse(commandWithoutFlag.experimentalParseDoxygenCommands)
-        XCTAssertFalse(actionWithoutFlag.experimentalParseDoxygenCommands)
         XCTAssertFalse(FeatureFlags.current.isExperimentalDoxygenSupportEnabled)
 
         let commandWithFlag = try Docc.Convert.parse([
             "--experimental-parse-doxygen-commands",
             testBundleURL.path,
         ])
-        let actionWithFlag = try ConvertAction(fromConvertCommand: commandWithFlag)
+        let _ = try ConvertAction(fromConvertCommand: commandWithFlag)
         XCTAssertTrue(commandWithFlag.experimentalParseDoxygenCommands)
-        XCTAssertTrue(actionWithFlag.experimentalParseDoxygenCommands)
         XCTAssertTrue(FeatureFlags.current.isExperimentalDoxygenSupportEnabled)
     }
     

--- a/Tests/SwiftDocCUtilitiesTests/ArgumentParsing/ConvertSubcommandTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ArgumentParsing/ConvertSubcommandTests.swift
@@ -165,7 +165,7 @@ class ConvertSubcommandTests: XCTestCase {
             ]), "Did not refuse target folder path '\(path)'")
         }
     }
-  
+
     func testAnalyzerIsTurnedOffByDefault() throws {
         setenv(TemplateOption.environmentVariableKey, testTemplateURL.path, 1)
         let convertOptions = try Docc.Convert.parse([
@@ -206,7 +206,7 @@ class ConvertSubcommandTests: XCTestCase {
             XCTAssertEqual(convertOptions.defaultCodeListingLanguage, "swift")
         }
         
-        // Are set when passed 
+        // Are set when passed
         do {
             let convertOptions = try Docc.Convert.parse([
                 testBundleURL.path,
@@ -389,6 +389,29 @@ class ConvertSubcommandTests: XCTestCase {
         _ = try ConvertAction(fromConvertCommand: commandWithFlag)
         XCTAssertTrue(commandWithFlag.enableExperimentalDeviceFrameSupport)
         XCTAssertTrue(FeatureFlags.current.isExperimentalDeviceFrameSupportEnabled)
+    }
+
+    func testExperimentalParseDoxygenFlag() throws {
+        let originalFeatureFlagsState = FeatureFlags.current
+
+        defer {
+            FeatureFlags.current = originalFeatureFlagsState
+        }
+
+        let commandWithoutFlag = try Docc.Convert.parse([testBundleURL.path])
+        let actionWithoutFlag = try ConvertAction(fromConvertCommand: commandWithoutFlag)
+        XCTAssertFalse(commandWithoutFlag.experimentalParseDoxygenCommands)
+        XCTAssertFalse(actionWithoutFlag.experimentalParseDoxygenCommands)
+        XCTAssertFalse(FeatureFlags.current.isExperimentalDoxygenSupportEnabled)
+
+        let commandWithFlag = try Docc.Convert.parse([
+            "--experimental-parse-doxygen-commands",
+            testBundleURL.path,
+        ])
+        let actionWithFlag = try ConvertAction(fromConvertCommand: commandWithFlag)
+        XCTAssertTrue(commandWithFlag.experimentalParseDoxygenCommands)
+        XCTAssertTrue(actionWithFlag.experimentalParseDoxygenCommands)
+        XCTAssertTrue(FeatureFlags.current.isExperimentalDoxygenSupportEnabled)
     }
     
     func testTransformForStaticHostingFlagWithoutHTMLTemplate() throws {


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://105848459

## Summary

This PR takes the Doxygen support added to Swift-Markdown in https://github.com/apple/swift-markdown/pull/107 and adds it to Swift-DocC behind an experimental flag. By passing `--experimental-parse-doxygen-commands` to `docc convert` or `docc preview`, `\param` and `\returns` commands will be handled as if they were `- Parameter` and `- Returns` list items. This allows users transitioning from a different documentation system that handles Doxygen or HeaderDoc commands to transition to Swift-DocC without needing to change these commands immediately.

## Dependencies

None (the Swift-Markdown PR is already merged and is being used in this PR)

## Testing

Steps:
1. Add the symbol graph from `Tests/SwiftDocCTests/Test Resources/DeckKit-Objective-C.symbols.json` to a documentation catalog.
2. `swift run docc preview MyDocs.docc --experimental-parse-doxygen-commands`
3. Ensure that the page for `[PlayingCard newWithRank:ofSuit:]` correctly displays "Parameters" and "Return Value" sections instead of the raw `\param` and `\returns` command lines.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
