### PR TITLE
Fix crash when running generate-symbol-graph

### DIFF
--- a/Sources/docc/DocCDocumentation.docc/DocC.symbols.json
+++ b/Sources/docc/DocCDocumentation.docc/DocC.symbols.json
@@ -35,453 +35,6 @@
         },
         {
           "kind" : "typeIdentifier",
-          "spelling" : "Forums"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "(...)"
-        },
-        {
-          "kind" : "text",
-          "spelling" : " {\n    ...\n}"
-        }
-      ],
-      "identifier" : {
-        "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$Forums"
-      },
-      "kind" : {
-        "displayName" : "Directive",
-        "identifier" : "class"
-      },
-      "names" : {
-        "navigator" : [
-          {
-            "kind" : "attribute",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$Forums",
-            "spelling" : "Forums"
-          }
-        ],
-        "subHeading" : [
-          {
-            "kind" : "identifier",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "Forums"
-          },
-          {
-            "kind" : "text",
-            "spelling" : "(...)"
-          }
-        ],
-        "title" : "Forums"
-      },
-      "pathComponents" : [
-        "Forums"
-      ]
-    },
-    {
-      "accessLevel" : "public",
-      "declarationFragments" : [
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "PageKind"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "("
-        },
-        {
-          "kind" : "text",
-          "spelling" : "_ "
-        },
-        {
-          "kind" : "identifier",
-          "spelling" : "kind"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ": "
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "Kind"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ")"
-        }
-      ],
-      "docComment" : {
-        "lines" : [
-          {
-            "text" : "A directive that allows you to set a page's kind, which affects its default title heading and page icon."
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "The `@PageKind` directive tells Swift-DocC to treat a documentation page as a particular"
-          },
-          {
-            "text" : "\"kind\". This is used to determine the page's default navigator icon, as well as the default"
-          },
-          {
-            "text" : "title heading on the page itself."
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "The available page kinds are `article` and `sampleCode`."
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "This directive is only valid within a `@Metadata` directive:"
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "```markdown"
-          },
-          {
-            "text" : "@Metadata {"
-          },
-          {
-            "text" : "    @PageKind(sampleCode)"
-          },
-          {
-            "text" : "}"
-          },
-          {
-            "text" : "```"
-          },
-          {
-            "text" : "- Parameters:"
-          },
-          {
-            "text" : "  - kind: The page kind to apply to the page."
-          },
-          {
-            "text" : "     **(required)**"
-          },
-          {
-            "text" : "     - term `article`: An article of free-form text; the default for standalone markdown files."
-          },
-          {
-            "text" : "     - term `sampleCode`: A page describing a \"sample code\" project."
-          }
-        ]
-      },
-      "identifier" : {
-        "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$PageKind"
-      },
-      "kind" : {
-        "displayName" : "Directive",
-        "identifier" : "class"
-      },
-      "names" : {
-        "navigator" : [
-          {
-            "kind" : "attribute",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$PageKind",
-            "spelling" : "PageKind"
-          }
-        ],
-        "subHeading" : [
-          {
-            "kind" : "identifier",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "PageKind"
-          },
-          {
-            "kind" : "text",
-            "spelling" : "("
-          },
-          {
-            "kind" : "text",
-            "spelling" : "_ "
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "kind"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ": "
-          },
-          {
-            "kind" : "typeIdentifier",
-            "spelling" : "Kind"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ")"
-          }
-        ],
-        "title" : "PageKind"
-      },
-      "pathComponents" : [
-        "PageKind"
-      ]
-    },
-    {
-      "accessLevel" : "public",
-      "declarationFragments" : [
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "Tutorial"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "("
-        },
-        {
-          "kind" : "identifier",
-          "spelling" : "time"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ": "
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "Int"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "?"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ", "
-        },
-        {
-          "kind" : "identifier",
-          "spelling" : "projectFiles"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ": "
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "ResourceReference"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "?"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ")"
-        },
-        {
-          "kind" : "text",
-          "spelling" : " {\n"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "    "
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "preciseIdentifier" : "__docc_universal_symbol_reference_$Intro",
-          "spelling" : "Intro"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "("
-        },
-        {
-          "kind" : "identifier",
-          "spelling" : "title"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ": "
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "String"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ")"
-        },
-        {
-          "kind" : "text",
-          "spelling" : " { ... }"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "\n"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "    "
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "preciseIdentifier" : "__docc_universal_symbol_reference_$Section",
-          "spelling" : "Section"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "(...)"
-        },
-        {
-          "kind" : "text",
-          "spelling" : " { ... }"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "\n"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "}"
-        }
-      ],
-      "docComment" : {
-        "lines" : [
-          {
-            "text" : "A tutorial to complete in order to gain knowledge of a ``Technology``."
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "- Parameters:"
-          },
-          {
-            "text" : "  - time: The estimated time in minutes that the containing ``Tutorial`` will take."
-          },
-          {
-            "text" : "     **(optional)**"
-          },
-          {
-            "text" : "  - projectFiles: Project files to download to get started with the ``Tutorial``."
-          },
-          {
-            "text" : "     **(optional)**"
-          }
-        ]
-      },
-      "identifier" : {
-        "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$Tutorial"
-      },
-      "kind" : {
-        "displayName" : "Directive",
-        "identifier" : "class"
-      },
-      "names" : {
-        "navigator" : [
-          {
-            "kind" : "attribute",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$Tutorial",
-            "spelling" : "Tutorial"
-          }
-        ],
-        "subHeading" : [
-          {
-            "kind" : "identifier",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "Tutorial"
-          },
-          {
-            "kind" : "text",
-            "spelling" : "("
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "time"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ": "
-          },
-          {
-            "kind" : "typeIdentifier",
-            "spelling" : "Int"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ", "
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "projectFiles"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ": "
-          },
-          {
-            "kind" : "typeIdentifier",
-            "spelling" : "ResourceReference"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ")"
-          }
-        ],
-        "title" : "Tutorial"
-      },
-      "pathComponents" : [
-        "Tutorial"
-      ]
-    },
-    {
-      "accessLevel" : "public",
-      "declarationFragments" : [
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
           "spelling" : "Assessments"
         },
         {
@@ -566,91 +119,7 @@
         },
         {
           "kind" : "typeIdentifier",
-          "spelling" : "Stack"
-        },
-        {
-          "kind" : "text",
-          "spelling" : " {\n"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "    "
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "preciseIdentifier" : "__docc_universal_symbol_reference_$ContentAndMedia",
-          "spelling" : "ContentAndMedia"
-        },
-        {
-          "kind" : "text",
-          "spelling" : " { ... }"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "\n"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "}"
-        }
-      ],
-      "docComment" : {
-        "lines" : [
-          {
-            "text" : "A semantic model for a view that arranges its children in a row."
-          }
-        ]
-      },
-      "identifier" : {
-        "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$Stack"
-      },
-      "kind" : {
-        "displayName" : "Directive",
-        "identifier" : "class"
-      },
-      "names" : {
-        "navigator" : [
-          {
-            "kind" : "attribute",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$Stack",
-            "spelling" : "Stack"
-          }
-        ],
-        "subHeading" : [
-          {
-            "kind" : "identifier",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "Stack"
-          }
-        ],
-        "title" : "Stack"
-      },
-      "pathComponents" : [
-        "Stack"
-      ]
-    },
-    {
-      "accessLevel" : "public",
-      "declarationFragments" : [
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "DisplayName"
+          "spelling" : "AutomaticArticleSubheading"
         },
         {
           "kind" : "text",
@@ -662,7 +131,7 @@
         },
         {
           "kind" : "identifier",
-          "spelling" : "name"
+          "spelling" : "enabledness"
         },
         {
           "kind" : "text",
@@ -670,27 +139,7 @@
         },
         {
           "kind" : "typeIdentifier",
-          "spelling" : "String"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ", "
-        },
-        {
-          "kind" : "identifier",
-          "spelling" : "style"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ": "
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "Style"
-        },
-        {
-          "kind" : "text",
-          "spelling" : " = conceptual"
+          "spelling" : "Enabledness"
         },
         {
           "kind" : "text",
@@ -700,76 +149,40 @@
       "docComment" : {
         "lines" : [
           {
-            "text" : "A directive that controls how the documentation-extension file overrides the symbol's display name."
+            "text" : "A directive that modifies Swift-DocC's default behavior for automatic subheading generation on"
+          },
+          {
+            "text" : "article pages."
           },
           {
             "text" : ""
           },
           {
-            "text" : "The ``name`` property will override the symbol's default display name."
+            "text" : "By default, articles receive a second-level \"Overview\" heading unless the author explicitly writes"
           },
           {
-            "text" : ""
-          },
-          {
-            "text" : "When the ``style-swift.property`` property is ``Style-swift.enum\/conceptual``, the symbol's name is rendered as \"conceptual\"—same as article names or tutorial names —where applicable. The default style is ``Style-swift.enum\/conceptual``."
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "When the ``style-swift.property`` property is ``Style-swift.enum\/symbol``, the symbol's name is rendered as \"symbol\"—same as article names or tutorial names —where applicable. The default style is ``Style-swift.enum\/conceptual``."
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "This directive is only valid within a ``Metadata`` directive:"
-          },
-          {
-            "text" : "```"
-          },
-          {
-            "text" : "@Metadata {"
-          },
-          {
-            "text" : "   @DisplayName(\"Custom Symbol Name\", style: conceptual)"
-          },
-          {
-            "text" : "}"
-          },
-          {
-            "text" : "```"
+            "text" : "some other H2 heading below the abstract. This allows for opting out of that behavior."
           },
           {
             "text" : "- Parameters:"
           },
           {
-            "text" : "  - name: The custom display name for this symbol."
+            "text" : "  - enabledness: Whether or not DocC generates automatic second-level \"Overview\" subheadings."
           },
           {
             "text" : "     **(required)**"
           },
           {
-            "text" : "  - style: The style of the display name for this symbol."
+            "text" : "     - term `enabled`: An overview subheading should be automatically created for the article (the default)."
           },
           {
-            "text" : "     **(optional)**"
-          },
-          {
-            "text" : "     "
-          },
-          {
-            "text" : "     Defaults to ``Style-swift.enum\/conceptual``."
-          },
-          {
-            "text" : "     - term `symbol`: Completely override any in-source content with the content from the documentation-extension."
+            "text" : "     - term `disabled`: No automatic overview subheading should be created for the article."
           }
         ]
       },
       "identifier" : {
         "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$DisplayName"
+        "precise" : "__docc_universal_symbol_reference_$AutomaticArticleSubheading"
       },
       "kind" : {
         "displayName" : "Directive",
@@ -783,8 +196,8 @@
           },
           {
             "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$DisplayName",
-            "spelling" : "DisplayName"
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$AutomaticArticleSubheading",
+            "spelling" : "AutomaticArticleSubheading"
           }
         ],
         "subHeading" : [
@@ -794,7 +207,7 @@
           },
           {
             "kind" : "identifier",
-            "spelling" : "DisplayName"
+            "spelling" : "AutomaticArticleSubheading"
           },
           {
             "kind" : "text",
@@ -806,7 +219,7 @@
           },
           {
             "kind" : "identifier",
-            "spelling" : "name"
+            "spelling" : "enabledness"
           },
           {
             "kind" : "text",
@@ -814,535 +227,17 @@
           },
           {
             "kind" : "typeIdentifier",
-            "spelling" : "String"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ", "
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "style"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ": "
-          },
-          {
-            "kind" : "typeIdentifier",
-            "spelling" : "Style"
+            "spelling" : "Enabledness"
           },
           {
             "kind" : "text",
             "spelling" : ")"
           }
         ],
-        "title" : "DisplayName"
+        "title" : "AutomaticArticleSubheading"
       },
       "pathComponents" : [
-        "DisplayName"
-      ]
-    },
-    {
-      "accessLevel" : "public",
-      "declarationFragments" : [
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "Step"
-        },
-        {
-          "kind" : "text",
-          "spelling" : " {\n    ...\n}"
-        }
-      ],
-      "identifier" : {
-        "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$Step"
-      },
-      "kind" : {
-        "displayName" : "Directive",
-        "identifier" : "class"
-      },
-      "names" : {
-        "navigator" : [
-          {
-            "kind" : "attribute",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$Step",
-            "spelling" : "Step"
-          }
-        ],
-        "subHeading" : [
-          {
-            "kind" : "identifier",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "Step"
-          }
-        ],
-        "title" : "Step"
-      },
-      "pathComponents" : [
-        "Step"
-      ]
-    },
-    {
-      "accessLevel" : "public",
-      "declarationFragments" : [
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "TechnologyRoot"
-        }
-      ],
-      "docComment" : {
-        "lines" : [
-          {
-            "text" : "A directive to set this page as a documentation root-level node."
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "This directive is only valid within a top-level ``Metadata`` directive:"
-          },
-          {
-            "text" : "```"
-          },
-          {
-            "text" : "@Metadata {"
-          },
-          {
-            "text" : "   @TechnologyRoot"
-          },
-          {
-            "text" : "}"
-          },
-          {
-            "text" : "```"
-          }
-        ]
-      },
-      "identifier" : {
-        "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$TechnologyRoot"
-      },
-      "kind" : {
-        "displayName" : "Directive",
-        "identifier" : "class"
-      },
-      "names" : {
-        "navigator" : [
-          {
-            "kind" : "attribute",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$TechnologyRoot",
-            "spelling" : "TechnologyRoot"
-          }
-        ],
-        "subHeading" : [
-          {
-            "kind" : "identifier",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "TechnologyRoot"
-          }
-        ],
-        "title" : "TechnologyRoot"
-      },
-      "pathComponents" : [
-        "TechnologyRoot"
-      ]
-    },
-    {
-      "accessLevel" : "public",
-      "declarationFragments" : [
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "Section"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "(...)"
-        },
-        {
-          "kind" : "text",
-          "spelling" : " {\n    ...\n}"
-        }
-      ],
-      "identifier" : {
-        "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$Section"
-      },
-      "kind" : {
-        "displayName" : "Directive",
-        "identifier" : "class"
-      },
-      "names" : {
-        "navigator" : [
-          {
-            "kind" : "attribute",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$Section",
-            "spelling" : "Section"
-          }
-        ],
-        "subHeading" : [
-          {
-            "kind" : "identifier",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "Section"
-          },
-          {
-            "kind" : "text",
-            "spelling" : "(...)"
-          }
-        ],
-        "title" : "Section"
-      },
-      "pathComponents" : [
-        "Section"
-      ]
-    },
-    {
-      "accessLevel" : "public",
-      "declarationFragments" : [
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "Links"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "("
-        },
-        {
-          "kind" : "identifier",
-          "spelling" : "visualStyle"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ": "
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "VisualStyle"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ")"
-        },
-        {
-          "kind" : "text",
-          "spelling" : " {\n    ...\n}"
-        }
-      ],
-      "docComment" : {
-        "lines" : [
-          {
-            "text" : "A directive for authoring authoring embedded"
-          },
-          {
-            "text" : "previews of documentation links (similar to how links are currently"
-          },
-          {
-            "text" : "rendered in Topics sections) anywhere on the page without affecting page"
-          },
-          {
-            "text" : "curation behavior."
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "`@Links` gives authors flexibility in choosing how they want to highlight"
-          },
-          {
-            "text" : "documentation on the page itself versus in the navigation sidebar."
-          },
-          {
-            "text" : "It also allows for mixing and matching different visual styles of"
-          },
-          {
-            "text" : "topics."
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "```md"
-          },
-          {
-            "text" : "..."
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "### What's New in SlothCreator"
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "@Links(visualStyle: compactGrid) {"
-          },
-          {
-            "text" : "   - <doc:get-started-preparing-sloth-food>"
-          },
-          {
-            "text" : "   - <doc:feeding-your-sloth-in-winter>"
-          },
-          {
-            "text" : "   - <doc:ordering-food-delivery>"
-          },
-          {
-            "text" : "}"
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "..."
-          },
-          {
-            "text" : "```"
-          },
-          {
-            "text" : "- Parameters:"
-          },
-          {
-            "text" : "  - visualStyle: The specified style that should be used when rendering the specified links."
-          },
-          {
-            "text" : "     **(required)**"
-          },
-          {
-            "text" : "     - term `list`: A list of the linked pages, including their full declaration and abstract."
-          },
-          {
-            "text" : "     - term `compactGrid`: A grid of items based on the card image for the linked pages."
-          },
-          {
-            "text" : "        "
-          },
-          {
-            "text" : "        Includes each page’s title and card image but excludes their abstracts."
-          },
-          {
-            "text" : "     - term `detailedGrid`: A grid of items based on the card image for the linked pages."
-          },
-          {
-            "text" : "        "
-          },
-          {
-            "text" : "        Unlike ``compactGrid``, this style includes the abstract for each page."
-          }
-        ]
-      },
-      "identifier" : {
-        "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$Links"
-      },
-      "kind" : {
-        "displayName" : "Directive",
-        "identifier" : "class"
-      },
-      "names" : {
-        "navigator" : [
-          {
-            "kind" : "attribute",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$Links",
-            "spelling" : "Links"
-          }
-        ],
-        "subHeading" : [
-          {
-            "kind" : "identifier",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "Links"
-          },
-          {
-            "kind" : "text",
-            "spelling" : "("
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "visualStyle"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ": "
-          },
-          {
-            "kind" : "typeIdentifier",
-            "spelling" : "VisualStyle"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ")"
-          }
-        ],
-        "title" : "Links"
-      },
-      "pathComponents" : [
-        "Links"
-      ]
-    },
-    {
-      "accessLevel" : "public",
-      "declarationFragments" : [
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "Tab"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "("
-        },
-        {
-          "kind" : "text",
-          "spelling" : "_ "
-        },
-        {
-          "kind" : "identifier",
-          "spelling" : "title"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ": "
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "String"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ")"
-        },
-        {
-          "kind" : "text",
-          "spelling" : " {\n    ...\n}"
-        }
-      ],
-      "docComment" : {
-        "lines" : [
-          {
-            "text" : "A container directive that holds general markup content describing an individual"
-          },
-          {
-            "text" : "tab within a tab-based layout."
-          },
-          {
-            "text" : "- Parameters:"
-          },
-          {
-            "text" : "  - title: The title that should identify the content in this tab when rendered."
-          },
-          {
-            "text" : "     **(required)**"
-          }
-        ]
-      },
-      "identifier" : {
-        "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$Tab"
-      },
-      "kind" : {
-        "displayName" : "Directive",
-        "identifier" : "class"
-      },
-      "names" : {
-        "navigator" : [
-          {
-            "kind" : "attribute",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$Tab",
-            "spelling" : "Tab"
-          }
-        ],
-        "subHeading" : [
-          {
-            "kind" : "identifier",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "Tab"
-          },
-          {
-            "kind" : "text",
-            "spelling" : "("
-          },
-          {
-            "kind" : "text",
-            "spelling" : "_ "
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "title"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ": "
-          },
-          {
-            "kind" : "typeIdentifier",
-            "spelling" : "String"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ")"
-          }
-        ],
-        "title" : "Tab"
-      },
-      "pathComponents" : [
-        "Tab"
+        "AutomaticArticleSubheading"
       ]
     },
     {
@@ -1475,7 +370,7 @@
         },
         {
           "kind" : "typeIdentifier",
-          "spelling" : "AutomaticArticleSubheading"
+          "spelling" : "AutomaticTitleHeading"
         },
         {
           "kind" : "text",
@@ -1505,40 +400,37 @@
       "docComment" : {
         "lines" : [
           {
-            "text" : "A directive that modifies Swift-DocC's default behavior for automatic subheading generation on"
+            "text" : "A directive for specifying Swift-DocC's automatic behavior when generating a page's"
           },
           {
-            "text" : "article pages."
+            "text" : "title heading."
           },
           {
             "text" : ""
           },
           {
-            "text" : "By default, articles receive a second-level \"Overview\" heading unless the author explicitly writes"
-          },
-          {
-            "text" : "some other H2 heading below the abstract. This allows for opting out of that behavior."
+            "text" : "A title heading is also known as a page eyebrow or kicker."
           },
           {
             "text" : "- Parameters:"
           },
           {
-            "text" : "  - enabledness: Whether or not DocC generates automatic second-level \"Overview\" subheadings."
+            "text" : "  - enabledness: Whether or not DocC generates automatic title headings."
           },
           {
             "text" : "     **(required)**"
           },
           {
-            "text" : "     - term `enabled`: An overview subheading should be automatically created for the article (the default)."
+            "text" : "     - term `enabled`: A title heading should be automatically created for the page (the default)."
           },
           {
-            "text" : "     - term `disabled`: No automatic overview subheading should be created for the article."
+            "text" : "     - term `disabled`: No automatic title heading should be created for the page."
           }
         ]
       },
       "identifier" : {
         "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$AutomaticArticleSubheading"
+        "precise" : "__docc_universal_symbol_reference_$AutomaticTitleHeading"
       },
       "kind" : {
         "displayName" : "Directive",
@@ -1552,8 +444,8 @@
           },
           {
             "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$AutomaticArticleSubheading",
-            "spelling" : "AutomaticArticleSubheading"
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$AutomaticTitleHeading",
+            "spelling" : "AutomaticTitleHeading"
           }
         ],
         "subHeading" : [
@@ -1563,7 +455,7 @@
           },
           {
             "kind" : "identifier",
-            "spelling" : "AutomaticArticleSubheading"
+            "spelling" : "AutomaticTitleHeading"
           },
           {
             "kind" : "text",
@@ -1590,10 +482,138 @@
             "spelling" : ")"
           }
         ],
-        "title" : "AutomaticArticleSubheading"
+        "title" : "AutomaticTitleHeading"
       },
       "pathComponents" : [
-        "AutomaticArticleSubheading"
+        "AutomaticTitleHeading"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Available"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "("
+        },
+        {
+          "kind" : "text",
+          "spelling" : "_ "
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "platform"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Platform"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ", "
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "introduced"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "String"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ")"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$Available"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$Available",
+            "spelling" : "Available"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "Available"
+          },
+          {
+            "kind" : "text",
+            "spelling" : "("
+          },
+          {
+            "kind" : "text",
+            "spelling" : "_ "
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "platform"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "spelling" : "Platform"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ", "
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "introduced"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "spelling" : "String"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ")"
+          }
+        ],
+        "title" : "Available"
+      },
+      "pathComponents" : [
+        "Available"
       ]
     },
     {
@@ -1929,546 +949,6 @@
         },
         {
           "kind" : "typeIdentifier",
-          "spelling" : "Comment"
-        },
-        {
-          "kind" : "text",
-          "spelling" : " {\n    ...\n}"
-        }
-      ],
-      "identifier" : {
-        "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$Comment"
-      },
-      "kind" : {
-        "displayName" : "Directive",
-        "identifier" : "class"
-      },
-      "names" : {
-        "navigator" : [
-          {
-            "kind" : "attribute",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$Comment",
-            "spelling" : "Comment"
-          }
-        ],
-        "subHeading" : [
-          {
-            "kind" : "identifier",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "Comment"
-          }
-        ],
-        "title" : "Comment"
-      },
-      "pathComponents" : [
-        "Comment"
-      ]
-    },
-    {
-      "accessLevel" : "public",
-      "declarationFragments" : [
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "Options"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "("
-        },
-        {
-          "kind" : "identifier",
-          "spelling" : "scope"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ": "
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "Scope"
-        },
-        {
-          "kind" : "text",
-          "spelling" : " = local"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ")"
-        },
-        {
-          "kind" : "text",
-          "spelling" : " {\n    ...\n}"
-        }
-      ],
-      "docComment" : {
-        "lines" : [
-          {
-            "text" : "Use Option directives to adjust DocC's default behaviors when rendering a page."
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "- Parameters:"
-          },
-          {
-            "text" : "  - scope: Whether the options in this Options directive should apply locally to the page"
-          },
-          {
-            "text" : "     or globally to the DocC catalog."
-          },
-          {
-            "text" : "     **(optional)**"
-          },
-          {
-            "text" : "     - term `local`: The directive should only affect the current page."
-          },
-          {
-            "text" : "     - term `global`: The directive should affect all pages in the current DocC catalog."
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "## Topics"
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "### Adjusting Automatic Behaviors"
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "- ``AutomaticSeeAlso``"
-          },
-          {
-            "text" : "- ``AutomaticTitleHeading``"
-          },
-          {
-            "text" : "- ``AutomaticArticleSubheading``"
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "### Adjusting Visual Style"
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "- ``TopicsVisualStyle``"
-          }
-        ]
-      },
-      "identifier" : {
-        "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$Options"
-      },
-      "kind" : {
-        "displayName" : "Directive",
-        "identifier" : "class"
-      },
-      "names" : {
-        "navigator" : [
-          {
-            "kind" : "attribute",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$Options",
-            "spelling" : "Options"
-          }
-        ],
-        "subHeading" : [
-          {
-            "kind" : "identifier",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "Options"
-          },
-          {
-            "kind" : "text",
-            "spelling" : "("
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "scope"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ": "
-          },
-          {
-            "kind" : "typeIdentifier",
-            "spelling" : "Scope"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ")"
-          }
-        ],
-        "title" : "Options"
-      },
-      "pathComponents" : [
-        "Options"
-      ]
-    },
-    {
-      "accessLevel" : "public",
-      "declarationFragments" : [
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "Volume"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "(...)"
-        },
-        {
-          "kind" : "text",
-          "spelling" : " {\n    ...\n}"
-        }
-      ],
-      "identifier" : {
-        "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$Volume"
-      },
-      "kind" : {
-        "displayName" : "Directive",
-        "identifier" : "class"
-      },
-      "names" : {
-        "navigator" : [
-          {
-            "kind" : "attribute",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$Volume",
-            "spelling" : "Volume"
-          }
-        ],
-        "subHeading" : [
-          {
-            "kind" : "identifier",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "Volume"
-          },
-          {
-            "kind" : "text",
-            "spelling" : "(...)"
-          }
-        ],
-        "title" : "Volume"
-      },
-      "pathComponents" : [
-        "Volume"
-      ]
-    },
-    {
-      "accessLevel" : "public",
-      "declarationFragments" : [
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "Choice"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "("
-        },
-        {
-          "kind" : "identifier",
-          "spelling" : "isCorrect"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ": "
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "Bool"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ")"
-        },
-        {
-          "kind" : "text",
-          "spelling" : " {\n"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "    ...\n\n"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "    "
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "preciseIdentifier" : "__docc_universal_symbol_reference_$Justification",
-          "spelling" : "Justification"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "("
-        },
-        {
-          "kind" : "identifier",
-          "spelling" : "reaction"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ": "
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "String"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "?"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ")"
-        },
-        {
-          "kind" : "text",
-          "spelling" : " { ... }"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "\n"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "}"
-        }
-      ],
-      "docComment" : {
-        "lines" : [
-          {
-            "text" : "One of possibly many choices in a ``MultipleChoice`` question."
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "- Parameters:"
-          },
-          {
-            "text" : "  - isCorrect: `true` if this choice is a correct one; there can be multiple correct choices."
-          },
-          {
-            "text" : "     **(required)**"
-          }
-        ]
-      },
-      "identifier" : {
-        "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$Choice"
-      },
-      "kind" : {
-        "displayName" : "Directive",
-        "identifier" : "class"
-      },
-      "names" : {
-        "navigator" : [
-          {
-            "kind" : "attribute",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$Choice",
-            "spelling" : "Choice"
-          }
-        ],
-        "subHeading" : [
-          {
-            "kind" : "identifier",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "Choice"
-          },
-          {
-            "kind" : "text",
-            "spelling" : "("
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "isCorrect"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ": "
-          },
-          {
-            "kind" : "typeIdentifier",
-            "spelling" : "Bool"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ")"
-          }
-        ],
-        "title" : "Choice"
-      },
-      "pathComponents" : [
-        "Choice"
-      ]
-    },
-    {
-      "accessLevel" : "public",
-      "declarationFragments" : [
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "Metadata"
-        },
-        {
-          "kind" : "text",
-          "spelling" : " {\n    ...\n}"
-        }
-      ],
-      "docComment" : {
-        "lines" : [
-          {
-            "text" : "A directive that contains various metadata about a page."
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "This directive acts as a container for metadata and configuration without any arguments of its own."
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "## Topics"
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "### Child Directives"
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "- ``DocumentationExtension``"
-          },
-          {
-            "text" : "- ``TechnologyRoot``"
-          },
-          {
-            "text" : "- ``DisplayName``"
-          },
-          {
-            "text" : "- ``PageImage``"
-          },
-          {
-            "text" : "- ``CallToAction``"
-          },
-          {
-            "text" : "- ``Availability``"
-          },
-          {
-            "text" : "- ``PageKind``"
-          }
-        ]
-      },
-      "identifier" : {
-        "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$Metadata"
-      },
-      "kind" : {
-        "displayName" : "Directive",
-        "identifier" : "class"
-      },
-      "names" : {
-        "navigator" : [
-          {
-            "kind" : "attribute",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$Metadata",
-            "spelling" : "Metadata"
-          }
-        ],
-        "subHeading" : [
-          {
-            "kind" : "identifier",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "Metadata"
-          }
-        ],
-        "title" : "Metadata"
-      },
-      "pathComponents" : [
-        "Metadata"
-      ]
-    },
-    {
-      "accessLevel" : "public",
-      "declarationFragments" : [
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
           "spelling" : "Chapter"
         },
         {
@@ -2683,7 +1163,171 @@
         },
         {
           "kind" : "typeIdentifier",
-          "spelling" : "Videos"
+          "spelling" : "Choice"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "("
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "isCorrect"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Bool"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ")"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " {\n"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "    ...\n\n"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "    "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "preciseIdentifier" : "__docc_universal_symbol_reference_$Justification",
+          "spelling" : "Justification"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "("
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "reaction"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "String"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "?"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ")"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " { ... }"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "\n"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "}"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "text" : "One of possibly many choices in a ``MultipleChoice`` question."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "- Parameters:"
+          },
+          {
+            "text" : "  - isCorrect: `true` if this choice is a correct one; there can be multiple correct choices."
+          },
+          {
+            "text" : "     **(required)**"
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$Choice"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$Choice",
+            "spelling" : "Choice"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "Choice"
+          },
+          {
+            "kind" : "text",
+            "spelling" : "("
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "isCorrect"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "spelling" : "Bool"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ")"
+          }
+        ],
+        "title" : "Choice"
+      },
+      "pathComponents" : [
+        "Choice"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Code"
         },
         {
           "kind" : "text",
@@ -2696,7 +1340,7 @@
       ],
       "identifier" : {
         "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$Videos"
+        "precise" : "__docc_universal_symbol_reference_$Code"
       },
       "kind" : {
         "displayName" : "Directive",
@@ -2710,8 +1354,8 @@
           },
           {
             "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$Videos",
-            "spelling" : "Videos"
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$Code",
+            "spelling" : "Code"
           }
         ],
         "subHeading" : [
@@ -2721,290 +1365,17 @@
           },
           {
             "kind" : "identifier",
-            "spelling" : "Videos"
+            "spelling" : "Code"
           },
           {
             "kind" : "text",
             "spelling" : "(...)"
           }
         ],
-        "title" : "Videos"
+        "title" : "Code"
       },
       "pathComponents" : [
-        "Videos"
-      ]
-    },
-    {
-      "accessLevel" : "public",
-      "declarationFragments" : [
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "XcodeRequirement"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "("
-        },
-        {
-          "kind" : "identifier",
-          "spelling" : "title"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ": "
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "String"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ", "
-        },
-        {
-          "kind" : "identifier",
-          "spelling" : "destination"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ": "
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "URL"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ")"
-        }
-      ],
-      "docComment" : {
-        "lines" : [
-          {
-            "text" : "An informal Xcode requirement for completing an instructional ``Tutorial``."
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "- Parameters:"
-          },
-          {
-            "text" : "  - title: Human readable title."
-          },
-          {
-            "text" : "     **(required)**"
-          },
-          {
-            "text" : "  - destination: Domain where requirement applies."
-          },
-          {
-            "text" : "     **(required)**"
-          }
-        ]
-      },
-      "identifier" : {
-        "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$XcodeRequirement"
-      },
-      "kind" : {
-        "displayName" : "Directive",
-        "identifier" : "class"
-      },
-      "names" : {
-        "navigator" : [
-          {
-            "kind" : "attribute",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$XcodeRequirement",
-            "spelling" : "XcodeRequirement"
-          }
-        ],
-        "subHeading" : [
-          {
-            "kind" : "identifier",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "XcodeRequirement"
-          },
-          {
-            "kind" : "text",
-            "spelling" : "("
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "title"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ": "
-          },
-          {
-            "kind" : "typeIdentifier",
-            "spelling" : "String"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ", "
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "destination"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ": "
-          },
-          {
-            "kind" : "typeIdentifier",
-            "spelling" : "URL"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ")"
-          }
-        ],
-        "title" : "XcodeRequirement"
-      },
-      "pathComponents" : [
-        "XcodeRequirement"
-      ]
-    },
-    {
-      "accessLevel" : "public",
-      "declarationFragments" : [
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "Available"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "("
-        },
-        {
-          "kind" : "text",
-          "spelling" : "_ "
-        },
-        {
-          "kind" : "identifier",
-          "spelling" : "platform"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ": "
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "Platform"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ", "
-        },
-        {
-          "kind" : "identifier",
-          "spelling" : "introduced"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ": "
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "String"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ")"
-        }
-      ],
-      "identifier" : {
-        "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$Available"
-      },
-      "kind" : {
-        "displayName" : "Directive",
-        "identifier" : "class"
-      },
-      "names" : {
-        "navigator" : [
-          {
-            "kind" : "attribute",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$Available",
-            "spelling" : "Available"
-          }
-        ],
-        "subHeading" : [
-          {
-            "kind" : "identifier",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "Available"
-          },
-          {
-            "kind" : "text",
-            "spelling" : "("
-          },
-          {
-            "kind" : "text",
-            "spelling" : "_ "
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "platform"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ": "
-          },
-          {
-            "kind" : "typeIdentifier",
-            "spelling" : "Platform"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ", "
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "introduced"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ": "
-          },
-          {
-            "kind" : "typeIdentifier",
-            "spelling" : "String"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ")"
-          }
-        ],
-        "title" : "Available"
-      },
-      "pathComponents" : [
-        "Available"
+        "Code"
       ]
     },
     {
@@ -3140,7 +1511,313 @@
         },
         {
           "kind" : "typeIdentifier",
-          "spelling" : "SampleCode"
+          "spelling" : "Comment"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " {\n    ...\n}"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$Comment"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$Comment",
+            "spelling" : "Comment"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "Comment"
+          }
+        ],
+        "title" : "Comment"
+      },
+      "pathComponents" : [
+        "Comment"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "ContentAndMedia"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " {\n    ...\n}"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$ContentAndMedia"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$ContentAndMedia",
+            "spelling" : "ContentAndMedia"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "ContentAndMedia"
+          }
+        ],
+        "title" : "ContentAndMedia"
+      },
+      "pathComponents" : [
+        "ContentAndMedia"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "DisplayName"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "("
+        },
+        {
+          "kind" : "text",
+          "spelling" : "_ "
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "name"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "String"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ", "
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "style"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Style"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " = conceptual"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ")"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "text" : "A directive that controls how the documentation-extension file overrides the symbol's display name."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "The ``name`` property will override the symbol's default display name."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "When the ``style`` property is ``Style\/conceptual``, the symbol's name is rendered as \"conceptual\"—same as article names or tutorial names —where applicable. The default style is ``Style\/conceptual``."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "When the ``style`` property is ``Style\/symbol``, the symbol's name is rendered as \"symbol\"—same as article names or tutorial names —where applicable. The default style is ``Style\/conceptual``."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "This directive is only valid within a ``Metadata`` directive:"
+          },
+          {
+            "text" : "```"
+          },
+          {
+            "text" : "@Metadata {"
+          },
+          {
+            "text" : "   @DisplayName(\"Custom Symbol Name\", style: conceptual)"
+          },
+          {
+            "text" : "}"
+          },
+          {
+            "text" : "```"
+          },
+          {
+            "text" : "- Parameters:"
+          },
+          {
+            "text" : "  - name: The custom display name for this symbol."
+          },
+          {
+            "text" : "     **(required)**"
+          },
+          {
+            "text" : "  - style: The style of the display name for this symbol."
+          },
+          {
+            "text" : "     **(optional)**"
+          },
+          {
+            "text" : "     "
+          },
+          {
+            "text" : "     Defaults to ``Style\/conceptual``."
+          },
+          {
+            "text" : "     - term `symbol`: Completely override any in-source content with the content from the documentation-extension."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$DisplayName"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$DisplayName",
+            "spelling" : "DisplayName"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "DisplayName"
+          },
+          {
+            "kind" : "text",
+            "spelling" : "("
+          },
+          {
+            "kind" : "text",
+            "spelling" : "_ "
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "name"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "spelling" : "String"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ", "
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "style"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "spelling" : "Style"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ")"
+          }
+        ],
+        "title" : "DisplayName"
+      },
+      "pathComponents" : [
+        "DisplayName"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Documentation"
         },
         {
           "kind" : "text",
@@ -3153,7 +1830,7 @@
       ],
       "identifier" : {
         "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$SampleCode"
+        "precise" : "__docc_universal_symbol_reference_$Documentation"
       },
       "kind" : {
         "displayName" : "Directive",
@@ -3167,8 +1844,8 @@
           },
           {
             "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$SampleCode",
-            "spelling" : "SampleCode"
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$Documentation",
+            "spelling" : "Documentation"
           }
         ],
         "subHeading" : [
@@ -3178,17 +1855,17 @@
           },
           {
             "kind" : "identifier",
-            "spelling" : "SampleCode"
+            "spelling" : "Documentation"
           },
           {
             "kind" : "text",
             "spelling" : "(...)"
           }
         ],
-        "title" : "SampleCode"
+        "title" : "Documentation"
       },
       "pathComponents" : [
-        "SampleCode"
+        "Documentation"
       ]
     },
     {
@@ -3200,36 +1877,15 @@
         },
         {
           "kind" : "typeIdentifier",
-          "spelling" : "TabNavigator"
-        },
-        {
-          "kind" : "text",
-          "spelling" : " {\n"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "    "
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "preciseIdentifier" : "__docc_universal_symbol_reference_$Tab",
-          "spelling" : "Tab"
+          "spelling" : "DocumentationExtension"
         },
         {
           "kind" : "text",
           "spelling" : "("
         },
         {
-          "kind" : "text",
-          "spelling" : "_ "
-        },
-        {
           "kind" : "identifier",
-          "spelling" : "title"
+          "spelling" : "mergeBehavior"
         },
         {
           "kind" : "text",
@@ -3237,80 +1893,53 @@
         },
         {
           "kind" : "typeIdentifier",
-          "spelling" : "String"
+          "spelling" : "Behavior"
         },
         {
           "kind" : "text",
           "spelling" : ")"
-        },
-        {
-          "kind" : "text",
-          "spelling" : " { ... }"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "\n"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "}"
         }
       ],
       "docComment" : {
         "lines" : [
           {
-            "text" : "A container directive that arranges content into a tab-based layout."
+            "text" : "A directive that controls how the documentation-extension file merges with or overrides the in-source documentation."
           },
           {
             "text" : ""
           },
           {
-            "text" : "Create a new tab navigator by writing a `@TabNavigator` directive that contains child"
+            "text" : "When the ``behavior`` property is ``Behavior\/append``, the content from the documentation-extension file is added after the content from"
           },
           {
-            "text" : "`@Tab` directives."
+            "text" : "the in-source documentation for that symbol."
           },
           {
-            "text" : ""
-          },
-          {
-            "text" : "```md"
-          },
-          {
-            "text" : "@TabNavigator {"
-          },
-          {
-            "text" : "   @Tab(\"Powers\") {"
-          },
-          {
-            "text" : "      ![A diagram with the five sloth power types.](sloth-powers)"
-          },
-          {
-            "text" : "   }"
+            "text" : "If a documentation-extension file doesn't have a `DocumentationExtension` directive, then it has the ``Behavior\/append`` behavior."
           },
           {
             "text" : ""
           },
           {
-            "text" : "   @Tab(\"Excerise routines\") {"
+            "text" : "When the ``behavior`` property is ``Behavior\/override``, the content from the documentation-extension file completely replaces the content"
           },
           {
-            "text" : "      ![A sloth relaxing and enjoying a good book.](sloth-exercise)"
-          },
-          {
-            "text" : "   }"
+            "text" : "from the in-source documentation for that symbol"
           },
           {
             "text" : ""
           },
           {
-            "text" : "   @Tab(\"Hats\") {"
+            "text" : "This directive is only valid within a ``Metadata`` directive:"
           },
           {
-            "text" : "      ![A sloth discovering newfound confidence after donning a fedora.](sloth-hats)"
+            "text" : "```"
           },
           {
-            "text" : "   }"
+            "text" : "@Metadata {"
+          },
+          {
+            "text" : "   @DocumentationExtension(mergeBehavior: override)"
           },
           {
             "text" : "}"
@@ -3319,25 +1948,25 @@
             "text" : "```"
           },
           {
-            "text" : ""
+            "text" : "- Parameters:"
           },
           {
-            "text" : ""
+            "text" : "  - mergeBehavior: The merge behavior for this documentation extension."
           },
           {
-            "text" : "## Topics"
+            "text" : "     **(required)**"
           },
           {
-            "text" : ""
+            "text" : "     - term `append`: Append the documentation-extension content to the in-source content and process them together."
           },
           {
-            "text" : "- ``Tab``"
+            "text" : "     - term `override`: Completely override any in-source content with the content from the documentation-extension."
           }
         ]
       },
       "identifier" : {
         "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$TabNavigator"
+        "precise" : "__docc_universal_symbol_reference_$DocumentationExtension"
       },
       "kind" : {
         "displayName" : "Directive",
@@ -3351,8 +1980,8 @@
           },
           {
             "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$TabNavigator",
-            "spelling" : "TabNavigator"
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$DocumentationExtension",
+            "spelling" : "DocumentationExtension"
           }
         ],
         "subHeading" : [
@@ -3362,13 +1991,33 @@
           },
           {
             "kind" : "identifier",
-            "spelling" : "TabNavigator"
+            "spelling" : "DocumentationExtension"
+          },
+          {
+            "kind" : "text",
+            "spelling" : "("
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "mergeBehavior"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "spelling" : "Behavior"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ")"
           }
         ],
-        "title" : "TabNavigator"
+        "title" : "DocumentationExtension"
       },
       "pathComponents" : [
-        "TabNavigator"
+        "DocumentationExtension"
       ]
     },
     {
@@ -3429,6 +2078,66 @@
       },
       "pathComponents" : [
         "Downloads"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Forums"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "(...)"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " {\n    ...\n}"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$Forums"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$Forums",
+            "spelling" : "Forums"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "Forums"
+          },
+          {
+            "kind" : "text",
+            "spelling" : "(...)"
+          }
+        ],
+        "title" : "Forums"
+      },
+      "pathComponents" : [
+        "Forums"
       ]
     },
     {
@@ -3568,7 +2277,27 @@
         },
         {
           "kind" : "typeIdentifier",
-          "spelling" : "Small"
+          "spelling" : "Intro"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "("
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "title"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "String"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ")"
         },
         {
           "kind" : "text",
@@ -3578,22 +2307,257 @@
       "docComment" : {
         "lines" : [
           {
-            "text" : "A directive for specifying small print text like legal, license, or copyright text that"
-          },
-          {
-            "text" : "should be rendered in a smaller font size."
+            "text" : "An introductory section for instructional pages."
           },
           {
             "text" : ""
           },
           {
-            "text" : "The `@Small` directive is based on HTML's small tag (`<small>`). It supports any inline markup"
+            "text" : "- Parameters:"
           },
           {
-            "text" : "formatting like bold and italics but does not support more structured markup like ``Row``"
+            "text" : "  - title: The title of the containing ``Tutorial``."
           },
           {
-            "text" : "and ``Row\/Column``."
+            "text" : "     **(required)**"
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$Intro"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$Intro",
+            "spelling" : "Intro"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "Intro"
+          },
+          {
+            "kind" : "text",
+            "spelling" : "("
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "title"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "spelling" : "String"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ")"
+          }
+        ],
+        "title" : "Intro"
+      },
+      "pathComponents" : [
+        "Intro"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Justification"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "("
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "reaction"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "String"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "?"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ")"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " {\n    ...\n}"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "text" : "A short justification as to whether a ``Choice`` is correct for a question."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "- Parameters:"
+          },
+          {
+            "text" : "  - reaction: The reaction to the reader selecting the containing ``Choice``. Defaults to nil."
+          },
+          {
+            "text" : "     **(optional)**"
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$Justification"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$Justification",
+            "spelling" : "Justification"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "Justification"
+          },
+          {
+            "kind" : "text",
+            "spelling" : "("
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "reaction"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "spelling" : "String"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ")"
+          }
+        ],
+        "title" : "Justification"
+      },
+      "pathComponents" : [
+        "Justification"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Links"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "("
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "visualStyle"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "VisualStyle"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ")"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " {\n    ...\n}"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "text" : "A directive for authoring authoring embedded"
+          },
+          {
+            "text" : "previews of documentation links (similar to how links are currently"
+          },
+          {
+            "text" : "rendered in Topics sections) anywhere on the page without affecting page"
+          },
+          {
+            "text" : "curation behavior."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "`@Links` gives authors flexibility in choosing how they want to highlight"
+          },
+          {
+            "text" : "documentation on the page itself versus in the navigation sidebar."
+          },
+          {
+            "text" : "It also allows for mixing and matching different visual styles of"
+          },
+          {
+            "text" : "topics."
           },
           {
             "text" : ""
@@ -3602,209 +2566,37 @@
             "text" : "```md"
           },
           {
-            "text" : "You can create a sloth using the ``init(name:color:power:)``"
-          },
-          {
-            "text" : "initializer, or create randomly generated sloth using a"
-          },
-          {
-            "text" : "``SlothGenerator``:"
-          },
-          {
-            "text" : "   "
-          },
-          {
-            "text" : "   let slothGenerator = MySlothGenerator(seed: randomSeed())"
-          },
-          {
-            "text" : "   let habitat = Habitat(isHumid: false, isWarm: true)"
+            "text" : "..."
           },
           {
             "text" : ""
           },
           {
-            "text" : "   \/\/ ..."
+            "text" : "### What's New in SlothCreator"
           },
           {
             "text" : ""
           },
           {
-            "text" : "@Small {"
+            "text" : "@Links(visualStyle: compactGrid) {"
           },
           {
-            "text" : "    _Licensed under Apache License v2.0 with Runtime Library Exception._"
+            "text" : "   - <doc:get-started-preparing-sloth-food>"
+          },
+          {
+            "text" : "   - <doc:feeding-your-sloth-in-winter>"
+          },
+          {
+            "text" : "   - <doc:ordering-food-delivery>"
           },
           {
             "text" : "}"
           },
           {
-            "text" : "```"
-          }
-        ]
-      },
-      "identifier" : {
-        "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$Small"
-      },
-      "kind" : {
-        "displayName" : "Directive",
-        "identifier" : "class"
-      },
-      "names" : {
-        "navigator" : [
-          {
-            "kind" : "attribute",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$Small",
-            "spelling" : "Small"
-          }
-        ],
-        "subHeading" : [
-          {
-            "kind" : "identifier",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "Small"
-          }
-        ],
-        "title" : "Small"
-      },
-      "pathComponents" : [
-        "Small"
-      ]
-    },
-    {
-      "accessLevel" : "public",
-      "declarationFragments" : [
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "Resources"
-        },
-        {
-          "kind" : "text",
-          "spelling" : " {\n    ...\n}"
-        }
-      ],
-      "identifier" : {
-        "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$Resources"
-      },
-      "kind" : {
-        "displayName" : "Directive",
-        "identifier" : "class"
-      },
-      "names" : {
-        "navigator" : [
-          {
-            "kind" : "attribute",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$Resources",
-            "spelling" : "Resources"
-          }
-        ],
-        "subHeading" : [
-          {
-            "kind" : "identifier",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "Resources"
-          }
-        ],
-        "title" : "Resources"
-      },
-      "pathComponents" : [
-        "Resources"
-      ]
-    },
-    {
-      "accessLevel" : "public",
-      "declarationFragments" : [
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "DocumentationExtension"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "("
-        },
-        {
-          "kind" : "identifier",
-          "spelling" : "mergeBehavior"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ": "
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "Behavior"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ")"
-        }
-      ],
-      "docComment" : {
-        "lines" : [
-          {
-            "text" : "A directive that controls how the documentation-extension file merges with or overrides the in-source documentation."
-          },
-          {
             "text" : ""
           },
           {
-            "text" : "When the ``behavior-swift.property`` property is ``Behavior-swift.enum\/append``, the content from the documentation-extension file is added after the content from"
-          },
-          {
-            "text" : "the in-source documentation for that symbol."
-          },
-          {
-            "text" : "If a documentation-extension file doesn't have a `DocumentationExtension` directive, then it has the ``Behavior-swift.enum\/append`` behavior."
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "When the ``behavior-swift.property`` property is ``Behavior-swift.enum\/override``, the content from the documentation-extension file completely replaces the content"
-          },
-          {
-            "text" : "from the in-source documentation for that symbol"
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "This directive is only valid within a ``Metadata`` directive:"
-          },
-          {
-            "text" : "```"
-          },
-          {
-            "text" : "@Metadata {"
-          },
-          {
-            "text" : "   @DocumentationExtension(mergeBehavior: override)"
-          },
-          {
-            "text" : "}"
+            "text" : "..."
           },
           {
             "text" : "```"
@@ -3813,22 +2605,37 @@
             "text" : "- Parameters:"
           },
           {
-            "text" : "  - mergeBehavior: The merge behavior for this documentation extension."
+            "text" : "  - visualStyle: The specified style that should be used when rendering the specified links."
           },
           {
             "text" : "     **(required)**"
           },
           {
-            "text" : "     - term `append`: Append the documentation-extension content to the in-source content and process them together."
+            "text" : "     - term `list`: A list of the linked pages, including their full declaration and abstract."
           },
           {
-            "text" : "     - term `override`: Completely override any in-source content with the content from the documentation-extension."
+            "text" : "     - term `compactGrid`: A grid of items based on the card image for the linked pages."
+          },
+          {
+            "text" : "        "
+          },
+          {
+            "text" : "        Includes each page’s title and card image but excludes their abstracts."
+          },
+          {
+            "text" : "     - term `detailedGrid`: A grid of items based on the card image for the linked pages."
+          },
+          {
+            "text" : "        "
+          },
+          {
+            "text" : "        Unlike ``compactGrid``, this style includes the abstract for each page."
           }
         ]
       },
       "identifier" : {
         "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$DocumentationExtension"
+        "precise" : "__docc_universal_symbol_reference_$Links"
       },
       "kind" : {
         "displayName" : "Directive",
@@ -3842,8 +2649,8 @@
           },
           {
             "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$DocumentationExtension",
-            "spelling" : "DocumentationExtension"
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$Links",
+            "spelling" : "Links"
           }
         ],
         "subHeading" : [
@@ -3853,7 +2660,7 @@
           },
           {
             "kind" : "identifier",
-            "spelling" : "DocumentationExtension"
+            "spelling" : "Links"
           },
           {
             "kind" : "text",
@@ -3861,7 +2668,7 @@
           },
           {
             "kind" : "identifier",
-            "spelling" : "mergeBehavior"
+            "spelling" : "visualStyle"
           },
           {
             "kind" : "text",
@@ -3869,17 +2676,336 @@
           },
           {
             "kind" : "typeIdentifier",
-            "spelling" : "Behavior"
+            "spelling" : "VisualStyle"
           },
           {
             "kind" : "text",
             "spelling" : ")"
           }
         ],
-        "title" : "DocumentationExtension"
+        "title" : "Links"
       },
       "pathComponents" : [
-        "DocumentationExtension"
+        "Links"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Metadata"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " {\n    ...\n}"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "text" : "A directive that contains various metadata about a page."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "This directive acts as a container for metadata and configuration without any arguments of its own."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "## Topics"
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "### Child Directives"
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "- ``DocumentationExtension``"
+          },
+          {
+            "text" : "- ``TechnologyRoot``"
+          },
+          {
+            "text" : "- ``DisplayName``"
+          },
+          {
+            "text" : "- ``PageImage``"
+          },
+          {
+            "text" : "- ``CallToAction``"
+          },
+          {
+            "text" : "- ``Availability``"
+          },
+          {
+            "text" : "- ``PageKind``"
+          },
+          {
+            "text" : "- ``SupportedLanguage``"
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$Metadata"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$Metadata",
+            "spelling" : "Metadata"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "Metadata"
+          }
+        ],
+        "title" : "Metadata"
+      },
+      "pathComponents" : [
+        "Metadata"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "MultipleChoice"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " {\n    ...\n}"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$MultipleChoice"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$MultipleChoice",
+            "spelling" : "MultipleChoice"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "MultipleChoice"
+          }
+        ],
+        "title" : "MultipleChoice"
+      },
+      "pathComponents" : [
+        "MultipleChoice"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Options"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "("
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "scope"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Scope"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " = local"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ")"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " {\n    ...\n}"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "text" : "Use Option directives to adjust DocC's default behaviors when rendering a page."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "- Parameters:"
+          },
+          {
+            "text" : "  - scope: Whether the options in this Options directive should apply locally to the page"
+          },
+          {
+            "text" : "     or globally to the DocC catalog."
+          },
+          {
+            "text" : "     **(optional)**"
+          },
+          {
+            "text" : "     - term `local`: The directive should only affect the current page."
+          },
+          {
+            "text" : "     - term `global`: The directive should affect all pages in the current DocC catalog."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "## Topics"
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "### Adjusting Automatic Behaviors"
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "- ``AutomaticSeeAlso``"
+          },
+          {
+            "text" : "- ``AutomaticTitleHeading``"
+          },
+          {
+            "text" : "- ``AutomaticArticleSubheading``"
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "### Adjusting Visual Style"
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "- ``TopicsVisualStyle``"
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$Options"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$Options",
+            "spelling" : "Options"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "Options"
+          },
+          {
+            "kind" : "text",
+            "spelling" : "("
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "scope"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "spelling" : "Scope"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ")"
+          }
+        ],
+        "title" : "Options"
+      },
+      "pathComponents" : [
+        "Options"
       ]
     },
     {
@@ -4047,7 +3173,7 @@
         },
         {
           "kind" : "typeIdentifier",
-          "spelling" : "TopicsVisualStyle"
+          "spelling" : "PageKind"
         },
         {
           "kind" : "text",
@@ -4059,7 +3185,7 @@
         },
         {
           "kind" : "identifier",
-          "spelling" : "style"
+          "spelling" : "kind"
         },
         {
           "kind" : "text",
@@ -4067,7 +3193,7 @@
         },
         {
           "kind" : "typeIdentifier",
-          "spelling" : "Style"
+          "spelling" : "Kind"
         },
         {
           "kind" : "text",
@@ -4077,49 +3203,70 @@
       "docComment" : {
         "lines" : [
           {
-            "text" : "A directive for specifying the style that should be used when rendering a page's"
+            "text" : "A directive that allows you to set a page's kind, which affects its default title heading and page icon."
           },
           {
-            "text" : "Topics section."
+            "text" : ""
+          },
+          {
+            "text" : "The `@PageKind` directive tells Swift-DocC to treat a documentation page as a particular"
+          },
+          {
+            "text" : "\"kind\". This is used to determine the page's default navigator icon, as well as the default"
+          },
+          {
+            "text" : "title heading on the page itself."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "The available page kinds are `article` and `sampleCode`."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "This directive is only valid within a `@Metadata` directive:"
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "```markdown"
+          },
+          {
+            "text" : "@Metadata {"
+          },
+          {
+            "text" : "    @PageKind(sampleCode)"
+          },
+          {
+            "text" : "}"
+          },
+          {
+            "text" : "```"
           },
           {
             "text" : "- Parameters:"
           },
           {
-            "text" : "  - style: The specified style that should be used when rendering a page's Topics section."
+            "text" : "  - kind: The page kind to apply to the page."
           },
           {
             "text" : "     **(required)**"
           },
           {
-            "text" : "     - term `list`: A list of the page's topics, including their full declaration and abstract."
+            "text" : "     - term `article`: An article of free-form text; the default for standalone markdown files."
           },
           {
-            "text" : "     - term `compactGrid`: A grid of items based on the card image for each page."
-          },
-          {
-            "text" : "        "
-          },
-          {
-            "text" : "        Includes each page’s title and card image but excludes their abstracts."
-          },
-          {
-            "text" : "     - term `detailedGrid`: A grid of items based on the card image for each page."
-          },
-          {
-            "text" : "        "
-          },
-          {
-            "text" : "        Unlike ``compactGrid``, this style includes the abstract for each page."
-          },
-          {
-            "text" : "     - term `hidden`: Do not show child pages anywhere on the page."
+            "text" : "     - term `sampleCode`: A page describing a \"sample code\" project."
           }
         ]
       },
       "identifier" : {
         "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$TopicsVisualStyle"
+        "precise" : "__docc_universal_symbol_reference_$PageKind"
       },
       "kind" : {
         "displayName" : "Directive",
@@ -4133,8 +3280,8 @@
           },
           {
             "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$TopicsVisualStyle",
-            "spelling" : "TopicsVisualStyle"
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$PageKind",
+            "spelling" : "PageKind"
           }
         ],
         "subHeading" : [
@@ -4144,7 +3291,7 @@
           },
           {
             "kind" : "identifier",
-            "spelling" : "TopicsVisualStyle"
+            "spelling" : "PageKind"
           },
           {
             "kind" : "text",
@@ -4156,7 +3303,7 @@
           },
           {
             "kind" : "identifier",
-            "spelling" : "style"
+            "spelling" : "kind"
           },
           {
             "kind" : "text",
@@ -4164,17 +3311,17 @@
           },
           {
             "kind" : "typeIdentifier",
-            "spelling" : "Style"
+            "spelling" : "Kind"
           },
           {
             "kind" : "text",
             "spelling" : ")"
           }
         ],
-        "title" : "TopicsVisualStyle"
+        "title" : "PageKind"
       },
       "pathComponents" : [
-        "TopicsVisualStyle"
+        "PageKind"
       ]
     },
     {
@@ -4186,364 +3333,7 @@
         },
         {
           "kind" : "typeIdentifier",
-          "spelling" : "Intro"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "("
-        },
-        {
-          "kind" : "identifier",
-          "spelling" : "title"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ": "
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "String"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ")"
-        },
-        {
-          "kind" : "text",
-          "spelling" : " {\n    ...\n}"
-        }
-      ],
-      "docComment" : {
-        "lines" : [
-          {
-            "text" : "An introductory section for instructional pages."
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "- Parameters:"
-          },
-          {
-            "text" : "  - title: The title of the containing ``Tutorial``."
-          },
-          {
-            "text" : "     **(required)**"
-          }
-        ]
-      },
-      "identifier" : {
-        "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$Intro"
-      },
-      "kind" : {
-        "displayName" : "Directive",
-        "identifier" : "class"
-      },
-      "names" : {
-        "navigator" : [
-          {
-            "kind" : "attribute",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$Intro",
-            "spelling" : "Intro"
-          }
-        ],
-        "subHeading" : [
-          {
-            "kind" : "identifier",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "Intro"
-          },
-          {
-            "kind" : "text",
-            "spelling" : "("
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "title"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ": "
-          },
-          {
-            "kind" : "typeIdentifier",
-            "spelling" : "String"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ")"
-          }
-        ],
-        "title" : "Intro"
-      },
-      "pathComponents" : [
-        "Intro"
-      ]
-    },
-    {
-      "accessLevel" : "public",
-      "declarationFragments" : [
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "AutomaticTitleHeading"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "("
-        },
-        {
-          "kind" : "text",
-          "spelling" : "_ "
-        },
-        {
-          "kind" : "identifier",
-          "spelling" : "enabledness"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ": "
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "Enabledness"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ")"
-        }
-      ],
-      "docComment" : {
-        "lines" : [
-          {
-            "text" : "A directive for specifying Swift-DocC's automatic behavior when generating a page's"
-          },
-          {
-            "text" : "title heading."
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "A title heading is also known as a page eyebrow or kicker."
-          },
-          {
-            "text" : "- Parameters:"
-          },
-          {
-            "text" : "  - enabledness: Whether or not DocC generates automatic title headings."
-          },
-          {
-            "text" : "     **(required)**"
-          },
-          {
-            "text" : "     - term `enabled`: A title heading should be automatically created for the page (the default)."
-          },
-          {
-            "text" : "     - term `disabled`: No automatic title heading should be created for the page."
-          }
-        ]
-      },
-      "identifier" : {
-        "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$AutomaticTitleHeading"
-      },
-      "kind" : {
-        "displayName" : "Directive",
-        "identifier" : "class"
-      },
-      "names" : {
-        "navigator" : [
-          {
-            "kind" : "attribute",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$AutomaticTitleHeading",
-            "spelling" : "AutomaticTitleHeading"
-          }
-        ],
-        "subHeading" : [
-          {
-            "kind" : "identifier",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "AutomaticTitleHeading"
-          },
-          {
-            "kind" : "text",
-            "spelling" : "("
-          },
-          {
-            "kind" : "text",
-            "spelling" : "_ "
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "enabledness"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ": "
-          },
-          {
-            "kind" : "typeIdentifier",
-            "spelling" : "Enabledness"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ")"
-          }
-        ],
-        "title" : "AutomaticTitleHeading"
-      },
-      "pathComponents" : [
-        "AutomaticTitleHeading"
-      ]
-    },
-    {
-      "accessLevel" : "public",
-      "declarationFragments" : [
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "Justification"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "("
-        },
-        {
-          "kind" : "identifier",
-          "spelling" : "reaction"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ": "
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "String"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "?"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ")"
-        },
-        {
-          "kind" : "text",
-          "spelling" : " {\n    ...\n}"
-        }
-      ],
-      "docComment" : {
-        "lines" : [
-          {
-            "text" : "A short justification as to whether a ``Choice`` is correct for a question."
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "- Parameters:"
-          },
-          {
-            "text" : "  - reaction: The reaction to the reader selecting the containing ``Choice``. Defaults to nil."
-          },
-          {
-            "text" : "     **(optional)**"
-          }
-        ]
-      },
-      "identifier" : {
-        "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$Justification"
-      },
-      "kind" : {
-        "displayName" : "Directive",
-        "identifier" : "class"
-      },
-      "names" : {
-        "navigator" : [
-          {
-            "kind" : "attribute",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$Justification",
-            "spelling" : "Justification"
-          }
-        ],
-        "subHeading" : [
-          {
-            "kind" : "identifier",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "Justification"
-          },
-          {
-            "kind" : "text",
-            "spelling" : "("
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "reaction"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ": "
-          },
-          {
-            "kind" : "typeIdentifier",
-            "spelling" : "String"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ")"
-          }
-        ],
-        "title" : "Justification"
-      },
-      "pathComponents" : [
-        "Justification"
-      ]
-    },
-    {
-      "accessLevel" : "public",
-      "declarationFragments" : [
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "Code"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "(...)"
+          "spelling" : "Resources"
         },
         {
           "kind" : "text",
@@ -4552,7 +3342,7 @@
       ],
       "identifier" : {
         "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$Code"
+        "precise" : "__docc_universal_symbol_reference_$Resources"
       },
       "kind" : {
         "displayName" : "Directive",
@@ -4566,8 +3356,8 @@
           },
           {
             "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$Code",
-            "spelling" : "Code"
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$Resources",
+            "spelling" : "Resources"
           }
         ],
         "subHeading" : [
@@ -4577,173 +3367,13 @@
           },
           {
             "kind" : "identifier",
-            "spelling" : "Code"
-          },
-          {
-            "kind" : "text",
-            "spelling" : "(...)"
+            "spelling" : "Resources"
           }
         ],
-        "title" : "Code"
+        "title" : "Resources"
       },
       "pathComponents" : [
-        "Code"
-      ]
-    },
-    {
-      "accessLevel" : "public",
-      "declarationFragments" : [
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "TutorialReference"
-        },
-        {
-          "kind" : "text",
-          "spelling" : "("
-        },
-        {
-          "kind" : "identifier",
-          "spelling" : "tutorial"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ": "
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "TopicReference"
-        },
-        {
-          "kind" : "text",
-          "spelling" : ")"
-        }
-      ],
-      "docComment" : {
-        "lines" : [
-          {
-            "text" : "A reference to a ``Tutorial`` or ``TutorialArticle`` by `URL`."
-          },
-          {
-            "text" : "- Parameters:"
-          },
-          {
-            "text" : "  - tutorial: The tutorial page or tutorial article to which this refers."
-          },
-          {
-            "text" : "     **(required)**"
-          }
-        ]
-      },
-      "identifier" : {
-        "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$TutorialReference"
-      },
-      "kind" : {
-        "displayName" : "Directive",
-        "identifier" : "class"
-      },
-      "names" : {
-        "navigator" : [
-          {
-            "kind" : "attribute",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$TutorialReference",
-            "spelling" : "TutorialReference"
-          }
-        ],
-        "subHeading" : [
-          {
-            "kind" : "identifier",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "TutorialReference"
-          },
-          {
-            "kind" : "text",
-            "spelling" : "("
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "tutorial"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ": "
-          },
-          {
-            "kind" : "typeIdentifier",
-            "spelling" : "TopicReference"
-          },
-          {
-            "kind" : "text",
-            "spelling" : ")"
-          }
-        ],
-        "title" : "TutorialReference"
-      },
-      "pathComponents" : [
-        "TutorialReference"
-      ]
-    },
-    {
-      "accessLevel" : "public",
-      "declarationFragments" : [
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "@"
-        },
-        {
-          "kind" : "typeIdentifier",
-          "spelling" : "MultipleChoice"
-        },
-        {
-          "kind" : "text",
-          "spelling" : " {\n    ...\n}"
-        }
-      ],
-      "identifier" : {
-        "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$MultipleChoice"
-      },
-      "kind" : {
-        "displayName" : "Directive",
-        "identifier" : "class"
-      },
-      "names" : {
-        "navigator" : [
-          {
-            "kind" : "attribute",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$MultipleChoice",
-            "spelling" : "MultipleChoice"
-          }
-        ],
-        "subHeading" : [
-          {
-            "kind" : "identifier",
-            "spelling" : "@"
-          },
-          {
-            "kind" : "identifier",
-            "spelling" : "MultipleChoice"
-          }
-        ],
-        "title" : "MultipleChoice"
-      },
-      "pathComponents" : [
-        "MultipleChoice"
+        "Resources"
       ]
     },
     {
@@ -5024,7 +3654,7 @@
         },
         {
           "kind" : "typeIdentifier",
-          "spelling" : "Documentation"
+          "spelling" : "SampleCode"
         },
         {
           "kind" : "text",
@@ -5037,7 +3667,7 @@
       ],
       "identifier" : {
         "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$Documentation"
+        "precise" : "__docc_universal_symbol_reference_$SampleCode"
       },
       "kind" : {
         "displayName" : "Directive",
@@ -5051,8 +3681,8 @@
           },
           {
             "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$Documentation",
-            "spelling" : "Documentation"
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$SampleCode",
+            "spelling" : "SampleCode"
           }
         ],
         "subHeading" : [
@@ -5062,17 +3692,1461 @@
           },
           {
             "kind" : "identifier",
-            "spelling" : "Documentation"
+            "spelling" : "SampleCode"
           },
           {
             "kind" : "text",
             "spelling" : "(...)"
           }
         ],
-        "title" : "Documentation"
+        "title" : "SampleCode"
       },
       "pathComponents" : [
-        "Documentation"
+        "SampleCode"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Section"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "(...)"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " {\n    ...\n}"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$Section"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$Section",
+            "spelling" : "Section"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "Section"
+          },
+          {
+            "kind" : "text",
+            "spelling" : "(...)"
+          }
+        ],
+        "title" : "Section"
+      },
+      "pathComponents" : [
+        "Section"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Small"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " {\n    ...\n}"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "text" : "A directive for specifying small print text like legal, license, or copyright text that"
+          },
+          {
+            "text" : "should be rendered in a smaller font size."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "The `@Small` directive is based on HTML's small tag (`<small>`). It supports any inline markup"
+          },
+          {
+            "text" : "formatting like bold and italics but does not support more structured markup like ``Row``"
+          },
+          {
+            "text" : "and ``Row\/Column``."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "```md"
+          },
+          {
+            "text" : "You can create a sloth using the ``init(name:color:power:)``"
+          },
+          {
+            "text" : "initializer, or create randomly generated sloth using a"
+          },
+          {
+            "text" : "``SlothGenerator``:"
+          },
+          {
+            "text" : "   "
+          },
+          {
+            "text" : "   let slothGenerator = MySlothGenerator(seed: randomSeed())"
+          },
+          {
+            "text" : "   let habitat = Habitat(isHumid: false, isWarm: true)"
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "   \/\/ ..."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "@Small {"
+          },
+          {
+            "text" : "    _Licensed under Apache License v2.0 with Runtime Library Exception._"
+          },
+          {
+            "text" : "}"
+          },
+          {
+            "text" : "```"
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$Small"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$Small",
+            "spelling" : "Small"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "Small"
+          }
+        ],
+        "title" : "Small"
+      },
+      "pathComponents" : [
+        "Small"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Stack"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " {\n"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "    "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "preciseIdentifier" : "__docc_universal_symbol_reference_$ContentAndMedia",
+          "spelling" : "ContentAndMedia"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " { ... }"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "\n"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "}"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "text" : "A semantic model for a view that arranges its children in a row."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$Stack"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$Stack",
+            "spelling" : "Stack"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "Stack"
+          }
+        ],
+        "title" : "Stack"
+      },
+      "pathComponents" : [
+        "Stack"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Step"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " {\n    ...\n}"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$Step"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$Step",
+            "spelling" : "Step"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "Step"
+          }
+        ],
+        "title" : "Step"
+      },
+      "pathComponents" : [
+        "Step"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Steps"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " {\n    ...\n}"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$Steps"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$Steps",
+            "spelling" : "Steps"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "Steps"
+          }
+        ],
+        "title" : "Steps"
+      },
+      "pathComponents" : [
+        "Steps"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "SupportedLanguage"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "("
+        },
+        {
+          "kind" : "text",
+          "spelling" : "_ "
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "language"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "SourceLanguage"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ")"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "text" : "A directive that controls what programming languages an article is available in."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "By default, an article is available in the languages the module that's being documented is available in. Use"
+          },
+          {
+            "text" : "this directive to override this behavior in a ``Metadata`` directive:"
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "```"
+          },
+          {
+            "text" : "@Metadata {"
+          },
+          {
+            "text" : "    @SupportedLanguage(swift)"
+          },
+          {
+            "text" : "    @SupportedLanguage(objc)"
+          },
+          {
+            "text" : "}"
+          },
+          {
+            "text" : "```"
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "This directive supports any language identifier, but only the following are currently supported"
+          },
+          {
+            "text" : "by Swift-DocC Render:"
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "| Identifier                                 | Language               |"
+          },
+          {
+            "text" : "| --------------------------------- | ----------------------|"
+          },
+          {
+            "text" : "| `swift`                                | Swift                       |"
+          },
+          {
+            "text" : "| `objc`, `objective-c`   | Objective-C            |"
+          },
+          {
+            "text" : "- Parameters:"
+          },
+          {
+            "text" : "  - language: A source language that this symbol is available in."
+          },
+          {
+            "text" : "     **(required)**"
+          },
+          {
+            "text" : "     "
+          },
+          {
+            "text" : "     For supported values, see ``SupportedLanguage``."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$SupportedLanguage"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$SupportedLanguage",
+            "spelling" : "SupportedLanguage"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "SupportedLanguage"
+          },
+          {
+            "kind" : "text",
+            "spelling" : "("
+          },
+          {
+            "kind" : "text",
+            "spelling" : "_ "
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "language"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "spelling" : "SourceLanguage"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ")"
+          }
+        ],
+        "title" : "SupportedLanguage"
+      },
+      "pathComponents" : [
+        "SupportedLanguage"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Tab"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "("
+        },
+        {
+          "kind" : "text",
+          "spelling" : "_ "
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "title"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "String"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ")"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " {\n    ...\n}"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "text" : "A container directive that holds general markup content describing an individual"
+          },
+          {
+            "text" : "tab within a tab-based layout."
+          },
+          {
+            "text" : "- Parameters:"
+          },
+          {
+            "text" : "  - title: The title that should identify the content in this tab when rendered."
+          },
+          {
+            "text" : "     **(required)**"
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$Tab"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$Tab",
+            "spelling" : "Tab"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "Tab"
+          },
+          {
+            "kind" : "text",
+            "spelling" : "("
+          },
+          {
+            "kind" : "text",
+            "spelling" : "_ "
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "title"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "spelling" : "String"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ")"
+          }
+        ],
+        "title" : "Tab"
+      },
+      "pathComponents" : [
+        "Tab"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "TabNavigator"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " {\n"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "    "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "preciseIdentifier" : "__docc_universal_symbol_reference_$Tab",
+          "spelling" : "Tab"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "("
+        },
+        {
+          "kind" : "text",
+          "spelling" : "_ "
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "title"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "String"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ")"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " { ... }"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "\n"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "}"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "text" : "A container directive that arranges content into a tab-based layout."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "Create a new tab navigator by writing a `@TabNavigator` directive that contains child"
+          },
+          {
+            "text" : "`@Tab` directives."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "```md"
+          },
+          {
+            "text" : "@TabNavigator {"
+          },
+          {
+            "text" : "   @Tab(\"Powers\") {"
+          },
+          {
+            "text" : "      ![A diagram with the five sloth power types.](sloth-powers)"
+          },
+          {
+            "text" : "   }"
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "   @Tab(\"Excerise routines\") {"
+          },
+          {
+            "text" : "      ![A sloth relaxing and enjoying a good book.](sloth-exercise)"
+          },
+          {
+            "text" : "   }"
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "   @Tab(\"Hats\") {"
+          },
+          {
+            "text" : "      ![A sloth discovering newfound confidence after donning a fedora.](sloth-hats)"
+          },
+          {
+            "text" : "   }"
+          },
+          {
+            "text" : "}"
+          },
+          {
+            "text" : "```"
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "## Topics"
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "- ``Tab``"
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$TabNavigator"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$TabNavigator",
+            "spelling" : "TabNavigator"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "TabNavigator"
+          }
+        ],
+        "title" : "TabNavigator"
+      },
+      "pathComponents" : [
+        "TabNavigator"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "TechnologyRoot"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "text" : "A directive to set this page as a documentation root-level node."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "This directive is only valid within a top-level ``Metadata`` directive:"
+          },
+          {
+            "text" : "```"
+          },
+          {
+            "text" : "@Metadata {"
+          },
+          {
+            "text" : "   @TechnologyRoot"
+          },
+          {
+            "text" : "}"
+          },
+          {
+            "text" : "```"
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$TechnologyRoot"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$TechnologyRoot",
+            "spelling" : "TechnologyRoot"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "TechnologyRoot"
+          }
+        ],
+        "title" : "TechnologyRoot"
+      },
+      "pathComponents" : [
+        "TechnologyRoot"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "TopicsVisualStyle"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "("
+        },
+        {
+          "kind" : "text",
+          "spelling" : "_ "
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "style"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Style"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ")"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "text" : "A directive for specifying the style that should be used when rendering a page's"
+          },
+          {
+            "text" : "Topics section."
+          },
+          {
+            "text" : "- Parameters:"
+          },
+          {
+            "text" : "  - style: The specified style that should be used when rendering a page's Topics section."
+          },
+          {
+            "text" : "     **(required)**"
+          },
+          {
+            "text" : "     - term `list`: A list of the page's topics, including their full declaration and abstract."
+          },
+          {
+            "text" : "     - term `compactGrid`: A grid of items based on the card image for each page."
+          },
+          {
+            "text" : "        "
+          },
+          {
+            "text" : "        Includes each page’s title and card image but excludes their abstracts."
+          },
+          {
+            "text" : "     - term `detailedGrid`: A grid of items based on the card image for each page."
+          },
+          {
+            "text" : "        "
+          },
+          {
+            "text" : "        Unlike ``compactGrid``, this style includes the abstract for each page."
+          },
+          {
+            "text" : "     - term `hidden`: Do not show child pages anywhere on the page."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$TopicsVisualStyle"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$TopicsVisualStyle",
+            "spelling" : "TopicsVisualStyle"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "TopicsVisualStyle"
+          },
+          {
+            "kind" : "text",
+            "spelling" : "("
+          },
+          {
+            "kind" : "text",
+            "spelling" : "_ "
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "style"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "spelling" : "Style"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ")"
+          }
+        ],
+        "title" : "TopicsVisualStyle"
+      },
+      "pathComponents" : [
+        "TopicsVisualStyle"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Tutorial"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "("
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "time"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Int"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "?"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ", "
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "projectFiles"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "ResourceReference"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "?"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ")"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " {\n"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "    "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "preciseIdentifier" : "__docc_universal_symbol_reference_$Intro",
+          "spelling" : "Intro"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "("
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "title"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "String"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ")"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " { ... }"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "\n"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "    "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "preciseIdentifier" : "__docc_universal_symbol_reference_$Section",
+          "spelling" : "Section"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "(...)"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " { ... }"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "\n"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "}"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "text" : "A tutorial to complete in order to gain knowledge of a ``Technology``."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "- Parameters:"
+          },
+          {
+            "text" : "  - time: The estimated time in minutes that the containing ``Tutorial`` will take."
+          },
+          {
+            "text" : "     **(optional)**"
+          },
+          {
+            "text" : "  - projectFiles: Project files to download to get started with the ``Tutorial``."
+          },
+          {
+            "text" : "     **(optional)**"
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$Tutorial"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$Tutorial",
+            "spelling" : "Tutorial"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "Tutorial"
+          },
+          {
+            "kind" : "text",
+            "spelling" : "("
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "time"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "spelling" : "Int"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ", "
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "projectFiles"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "spelling" : "ResourceReference"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ")"
+          }
+        ],
+        "title" : "Tutorial"
+      },
+      "pathComponents" : [
+        "Tutorial"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "TutorialReference"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "("
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "tutorial"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "TopicReference"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ")"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "text" : "A reference to a ``Tutorial`` or ``TutorialArticle`` by `URL`."
+          },
+          {
+            "text" : "- Parameters:"
+          },
+          {
+            "text" : "  - tutorial: The tutorial page or tutorial article to which this refers."
+          },
+          {
+            "text" : "     **(required)**"
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$TutorialReference"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$TutorialReference",
+            "spelling" : "TutorialReference"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "TutorialReference"
+          },
+          {
+            "kind" : "text",
+            "spelling" : "("
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "tutorial"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "spelling" : "TopicReference"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ")"
+          }
+        ],
+        "title" : "TutorialReference"
+      },
+      "pathComponents" : [
+        "TutorialReference"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Tutorials"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "(...)"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " {\n    ...\n}"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$Tutorials"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$Tutorials",
+            "spelling" : "Tutorials"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "Tutorials"
+          },
+          {
+            "kind" : "text",
+            "spelling" : "(...)"
+          }
+        ],
+        "title" : "Tutorials"
+      },
+      "pathComponents" : [
+        "Tutorials"
       ]
     },
     {
@@ -5248,7 +5322,7 @@
         },
         {
           "kind" : "typeIdentifier",
-          "spelling" : "Tutorials"
+          "spelling" : "Videos"
         },
         {
           "kind" : "text",
@@ -5261,7 +5335,7 @@
       ],
       "identifier" : {
         "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$Tutorials"
+        "precise" : "__docc_universal_symbol_reference_$Videos"
       },
       "kind" : {
         "displayName" : "Directive",
@@ -5275,8 +5349,8 @@
           },
           {
             "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$Tutorials",
-            "spelling" : "Tutorials"
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$Videos",
+            "spelling" : "Videos"
           }
         ],
         "subHeading" : [
@@ -5286,17 +5360,17 @@
           },
           {
             "kind" : "identifier",
-            "spelling" : "Tutorials"
+            "spelling" : "Videos"
           },
           {
             "kind" : "text",
             "spelling" : "(...)"
           }
         ],
-        "title" : "Tutorials"
+        "title" : "Videos"
       },
       "pathComponents" : [
-        "Tutorials"
+        "Videos"
       ]
     },
     {
@@ -5308,7 +5382,11 @@
         },
         {
           "kind" : "typeIdentifier",
-          "spelling" : "Steps"
+          "spelling" : "Volume"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "(...)"
         },
         {
           "kind" : "text",
@@ -5317,7 +5395,7 @@
       ],
       "identifier" : {
         "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$Steps"
+        "precise" : "__docc_universal_symbol_reference_$Volume"
       },
       "kind" : {
         "displayName" : "Directive",
@@ -5331,8 +5409,8 @@
           },
           {
             "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$Steps",
-            "spelling" : "Steps"
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$Volume",
+            "spelling" : "Volume"
           }
         ],
         "subHeading" : [
@@ -5342,13 +5420,17 @@
           },
           {
             "kind" : "identifier",
-            "spelling" : "Steps"
+            "spelling" : "Volume"
+          },
+          {
+            "kind" : "text",
+            "spelling" : "(...)"
           }
         ],
-        "title" : "Steps"
+        "title" : "Volume"
       },
       "pathComponents" : [
-        "Steps"
+        "Volume"
       ]
     },
     {
@@ -5360,16 +5442,73 @@
         },
         {
           "kind" : "typeIdentifier",
-          "spelling" : "ContentAndMedia"
+          "spelling" : "XcodeRequirement"
         },
         {
           "kind" : "text",
-          "spelling" : " {\n    ...\n}"
+          "spelling" : "("
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "title"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "String"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ", "
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "destination"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "URL"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ")"
         }
       ],
+      "docComment" : {
+        "lines" : [
+          {
+            "text" : "An informal Xcode requirement for completing an instructional ``Tutorial``."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "- Parameters:"
+          },
+          {
+            "text" : "  - title: Human readable title."
+          },
+          {
+            "text" : "     **(required)**"
+          },
+          {
+            "text" : "  - destination: Domain where requirement applies."
+          },
+          {
+            "text" : "     **(required)**"
+          }
+        ]
+      },
       "identifier" : {
         "interfaceLanguage" : "swift",
-        "precise" : "__docc_universal_symbol_reference_$ContentAndMedia"
+        "precise" : "__docc_universal_symbol_reference_$XcodeRequirement"
       },
       "kind" : {
         "displayName" : "Directive",
@@ -5383,8 +5522,8 @@
           },
           {
             "kind" : "identifier",
-            "preciseIdentifier" : "__docc_universal_symbol_reference_$ContentAndMedia",
-            "spelling" : "ContentAndMedia"
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$XcodeRequirement",
+            "spelling" : "XcodeRequirement"
           }
         ],
         "subHeading" : [
@@ -5394,13 +5533,49 @@
           },
           {
             "kind" : "identifier",
-            "spelling" : "ContentAndMedia"
+            "spelling" : "XcodeRequirement"
+          },
+          {
+            "kind" : "text",
+            "spelling" : "("
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "title"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "spelling" : "String"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ", "
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "destination"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "spelling" : "URL"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ")"
           }
         ],
-        "title" : "ContentAndMedia"
+        "title" : "XcodeRequirement"
       },
       "pathComponents" : [
-        "ContentAndMedia"
+        "XcodeRequirement"
       ]
     }
   ]

--- a/Sources/generate-symbol-graph/main.swift
+++ b/Sources/generate-symbol-graph/main.swift
@@ -189,7 +189,7 @@ func generateSwiftDocCFrameworkSymbolGraph() throws -> SymbolGraph {
 func extractDocumentationCommentsForDirectives() throws -> [String : SymbolGraph.LineList] {
     let swiftDocCFrameworkSymbolGraph = try generateSwiftDocCFrameworkSymbolGraph()
     
-    let directiveSymbols = swiftDocCFrameworkSymbolGraph.relationships.compactMap { relationship in
+    let directiveSymbolUSRs: [String] = swiftDocCFrameworkSymbolGraph.relationships.compactMap { relationship in
         guard relationship.kind == .conformsTo
             && relationship.target == "s:9SwiftDocC29AutomaticDirectiveConvertibleP"
         else {
@@ -198,8 +198,9 @@ func extractDocumentationCommentsForDirectives() throws -> [String : SymbolGraph
     
         return relationship.source
     }
-    .compactMap { swiftDocCFrameworkSymbolGraph.symbols[$0] }
-    .map { (String($0.title.split(separator: ".").last ?? $0.title[...]), $0) }
+    let directiveSymbols = Set(directiveSymbolUSRs)
+        .compactMap { swiftDocCFrameworkSymbolGraph.symbols[$0] }
+        .map { (String($0.title.split(separator: ".").last ?? $0.title[...]), $0) }
     
     let directiveDocComments: [(String, SymbolGraph.LineList)] = directiveSymbols.compactMap {
         let (directiveName, directiveSymbol) = $0


### PR DESCRIPTION
<!--
If you're opening a PR to cherry-pick a change for a release branch, use this template instead:
https://github.com/apple/swift-docc/blob/main/.github/PULL_REQUEST_TEMPLATE/CHERRY_PICK.md
-->

Bug/issue #, if applicable: rdar://106651935

## Summary

This fixes a crash when running generate-symbol-graph that's caused by two `Row` directive symbol entires.

It also sorts the symbols in the generated output to make it easier to diff the file over time as we add new directives are or update their documentation.

## Dependencies

None

## Testing

Running `swift run generate-symbol-graph` no longer crashes.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- ~[ ] Added tests~
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
