### PR TITLE
Rephrase link diagnostic error messages to provide more specific information first

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Bundle Assets/SVGIDExtractor.swift
+++ b/Sources/SwiftDocC/Infrastructure/Bundle Assets/SVGIDExtractor.swift
@@ -28,7 +28,9 @@ enum SVGIDExtractor {
         let delegate = SVGIDParserDelegate()
         let svgParser = XMLParser(data: data)
         svgParser.delegate = delegate
-        svgParser.parse()
+        
+        // The delegate aborts the parsing when it finds the ID so the larger parsing operation is not "successful"
+        _ = svgParser.parse()
         
         return delegate.id
     }

--- a/Sources/SwiftDocC/Model/Identifier.swift
+++ b/Sources/SwiftDocC/Model/Identifier.swift
@@ -72,11 +72,18 @@ public struct TopicReferenceResolutionErrorInfo: Hashable {
     public var message: String
     public var note: String?
     public var solutions: [Solution]
+    public var rangeAdjustment: SourceRange?
     
-    public init(_ message: String, note: String? = nil, solutions: [Solution] = []) {
+    public init(
+        _ message: String,
+        note: String? = nil,
+        solutions: [Solution] = [],
+        rangeAdjustment: SourceRange? = nil
+    ) {
         self.message = message
         self.note = note
         self.solutions = solutions
+        self.rangeAdjustment = rangeAdjustment
     }
 }
 
@@ -90,6 +97,7 @@ extension TopicReferenceResolutionErrorInfo {
             self.note = nil
         }
         self.solutions = solutions
+        self.rangeAdjustment = nil
     }
 }
 

--- a/Sources/SwiftDocC/Semantics/MarkupReferenceResolver.swift
+++ b/Sources/SwiftDocC/Semantics/MarkupReferenceResolver.swift
@@ -71,7 +71,7 @@ struct MarkupReferenceResolver: MarkupRewriter {
             }
             
             let uncuratedArticleMatch = context.uncuratedArticles[bundle.articlesDocumentationRootReference.appendingPathOfReference(unresolved)]?.source
-            problems.append(unresolvedReferenceProblem(reference: reference, source: source, range: range, severity: severity, uncuratedArticleMatch: uncuratedArticleMatch, underlyingError: error, fromSymbolLink: fromSymbolLink))
+            problems.append(unresolvedReferenceProblem(reference: reference, source: source, range: range, severity: severity, uncuratedArticleMatch: uncuratedArticleMatch, errorInfo: error, fromSymbolLink: fromSymbolLink))
             return nil
         }
     }

--- a/Sources/SwiftDocC/Semantics/ReferenceResolver.swift
+++ b/Sources/SwiftDocC/Semantics/ReferenceResolver.swift
@@ -54,7 +54,7 @@ func unresolvedReferenceProblem(reference: TopicReference, source: URL?, range: 
         diagnosticRange = referenceSourceRange
     }
     
-    let diagnostic = Diagnostic(source: source, severity: severity, range: diagnosticRange, identifier: "org.swift.docc.unresolvedTopicReference", summary: "Topic reference \(reference.description.singleQuoted) couldn't be resolved. \(errorInfo.message)", notes: notes)
+    let diagnostic = Diagnostic(source: source, severity: severity, range: diagnosticRange, identifier: "org.swift.docc.unresolvedTopicReference", summary: errorInfo.message, notes: notes)
     return Problem(diagnostic: diagnostic, possibleSolutions: solutions)
 }
 

--- a/Sources/SwiftDocC/Semantics/ReferenceResolver.swift
+++ b/Sources/SwiftDocC/Semantics/ReferenceResolver.swift
@@ -46,7 +46,15 @@ func unresolvedReferenceProblem(reference: TopicReference, source: URL?, range: 
         solutions.append(contentsOf: errorInfo.solutions(referenceSourceRange: referenceSourceRange))
     }
     
-    let diagnostic = Diagnostic(source: source, severity: severity, range: referenceSourceRange, identifier: "org.swift.docc.unresolvedTopicReference", summary: "Topic reference \(reference.description.singleQuoted) couldn't be resolved. \(errorInfo.message)", notes: notes)
+    let diagnosticRange: SourceRange?
+    if var rangeAdjustment = errorInfo.rangeAdjustment, let referenceSourceRange = referenceSourceRange {
+        rangeAdjustment.offsetWithRange(referenceSourceRange)
+        diagnosticRange = rangeAdjustment
+    } else {
+        diagnosticRange = referenceSourceRange
+    }
+    
+    let diagnostic = Diagnostic(source: source, severity: severity, range: diagnosticRange, identifier: "org.swift.docc.unresolvedTopicReference", summary: "Topic reference \(reference.description.singleQuoted) couldn't be resolved. \(errorInfo.message)", notes: notes)
     return Problem(diagnostic: diagnostic, possibleSolutions: solutions)
 }
 

--- a/Sources/SwiftDocC/Utility/NearMiss.swift
+++ b/Sources/SwiftDocC/Utility/NearMiss.swift
@@ -16,7 +16,7 @@ import Foundation
 enum NearMiss {
     
     /// Returns the "best matches" among a list of possibilities based on how "similar" they are to a given string.
-    static func bestMatches(for possibilities: [String], against authored: String) -> [String] {
+    static func bestMatches<Possibilities: Sequence>(for possibilities: Possibilities, against authored: String) -> [String] where Possibilities.Element == String {
         // There is no single right or wrong way to score changes. This implementation is completely arbitrary.
         // It's chosen because the relative scores that it computes provide "best match" results that are close
         // to what a person would expect. See ``NearMissTests``.

--- a/Tests/SwiftDocCTests/Diagnostics/DiagnosticTests.swift
+++ b/Tests/SwiftDocCTests/Diagnostics/DiagnosticTests.swift
@@ -89,14 +89,14 @@ class DiagnosticTests: XCTestCase {
         // Resolve references
         _ = resolver.visitMarkup(markup)
         
-        XCTAssertEqual(resolver.problems.first?.diagnostic.range, SourceLocation(line: 1, column: 8, source: nil)..<SourceLocation(line: 1, column: 21, source: nil))
+        XCTAssertEqual(resolver.problems.first?.diagnostic.range, SourceLocation(line: 1, column: 10, source: nil)..<SourceLocation(line: 1, column: 19, source: nil))
         
         let offset = SymbolGraph.LineList.SourceRange(start: .init(line: 10, character: 10), end: .init(line: 10, character: 20))
         
         var problem = try XCTUnwrap(resolver.problems.first)
         problem.offsetWithRange(offset)
         
-        XCTAssertEqual(problem.diagnostic.range, SourceLocation(line: 11, column: 18, source: nil)..<SourceLocation(line: 11, column: 31, source: nil))
+        XCTAssertEqual(problem.diagnostic.range, SourceLocation(line: 11, column: 20, source: nil)..<SourceLocation(line: 11, column: 29, source: nil))
     }
 
     func testFormattedDescription() {

--- a/Tests/SwiftDocCTests/Diagnostics/DiagnosticTests.swift
+++ b/Tests/SwiftDocCTests/Diagnostics/DiagnosticTests.swift
@@ -89,14 +89,21 @@ class DiagnosticTests: XCTestCase {
         // Resolve references
         _ = resolver.visitMarkup(markup)
         
-        XCTAssertEqual(resolver.problems.first?.diagnostic.range, SourceLocation(line: 1, column: 10, source: nil)..<SourceLocation(line: 1, column: 19, source: nil))
-        
+        if LinkResolutionMigrationConfiguration.shouldUseHierarchyBasedLinkResolver {
+            XCTAssertEqual(resolver.problems.first?.diagnostic.range, SourceLocation(line: 1, column: 10, source: nil)..<SourceLocation(line: 1, column: 19, source: nil))
+        } else {
+            XCTAssertEqual(resolver.problems.first?.diagnostic.range, SourceLocation(line: 1, column: 8, source: nil)..<SourceLocation(line: 1, column: 21, source: nil))
+        }
         let offset = SymbolGraph.LineList.SourceRange(start: .init(line: 10, character: 10), end: .init(line: 10, character: 20))
         
         var problem = try XCTUnwrap(resolver.problems.first)
         problem.offsetWithRange(offset)
         
-        XCTAssertEqual(problem.diagnostic.range, SourceLocation(line: 11, column: 20, source: nil)..<SourceLocation(line: 11, column: 29, source: nil))
+        if LinkResolutionMigrationConfiguration.shouldUseHierarchyBasedLinkResolver {
+            XCTAssertEqual(problem.diagnostic.range, SourceLocation(line: 11, column: 20, source: nil)..<SourceLocation(line: 11, column: 29, source: nil))
+        } else {
+            XCTAssertEqual(problem.diagnostic.range, SourceLocation(line: 11, column: 18, source: nil)..<SourceLocation(line: 11, column: 31, source: nil))
+        }
     }
 
     func testFormattedDescription() {

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -2159,7 +2159,7 @@ let expected = """
             // Verify the expected source ranges
             XCTAssertEqual(
                 context.problems.map { "\($0.diagnostic.range!.lowerBound.line):\($0.diagnostic.range!.lowerBound.column)" }.sorted(),
-                ["17:96", "18:23", "18:43", "18:60", "18:89"].sorted()
+                ["17:98", "18:100", "18:25", "18:45", "18:62"].sorted()
             )
         }
     }
@@ -2389,7 +2389,9 @@ let expected = """
         XCTAssertEqual(linkResolutionProblems.count, 1)
         let problem = try XCTUnwrap(linkResolutionProblems.first)
         XCTAssertEqual(problem.diagnostic.range?.lowerBound.line, 7)
-        XCTAssertEqual(problem.diagnostic.range?.lowerBound.column, 23)
+        XCTAssertEqual(problem.diagnostic.range?.lowerBound.column, 28)
+        XCTAssertEqual(problem.diagnostic.range?.upperBound.line, 7)
+        XCTAssertEqual(problem.diagnostic.range?.upperBound.column, 42)
 
         let functionNode = try XCTUnwrap(context.symbolIndex["s:7SideKit0A5ClassC10myFunctionyyF"])
         XCTAssertEqual(functionNode.docChunks.count, 2)

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -2157,10 +2157,17 @@ let expected = """
             XCTAssert(context.problems.allSatisfy { $0.diagnostic.source?.absoluteString == expectedDiagnosticSource })
             
             // Verify the expected source ranges
-            XCTAssertEqual(
-                context.problems.map { "\($0.diagnostic.range!.lowerBound.line):\($0.diagnostic.range!.lowerBound.column)" }.sorted(),
-                ["17:98", "18:100", "18:25", "18:45", "18:62"].sorted()
-            )
+            if LinkResolutionMigrationConfiguration.shouldUseHierarchyBasedLinkResolver {
+                XCTAssertEqual(
+                    context.problems.map { "\($0.diagnostic.range!.lowerBound.line):\($0.diagnostic.range!.lowerBound.column)" }.sorted(),
+                    ["17:98", "18:100", "18:25", "18:45", "18:62"].sorted()
+                )
+            } else {
+                XCTAssertEqual(
+                    context.problems.map { "\($0.diagnostic.range!.lowerBound.line):\($0.diagnostic.range!.lowerBound.column)" }.sorted(),
+                    ["17:96", "18:23", "18:43", "18:60", "18:89"].sorted()
+                )
+            }
         }
     }
     
@@ -2388,10 +2395,15 @@ let expected = """
         let linkResolutionProblems = problems.filter { $0.diagnostic.source?.relativePath.hasSuffix("myFunction.md") == true }
         XCTAssertEqual(linkResolutionProblems.count, 1)
         let problem = try XCTUnwrap(linkResolutionProblems.first)
-        XCTAssertEqual(problem.diagnostic.range?.lowerBound.line, 7)
-        XCTAssertEqual(problem.diagnostic.range?.lowerBound.column, 28)
-        XCTAssertEqual(problem.diagnostic.range?.upperBound.line, 7)
-        XCTAssertEqual(problem.diagnostic.range?.upperBound.column, 42)
+        if LinkResolutionMigrationConfiguration.shouldUseHierarchyBasedLinkResolver {
+            XCTAssertEqual(problem.diagnostic.range?.lowerBound.line, 7)
+            XCTAssertEqual(problem.diagnostic.range?.lowerBound.column, 28)
+            XCTAssertEqual(problem.diagnostic.range?.upperBound.line, 7)
+            XCTAssertEqual(problem.diagnostic.range?.upperBound.column, 42)
+        } else {
+            XCTAssertEqual(problem.diagnostic.range?.lowerBound.line, 7)
+            XCTAssertEqual(problem.diagnostic.range?.lowerBound.column, 23)
+        }
 
         let functionNode = try XCTUnwrap(context.symbolIndex["s:7SideKit0A5ClassC10myFunctionyyF"])
         XCTAssertEqual(functionNode.docChunks.count, 2)

--- a/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
@@ -296,19 +296,19 @@ class PathHierarchyTests: XCTestCase {
             (symbolID: "s:14MixedFramework28CollisionsWithDifferentKindsO9somethingSSvp", disambiguation: "property"),
         ])
         try assertPathRaisesErrorMessage("/MixedFramework/CollisionsWithDifferentKinds/something", in: tree, context: context, expectedErrorMessage: """
-        Reference is ambiguous after '/MixedFramework/CollisionsWithDifferentKinds'.
+        'something' is ambiguous at '/MixedFramework/CollisionsWithDifferentKinds'
         """) { error in
             XCTAssertEqual(error.solutions, [
-                .init(summary: "Insert 'enum.case' to refer to 'case something'", replacements: [("-enum.case", 54, 54)]),
-                .init(summary: "Insert 'property' to refer to 'var something: String { get }'", replacements: [("-property", 54, 54)]),
+                .init(summary: "Insert 'enum.case' for\n'case something'", replacements: [("-enum.case", 54, 54)]),
+                .init(summary: "Insert 'property' for\n'var something: String { get }'", replacements: [("-property", 54, 54)]),
             ])
         }
         try assertPathRaisesErrorMessage("/MixedFramework/CollisionsWithDifferentKinds/something-class", in: tree, context: context, expectedErrorMessage: """
-        Reference 'something' at '/MixedFramework/CollisionsWithDifferentKinds' can't be disambiguated with 'class'.
+        'class' isn't a disambiguation for 'something' at '/MixedFramework/CollisionsWithDifferentKinds'
         """) { error in
             XCTAssertEqual(error.solutions, [
-                .init(summary: "Replace 'class' with 'enum.case' to refer to 'case something'", replacements: [("-enum.case", 54, 60)]),
-                .init(summary: "Replace 'class' with 'property' to refer to 'var something: String { get }'", replacements: [("-property", 54, 60)]),
+                .init(summary: "Replace 'class' with 'enum.case' for\n'case something'", replacements: [("-enum.case", 54, 60)]),
+                .init(summary: "Replace 'class' with 'property' for\n'var something: String { get }'", replacements: [("-property", 54, 60)]),
             ])
         }
         
@@ -327,40 +327,40 @@ class PathHierarchyTests: XCTestCase {
             (symbolID: "s:14MixedFramework29CollisionsWithEscapedKeywordsC4inityyFZ", disambiguation: "type.method"),
         ])
         try assertPathRaisesErrorMessage("/MixedFramework/CollisionsWithEscapedKeywords/init()-abc123", in: tree, context: context, expectedErrorMessage: """
-        Reference 'init()' at '/MixedFramework/CollisionsWithEscapedKeywords' can't be disambiguated with 'abc123'.
+        'abc123' isn't a disambiguation for 'init()' at '/MixedFramework/CollisionsWithEscapedKeywords'
         """) { error in
             XCTAssertEqual(error.solutions, [
-                .init(summary: "Replace 'abc123' with 'method' to refer to 'func `init`()'", replacements: [("-method", 52, 59)]),
-                .init(summary: "Replace 'abc123' with 'init' to refer to 'init()'", replacements: [("-init", 52, 59)]),
-                .init(summary: "Replace 'abc123' with 'type.method' to refer to 'static func `init`()'", replacements: [("-type.method", 52, 59)]),
+                .init(summary: "Replace 'abc123' with 'method' for\n'func `init`()'", replacements: [("-method", 52, 59)]),
+                .init(summary: "Replace 'abc123' with 'init' for\n'init()'", replacements: [("-init", 52, 59)]),
+                .init(summary: "Replace 'abc123' with 'type.method' for\n'static func `init`()'", replacements: [("-type.method", 52, 59)]),
             ])
         }
         try assertPathRaisesErrorMessage("/MixedFramework/CollisionsWithEscapedKeywords/init()", in: tree, context: context, expectedErrorMessage: """
-        Reference is ambiguous after '/MixedFramework/CollisionsWithEscapedKeywords'.
+        'init()' is ambiguous at '/MixedFramework/CollisionsWithEscapedKeywords'
         """) { error in
             XCTAssertEqual(error.solutions, [
-                .init(summary: "Insert 'method' to refer to 'func `init`()'", replacements: [("-method", 52, 52)]),
-                .init(summary: "Insert 'init' to refer to 'init()'", replacements: [("-init", 52, 52)]),
-                .init(summary: "Insert 'type.method' to refer to 'static func `init`()'", replacements: [("-type.method", 52, 52)]),
+                .init(summary: "Insert 'method' for\n'func `init`()'", replacements: [("-method", 52, 52)]),
+                .init(summary: "Insert 'init' for\n'init()'", replacements: [("-init", 52, 52)]),
+                .init(summary: "Insert 'type.method' for\n'static func `init`()'", replacements: [("-type.method", 52, 52)]),
             ])
         }
         // Providing disambiguation will narrow down the suggestions. Note that `()` is missing in the last path component
         try assertPathRaisesErrorMessage("/MixedFramework/CollisionsWithEscapedKeywords/init-method", in: tree, context: context, expectedErrorMessage: """
-        Reference at '/MixedFramework/CollisionsWithEscapedKeywords' can't resolve 'init-method'. Did you mean 'init()'?
+        'init-method' doesn't exist at '/MixedFramework/CollisionsWithEscapedKeywords'
         """) { error in
             XCTAssertEqual(error.solutions, [
                 .init(summary: "Replace 'init' with 'init()'", replacements: [("init()", 46, 50)]), // The disambiguation is not replaced so the suggested link is unambiguous
             ])
         }
         try assertPathRaisesErrorMessage("/MixedFramework/CollisionsWithEscapedKeywords/init-init", in: tree, context: context, expectedErrorMessage: """
-        Reference at '/MixedFramework/CollisionsWithEscapedKeywords' can't resolve 'init-init'. Did you mean 'init()'?
+        'init-init' doesn't exist at '/MixedFramework/CollisionsWithEscapedKeywords'
         """) { error in
             XCTAssertEqual(error.solutions, [
                 .init(summary: "Replace 'init' with 'init()'", replacements: [("init()", 46, 50)]), // The disambiguation is not replaced so the suggested link is unambiguous
             ])
         }
         try assertPathRaisesErrorMessage("/MixedFramework/CollisionsWithEscapedKeywords/init-type.method", in: tree, context: context, expectedErrorMessage: """
-        Reference at '/MixedFramework/CollisionsWithEscapedKeywords' can't resolve 'init-type.method'. Did you mean 'init()'?
+        'init-type.method' doesn't exist at '/MixedFramework/CollisionsWithEscapedKeywords'
         """) { error in
             XCTAssertEqual(error.solutions, [
                 .init(summary: "Replace 'init' with 'init()'", replacements: [("init()", 46, 50)]), // The disambiguation is not replaced so the suggested link is unambiguous
@@ -373,12 +373,12 @@ class PathHierarchyTests: XCTestCase {
             (symbolID: "s:14MixedFramework29CollisionsWithEscapedKeywordsC9subscriptyyFZ", disambiguation: "type.method"),
         ])
         try assertPathRaisesErrorMessage("/MixedFramework/CollisionsWithEscapedKeywords/subscript()", in: tree, context: context, expectedErrorMessage: """
-        Reference is ambiguous after '/MixedFramework/CollisionsWithEscapedKeywords'.
+        'subscript()' is ambiguous at '/MixedFramework/CollisionsWithEscapedKeywords'
         """) { error in
             XCTAssertEqual(error.solutions, [
-                .init(summary: "Insert 'method' to refer to 'func `subscript`()'", replacements: [("-method", 57, 57)]),
-                .init(summary: "Insert 'type.method' to refer to 'static func `subscript`()'", replacements: [("-type.method", 57, 57)]),
-                .init(summary: "Insert 'subscript' to refer to 'subscript() -> Int { get }'", replacements: [("-subscript", 57, 57)]),
+                .init(summary: "Insert 'method' for\n'func `subscript`()'", replacements: [("-method", 57, 57)]),
+                .init(summary: "Insert 'type.method' for\n'static func `subscript`()'", replacements: [("-type.method", 57, 57)]),
+                .init(summary: "Insert 'subscript' for\n'subscript() -> Int { get }'", replacements: [("-subscript", 57, 57)]),
             ])
         }
         
@@ -391,31 +391,31 @@ class PathHierarchyTests: XCTestCase {
             (symbolID: "s:14MixedFramework40CollisionsWithDifferentFunctionArgumentsO9something8argumentSiSS_tF", disambiguation: "2vke2"),
         ])
         try assertPathRaisesErrorMessage("/MixedFramework/CollisionsWithDifferentFunctionArguments/something(argument:)", in: tree, context: context, expectedErrorMessage: """
-        Reference is ambiguous after '/MixedFramework/CollisionsWithDifferentFunctionArguments'.
+        'something(argument:)' is ambiguous at '/MixedFramework/CollisionsWithDifferentFunctionArguments'
         """) { error in
             XCTAssertEqual(error.solutions, [
-                .init(summary: "Insert '1cyvp' to refer to 'func something(argument: Int) -> Int'", replacements: [("-1cyvp", 77, 77)]),
-                .init(summary: "Insert '2vke2' to refer to 'func something(argument: String) -> Int'", replacements: [("-2vke2", 77, 77)]),
+                .init(summary: "Insert '1cyvp' for\n'func something(argument: Int) -> Int'", replacements: [("-1cyvp", 77, 77)]),
+                .init(summary: "Insert '2vke2' for\n'func something(argument: String) -> Int'", replacements: [("-2vke2", 77, 77)]),
             ])
         }
         try assertPathRaisesErrorMessage("/MixedFramework/CollisionsWithDifferentFunctionArguments/something(argument:)-abc123", in: tree, context: context, expectedErrorMessage: """
-        Reference 'something(argument:)' at '/MixedFramework/CollisionsWithDifferentFunctionArguments' can't be disambiguated with 'abc123'.
+        'abc123' isn't a disambiguation for 'something(argument:)' at '/MixedFramework/CollisionsWithDifferentFunctionArguments'
         """) { error in
             XCTAssertEqual(error.solutions, [
-                .init(summary: "Replace 'abc123' with '1cyvp' to refer to 'func something(argument: Int) -> Int'", replacements: [("-1cyvp", 77, 84)]),
-                .init(summary: "Replace 'abc123' with '2vke2' to refer to 'func something(argument: String) -> Int'", replacements: [("-2vke2", 77, 84)]),
+                .init(summary: "Replace 'abc123' with '1cyvp' for\n'func something(argument: Int) -> Int'", replacements: [("-1cyvp", 77, 84)]),
+                .init(summary: "Replace 'abc123' with '2vke2' for\n'func something(argument: String) -> Int'", replacements: [("-2vke2", 77, 84)]),
             ])
         }
         // Providing disambiguation will narrow down the suggestions. Note that `argument` label is missing in the last path component
         try assertPathRaisesErrorMessage("/MixedFramework/CollisionsWithDifferentFunctionArguments/something(_:)-1cyvp", in: tree, context: context, expectedErrorMessage: """
-        Reference at '/MixedFramework/CollisionsWithDifferentFunctionArguments' can't resolve 'something(_:)-1cyvp'. Did you mean 'something(argument:)'?
+        'something(_:)-1cyvp' doesn't exist at '/MixedFramework/CollisionsWithDifferentFunctionArguments'
         """) { error in
             XCTAssertEqual(error.solutions, [
                 .init(summary: "Replace 'something(_:)' with 'something(argument:)'", replacements: [("something(argument:)", 57, 70)]), // The disambiguation is not replaced so the suggested link is unambiguous
             ])
         }
         try assertPathRaisesErrorMessage("/MixedFramework/CollisionsWithDifferentFunctionArguments/something(_:)-2vke2", in: tree, context: context, expectedErrorMessage: """
-        Reference at '/MixedFramework/CollisionsWithDifferentFunctionArguments' can't resolve 'something(_:)-2vke2'. Did you mean 'something(argument:)'?
+        'something(_:)-2vke2' doesn't exist at '/MixedFramework/CollisionsWithDifferentFunctionArguments'
         """) { error in
             XCTAssertEqual(error.solutions, [
                 .init(summary: "Replace 'something(_:)' with 'something(argument:)'", replacements: [("something(argument:)", 57, 70)]), // The disambiguation is not replaced so the suggested link is unambiguous
@@ -423,11 +423,11 @@ class PathHierarchyTests: XCTestCase {
         }
         
         try assertPathRaisesErrorMessage("/MixedFramework/CollisionsWithDifferentFunctionArguments/something(argument:)-method", in: tree, context: context, expectedErrorMessage: """
-        Reference is ambiguous after '/MixedFramework/CollisionsWithDifferentFunctionArguments'.
+        'something(argument:)-method' is ambiguous at '/MixedFramework/CollisionsWithDifferentFunctionArguments'
         """) { error in
             XCTAssertEqual(error.solutions, [
-                .init(summary: "Replace 'method' with '1cyvp' to refer to 'func something(argument: Int) -> Int'", replacements: [("-1cyvp", 77, 84)]),
-                .init(summary: "Replace 'method' with '2vke2' to refer to 'func something(argument: String) -> Int'", replacements: [("-2vke2", 77, 84)]),
+                .init(summary: "Replace 'method' with '1cyvp' for\n'func something(argument: Int) -> Int'", replacements: [("-1cyvp", 77, 84)]),
+                .init(summary: "Replace 'method' with '2vke2' for\n'func something(argument: String) -> Int'", replacements: [("-2vke2", 77, 84)]),
             ])
         }
         
@@ -440,20 +440,20 @@ class PathHierarchyTests: XCTestCase {
             (symbolID: "s:14MixedFramework41CollisionsWithDifferentSubscriptArgumentsOySiSScip", disambiguation: "757cj"),
         ])
         try assertPathRaisesErrorMessage("/MixedFramework/CollisionsWithDifferentSubscriptArguments/subscript(_:)", in: tree, context: context, expectedErrorMessage: """
-        Reference is ambiguous after '/MixedFramework/CollisionsWithDifferentSubscriptArguments'.
+        'subscript(_:)' is ambiguous at '/MixedFramework/CollisionsWithDifferentSubscriptArguments'
         """) { error in
             XCTAssertEqual(error.solutions, [
-                .init(summary: "Insert '4fd0l' to refer to 'subscript(something: Int) -> Int { get }'", replacements: [("-4fd0l", 71, 71)]),
-                .init(summary: "Insert '757cj' to refer to 'subscript(somethingElse: String) -> Int { get }'", replacements: [("-757cj", 71, 71)]),
+                .init(summary: "Insert '4fd0l' for\n'subscript(something: Int) -> Int { get }'", replacements: [("-4fd0l", 71, 71)]),
+                .init(summary: "Insert '757cj' for\n'subscript(somethingElse: String) -> Int { get }'", replacements: [("-757cj", 71, 71)]),
             ])
         }
         
         try assertPathRaisesErrorMessage("/MixedFramework/CollisionsWithDifferentSubscriptArguments/subscript(_:)-subscript", in: tree, context: context, expectedErrorMessage: """
-        Reference is ambiguous after '/MixedFramework/CollisionsWithDifferentSubscriptArguments'.
+        'subscript(_:)-subscript' is ambiguous at '/MixedFramework/CollisionsWithDifferentSubscriptArguments'
         """) { error in
             XCTAssertEqual(error.solutions, [
-                .init(summary: "Replace 'subscript' with '4fd0l' to refer to 'subscript(something: Int) -> Int { get }'", replacements: [("-4fd0l", 71, 81)]),
-                .init(summary: "Replace 'subscript' with '757cj' to refer to 'subscript(somethingElse: String) -> Int { get }'", replacements: [("-757cj", 71, 81)]),
+                .init(summary: "Replace 'subscript' with '4fd0l' for\n'subscript(something: Int) -> Int { get }'", replacements: [("-4fd0l", 71, 81)]),
+                .init(summary: "Replace 'subscript' with '757cj' for\n'subscript(somethingElse: String) -> Int { get }'", replacements: [("-757cj", 71, 81)]),
             ])
         }
         
@@ -962,11 +962,11 @@ class PathHierarchyTests: XCTestCase {
             ("s:5MyKit0A5MyProtocol0Afunc()", "6ijsi"),
         ])
         try assertPathRaisesErrorMessage("/SideKit/SideProtocol/func()", in: tree, context: context, expectedErrorMessage: """
-        Reference is ambiguous after '/SideKit/SideProtocol'.
+        'func()' is ambiguous at '/SideKit/SideProtocol'
         """) { error in
             XCTAssertEqual(error.solutions, [
-                .init(summary: "Insert '2dxqn' to refer to 'func1()'", replacements: [("-2dxqn", 28, 28)]),
-                .init(summary: "Insert '6ijsi' to refer to 'func1()'", replacements: [("-6ijsi", 28, 28)]),
+                .init(summary: "Insert '2dxqn' for\n'func1()'", replacements: [("-2dxqn", 28, 28)]),
+                .init(summary: "Insert '6ijsi' for\n'func1()'", replacements: [("-6ijsi", 28, 28)]),
             ])
         } // This test data have the same declaration for both symbols.
         
@@ -1010,12 +1010,12 @@ class PathHierarchyTests: XCTestCase {
             ("c:MixedLanguageFramework.h@T@Foo", "typealias"),
         ])
         try assertPathRaisesErrorMessage("MixedLanguageFramework/Foo", in: tree, context: context, expectedErrorMessage: """
-        Reference is ambiguous after '/MixedLanguageFramework'.
+        'Foo' is ambiguous at '/MixedLanguageFramework'
         """) { error in
             XCTAssertEqual(error.solutions, [
-                .init(summary: "Insert 'struct' to refer to 'struct Foo'", replacements: [("-struct", 26, 26)]),
-                .init(summary: "Insert 'enum' to refer to 'typedef enum Foo : NSString { ... } Foo;'", replacements: [("-enum", 26, 26)]),
-                .init(summary: "Insert 'typealias' to refer to 'typedef enum Foo : NSString { ... } Foo;'", replacements: [("-typealias", 26, 26)]),
+                .init(summary: "Insert 'struct' for\n'struct Foo'", replacements: [("-struct", 26, 26)]),
+                .init(summary: "Insert 'enum' for\n'typedef enum Foo : NSString { ... } Foo;'", replacements: [("-enum", 26, 26)]),
+                .init(summary: "Insert 'typealias' for\n'typedef enum Foo : NSString { ... } Foo;'", replacements: [("-typealias", 26, 26)]),
             ])
         } // The 'enum' and 'typealias' symbols have multi-line declarations that are presented on a single line
         

--- a/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
@@ -303,6 +303,14 @@ class PathHierarchyTests: XCTestCase {
                 .init(summary: "Insert 'property' to refer to 'var something: String { get }'", replacements: [("-property", 54, 54)]),
             ])
         }
+        try assertPathRaisesErrorMessage("/MixedFramework/CollisionsWithDifferentKinds/something-class", in: tree, context: context, expectedErrorMessage: """
+        Reference 'something' at '/MixedFramework/CollisionsWithDifferentKinds' can't be disambiguated with 'class'.
+        """) { error in
+            XCTAssertEqual(error.solutions, [
+                .init(summary: "Replace 'class' with 'enum.case' to refer to 'case something'", replacements: [("-enum.case", 54, 60)]),
+                .init(summary: "Replace 'class' with 'property' to refer to 'var something: String { get }'", replacements: [("-property", 54, 60)]),
+            ])
+        }
         
         // public final class CollisionsWithEscapedKeywords {
         //     public subscript() -> Int { 0 }
@@ -318,7 +326,18 @@ class PathHierarchyTests: XCTestCase {
             (symbolID: "s:14MixedFramework29CollisionsWithEscapedKeywordsC4inityyF", disambiguation: "method"),
             (symbolID: "s:14MixedFramework29CollisionsWithEscapedKeywordsC4inityyFZ", disambiguation: "type.method"),
         ])
-        try assertPathRaisesErrorMessage("/MixedFramework/CollisionsWithEscapedKeywords/init()", in: tree, context: context, expectedErrorMessage: "Reference is ambiguous after '/MixedFramework/CollisionsWithEscapedKeywords'.") { error in
+        try assertPathRaisesErrorMessage("/MixedFramework/CollisionsWithEscapedKeywords/init()-abc123", in: tree, context: context, expectedErrorMessage: """
+        Reference 'init()' at '/MixedFramework/CollisionsWithEscapedKeywords' can't be disambiguated with 'abc123'.
+        """) { error in
+            XCTAssertEqual(error.solutions, [
+                .init(summary: "Replace 'abc123' with 'method' to refer to 'func `init`()'", replacements: [("-method", 52, 59)]),
+                .init(summary: "Replace 'abc123' with 'init' to refer to 'init()'", replacements: [("-init", 52, 59)]),
+                .init(summary: "Replace 'abc123' with 'type.method' to refer to 'static func `init`()'", replacements: [("-type.method", 52, 59)]),
+            ])
+        }
+        try assertPathRaisesErrorMessage("/MixedFramework/CollisionsWithEscapedKeywords/init()", in: tree, context: context, expectedErrorMessage: """
+        Reference is ambiguous after '/MixedFramework/CollisionsWithEscapedKeywords'.
+        """) { error in
             XCTAssertEqual(error.solutions, [
                 .init(summary: "Insert 'method' to refer to 'func `init`()'", replacements: [("-method", 52, 52)]),
                 .init(summary: "Insert 'init' to refer to 'init()'", replacements: [("-init", 52, 52)]),
@@ -326,17 +345,23 @@ class PathHierarchyTests: XCTestCase {
             ])
         }
         // Providing disambiguation will narrow down the suggestions. Note that `()` is missing in the last path component
-        try assertPathRaisesErrorMessage("/MixedFramework/CollisionsWithEscapedKeywords/init-method", in: tree, context: context, expectedErrorMessage: "Reference at '/MixedFramework/CollisionsWithEscapedKeywords' can't resolve 'init-method'. Did you mean 'init()'?") { error in
+        try assertPathRaisesErrorMessage("/MixedFramework/CollisionsWithEscapedKeywords/init-method", in: tree, context: context, expectedErrorMessage: """
+        Reference at '/MixedFramework/CollisionsWithEscapedKeywords' can't resolve 'init-method'. Did you mean 'init()'?
+        """) { error in
             XCTAssertEqual(error.solutions, [
                 .init(summary: "Replace 'init' with 'init()'", replacements: [("init()", 46, 50)]), // The disambiguation is not replaced so the suggested link is unambiguous
             ])
         }
-        try assertPathRaisesErrorMessage("/MixedFramework/CollisionsWithEscapedKeywords/init-init", in: tree, context: context, expectedErrorMessage: "Reference at '/MixedFramework/CollisionsWithEscapedKeywords' can't resolve 'init-init'. Did you mean 'init()'?") { error in
+        try assertPathRaisesErrorMessage("/MixedFramework/CollisionsWithEscapedKeywords/init-init", in: tree, context: context, expectedErrorMessage: """
+        Reference at '/MixedFramework/CollisionsWithEscapedKeywords' can't resolve 'init-init'. Did you mean 'init()'?
+        """) { error in
             XCTAssertEqual(error.solutions, [
                 .init(summary: "Replace 'init' with 'init()'", replacements: [("init()", 46, 50)]), // The disambiguation is not replaced so the suggested link is unambiguous
             ])
         }
-        try assertPathRaisesErrorMessage("/MixedFramework/CollisionsWithEscapedKeywords/init-type.method", in: tree, context: context, expectedErrorMessage: "Reference at '/MixedFramework/CollisionsWithEscapedKeywords' can't resolve 'init-type.method'. Did you mean 'init()'?") { error in
+        try assertPathRaisesErrorMessage("/MixedFramework/CollisionsWithEscapedKeywords/init-type.method", in: tree, context: context, expectedErrorMessage: """
+        Reference at '/MixedFramework/CollisionsWithEscapedKeywords' can't resolve 'init-type.method'. Did you mean 'init()'?
+        """) { error in
             XCTAssertEqual(error.solutions, [
                 .init(summary: "Replace 'init' with 'init()'", replacements: [("init()", 46, 50)]), // The disambiguation is not replaced so the suggested link is unambiguous
             ])
@@ -347,7 +372,9 @@ class PathHierarchyTests: XCTestCase {
             (symbolID: "s:14MixedFramework29CollisionsWithEscapedKeywordsCSiycip", disambiguation: "subscript"),
             (symbolID: "s:14MixedFramework29CollisionsWithEscapedKeywordsC9subscriptyyFZ", disambiguation: "type.method"),
         ])
-        try assertPathRaisesErrorMessage("/MixedFramework/CollisionsWithEscapedKeywords/subscript()", in: tree, context: context, expectedErrorMessage: "Reference is ambiguous after '/MixedFramework/CollisionsWithEscapedKeywords'.") { error in
+        try assertPathRaisesErrorMessage("/MixedFramework/CollisionsWithEscapedKeywords/subscript()", in: tree, context: context, expectedErrorMessage: """
+        Reference is ambiguous after '/MixedFramework/CollisionsWithEscapedKeywords'.
+        """) { error in
             XCTAssertEqual(error.solutions, [
                 .init(summary: "Insert 'method' to refer to 'func `subscript`()'", replacements: [("-method", 57, 57)]),
                 .init(summary: "Insert 'type.method' to refer to 'static func `subscript`()'", replacements: [("-type.method", 57, 57)]),
@@ -363,29 +390,41 @@ class PathHierarchyTests: XCTestCase {
             (symbolID: "s:14MixedFramework40CollisionsWithDifferentFunctionArgumentsO9something8argumentS2i_tF", disambiguation: "1cyvp"),
             (symbolID: "s:14MixedFramework40CollisionsWithDifferentFunctionArgumentsO9something8argumentSiSS_tF", disambiguation: "2vke2"),
         ])
-        try assertPathRaisesErrorMessage("/MixedFramework/CollisionsWithDifferentFunctionArguments/something(argument:)", in: tree, context: context,
-                                         expectedErrorMessage: "Reference is ambiguous after '/MixedFramework/CollisionsWithDifferentFunctionArguments'.") { error in
+        try assertPathRaisesErrorMessage("/MixedFramework/CollisionsWithDifferentFunctionArguments/something(argument:)", in: tree, context: context, expectedErrorMessage: """
+        Reference is ambiguous after '/MixedFramework/CollisionsWithDifferentFunctionArguments'.
+        """) { error in
             XCTAssertEqual(error.solutions, [
                 .init(summary: "Insert '1cyvp' to refer to 'func something(argument: Int) -> Int'", replacements: [("-1cyvp", 77, 77)]),
                 .init(summary: "Insert '2vke2' to refer to 'func something(argument: String) -> Int'", replacements: [("-2vke2", 77, 77)]),
             ])
         }
+        try assertPathRaisesErrorMessage("/MixedFramework/CollisionsWithDifferentFunctionArguments/something(argument:)-abc123", in: tree, context: context, expectedErrorMessage: """
+        Reference 'something(argument:)' at '/MixedFramework/CollisionsWithDifferentFunctionArguments' can't be disambiguated with 'abc123'.
+        """) { error in
+            XCTAssertEqual(error.solutions, [
+                .init(summary: "Replace 'abc123' with '1cyvp' to refer to 'func something(argument: Int) -> Int'", replacements: [("-1cyvp", 77, 84)]),
+                .init(summary: "Replace 'abc123' with '2vke2' to refer to 'func something(argument: String) -> Int'", replacements: [("-2vke2", 77, 84)]),
+            ])
+        }
         // Providing disambiguation will narrow down the suggestions. Note that `argument` label is missing in the last path component
-        try assertPathRaisesErrorMessage("/MixedFramework/CollisionsWithDifferentFunctionArguments/something(_:)-1cyvp", in: tree, context: context,
-                                         expectedErrorMessage: "Reference at '/MixedFramework/CollisionsWithDifferentFunctionArguments' can't resolve 'something(_:)-1cyvp'. Did you mean 'something(argument:)'?") { error in
+        try assertPathRaisesErrorMessage("/MixedFramework/CollisionsWithDifferentFunctionArguments/something(_:)-1cyvp", in: tree, context: context, expectedErrorMessage: """
+        Reference at '/MixedFramework/CollisionsWithDifferentFunctionArguments' can't resolve 'something(_:)-1cyvp'. Did you mean 'something(argument:)'?
+        """) { error in
             XCTAssertEqual(error.solutions, [
                 .init(summary: "Replace 'something(_:)' with 'something(argument:)'", replacements: [("something(argument:)", 57, 70)]), // The disambiguation is not replaced so the suggested link is unambiguous
             ])
         }
-        try assertPathRaisesErrorMessage("/MixedFramework/CollisionsWithDifferentFunctionArguments/something(_:)-2vke2", in: tree, context: context,
-                                         expectedErrorMessage: "Reference at '/MixedFramework/CollisionsWithDifferentFunctionArguments' can't resolve 'something(_:)-2vke2'. Did you mean 'something(argument:)'?") { error in
+        try assertPathRaisesErrorMessage("/MixedFramework/CollisionsWithDifferentFunctionArguments/something(_:)-2vke2", in: tree, context: context, expectedErrorMessage: """
+        Reference at '/MixedFramework/CollisionsWithDifferentFunctionArguments' can't resolve 'something(_:)-2vke2'. Did you mean 'something(argument:)'?
+        """) { error in
             XCTAssertEqual(error.solutions, [
                 .init(summary: "Replace 'something(_:)' with 'something(argument:)'", replacements: [("something(argument:)", 57, 70)]), // The disambiguation is not replaced so the suggested link is unambiguous
             ])
         }
         
-        try assertPathRaisesErrorMessage("/MixedFramework/CollisionsWithDifferentFunctionArguments/something(argument:)-method", in: tree, context: context,
-                                         expectedErrorMessage: "Reference is ambiguous after '/MixedFramework/CollisionsWithDifferentFunctionArguments'.") { error in
+        try assertPathRaisesErrorMessage("/MixedFramework/CollisionsWithDifferentFunctionArguments/something(argument:)-method", in: tree, context: context, expectedErrorMessage: """
+        Reference is ambiguous after '/MixedFramework/CollisionsWithDifferentFunctionArguments'.
+        """) { error in
             XCTAssertEqual(error.solutions, [
                 .init(summary: "Replace 'method' with '1cyvp' to refer to 'func something(argument: Int) -> Int'", replacements: [("-1cyvp", 77, 84)]),
                 .init(summary: "Replace 'method' with '2vke2' to refer to 'func something(argument: String) -> Int'", replacements: [("-2vke2", 77, 84)]),
@@ -400,14 +439,18 @@ class PathHierarchyTests: XCTestCase {
             (symbolID: "s:14MixedFramework41CollisionsWithDifferentSubscriptArgumentsOyS2icip", disambiguation: "4fd0l"),
             (symbolID: "s:14MixedFramework41CollisionsWithDifferentSubscriptArgumentsOySiSScip", disambiguation: "757cj"),
         ])
-        try assertPathRaisesErrorMessage("/MixedFramework/CollisionsWithDifferentSubscriptArguments/subscript(_:)", in: tree, context: context, expectedErrorMessage: "Reference is ambiguous after '/MixedFramework/CollisionsWithDifferentSubscriptArguments'.") { error in
+        try assertPathRaisesErrorMessage("/MixedFramework/CollisionsWithDifferentSubscriptArguments/subscript(_:)", in: tree, context: context, expectedErrorMessage: """
+        Reference is ambiguous after '/MixedFramework/CollisionsWithDifferentSubscriptArguments'.
+        """) { error in
             XCTAssertEqual(error.solutions, [
                 .init(summary: "Insert '4fd0l' to refer to 'subscript(something: Int) -> Int { get }'", replacements: [("-4fd0l", 71, 71)]),
                 .init(summary: "Insert '757cj' to refer to 'subscript(somethingElse: String) -> Int { get }'", replacements: [("-757cj", 71, 71)]),
             ])
         }
         
-        try assertPathRaisesErrorMessage("/MixedFramework/CollisionsWithDifferentSubscriptArguments/subscript(_:)-subscript", in: tree, context: context, expectedErrorMessage: "Reference is ambiguous after '/MixedFramework/CollisionsWithDifferentSubscriptArguments'.") { error in
+        try assertPathRaisesErrorMessage("/MixedFramework/CollisionsWithDifferentSubscriptArguments/subscript(_:)-subscript", in: tree, context: context, expectedErrorMessage: """
+        Reference is ambiguous after '/MixedFramework/CollisionsWithDifferentSubscriptArguments'.
+        """) { error in
             XCTAssertEqual(error.solutions, [
                 .init(summary: "Replace 'subscript' with '4fd0l' to refer to 'subscript(something: Int) -> Int { get }'", replacements: [("-4fd0l", 71, 81)]),
                 .init(summary: "Replace 'subscript' with '757cj' to refer to 'subscript(somethingElse: String) -> Int { get }'", replacements: [("-757cj", 71, 81)]),
@@ -918,7 +961,9 @@ class PathHierarchyTests: XCTestCase {
             ("s:5MyKit0A5MyProtocol0Afunc()DefaultImp", "2dxqn"),
             ("s:5MyKit0A5MyProtocol0Afunc()", "6ijsi"),
         ])
-        try assertPathRaisesErrorMessage("/SideKit/SideProtocol/func()", in: tree, context: context, expectedErrorMessage: "Reference is ambiguous after '/SideKit/SideProtocol'.") { error in
+        try assertPathRaisesErrorMessage("/SideKit/SideProtocol/func()", in: tree, context: context, expectedErrorMessage: """
+        Reference is ambiguous after '/SideKit/SideProtocol'.
+        """) { error in
             XCTAssertEqual(error.solutions, [
                 .init(summary: "Insert '2dxqn' to refer to 'func1()'", replacements: [("-2dxqn", 28, 28)]),
                 .init(summary: "Insert '6ijsi' to refer to 'func1()'", replacements: [("-6ijsi", 28, 28)]),
@@ -964,7 +1009,9 @@ class PathHierarchyTests: XCTestCase {
             ("c:@E@Foo", "struct"),
             ("c:MixedLanguageFramework.h@T@Foo", "typealias"),
         ])
-        try assertPathRaisesErrorMessage("MixedLanguageFramework/Foo", in: tree, context: context, expectedErrorMessage: "Reference is ambiguous after '/MixedLanguageFramework'.") { error in
+        try assertPathRaisesErrorMessage("MixedLanguageFramework/Foo", in: tree, context: context, expectedErrorMessage: """
+        Reference is ambiguous after '/MixedLanguageFramework'.
+        """) { error in
             XCTAssertEqual(error.solutions, [
                 .init(summary: "Insert 'struct' to refer to 'struct Foo'", replacements: [("-struct", 26, 26)]),
                 .init(summary: "Insert 'enum' to refer to 'typedef enum Foo : NSString { ... } Foo;'", replacements: [("-enum", 26, 26)]),
@@ -1335,8 +1382,10 @@ class PathHierarchyTests: XCTestCase {
             XCTAssertEqual(symbol.identifier.precise, symbolID, file: file, line: line)
         } catch PathHierarchy.Error.notFound {
             XCTFail("Symbol for \(path.singleQuoted) not found in tree", file: file, line: line)
-        } catch PathHierarchy.Error.partialResult {
+        } catch PathHierarchy.Error.unknownName {
             XCTFail("Symbol for \(path.singleQuoted) not found in tree. Only part of path is found.", file: file, line: line)
+        } catch PathHierarchy.Error.unknownDisambiguation {
+            XCTFail("Symbol for \(path.singleQuoted) not found in tree. Unknown disambiguation.", file: file, line: line)
         } catch PathHierarchy.Error.lookupCollision(_, _, let collisions) {
             let symbols = collisions.map { $0.node.symbol! }
             XCTFail("Unexpected collision for \(path.singleQuoted); \(symbols.map { return "\($0.names.title) - \($0.kind.identifier.identifier) - \($0.identifier.precise.stableHashString)"})", file: file, line: line)
@@ -1349,7 +1398,9 @@ class PathHierarchyTests: XCTestCase {
             XCTFail("Unexpectedly found symbol with ID \(symbol.identifier.precise) for path \(path.singleQuoted)", file: file, line: line)
         } catch PathHierarchy.Error.notFound, PathHierarchy.Error.unfindableMatch, PathHierarchy.Error.nonSymbolMatchForSymbolLink {
             // This specific error is expected.
-        } catch PathHierarchy.Error.partialResult {
+        } catch PathHierarchy.Error.unknownName {
+            // For the purpose of this assertion, this also counts as "not found".
+        } catch PathHierarchy.Error.unknownDisambiguation {
             // For the purpose of this assertion, this also counts as "not found".
         } catch PathHierarchy.Error.lookupCollision(_, _, let collisions) {
             let symbols = collisions.map { $0.node.symbol! }
@@ -1363,8 +1414,10 @@ class PathHierarchyTests: XCTestCase {
             XCTFail("Unexpectedly found unambiguous symbol with ID \(symbol.identifier.precise) for path \(path.singleQuoted)", file: file, line: line)
         } catch PathHierarchy.Error.notFound {
             XCTFail("Symbol for \(path.singleQuoted) not found in tree", file: file, line: line)
-        } catch PathHierarchy.Error.partialResult {
+        } catch PathHierarchy.Error.unknownName {
             XCTFail("Symbol for \(path.singleQuoted) not found in tree. Only part of path is found.", file: file, line: line)
+        } catch PathHierarchy.Error.unknownDisambiguation {
+            XCTFail("Symbol for \(path.singleQuoted) not found in tree. Unknown disambiguation.", file: file, line: line)
         } catch PathHierarchy.Error.lookupCollision(_, _, let collisions) {
             let sortedCollisions = collisions.sorted(by: \.disambiguation)
             XCTAssertEqual(sortedCollisions.count, expectedCollisions.count, file: file, line: line)

--- a/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
@@ -325,6 +325,22 @@ class PathHierarchyTests: XCTestCase {
                 .init(summary: "Insert 'type.method' to refer to 'static func `init`()'", replacements: [("-type.method", 52, 52)]),
             ])
         }
+        // Providing disambiguation will narrow down the suggestions. Note that `()` is missing in the last path component
+        try assertPathRaisesErrorMessage("/MixedFramework/CollisionsWithEscapedKeywords/init-method", in: tree, context: context, expectedErrorMessage: "Reference at '/MixedFramework/CollisionsWithEscapedKeywords' can't resolve 'init-method'. Did you mean 'init()'?") { error in
+            XCTAssertEqual(error.solutions, [
+                .init(summary: "Replace 'init' with 'init()'", replacements: [("init()", 46, 50)]), // The disambiguation is not replaced so the suggested link is unambiguous
+            ])
+        }
+        try assertPathRaisesErrorMessage("/MixedFramework/CollisionsWithEscapedKeywords/init-init", in: tree, context: context, expectedErrorMessage: "Reference at '/MixedFramework/CollisionsWithEscapedKeywords' can't resolve 'init-init'. Did you mean 'init()'?") { error in
+            XCTAssertEqual(error.solutions, [
+                .init(summary: "Replace 'init' with 'init()'", replacements: [("init()", 46, 50)]), // The disambiguation is not replaced so the suggested link is unambiguous
+            ])
+        }
+        try assertPathRaisesErrorMessage("/MixedFramework/CollisionsWithEscapedKeywords/init-type.method", in: tree, context: context, expectedErrorMessage: "Reference at '/MixedFramework/CollisionsWithEscapedKeywords' can't resolve 'init-type.method'. Did you mean 'init()'?") { error in
+            XCTAssertEqual(error.solutions, [
+                .init(summary: "Replace 'init' with 'init()'", replacements: [("init()", 46, 50)]), // The disambiguation is not replaced so the suggested link is unambiguous
+            ])
+        }
         
         try assertPathCollision("/MixedFramework/CollisionsWithEscapedKeywords/subscript()", in: tree, collisions: [
             (symbolID: "s:14MixedFramework29CollisionsWithEscapedKeywordsC9subscriptyyF", disambiguation: "method"),
@@ -347,19 +363,28 @@ class PathHierarchyTests: XCTestCase {
             (symbolID: "s:14MixedFramework40CollisionsWithDifferentFunctionArgumentsO9something8argumentS2i_tF", disambiguation: "1cyvp"),
             (symbolID: "s:14MixedFramework40CollisionsWithDifferentFunctionArgumentsO9something8argumentSiSS_tF", disambiguation: "2vke2"),
         ])
-        try assertPathRaisesErrorMessage("/MixedFramework/CollisionsWithDifferentFunctionArguments/something(argument:)",
-                                         in: tree,
-                                         context: context,
+        try assertPathRaisesErrorMessage("/MixedFramework/CollisionsWithDifferentFunctionArguments/something(argument:)", in: tree, context: context,
                                          expectedErrorMessage: "Reference is ambiguous after '/MixedFramework/CollisionsWithDifferentFunctionArguments'.") { error in
             XCTAssertEqual(error.solutions, [
                 .init(summary: "Insert '1cyvp' to refer to 'func something(argument: Int) -> Int'", replacements: [("-1cyvp", 77, 77)]),
                 .init(summary: "Insert '2vke2' to refer to 'func something(argument: String) -> Int'", replacements: [("-2vke2", 77, 77)]),
             ])
         }
+        // Providing disambiguation will narrow down the suggestions. Note that `argument` label is missing in the last path component
+        try assertPathRaisesErrorMessage("/MixedFramework/CollisionsWithDifferentFunctionArguments/something(_:)-1cyvp", in: tree, context: context,
+                                         expectedErrorMessage: "Reference at '/MixedFramework/CollisionsWithDifferentFunctionArguments' can't resolve 'something(_:)-1cyvp'. Did you mean 'something(argument:)'?") { error in
+            XCTAssertEqual(error.solutions, [
+                .init(summary: "Replace 'something(_:)' with 'something(argument:)'", replacements: [("something(argument:)", 57, 70)]), // The disambiguation is not replaced so the suggested link is unambiguous
+            ])
+        }
+        try assertPathRaisesErrorMessage("/MixedFramework/CollisionsWithDifferentFunctionArguments/something(_:)-2vke2", in: tree, context: context,
+                                         expectedErrorMessage: "Reference at '/MixedFramework/CollisionsWithDifferentFunctionArguments' can't resolve 'something(_:)-2vke2'. Did you mean 'something(argument:)'?") { error in
+            XCTAssertEqual(error.solutions, [
+                .init(summary: "Replace 'something(_:)' with 'something(argument:)'", replacements: [("something(argument:)", 57, 70)]), // The disambiguation is not replaced so the suggested link is unambiguous
+            ])
+        }
         
-        try assertPathRaisesErrorMessage("/MixedFramework/CollisionsWithDifferentFunctionArguments/something(argument:)-method",
-                                         in: tree,
-                                         context: context,
+        try assertPathRaisesErrorMessage("/MixedFramework/CollisionsWithDifferentFunctionArguments/something(argument:)-method", in: tree, context: context,
                                          expectedErrorMessage: "Reference is ambiguous after '/MixedFramework/CollisionsWithDifferentFunctionArguments'.") { error in
             XCTAssertEqual(error.solutions, [
                 .init(summary: "Replace 'method' with '1cyvp' to refer to 'func something(argument: Int) -> Int'", replacements: [("-1cyvp", 77, 84)]),

--- a/Tests/SwiftDocCTests/Semantics/SymbolTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/SymbolTests.swift
@@ -585,7 +585,12 @@ class SymbolTests: XCTestCase {
         
         let unresolvedTopicProblems = context.problems.filter { $0.diagnostic.identifier == "org.swift.docc.unresolvedTopicReference" }
         
-        XCTAssertTrue(unresolvedTopicProblems.contains(where: { $0.diagnostic.summary == "No external resolver registered for 'com.test.external'." }))
+        if LinkResolutionMigrationConfiguration.shouldUseHierarchyBasedLinkResolver {
+            XCTAssertTrue(unresolvedTopicProblems.contains(where: { $0.diagnostic.summary == "No external resolver registered for 'com.test.external'." }))
+        } else {
+            XCTAssertTrue(unresolvedTopicProblems.contains(where: { $0.diagnostic.summary == "Topic reference 'doc://com.test.external/ExternalPage' couldn't be resolved. No external resolver registered for 'com.test.external'." }))
+        }
+        
         if LinkResolutionMigrationConfiguration.shouldUseHierarchyBasedLinkResolver {
             var problem: Problem
             

--- a/Tests/SwiftDocCTests/Semantics/SymbolTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/SymbolTests.swift
@@ -591,17 +591,17 @@ class SymbolTests: XCTestCase {
             
             problem = try XCTUnwrap(unresolvedTopicProblems.first(where: { $0.diagnostic.summary == "Topic reference 'UnresolvableSymbolLinkInMyClassOverview<>(_:))' couldn't be resolved. Reference at '/MyKit/MyClass' can't resolve 'UnresolvableSymbolLinkInMyClassOverview<>(_:))'. No similar pages." }))
             XCTAssertEqual(problem.diagnostic.notes.map(\.message), ["Available children: init(), myFunction()."])
-            XCTAssertEqual(problem.possibleSolutions.count, 2)
+            XCTAssertEqual(problem.possibleSolutions.count, 0)
             
             
             problem = try XCTUnwrap(unresolvedTopicProblems.first(where: { $0.diagnostic.summary == "Topic reference 'UnresolvableClassInMyClassTopicCuration' couldn't be resolved. Reference at '/MyKit/MyClass' can't resolve 'UnresolvableClassInMyClassTopicCuration'. No similar pages." }))
             XCTAssertEqual(problem.diagnostic.notes.map(\.message), ["Available children: init(), myFunction()."])
-            XCTAssertEqual(problem.possibleSolutions.count, 2)
+            XCTAssertEqual(problem.possibleSolutions.count, 0)
 
             
             problem = try XCTUnwrap(unresolvedTopicProblems.first(where: { $0.diagnostic.summary == "Topic reference 'MyClass/unresolvablePropertyInMyClassTopicCuration' couldn't be resolved. Reference at '/MyKit/MyClass' can't resolve 'unresolvablePropertyInMyClassTopicCuration'. No similar pages." }))
             XCTAssertEqual(problem.diagnostic.notes.map(\.message), ["Available children: init(), myFunction()."])
-            XCTAssertEqual(problem.possibleSolutions.count, 2)
+            XCTAssertEqual(problem.possibleSolutions.count, 0)
 
             
             problem = try XCTUnwrap(unresolvedTopicProblems.first(where: { $0.diagnostic.summary == "Topic reference 'init()' couldn't be resolved. Reference is ambiguous after '/MyKit/MyClass'." }))
@@ -742,12 +742,12 @@ class SymbolTests: XCTestCase {
             """)
 
             
-            problem = try XCTUnwrap(unresolvedTopicProblems.first(where: { $0.diagnostic.summary == "Topic reference 'otherFunction()' couldn't be resolved. Reference at '/MyKit/MyClass' can't resolve 'otherFunction()'. Did you mean myFunction()?" }))
-            XCTAssertEqual(problem.diagnostic.notes.map(\.message), ["Available children: init(), myFunction()."])
+            XCTAssertEqual(problem.diagnostic.notes.map(\.message), [])
+            problem = try XCTUnwrap(unresolvedTopicProblems.first(where: { $0.diagnostic.summary == "Topic reference 'otherFunction()' couldn't be resolved. Reference at '/MyKit/MyClass' can't resolve 'otherFunction()'. Did you mean 'myFunction()'?" }))
             XCTAssertEqual(problem.possibleSolutions.count, 1)
             XCTAssert(problem.possibleSolutions.map(\.replacements.count).allSatisfy { $0 == 1 })
             XCTAssertEqual(problem.possibleSolutions.map { [$0.summary, $0.replacements.first!.replacement] }, [
-                ["Replace 'otherFunction()' with 'myFunction()'.", "myFunction()"],
+                ["Replace 'otherFunction()' with 'myFunction()'", "myFunction()"],
             ])
             XCTAssertEqual(try problem.possibleSolutions.first!.applyTo(contentsOf: url.appendingPathComponent("documentation/myclass.md")), """
             # ``MyKit/MyClass``
@@ -787,12 +787,12 @@ class SymbolTests: XCTestCase {
             """)
             
             
-            problem = try XCTUnwrap(unresolvedTopicProblems.first(where: { $0.diagnostic.summary == "Topic reference '/MyKit/MyClas' couldn't be resolved. Reference at '/MyKit' can't resolve 'MyClas'. Did you mean MyClass?" }))
+            problem = try XCTUnwrap(unresolvedTopicProblems.first(where: { $0.diagnostic.summary == "Topic reference '/MyKit/MyClas' couldn't be resolved. Reference at '/MyKit' can't resolve 'MyClas'. Did you mean 'MyClass'?" }))
             XCTAssertEqual(problem.diagnostic.notes.map(\.message), ["Available children: Discussion, globalFunction(_:considering:), MyClass, MyProtocol."])
             XCTAssertEqual(problem.possibleSolutions.count, 1)
             XCTAssert(problem.possibleSolutions.map(\.replacements.count).allSatisfy { $0 == 1 })
             XCTAssertEqual(problem.possibleSolutions.map { [$0.summary, $0.replacements.first!.replacement] }, [
-                ["Replace 'MyClas' with 'MyClass'.", "MyClass"],
+                ["Replace 'MyClas' with 'MyClass'", "MyClass"],
             ])
             XCTAssertEqual(try problem.possibleSolutions.first!.applyTo(contentsOf: url.appendingPathComponent("documentation/myclass.md")), """
             # ``MyKit/MyClass``
@@ -832,12 +832,12 @@ class SymbolTests: XCTestCase {
             """)
             
             
-            problem = try XCTUnwrap(unresolvedTopicProblems.first(where: { $0.diagnostic.summary == "Topic reference 'MyKit/MyClas/myFunction()' couldn't be resolved. Reference at '/MyKit' can't resolve 'MyClas/myFunction()'. Did you mean MyClass?" }))
             XCTAssertEqual(problem.diagnostic.notes.map(\.message), ["Available children: Discussion, globalFunction(_:considering:), MyClass, MyProtocol."])
+            problem = try XCTUnwrap(unresolvedTopicProblems.first(where: { $0.diagnostic.summary == "Topic reference 'MyKit/MyClas/myFunction()' couldn't be resolved. Reference at '/MyKit' can't resolve 'MyClas/myFunction()'. Did you mean 'MyClass'?" }))
             XCTAssertEqual(problem.possibleSolutions.count, 1)
             XCTAssert(problem.possibleSolutions.map(\.replacements.count).allSatisfy { $0 == 1 })
             XCTAssertEqual(problem.possibleSolutions.map { [$0.summary, $0.replacements.first!.replacement] }, [
-                ["Replace 'MyClas' with 'MyClass'.", "MyClass"],
+                ["Replace 'MyClas' with 'MyClass'", "MyClass"],
             ])
             XCTAssertEqual(try problem.possibleSolutions.first!.applyTo(contentsOf: url.appendingPathComponent("documentation/myclass.md")), """
             # ``MyKit/MyClass``
@@ -877,12 +877,12 @@ class SymbolTests: XCTestCase {
             """)
             
             
-            problem = try XCTUnwrap(unresolvedTopicProblems.first(where: { $0.diagnostic.summary == "Topic reference 'MyKit/MyClas/myFunction()' couldn't be resolved. Reference at '/MyKit' can't resolve 'MyClas/myFunction()'. Did you mean MyClass?" }))
             XCTAssertEqual(problem.diagnostic.notes.map(\.message), ["Available children: Discussion, globalFunction(_:considering:), MyClass, MyProtocol."])
+            problem = try XCTUnwrap(unresolvedTopicProblems.first(where: { $0.diagnostic.summary == "Topic reference 'MyKit/MyClas/myFunction()' couldn't be resolved. Reference at '/MyKit' can't resolve 'MyClas/myFunction()'. Did you mean 'MyClass'?" }))
             XCTAssertEqual(problem.possibleSolutions.count, 1)
             XCTAssert(problem.possibleSolutions.map(\.replacements.count).allSatisfy { $0 == 1 })
             XCTAssertEqual(problem.possibleSolutions.map { [$0.summary, $0.replacements.first!.replacement] }, [
-                ["Replace 'MyClas' with 'MyClass'.", "MyClass"],
+                ["Replace 'MyClas' with 'MyClass'", "MyClass"],
             ])
             XCTAssertEqual(try problem.possibleSolutions.first!.applyTo(contentsOf: url.appendingPathComponent("documentation/myclass.md")), """
             # ``MyKit/MyClass``
@@ -922,12 +922,12 @@ class SymbolTests: XCTestCase {
             """)
             
             
-            problem = try XCTUnwrap(unresolvedTopicProblems.first(where: { $0.diagnostic.summary == "Topic reference 'doc:MyKit/MyClas/myFunction()' couldn't be resolved. Reference at '/MyKit' can't resolve 'MyClas/myFunction()'. Did you mean MyClass?" }))
             XCTAssertEqual(problem.diagnostic.notes.map(\.message), ["Available children: Discussion, globalFunction(_:considering:), MyClass, MyProtocol."])
+            problem = try XCTUnwrap(unresolvedTopicProblems.first(where: { $0.diagnostic.summary == "Topic reference 'doc:MyKit/MyClas/myFunction()' couldn't be resolved. Reference at '/MyKit' can't resolve 'MyClas/myFunction()'. Did you mean 'MyClass'?" }))
             XCTAssertEqual(problem.possibleSolutions.count, 1)
             XCTAssert(problem.possibleSolutions.map(\.replacements.count).allSatisfy { $0 == 1 })
             XCTAssertEqual(problem.possibleSolutions.map { [$0.summary, $0.replacements.first!.replacement] }, [
-                ["Replace 'MyClas' with 'MyClass'.", "MyClass"],
+                ["Replace 'MyClas' with 'MyClass'", "MyClass"],
             ])
             XCTAssertEqual(try problem.possibleSolutions.first!.applyTo(contentsOf: url.appendingPathComponent("documentation/myclass.md")), """
             # ``MyKit/MyClass``
@@ -1013,12 +1013,12 @@ class SymbolTests: XCTestCase {
         if LinkResolutionMigrationConfiguration.shouldUseHierarchyBasedLinkResolver {
             var problem: Problem
             
-            problem = try XCTUnwrap(unresolvedTopicProblems.first(where: { $0.diagnostic.summary == "Topic reference 'UnresolvableSymbolLinkInMyClassOverview' couldn't be resolved. Reference at '/MyKit/MyClass/myFunction()' can't resolve 'UnresolvableSymbolLinkInMyClassOverview'. Did you mean Unresolvable-curation?" }))
+            problem = try XCTUnwrap(unresolvedTopicProblems.first(where: { $0.diagnostic.summary == "Topic reference 'UnresolvableSymbolLinkInMyClassOverview' couldn't be resolved. Reference at '/MyKit/MyClass/myFunction()' can't resolve 'UnresolvableSymbolLinkInMyClassOverview'. Did you mean 'Unresolvable-curation'?" }))
             XCTAssert(problem.diagnostic.notes.isEmpty)
             XCTAssertEqual(problem.possibleSolutions.count, 1)
             XCTAssert(problem.possibleSolutions.map(\.replacements.count).allSatisfy { $0 == 1 })
             XCTAssertEqual(problem.possibleSolutions.map { [$0.summary, $0.replacements.first!.replacement] }, [
-                ["Replace 'UnresolvableSymbolLinkInMyClassOverview' with 'Unresolvable-curation'.", "Unresolvable-curation"],
+                ["Replace 'UnresolvableSymbolLinkInMyClassOverview' with 'Unresolvable-curation'", "Unresolvable-curation"],
             ])
             XCTAssertEqual(try problem.possibleSolutions.first!.applyTo(docComment), """
             A cool API to call.
@@ -1038,12 +1038,12 @@ class SymbolTests: XCTestCase {
             - <doc://com.test.external/ExternalPage>
             """)
             
-            problem = try XCTUnwrap(unresolvedTopicProblems.first(where: { $0.diagnostic.summary == "Topic reference 'UnresolvableClassInMyClassTopicCuration' couldn't be resolved. Reference at '/MyKit/MyClass/myFunction()' can't resolve 'UnresolvableClassInMyClassTopicCuration'. Did you mean Unresolvable-curation?" }))
+            problem = try XCTUnwrap(unresolvedTopicProblems.first(where: { $0.diagnostic.summary == "Topic reference 'UnresolvableClassInMyClassTopicCuration' couldn't be resolved. Reference at '/MyKit/MyClass/myFunction()' can't resolve 'UnresolvableClassInMyClassTopicCuration'. Did you mean 'Unresolvable-curation'?" }))
             XCTAssert(problem.diagnostic.notes.isEmpty)
             XCTAssertEqual(problem.possibleSolutions.count, 1)
             XCTAssert(problem.possibleSolutions.map(\.replacements.count).allSatisfy { $0 == 1 })
             XCTAssertEqual(problem.possibleSolutions.map { [$0.summary, $0.replacements.first!.replacement] }, [
-                ["Replace 'UnresolvableClassInMyClassTopicCuration' with 'Unresolvable-curation'.", "Unresolvable-curation"],
+                ["Replace 'UnresolvableClassInMyClassTopicCuration' with 'Unresolvable-curation'", "Unresolvable-curation"],
             ])
             XCTAssertEqual(try problem.possibleSolutions.first!.applyTo(docComment), """
             A cool API to call.
@@ -1066,29 +1066,8 @@ class SymbolTests: XCTestCase {
             
             problem = try XCTUnwrap(unresolvedTopicProblems.first(where: { $0.diagnostic.summary == "Topic reference 'MyClass/unresolvablePropertyInMyClassTopicCuration' couldn't be resolved. Reference at '/MyKit/MyClass' can't resolve 'unresolvablePropertyInMyClassTopicCuration'. No similar pages." }))
             XCTAssert(problem.diagnostic.notes.isEmpty)
-            XCTAssertEqual(problem.possibleSolutions.count, 2)
+            XCTAssertEqual(problem.possibleSolutions.count, 0)
             XCTAssert(problem.possibleSolutions.map(\.replacements.count).allSatisfy { $0 == 1 })
-            XCTAssertEqual(problem.possibleSolutions.map { [$0.summary, $0.replacements.first!.replacement] }, [
-                ["Replace 'unresolvablePropertyInMyClassTopicCuration' with 'init()'.", "init()"],
-                ["Replace 'unresolvablePropertyInMyClassTopicCuration' with 'myFunction()'.", "myFunction()"],
-            ])
-            XCTAssertEqual(try problem.possibleSolutions.first!.applyTo(docComment), """
-            A cool API to call.
-
-            This overview has an ``UnresolvableSymbolLinkInMyClassOverview``.
-
-            - Parameters:
-              - name: A parameter
-            - Returns: Return value
-
-            # Topics
-
-            ## Unresolvable curation
-
-            - ``UnresolvableClassInMyClassTopicCuration``
-            - ``MyClass/init()``
-            - <doc://com.test.external/ExternalPage>
-            """)
         } else {
             XCTAssertTrue(unresolvedTopicProblems.contains(where: { $0.diagnostic.summary == "Topic reference 'UnresolvableSymbolLinkInMyClassOverview' couldn't be resolved. No local documentation matches this reference." }))
             XCTAssertTrue(unresolvedTopicProblems.contains(where: { $0.diagnostic.summary == "Topic reference 'UnresolvableClassInMyClassTopicCuration' couldn't be resolved. No local documentation matches this reference." }))


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://99990978

## Summary

This PR does 4 things related to link diagnostics:

- It adds a new diagnostic when a known name but an unknown disambiguation
- It leverages the authored disambiguation to narrow down the suggestions (for example to only make suggestions of the matching symbol type)
- It rephrases the link diagnostic error messages to be more to the point and surface the most relevant and specific information first. 
- It shrinks the diagnostic range to the path component with the issue

For example, instead of highlighting the full link range and using this error message

```
- ``MyKit/MyClas/myFunction()``
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

>Topic reference 'MyKit/MyClas/myFunction()' couldn't be resolved. Reference at '/MyKit' can't resolve 'MyClas/myFunction()'. Did you mean 'MyClass'?"
>
>Replace 'MyClas' with 'MyClass'.  [Fix]

the same diagnostic now highlights the "MyClas" path component with this error message

```
- ``MyKit/MyClas/myFunction()``
          ~~~~~~
```

>'MyClas' doesn't exist at '/MyKit'
>
>Replace 'MyClas' with 'MyClass'  [Fix]


## Dependencies

None

## Testing

With any project with existing working symbol links:

- Add an incorrect disambiguation to a link
  There should be a specific diagnostic about the disambiguation
  
- Introduce a typo in a link path component
   The error message should indicate which path component can't be found and offer suggestions 
   
- Introduce a typo in a link path component that is already disambiguated (without altering the disambiguation)
   The error message should only offer suggestions that match the disambiguation
   
For any link diagnostic:
- The range of the diagnostic should highlight the path component where the issue is, not the full range of the link
- The error message should start with the information about why the link couldn't resolve, not start with the general information that the link didn't resolve.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
