### PR TITLE
Prefer resolving link to inner symbol when container has same name

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
@@ -508,6 +508,11 @@ struct PathHierarchy {
             // If a parent ID was provided, start at that node and continue up the hierarchy until that node has a child that matches the first path components name.
             var parentNode = lookup[parentID]!
             let firstComponent = remaining.first!
+            // Check if the start node has a child that matches the first path components name.
+            if parentNode.children.keys.contains(firstComponent.name) || parentNode.children.keys.contains(firstComponent.full) {
+                return parentNode
+            }
+            // Check if the start node itself matches the first path components name.
             if matches(node: parentNode, component: firstComponent) {
                 remaining = remaining.dropFirst()
                 return parentNode

--- a/Tests/SwiftDocCTests/Test Bundles/BundleWithSameNameForSymbolAndContainer.docc/symbol-graph/SameName.symbols.json
+++ b/Tests/SwiftDocCTests/Test Bundles/BundleWithSameNameForSymbolAndContainer.docc/symbol-graph/SameName.symbols.json
@@ -1,0 +1,279 @@
+{
+  "metadata": {
+    "formatVersion": {
+      "major": 0,
+      "minor": 6,
+      "patch": 0
+    },
+    "generator": "Apple Swift version 5.9 (swiftlang-5.9.0.100.22 clang-1500.0.7.24.100)"
+  },
+  "module": {
+    "name": "SameNames",
+    "platform": {
+      "architecture": "x86_64",
+      "vendor": "apple",
+      "operatingSystem": {
+        "name": "macosx",
+        "minimumVersion": {
+          "major": 13,
+          "minor": 3
+        }
+      }
+    }
+  },
+  "symbols": [
+    {
+      "kind": {
+        "identifier": "swift.enum",
+        "displayName": "Enumeration"
+      },
+      "identifier": {
+        "precise": "s:9SameNames9SomethingVABV0C4ElseO",
+        "interfaceLanguage": "swift"
+      },
+      "pathComponents": [
+        "Something",
+        "Something",
+        "SomethingElse"
+      ],
+      "names": {
+        "title": "Something.Something.SomethingElse",
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "SomethingElse"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "keyword",
+            "spelling": "enum"
+          },
+          {
+            "kind": "text",
+            "spelling": " "
+          },
+          {
+            "kind": "identifier",
+            "spelling": "SomethingElse"
+          }
+        ]
+      },
+      "declarationFragments": [
+        {
+          "kind": "keyword",
+          "spelling": "enum"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "SomethingElse"
+        }
+      ],
+      "accessLevel": "public",
+      "location": {
+        "uri": "file:///Users/username/path/to/SameNames/SameNames.swift",
+        "position": {
+          "line": 5,
+          "character": 20
+        }
+      }
+    },
+    {
+      "kind": {
+        "identifier": "swift.enum",
+        "displayName": "Enumeration"
+      },
+      "identifier": {
+        "precise": "s:9SameNames9SomethingV0C4ElseO",
+        "interfaceLanguage": "swift"
+      },
+      "pathComponents": [
+        "Something",
+        "SomethingElse"
+      ],
+      "names": {
+        "title": "Something.SomethingElse",
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "SomethingElse"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "keyword",
+            "spelling": "enum"
+          },
+          {
+            "kind": "text",
+            "spelling": " "
+          },
+          {
+            "kind": "identifier",
+            "spelling": "SomethingElse"
+          }
+        ]
+      },
+      "declarationFragments": [
+        {
+          "kind": "keyword",
+          "spelling": "enum"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "SomethingElse"
+        }
+      ],
+      "accessLevel": "public",
+      "location": {
+        "uri": "file:///Users/username/path/to/SameNames/SameNames.swift",
+        "position": {
+          "line": 7,
+          "character": 16
+        }
+      }
+    },
+    {
+      "kind": {
+        "identifier": "swift.struct",
+        "displayName": "Structure"
+      },
+      "identifier": {
+        "precise": "s:9SameNames9SomethingVABV",
+        "interfaceLanguage": "swift"
+      },
+      "pathComponents": [
+        "Something",
+        "Something"
+      ],
+      "names": {
+        "title": "Something.Something",
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "Something"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "keyword",
+            "spelling": "struct"
+          },
+          {
+            "kind": "text",
+            "spelling": " "
+          },
+          {
+            "kind": "identifier",
+            "spelling": "Something"
+          }
+        ]
+      },
+      "declarationFragments": [
+        {
+          "kind": "keyword",
+          "spelling": "struct"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "Something"
+        }
+      ],
+      "accessLevel": "public",
+      "location": {
+        "uri": "file:///Users/username/path/to/SameNames/SameNames.swift",
+        "position": {
+          "line": 4,
+          "character": 18
+        }
+      }
+    },
+    {
+      "kind": {
+        "identifier": "swift.struct",
+        "displayName": "Structure"
+      },
+      "identifier": {
+        "precise": "s:9SameNames9SomethingV",
+        "interfaceLanguage": "swift"
+      },
+      "pathComponents": [
+        "Something"
+      ],
+      "names": {
+        "title": "Something",
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "Something"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "keyword",
+            "spelling": "struct"
+          },
+          {
+            "kind": "text",
+            "spelling": " "
+          },
+          {
+            "kind": "identifier",
+            "spelling": "Something"
+          }
+        ]
+      },
+      "declarationFragments": [
+        {
+          "kind": "keyword",
+          "spelling": "struct"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "Something"
+        }
+      ],
+      "accessLevel": "public",
+      "location": {
+        "uri": "file:///Users/username/path/to/SameNames/SameNames.swift",
+        "position": {
+          "line": 3,
+          "character": 14
+        }
+      }
+    }
+  ],
+  "relationships": [
+    {
+      "kind": "memberOf",
+      "source": "s:9SameNames9SomethingV0C4ElseO",
+      "target": "s:9SameNames9SomethingV"
+    },
+    {
+      "kind": "memberOf",
+      "source": "s:9SameNames9SomethingVABV0C4ElseO",
+      "target": "s:9SameNames9SomethingVABV"
+    },
+    {
+      "kind": "memberOf",
+      "source": "s:9SameNames9SomethingVABV",
+      "target": "s:9SameNames9SomethingV"
+    }
+  ]
+}


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://106509292

## Summary

This makes an adjustment to the way the new link resolver implementation to preserve a behavior from the previous implementation. 

If a symbol has a child with the same name, links in the outer's symbol's context should resolve to the inner symbol

```swift
/// ``Something`` ◀︎─ This link should
///                  resolve to this symbol
public struct Something {    //   │
    public enum Something {} // ◀︎─╯
}
```

## Dependencies

None

## Testing

- Create a public type with an inner symbol with the same name (for example the above)
- Write a link in the documentation comment for the outer symbol
   The link should resolve to the inner symbols
- Curate the relative name of the inner symbol
  There shouldn't be a warning about a symbol curating itself.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
