### PR TITLE
[ConvertService] Allow overriding doc comments

### DIFF
--- a/Sources/SwiftDocC/DocumentationService/Models/Services/Convert/ConvertRequest.swift
+++ b/Sources/SwiftDocC/DocumentationService/Models/Services/Convert/ConvertRequest.swift
@@ -105,6 +105,12 @@ public struct ConvertRequest: Codable {
     /// - ``DocumentationBundle/symbolGraphURLs``
     public var symbolGraphs: [Data]
     
+    /// The mapping of external symbol identifiers to lines of a documentation comment that overrides the value in the symbol graph.
+    ///
+    /// Use this property to override the `docComment` mixin of a symbol entry in a symbol graph. This allows
+    /// the client to pass a more up-to-date value than is available in the symbol graph.
+    public var overridingDocumentationComments: [String: [Line]]? = nil
+    
     /// The article and documentation extension file data included in the documentation bundle to convert.
     ///
     /// ## See Also
@@ -177,6 +183,8 @@ public struct ConvertRequest: Codable {
     ///   response.
     ///   - bundleLocation: The file location of the documentation bundle to convert, if any.
     ///   - symbolGraphs: The symbols graph data included in the documentation bundle to convert.
+    ///   - overridingDocumentationComments: The mapping of external symbol identifiers to lines of a
+    ///   documentation comment that overrides the value in the symbol graph.
     ///   - knownDisambiguatedSymbolPathComponents: The mapping of external symbol identifiers to
     ///   known disambiguated symbol path components.
     ///   - markupFiles: The article and documentation extension file data included in the documentation bundle to convert.
@@ -190,6 +198,7 @@ public struct ConvertRequest: Codable {
         includeRenderReferenceStore: Bool? = nil,
         bundleLocation: URL? = nil,
         symbolGraphs: [Data],
+        overridingDocumentationComments: [String: [Line]]? = nil,
         knownDisambiguatedSymbolPathComponents: [String: [String]]? = nil,
         markupFiles: [Data],
         tutorialFiles: [Data] = [],
@@ -200,11 +209,70 @@ public struct ConvertRequest: Codable {
         self.includeRenderReferenceStore = includeRenderReferenceStore
         self.bundleLocation = bundleLocation
         self.symbolGraphs = symbolGraphs
+        self.overridingDocumentationComments = overridingDocumentationComments
         self.knownDisambiguatedSymbolPathComponents = knownDisambiguatedSymbolPathComponents
         self.markupFiles = markupFiles
         self.tutorialFiles = tutorialFiles
         self.miscResourceURLs = miscResourceURLs
         self.bundleInfo = bundleInfo
         self.featureFlags = featureFlags
+    }
+}
+
+extension ConvertRequest {
+    /// A line of text in source code.
+    public struct Line: Codable {
+        /// The string contents of a line.
+        ///
+        /// Do not include newline characters in this property.
+        public var text: String
+        
+        /// The line's range in a document if available.
+        public var sourceRange: SourceRange?
+        
+        /// Creates a line of text from source code.
+        /// - Parameters:
+        ///   - text: The strings contents of a line. Do not include newline characters.
+        ///   - sourceRange: The line's range in a document if available.
+        public init(
+            text: String,
+            sourceRange: SourceRange? = nil
+        ) {
+            self.text = text
+            self.sourceRange = sourceRange
+        }
+    }
+    
+    /// Represents a selection in text.
+    public struct SourceRange: Codable {
+        /// The range's start position.
+        public var start: Position
+        
+        /// The range's end position.
+        public var end: Position
+        
+        /// Creates a new source range with the given start and end positions.
+        public init(
+            start: Position,
+            end: Position
+        ) {
+            self.start = start
+            self.end = end
+        }
+    }
+    
+    /// Represents a cursor position in text.
+    public struct Position: Codable {
+        /// The zero-based line number in a document.
+        public var line: Int
+        
+        /// The zero-based byte offset into a line.
+        public var character: Int
+        
+        /// Creates a new cursor position with the given line number and character offset.
+        public init(line: Int, character: Int) {
+            self.line = line
+            self.character = character
+        }
     }
 }

--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -152,6 +152,11 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
     /// for example when ``ConvertService``.
     var allowsRegisteringUncuratedTutorials: Bool = false
     
+    /// A closure that modifies each symbol graph that the context registers.
+    ///
+    /// Set this property if you need to modify symbol graphs before the context registers its information.
+    var configureSymbolGraph: ((inout SymbolGraph) -> ())? = nil
+    
     /// The set of all manually curated references if `shouldStoreManuallyCuratedReferences` was true at the time of processing and has remained `true` since.. Nil if curation has not been processed yet.
     public private(set) var manuallyCuratedReferences: Set<ResolvedTopicReference>?
 
@@ -2084,7 +2089,12 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
         var hierarchyBasedResolver: PathHierarchyBasedLinkResolver!
         
         discoveryGroup.async(queue: discoveryQueue) { [unowned self] in
-            symbolGraphLoader = SymbolGraphLoader(bundle: bundle, dataProvider: self.dataProvider)
+            symbolGraphLoader = SymbolGraphLoader(
+                bundle: bundle,
+                dataProvider: self.dataProvider,
+                configureSymbolGraph: configureSymbolGraph
+            )
+            
             do {
                 try symbolGraphLoader.loadAll(using: decoder)
                 if LinkResolutionMigrationConfiguration.shouldSetUpHierarchyBasedLinkResolver {

--- a/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphLoader.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphLoader.swift
@@ -21,14 +21,20 @@ struct SymbolGraphLoader {
     private(set) var graphLocations: [String: [SymbolKit.GraphCollector.GraphKind]] = [:]
     private var dataProvider: DocumentationContextDataProvider
     private var bundle: DocumentationBundle
+    private var configureSymbolGraph: ((inout SymbolGraph) -> ())? = nil
     
     /// Creates a new loader, initialized with the given bundle.
     /// - Parameters:
     ///   - bundle: The documentation bundle from which to load symbol graphs.
     ///   - dataProvider: A data provider in the bundle's context.
-    init(bundle: DocumentationBundle, dataProvider: DocumentationContextDataProvider) {
+    init(
+        bundle: DocumentationBundle,
+        dataProvider: DocumentationContextDataProvider,
+        configureSymbolGraph: ((inout SymbolGraph) -> ())? = nil
+    ) {
         self.bundle = bundle
         self.dataProvider = dataProvider
+        self.configureSymbolGraph = configureSymbolGraph
     }
     
     /// A strategy to decode symbol graphs.
@@ -71,6 +77,8 @@ struct SymbolGraphLoader {
                 case .concurrentlyEachFileInBatches:
                     symbolGraph = try SymbolGraphConcurrentDecoder.decode(data, using: decoder)
                 }
+                
+                configureSymbolGraph?(&symbolGraph)
 
                 // `moduleNameFor(_:at:)` is static because it's pure function.
                 let (moduleName, isMainSymbolGraph) = Self.moduleNameFor(symbolGraph, at: symbolGraphURL)


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://106549009

## Summary

Adds an API in `ConvertRequest` that allows overriding the documentation comment of symbols in the symbol graphs provided by the client.

## Dependencies

None.

## Testing

Use the new `ConvertRequest` API to include an overriding documentation comment and verify that the render nodes you get back contain its contents.

## Checklist

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
