### PR TITLE
Minor peak memory reduction (1-2%)

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -2290,6 +2290,8 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
         topicGraphGlobalAnalysis()
         
         preResolveModuleNames()
+        
+        symbolIndex.removeAll(keepingCapacity: false)
     }
     
     /// Given a list of topics that have been automatically curated, checks if a topic has been additionally manually curated

--- a/Sources/SwiftDocC/Infrastructure/DocumentationConverter.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationConverter.swift
@@ -209,9 +209,10 @@ public struct DocumentationConverter: DocumentationConverterProtocol {
         cancelTimer.resume()
         
         // Start bundle registration
-        try workspace.registerProvider(dataProvider, options: bundleDiscoveryOptions)
-        self.currentDataProvider = dataProvider
-
+        try autoreleasepool {
+            try workspace.registerProvider(dataProvider, options: bundleDiscoveryOptions)
+            self.currentDataProvider = dataProvider
+        }
         // Bundle registration is finished - stop the timer and reset the context cancellation state.
         cancelTimer.cancel()
         cancelTimerQueue = nil
@@ -243,9 +244,13 @@ public struct DocumentationConverter: DocumentationConverterProtocol {
         }
         
         // Precompute the render context
-        let renderContext = RenderContext(documentationContext: context, bundle: bundle)
-        
-        try outputConsumer.consume(renderReferenceStore: renderContext.store)
+        let renderContext = try autoreleasepool {
+            let renderContext = RenderContext(documentationContext: context, bundle: bundle)
+            
+            try outputConsumer.consume(renderReferenceStore: renderContext.store)
+            
+            return renderContext
+        }
 
         // Copy images, sample files, and other static assets.
         try outputConsumer.consume(assetsInBundle: bundle)


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://106654403

## Summary

This reduces the peak memory usage by 1-2% in my local testing by making two changes:
- Add `autoreleasepool` around the registration of the documentation bundle and the pre-computation of the render context
- Clear out the `symbolIndex` after the documentation bundle has registered (it is never used after this)

This makes up for the peak memory reduction regression from enabling the new link resolver implementation by default. See https://github.com/apple/swift-docc/pull/498#issuecomment-1458992556

## Dependencies

Nonde

## Testing

Run the benchmark tools and compare this branch against `main`. For example

```
swift run --package-path bin/benchmark benchmark compare-to main --repetitions 15  --docc-arguments convert path/to/Size15TestBundle.docc/
```

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- ~[ ] Added tests~
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~ 
