### PR TITLE
don't perform asset lookup during CallToAction validation, fixing TSan in CallToActionTests

### DIFF
--- a/Sources/SwiftDocC/Semantics/Metadata/CallToAction.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/CallToAction.swift
@@ -136,6 +136,23 @@ public final class CallToAction: Semantic, AutomaticDirectiveConvertible {
             isValid = false
         }
 
+        return isValid
+    }
+
+    public let originalMarkup: Markdown.BlockDirective
+
+    @available(*, deprecated, message: "Do not call directly. Required for 'AutomaticDirectiveConvertible'.")
+    init(originalMarkup: Markdown.BlockDirective) {
+        self.originalMarkup = originalMarkup
+    }
+}
+
+extension CallToAction {
+    func resolveFile(
+        for bundle: DocumentationBundle,
+        in context: DocumentationContext,
+        problems: inout [Problem]) -> ResourceReference?
+    {
         if let file = self.file {
             if context.resolveAsset(named: file.url.lastPathComponent, in: bundle.rootReference) == nil {
                 problems.append(.init(
@@ -154,14 +171,7 @@ public final class CallToAction: Semantic, AutomaticDirectiveConvertible {
             }
         }
 
-        return isValid
-    }
-
-    public let originalMarkup: Markdown.BlockDirective
-
-    @available(*, deprecated, message: "Do not call directly. Required for 'AutomaticDirectiveConvertible'.")
-    init(originalMarkup: Markdown.BlockDirective) {
-        self.originalMarkup = originalMarkup
+        return self.file
     }
 }
 

--- a/Sources/SwiftDocC/Semantics/ReferenceResolver.swift
+++ b/Sources/SwiftDocC/Semantics/ReferenceResolver.swift
@@ -354,7 +354,7 @@ struct ReferenceResolver: SemanticVisitor {
             visitMarkupContainer($0) as? MarkupContainer
         }
         // If there's a call to action with a local-file reference, change its context to `download`
-        if let downloadFile = article.metadata?.callToAction?.file,
+        if let downloadFile = article.metadata?.callToAction?.resolveFile(for: bundle, in: context, problems: &problems),
             var resolvedDownload = context.resolveAsset(named: downloadFile.path, in: bundle.rootReference) {
             resolvedDownload.context = .download
             context.updateAsset(named: downloadFile.path, asset: resolvedDownload, in: bundle.rootReference)


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://106365392

## Summary

Thread Sanitizer emitted some warnings during the CallToAction tests, due to some racy access to the resolved assets. This is because directive parsing is done in parallel alongside asset registration, which could cause some spurious failures if accesses weren't aligned correctly. This PR changes the location that `@CallToAction(file:)` assets are validated so that they don't conflict with the initial asset registration.

## Dependencies

None

## Testing

Steps:
1. `swift test --sanitize thread --filter SwiftDocCTests.CallToActionTests`
2. Ensure that no warnings are emitted by Thread Sanitizer during the tests.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ n/a ] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ n/a ] Updated documentation if necessary
