### PR TITLE
Include tutorial article directive in generated documentation

### DIFF
--- a/Sources/docc/DocCDocumentation.docc/DocC.symbols.json
+++ b/Sources/docc/DocCDocumentation.docc/DocC.symbols.json
@@ -35,6 +35,66 @@
         },
         {
           "kind" : "typeIdentifier",
+          "spelling" : "Article"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "(...)"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " {\n    ...\n}"
+        }
+      ],
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$Article"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$Article",
+            "spelling" : "Article"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "Article"
+          },
+          {
+            "kind" : "text",
+            "spelling" : "(...)"
+          }
+        ],
+        "title" : "Article"
+      },
+      "pathComponents" : [
+        "Article"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
           "spelling" : "Assessments"
         },
         {

--- a/Sources/docc/DocCDocumentation.docc/Reference Syntax/API Reference Syntax/Metadata.md
+++ b/Sources/docc/DocCDocumentation.docc/Reference Syntax/API Reference Syntax/Metadata.md
@@ -52,10 +52,15 @@ A metadata element must contain one of the following items:
 
 - ``DisplayName``
 - ``PageImage``
+- ``PageKind``
 - ``CallToAction``
 
 ### Customizing the Languages of an Article
 
 - ``SupportedLanguage``
+
+### Customizing the Availability Information of a Page
+
+- ``Available``
 
 <!-- Copyright (c) 2021-2023 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Sources/docc/DocCDocumentation.docc/Reference Syntax/Tutorials Syntax/Top-Level Directives/Tutorial/TutorialArticle.md
+++ b/Sources/docc/DocCDocumentation.docc/Reference Syntax/Tutorials Syntax/Top-Level Directives/Tutorial/TutorialArticle.md
@@ -1,0 +1,47 @@
+# ``docc/Article``
+
+Displays a tutorial article page that teaches a conceptual topic about your Swift framework or package.
+
+@Metadata {
+    @DocumentationExtension(mergeBehavior: override)
+}
+
+- Parameters:
+    - time: An integer value that represents the estimated time it takes to complete the tutorial, in minutes. **(optional)**
+
+## Overview
+
+The `Article` directive defines the structure of an individual tutorial article page that teaches a conceptual topic about your Swift framework or package. 
+
+A tutorial article supports many of the same directives as a ``Tutorial`` directive but doesn't teach its content through interactive exercies.
+
+### Contained Elements
+
+A tutorial page can contain the following items:
+
+- term ``Intro``: Engaging introductory text and an image or video to display at the top of the page. **(optional)**
+- term ``ContentAndMedia``: A grouping that contains text and an image or video. At least one `ContentAndMedia` directive is required and must be the first element within a section. **(optional)**
+- term ``Stack``: A set of horizontally arranged groupings of text and media. **(optional)**
+- term ``Assessments``: Assessments that test the reader's knowledge about the content described in the article. **(optional)**
+- term ``Image``: An image that appears on the page. **(optional)**
+
+## Topics
+
+### Providing an Introduction
+
+- ``Intro``
+
+### Customizing Page Layout
+
+- ``ContentAndMedia``
+- ``Stack``
+
+### Displaying Images
+
+- ``Image``
+
+### Testing Reader Knowledge
+
+- ``Assessments``
+
+<!-- Copyright (c) 2023 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Sources/docc/DocCDocumentation.docc/Reference Syntax/Tutorials Syntax/tutorial-syntax.md
+++ b/Sources/docc/DocCDocumentation.docc/Reference Syntax/Tutorials Syntax/tutorial-syntax.md
@@ -25,6 +25,7 @@ You write tutorial content in Markdown, and use directives to define specific ty
 ### Adding Tutorial Pages
 
 - ``Tutorial``
+- ``Article``
 
 ### Shared Syntax
 

--- a/Sources/generate-symbol-graph/main.swift
+++ b/Sources/generate-symbol-graph/main.swift
@@ -117,6 +117,11 @@ let supportedDirectives: [Directive] = [
         isLeaf: false
     ),
     .init(
+        name: "Article",
+        implementationName: "TutorialArticle",
+        isLeaf: false
+    ),
+    .init(
         name: "ContentAndMedia",
         acceptsArguments: false,
         isLeaf: false


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://106652019

## Summary

This adds the tutorial article directive to the generated documentation and updates generate-symbol-graph to warn about missing directives.

It also adds basic documentation for the tutorial article directive that's based on the documentation for the tutorial directive.

<img width="1318" alt="Screenshot 2023-03-15 at 11 11 31 AM" src="https://user-images.githubusercontent.com/1228143/225403949-06b6cee7-d05b-4917-80d0-bae5cf37fa11.png">



## Dependencies

None.

## Testing

- Preview the documentation with 
   ```
   swift run docc preview Sources/docc/DocCDocumentation.docc 
   ```

Verify that there is a `Article` directive page 

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- ~ [ ] Added tests~ 
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
