### PR TITLE
Use a custom scheme for local "Declared In" source file URLs

### DIFF
--- a/Sources/SwiftDocC/SourceRepository/SourceRepository.swift
+++ b/Sources/SwiftDocC/SourceRepository/SourceRepository.swift
@@ -92,12 +92,15 @@ public extension SourceRepository {
     
     /// Creates a source repository hosted by the device's filesystem.
     ///
-    /// Use this source repository to format `file://` links to files on the
+    /// Use this source repository to format `doc-source-file://` links to files on the
     /// device where documentation is being presented.
+    ///
+    /// This source repository uses a custom scheme to offer more control local source file navigation.
     static func localFilesystem() -> SourceRepository {
         SourceRepository(
             checkoutPath: "",
-            sourceServiceBaseURL: URL(fileURLWithPath: "/"),
+            // 2 slashes to specify an empty authority/host component and 1 slash to specify a base path at the root.
+            sourceServiceBaseURL: URL(string: "doc-source-file:///")!,
             formatLineNumber: { line in "L\(line)" }
         )
     }

--- a/Tests/SwiftDocCTests/DocumentationService/ConvertService/ConvertServiceTests.swift
+++ b/Tests/SwiftDocCTests/DocumentationService/ConvertService/ConvertServiceTests.swift
@@ -188,7 +188,7 @@ class ConvertServiceTests: XCTestCase {
             
             XCTAssertEqual(
                 renderNode.metadata.remoteSource?.url.absoluteString,
-                "file:///private/tmp/test.swift#L2"
+                "doc-source-file:///private/tmp/test.swift#L2"
             )
         }
     }

--- a/Tests/SwiftDocCTests/SourceRepository/SourceRepositoryTests.swift
+++ b/Tests/SwiftDocCTests/SourceRepository/SourceRepositoryTests.swift
@@ -88,7 +88,7 @@ class SourceRepositoryTests: XCTestCase {
         XCTAssertEqual(
             SourceRepository.localFilesystem()
                 .format(sourceFileURL: URL(string: "file:///path/to/file")!, lineNumber: 5),
-            URL(string: "file:///path/to/file#L5")!
+            URL(string: "doc-source-file:///path/to/file#L5")!
         )
     }
 }


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://106667647

## Summary

This updates the `SourceRepository` for local files so that clients can customize the handling of local "Declared In" source file URLs while still using the default handling for other files. 

## Dependencies

None

## Testing

_Describe how a reviewer can test the functionality of your PR. Provide test content to test with if
applicable._

Steps:
1. _Provide setup instructions._
2. _Explain in detail how the functionality can be tested._

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] ~Added~ Updated tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
