### PR TITLE
Add authoring support for the `@PageColor` directive

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/References/TopicColor.swift
+++ b/Sources/SwiftDocC/Model/Rendering/References/TopicColor.swift
@@ -1,0 +1,36 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2023 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+/// A custom authored color that can be associated with a documentation topic.
+public struct TopicColor: Codable, Hashable {
+    /// An integer value between `0` and `255` that represents the
+    /// amount of red in the color.
+    public let red: Int
+    
+    /// An integer value between `0` and `255` that represents the
+    /// amount of green in the color.
+    public let green: Int
+    
+    /// An integer value between `0` and `255` that represents the
+    /// amount of blue in the color.
+    public let blue: Int
+    
+    /// A floating-point value between `0.0` and `1.0` that
+    /// represents the opacity of the color.
+    public let opacity: Double
+    
+    /// Create a new topic color with the given color channel values.
+    public init(red: Int, green: Int, blue: Int, opacity: Double) {
+        self.red = red
+        self.green = green
+        self.blue = blue
+        self.opacity = opacity
+    }
+}

--- a/Sources/SwiftDocC/Model/Rendering/RenderNode/RenderMetadata.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNode/RenderMetadata.swift
@@ -77,6 +77,11 @@ public struct RenderMetadata: VariantContainer {
     /// Authors can use the `@PageImage` metadata directive to provide custom icon and card images for a page.
     public var images: [TopicImage] = []
     
+    /// Custom authored color that represents this page.
+    ///
+    /// Authors can use the `@PageColor` metadata directive to provide a custom color for a page.
+    public var color: TopicColor?
+    
     /// Author provided custom metadata describing the page.
     public var customMetadata: [String: String] = [:]
     
@@ -231,6 +236,7 @@ extension RenderMetadata: Codable {
         public static let remoteSource = CodingKeys(stringValue: "remoteSource")
         public static let tags = CodingKeys(stringValue: "tags")
         public static let images = CodingKeys(stringValue: "images")
+        public static let color = CodingKeys(stringValue: "color")
         public static let customMetadata = CodingKeys(stringValue: "customMetadata")
     }
     
@@ -247,6 +253,7 @@ extension RenderMetadata: Codable {
         requiredVariants = try container.decodeVariantCollectionIfPresent(ofValueType: Bool.self, forKey: .required) ?? .init(defaultValue: false)
         roleHeadingVariants = try container.decodeVariantCollectionIfPresent(ofValueType: String?.self, forKey: .roleHeading)
         images = try container.decodeIfPresent([TopicImage].self, forKey: .images) ?? []
+        color = try container.decodeIfPresent(TopicColor.self, forKey: .color)
         customMetadata = try container.decodeIfPresent([String: String].self, forKey: .customMetadata) ?? [:]
         let rawRole = try container.decodeIfPresent(String.self, forKey: .role)
         role = rawRole == "tutorial" ? Role.tutorial.rawValue : rawRole
@@ -321,6 +328,7 @@ extension RenderMetadata: Codable {
         }
         
         try container.encodeIfNotEmpty(images, forKey: .images)
+        try container.encodeIfPresent(color, forKey: .color)
         try container.encodeIfNotEmpty(customMetadata, forKey: .customMetadata)
     }
 }

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -734,6 +734,15 @@ public struct RenderNodeTranslator: SemanticVisitor {
                 )
             }
         }
+        
+        if let pageColor = documentationNode.metadata?.pageColor {
+            node.metadata.color = TopicColor(
+                red: pageColor.red,
+                green: pageColor.green,
+                blue: pageColor.blue,
+                opacity: pageColor.opacity
+            )
+        }
 
         var metadataCustomDictionary : [String: String] = [:]
         if let customMetadatas = documentationNode.metadata?.customMetadata {

--- a/Sources/SwiftDocC/Semantics/DirectiveInfrastructure/DirectiveArgumentValueConvertible.swift
+++ b/Sources/SwiftDocC/Semantics/DirectiveInfrastructure/DirectiveArgumentValueConvertible.swift
@@ -71,3 +71,13 @@ extension Int: DirectiveArgumentValueConvertible {
         return nil
     }
 }
+
+extension Double: DirectiveArgumentValueConvertible {
+    init?(rawDirectiveArgumentValue: String) {
+        self.init(rawDirectiveArgumentValue)
+    }
+    
+    static func allowedValues() -> [String]? {
+        return nil
+    }
+}

--- a/Sources/SwiftDocC/Semantics/Metadata/Metadata.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/Metadata.swift
@@ -61,6 +61,9 @@ public final class Metadata: Semantic, AutomaticDirectiveConvertible {
     @ChildDirective(requirements: .zeroOrMore)
     var supportedLanguages: [SupportedLanguage]
     
+    @ChildDirective
+    var pageColor: PageColor? = nil
+    
     static var keyPaths: [String : AnyKeyPath] = [
         "documentationOptions"  : \Metadata._documentationOptions,
         "technologyRoot"        : \Metadata._technologyRoot,
@@ -71,6 +74,7 @@ public final class Metadata: Semantic, AutomaticDirectiveConvertible {
         "availability"          : \Metadata._availability,
         "pageKind"              : \Metadata._pageKind,
         "supportedLanguages"    : \Metadata._supportedLanguages,
+        "pageColor"             : \Metadata._pageColor,
     ]
     
     /// Creates a metadata object with a given markup, documentation extension, and technology root.
@@ -93,7 +97,7 @@ public final class Metadata: Semantic, AutomaticDirectiveConvertible {
     
     func validate(source: URL?, for bundle: DocumentationBundle, in context: DocumentationContext, problems: inout [Problem]) -> Bool {
         // Check that something is configured in the metadata block
-        if documentationOptions == nil && technologyRoot == nil && displayName == nil && pageImages.isEmpty && customMetadata.isEmpty && callToAction == nil && availability.isEmpty && pageKind == nil {
+        if documentationOptions == nil && technologyRoot == nil && displayName == nil && pageImages.isEmpty && customMetadata.isEmpty && callToAction == nil && availability.isEmpty && pageKind == nil && pageColor == nil {
             let diagnostic = Diagnostic(
                 source: source,
                 severity: .information,

--- a/Sources/SwiftDocC/Semantics/Metadata/PageColor.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/PageColor.swift
@@ -1,0 +1,64 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2023 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+import Markdown
+
+/// A directive that allows you to set the color that should be used to
+/// represent a documentation page.
+///
+/// Use the `PageColor` directive to tell Swift-DocC a specific color to use when representing the
+/// given documentation page. For example, Swift-DocC-Render will use this color for the background
+/// color of a page's introduction section.
+///
+/// This directive is only valid within a ``Metadata`` directive:
+///
+/// ```markdown
+/// @Metadata {
+///     @PageColor(red: 233, green: 58, blue: 43)
+/// }
+/// ```
+public final class PageColor: Semantic, AutomaticDirectiveConvertible {
+    public let originalMarkup: BlockDirective
+    
+    /// An integer value between `0` and `255` that represents the
+    /// amount of red in the color.
+    @DirectiveArgumentWrapped
+    public var red: Int
+    
+    /// An integer value between `0` and `255` that represents the
+    /// amount of green in the color.
+    @DirectiveArgumentWrapped
+    public var green: Int
+    
+    /// An integer value between `0` and `255` that represents the
+    /// amount of blue in the color.
+    @DirectiveArgumentWrapped
+    public var blue: Int
+    
+    /// A floating-point value between `0.0` and `1.0` that
+    /// represents the opacity of the color.
+    ///
+    /// Defaults to 1.0.
+    @DirectiveArgumentWrapped
+    public var opacity: Double = 1.0
+    
+    static var keyPaths: [String : AnyKeyPath] = [
+        "red"       : \PageColor._red,
+        "green"     : \PageColor._green,
+        "blue"      : \PageColor._blue,
+        "opacity"   : \PageColor._opacity,
+    ]
+
+    @available(*, deprecated, message: "Do not call directly. Required for 'AutomaticDirectiveConvertible'.")
+    init(originalMarkup: BlockDirective) {
+        self.originalMarkup = originalMarkup
+    }
+}

--- a/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderNode.spec.json
+++ b/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderNode.spec.json
@@ -1791,6 +1791,38 @@
                     }
                 }
             },
+            "TopicColor": {
+                "type": "object",
+                "required": [
+                    "red",
+                    "green",
+                    "blue",
+                    "opacity"
+                ],
+                "properties": {
+                    "red": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 255
+                    },
+                    "green": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 255
+                    },
+                    "blue": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 255
+                    },
+                    "opacity": {
+                        "type": "number",
+                        "format": "double",
+                        "minimum": 0.0,
+                        "maximum": 1.0
+                    }
+                }
+            },
             "SymbolTag": {
                 "type": "object",
                 "required": [
@@ -2249,6 +2281,9 @@
                         "items": {
                             "$ref": "#/components/schemas/TopicImage"
                         }
+                    },
+                    "color": {
+                        "$ref": "#/components/schemas/TopicColor"
                     },
                     "customMetadata": {
                         "type": "object",

--- a/Sources/docc/DocCDocumentation.docc/DocC.symbols.json
+++ b/Sources/docc/DocCDocumentation.docc/DocC.symbols.json
@@ -3077,6 +3077,285 @@
         },
         {
           "kind" : "typeIdentifier",
+          "spelling" : "PageColor"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "("
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "red"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Int"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ", "
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "green"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Int"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ", "
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "blue"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Int"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ", "
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "opacity"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Double"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " = 1.0"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ")"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "text" : "A directive that allows you to set the color that should be used to"
+          },
+          {
+            "text" : "represent a documentation page."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "Use the `PageColor` directive to tell Swift-DocC a specific color to use when representing the"
+          },
+          {
+            "text" : "given documentation page. For example, Swift-DocC-Render will use this color for the background"
+          },
+          {
+            "text" : "color of a page's introduction section."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "This directive is only valid within a ``Metadata`` directive:"
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "```markdown"
+          },
+          {
+            "text" : "@Metadata {"
+          },
+          {
+            "text" : "    @PageColor(red: 233, green: 58, blue: 43)"
+          },
+          {
+            "text" : "}"
+          },
+          {
+            "text" : "```"
+          },
+          {
+            "text" : "- Parameters:"
+          },
+          {
+            "text" : "  - red: An integer value between `0` and `255` that represents the"
+          },
+          {
+            "text" : "     amount of red in the color."
+          },
+          {
+            "text" : "     **(required)**"
+          },
+          {
+            "text" : "  - green: An integer value between `0` and `255` that represents the"
+          },
+          {
+            "text" : "     amount of green in the color."
+          },
+          {
+            "text" : "     **(required)**"
+          },
+          {
+            "text" : "  - blue: An integer value between `0` and `255` that represents the"
+          },
+          {
+            "text" : "     amount of blue in the color."
+          },
+          {
+            "text" : "     **(required)**"
+          },
+          {
+            "text" : "  - opacity: A floating-point value between `0.0` and `1.0` that"
+          },
+          {
+            "text" : "     represents the opacity of the color."
+          },
+          {
+            "text" : "     **(optional)**"
+          },
+          {
+            "text" : "     "
+          },
+          {
+            "text" : "     Defaults to 1.0."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$PageColor"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$PageColor",
+            "spelling" : "PageColor"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "PageColor"
+          },
+          {
+            "kind" : "text",
+            "spelling" : "("
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "red"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "spelling" : "Int"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ", "
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "green"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "spelling" : "Int"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ", "
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "blue"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "spelling" : "Int"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ", "
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "opacity"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "spelling" : "Double"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ")"
+          }
+        ],
+        "title" : "PageColor"
+      },
+      "pathComponents" : [
+        "PageColor"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
           "spelling" : "PageImage"
         },
         {

--- a/Sources/docc/DocCDocumentation.docc/Reference Syntax/API Reference Syntax/Metadata.md
+++ b/Sources/docc/DocCDocumentation.docc/Reference Syntax/API Reference Syntax/Metadata.md
@@ -28,15 +28,7 @@ Use the `Metadata` directive with the ``DisplayName`` directive to configure a s
 @Metadata {
     @DisplayName("Sloth Creator")
 }
-````
-
-### Contained Elements
-
-A metadata element must contain one of the following items:
-
-- term ``DocumentationExtension``: Defines whether the content in a documentation extension file amends or replaces in-source documentation. **(optional)**
-- term ``TechnologyRoot``: Configures a documentation page that's not associated with a particular framework to appear as a top-level page. **(optional)**
-- term ``DisplayName``: Configures a symbol's documentation page to use a custom display name. **(optional)**
+```
 
 ## Topics
 
@@ -53,6 +45,7 @@ A metadata element must contain one of the following items:
 - ``DisplayName``
 - ``PageImage``
 - ``PageKind``
+- ``PageColor``
 - ``CallToAction``
 
 ### Customizing the Languages of an Article

--- a/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorTests.swift
@@ -1149,7 +1149,7 @@ class RenderNodeTranslatorTests: XCTestCase {
         XCTAssertEqual(tabNavigator.tabs[2].content.count, 1)
     }
     
-    func testCustomPageImage() throws {
+    func testRenderNodeMetadata() throws {
          let (bundle, context) = try testBundleAndContext(named: "BookLikeContent")
          let reference = ResolvedTopicReference(
              bundleIdentifier: bundle.identifier,
@@ -1220,5 +1220,10 @@ class RenderNodeTranslatorTests: XCTestCase {
         XCTAssertEqual(roundTrippedArticle.metadata.customMetadata.keys.first, "country")
         XCTAssertEqual(roundTrippedArticle.metadata.customMetadata.values.count, 1)
         XCTAssertEqual(roundTrippedArticle.metadata.customMetadata.values.first, "Belgium")
+        
+        XCTAssertEqual(
+            roundTrippedArticle.metadata.color,
+            TopicColor(red: 233, green: 58, blue: 43, opacity: 0.8)
+        )
      }
 }

--- a/Tests/SwiftDocCTests/Semantics/DirectiveInfrastructure/DirectiveIndexTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/DirectiveInfrastructure/DirectiveIndexTests.swift
@@ -36,6 +36,7 @@ class DirectiveIndexTests: XCTestCase {
                 "Links",
                 "Metadata",
                 "Options",
+                "PageColor",
                 "PageImage",
                 "PageKind",
                 "Redirected",

--- a/Tests/SwiftDocCTests/Semantics/DirectiveInfrastructure/DirectiveMirrorTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/DirectiveInfrastructure/DirectiveMirrorTests.swift
@@ -39,7 +39,7 @@ class DirectiveMirrorTests: XCTestCase {
         XCTAssertFalse(reflectedDirective.allowsMarkup)
         XCTAssert(reflectedDirective.arguments.isEmpty)
         
-        XCTAssertEqual(reflectedDirective.childDirectives.count, 9)
+        XCTAssertEqual(reflectedDirective.childDirectives.count, 10)
         
         XCTAssertEqual(
             reflectedDirective.childDirectives["DocumentationExtension"]?.propertyLabel,

--- a/Tests/SwiftDocCTests/Semantics/MetadataTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/MetadataTests.swift
@@ -311,6 +311,48 @@ class MetadataTests: XCTestCase {
         )
     }
     
+    func testPageColorSupport() throws {
+        do {
+            let (problems, metadata) = try parseMetadataFromSource(
+            """
+            # Article title
+            
+            @Metadata {
+                @PageColor(red: 233, green: 58, blue: 43)
+            }
+            
+            The abstract of this article.
+            """
+            )
+            
+            XCTAssertEqual(problems, [])
+            XCTAssertEqual(metadata.pageColor?.red, 233)
+            XCTAssertEqual(metadata.pageColor?.green, 58)
+            XCTAssertEqual(metadata.pageColor?.blue, 43)
+            XCTAssertEqual(metadata.pageColor?.opacity, 1.0)
+        }
+        
+        do {
+            let (problems, metadata) = try parseMetadataFromSource(
+            """
+            # Article title
+            
+            @Metadata {
+                @PageColor(red: 233, green: 58, blue: 43, opacity: 0.5)
+            }
+            
+            The abstract of this article.
+            """
+            )
+            
+            XCTAssertEqual(problems, [])
+            XCTAssertEqual(metadata.pageColor?.red, 233)
+            XCTAssertEqual(metadata.pageColor?.green, 58)
+            XCTAssertEqual(metadata.pageColor?.blue, 43)
+            XCTAssertEqual(metadata.pageColor?.opacity, 0.5)
+        }
+    }
+    
     func parseMetadataFromSource(
         _ source: String,
         file: StaticString = #file,

--- a/Tests/SwiftDocCTests/Test Bundles/BookLikeContent.docc/MyArticle.md
+++ b/Tests/SwiftDocCTests/Test Bundles/BookLikeContent.docc/MyArticle.md
@@ -6,6 +6,7 @@ This is the abstract of my article. Nice!
     @PageImage(source: "plus", alt: "A plus icon.", purpose: icon)
     @PageImage(source: "figure1", alt: "An example figure.", purpose: card)
     @CustomMetadata(key: "country", value: "Belgium")
+    @PageColor(red: 233, green: 58, blue: 43, opacity: 0.8)
 }
 
 @Row(numberOfColumns: 8) {


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://106153042

## Summary

Adds a new `@PageColor` metadata directive that allows for customizing the color used to represent a given page.

`@PageColor` gives authors control over the color used when rendering a page – initially this will affect the background color Swift-DocC-Render uses in the page's introduction (hero) section.

## Example:

    # What's New in SlothCreator

    @Metadata {
        @PageColor(red: 233, green: 58, blue: 43)
    }

    ![A sloth on a tree wearing a fedora.](sloth-fedora)

    Let's check out what's new in SlothCreator!

    ...

## Details:

`@PageColor` accepts the following parameters:

  - `red`: An integer value between `0` and `255` that represents the amount of red in the color.

  - `green`: An integer value between `0` and `255` that represents the amount of green in the color.

  - `blue`: An integer value between `0` and `255` that represents the amount of blue in the color.

  - `opacity`: An optional floating-point integer value between `0.0` and `1.0` that represents the opacity of the color.

    Defaults to `1.0`.

This forums post for this change is still pending.

## Dependencies

Swift-DocC-Render PR TBD.

## Testing

Add `@PageColor` to the `@Metadata` directive in a Swift-DocC article or extension file and confirm that the resulting RenderNode includes a `color` metadata property.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
