### PR TITLE
[5.9] enable Doxygen support by default

### DIFF
--- a/Sources/SwiftDocC/Model/DocumentationNode.swift
+++ b/Sources/SwiftDocC/Model/DocumentationNode.swift
@@ -438,10 +438,7 @@ public struct DocumentationNode {
         } else if let symbol = documentedSymbol, let docComment = symbol.docComment {
             let docCommentString = docComment.lines.map { $0.text }.joined(separator: "\n")
 
-            var documentOptions: ParseOptions = [.parseBlockDirectives, .parseSymbolLinks]
-            if FeatureFlags.current.isExperimentalDoxygenSupportEnabled {
-                documentOptions.insert(.parseMinimalDoxygen)
-            }
+            let documentOptions: ParseOptions = [.parseBlockDirectives, .parseSymbolLinks, .parseMinimalDoxygen]
             let docCommentMarkup = Document(parsing: docCommentString, options: documentOptions)
             
             let docCommentDirectives = docCommentMarkup.children.compactMap({ $0 as? BlockDirective })

--- a/Sources/SwiftDocC/Utility/FeatureFlags.swift
+++ b/Sources/SwiftDocC/Utility/FeatureFlags.swift
@@ -32,6 +32,7 @@ public struct FeatureFlags: Codable {
     public var isExperimentalDeviceFrameSupportEnabled = false
 
     /// Whether or not experimental support for parsing Doxygen commands is enabled.
+    @available(*, deprecated, message: "Doxygen support is now enabled by default.")
     public var isExperimentalDoxygenSupportEnabled = false
     
     /// Creates a set of feature flags with the given values.

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/ActionExtensions/ConvertAction+CommandInitialization.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/ActionExtensions/ConvertAction+CommandInitialization.swift
@@ -21,7 +21,6 @@ extension ConvertAction {
         let outOfProcessResolver: OutOfProcessReferenceResolver?
         
         FeatureFlags.current.isExperimentalDeviceFrameSupportEnabled = convert.enableExperimentalDeviceFrameSupport
-        FeatureFlags.current.isExperimentalDoxygenSupportEnabled = convert.experimentalParseDoxygenCommands
         
         // If the user-provided a URL for an external link resolver, attempt to
         // initialize an `OutOfProcessReferenceResolver` with the provided URL.

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Convert.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Convert.swift
@@ -169,8 +169,9 @@ extension Docc {
 
         /// A user-provided value that is true if experimental Doxygen support should be enabled.
         ///
-        /// Defaults to false.
+        /// > Important: This flag is deprecated now that the feature is enabled by default, and will be removed in a future release.
         @Flag(help: .hidden)
+        @available(*, deprecated, message: "Doxygen support is now enabled by default.")
         public var experimentalParseDoxygenCommands = false
 
         // MARK: - Info.plist fallbacks

--- a/Tests/SwiftDocCTests/Semantics/SymbolTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/SymbolTests.swift
@@ -514,9 +514,7 @@ class SymbolTests: XCTestCase {
         XCTAssertEqual(problems.count, 0)
     }
 
-    func testParseDoxygenWithFeatureFlag() throws {
-        enableFeatureFlag(\.isExperimentalDoxygenSupportEnabled)
-
+    func testParseDoxygen() throws {
         let deckKitSymbolGraph = Bundle.module.url(
             forResource: "DeckKit-Objective-C",
             withExtension: "symbols.json",

--- a/Tests/SwiftDocCUtilitiesTests/ArgumentParsing/ConvertSubcommandTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ArgumentParsing/ConvertSubcommandTests.swift
@@ -390,27 +390,6 @@ class ConvertSubcommandTests: XCTestCase {
         XCTAssertTrue(commandWithFlag.enableExperimentalDeviceFrameSupport)
         XCTAssertTrue(FeatureFlags.current.isExperimentalDeviceFrameSupportEnabled)
     }
-
-    func testExperimentalParseDoxygenFlag() throws {
-        let originalFeatureFlagsState = FeatureFlags.current
-
-        defer {
-            FeatureFlags.current = originalFeatureFlagsState
-        }
-
-        let commandWithoutFlag = try Docc.Convert.parse([testBundleURL.path])
-        let _ = try ConvertAction(fromConvertCommand: commandWithoutFlag)
-        XCTAssertFalse(commandWithoutFlag.experimentalParseDoxygenCommands)
-        XCTAssertFalse(FeatureFlags.current.isExperimentalDoxygenSupportEnabled)
-
-        let commandWithFlag = try Docc.Convert.parse([
-            "--experimental-parse-doxygen-commands",
-            testBundleURL.path,
-        ])
-        let _ = try ConvertAction(fromConvertCommand: commandWithFlag)
-        XCTAssertTrue(commandWithFlag.experimentalParseDoxygenCommands)
-        XCTAssertTrue(FeatureFlags.current.isExperimentalDoxygenSupportEnabled)
-    }
     
     func testTransformForStaticHostingFlagWithoutHTMLTemplate() throws {
         unsetenv(TemplateOption.environmentVariableKey)


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift-docc/pull/497

- **Explanation**: To make migration to Swift-DocC easier from alternate documentation engines, we have decided to enable the basic Doxygen support by default.
- **Scope**: Enhancement for users who have `@param` and `@returns` Doxygen commands in their documentation.
- **Issue**: rdar://107002535
- **Risk**: Low. The implementation is tightly focused for just the above-mentioned commands, and should not affect other documentation content.
- **Testing**: Automated tests pass without needing to pass the "experimental" flag.
- **Reviewer**: @ethan-kusters 