### PR TITLE
Add authoring support for a `@PageColor` directive

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/References/TopicColor.swift
+++ b/Sources/SwiftDocC/Model/Rendering/References/TopicColor.swift
@@ -1,0 +1,43 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2023 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+/// A color that associated with a documentation topic.
+public struct TopicColor: Codable, Hashable {
+    /// A string identifier for a built-in, standard color.
+    ///
+    /// This value is expected to be one of the following:
+    ///  - term `blue`: A context-dependent blue color.
+    ///
+    ///  - term `gray`: A context-dependent gray color.
+    ///
+    ///  - term `green`: A context-dependent orange color.
+    ///
+    ///  - term `orange`: A context-dependent orange color.
+    ///
+    ///  - term `purple`: A context-dependent purple color.
+    ///
+    ///  - term `red`: A context-dependent red color.
+    ///
+    ///  - term `yellow`: A context-dependent yellow color.
+    ///
+    ///  @Comment {
+    ///     This value is optional to allow for a future where topic colors
+    ///     can be defined by something besides the standard color identifiers.
+    ///
+    ///     For example, we may allow fully custom colors in the future and allow
+    ///     for providing some kind of `ColorReference` here.
+    ///  }
+    public let standardColorIdentifier: String?
+    
+    /// Create a topic color with the given standard color identifier.
+    public init(standardColorIdentifier: String) {
+        self.standardColorIdentifier = standardColorIdentifier
+    }
+}

--- a/Sources/SwiftDocC/Model/Rendering/RenderNode/RenderMetadata.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNode/RenderMetadata.swift
@@ -77,6 +77,11 @@ public struct RenderMetadata: VariantContainer {
     /// Authors can use the `@PageImage` metadata directive to provide custom icon and card images for a page.
     public var images: [TopicImage] = []
     
+    /// Custom authored color that represents this page.
+    ///
+    /// Authors can use the `@PageColor` metadata directive to provide a custom color for a page.
+    public var color: TopicColor?
+    
     /// Author provided custom metadata describing the page.
     public var customMetadata: [String: String] = [:]
     
@@ -231,6 +236,7 @@ extension RenderMetadata: Codable {
         public static let remoteSource = CodingKeys(stringValue: "remoteSource")
         public static let tags = CodingKeys(stringValue: "tags")
         public static let images = CodingKeys(stringValue: "images")
+        public static let color = CodingKeys(stringValue: "color")
         public static let customMetadata = CodingKeys(stringValue: "customMetadata")
     }
     
@@ -247,6 +253,7 @@ extension RenderMetadata: Codable {
         requiredVariants = try container.decodeVariantCollectionIfPresent(ofValueType: Bool.self, forKey: .required) ?? .init(defaultValue: false)
         roleHeadingVariants = try container.decodeVariantCollectionIfPresent(ofValueType: String?.self, forKey: .roleHeading)
         images = try container.decodeIfPresent([TopicImage].self, forKey: .images) ?? []
+        color = try container.decodeIfPresent(TopicColor.self, forKey: .color)
         customMetadata = try container.decodeIfPresent([String: String].self, forKey: .customMetadata) ?? [:]
         let rawRole = try container.decodeIfPresent(String.self, forKey: .role)
         role = rawRole == "tutorial" ? Role.tutorial.rawValue : rawRole
@@ -321,6 +328,7 @@ extension RenderMetadata: Codable {
         }
         
         try container.encodeIfNotEmpty(images, forKey: .images)
+        try container.encodeIfPresent(color, forKey: .color)
         try container.encodeIfNotEmpty(customMetadata, forKey: .customMetadata)
     }
 }

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -734,6 +734,10 @@ public struct RenderNodeTranslator: SemanticVisitor {
                 )
             }
         }
+        
+        if let pageColor = documentationNode.metadata?.pageColor {
+            node.metadata.color = TopicColor(standardColorIdentifier: pageColor.rawValue)
+        }
 
         var metadataCustomDictionary : [String: String] = [:]
         if let customMetadatas = documentationNode.metadata?.customMetadata {

--- a/Sources/SwiftDocC/Semantics/Metadata/Metadata.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/Metadata.swift
@@ -61,6 +61,14 @@ public final class Metadata: Semantic, AutomaticDirectiveConvertible {
     @ChildDirective(requirements: .zeroOrMore)
     var supportedLanguages: [SupportedLanguage]
     
+    @ChildDirective
+    var _pageColor: PageColor? = nil
+    
+    /// The optional, context-dependent color used to represent this page.
+    var pageColor: PageColor.Color? {
+        _pageColor?.color
+    }
+    
     static var keyPaths: [String : AnyKeyPath] = [
         "documentationOptions"  : \Metadata._documentationOptions,
         "technologyRoot"        : \Metadata._technologyRoot,
@@ -71,6 +79,7 @@ public final class Metadata: Semantic, AutomaticDirectiveConvertible {
         "availability"          : \Metadata._availability,
         "pageKind"              : \Metadata._pageKind,
         "supportedLanguages"    : \Metadata._supportedLanguages,
+        "_pageColor"             : \Metadata.__pageColor,
     ]
     
     /// Creates a metadata object with a given markup, documentation extension, and technology root.
@@ -93,7 +102,7 @@ public final class Metadata: Semantic, AutomaticDirectiveConvertible {
     
     func validate(source: URL?, for bundle: DocumentationBundle, in context: DocumentationContext, problems: inout [Problem]) -> Bool {
         // Check that something is configured in the metadata block
-        if documentationOptions == nil && technologyRoot == nil && displayName == nil && pageImages.isEmpty && customMetadata.isEmpty && callToAction == nil && availability.isEmpty && pageKind == nil {
+        if documentationOptions == nil && technologyRoot == nil && displayName == nil && pageImages.isEmpty && customMetadata.isEmpty && callToAction == nil && availability.isEmpty && pageKind == nil && pageColor == nil {
             let diagnostic = Diagnostic(
                 source: source,
                 severity: .information,

--- a/Sources/SwiftDocC/Semantics/Metadata/PageColor.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/PageColor.swift
@@ -1,0 +1,69 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2023 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+import Markdown
+
+/// A directive that specifies an accent color for a given documentation page.
+///
+/// Use the `PageColor` directive to provide a hint to the renderer as to how
+/// the page should be accented with color. The renderer may use this color,
+/// depending on the context, as a foundation for other colors used on the
+/// page. For example, Swift-DocC-Render uses this color as the primary
+/// background color of a page's introduction section and adjusts other
+/// elements in the introduction section to account for the new background.
+///
+/// This directive is only valid within a ``Metadata`` directive:
+///
+/// ```markdown
+/// @Metadata {
+///     @PageColor(orange)
+/// }
+/// ```
+public final class PageColor: Semantic, AutomaticDirectiveConvertible {
+    public let originalMarkup: BlockDirective
+    
+    /// A context-dependent, standard color.
+    @DirectiveArgumentWrapped(name: .unnamed)
+    public var color: Color
+    
+    /// A context-dependent, standard color.
+    public enum Color: String, CaseIterable, DirectiveArgumentValueConvertible {
+        /// A context-dependent blue color.
+        case blue
+        
+        /// A context-dependent gray color.
+        case gray
+        
+        /// A context-dependent green color.
+        case green
+        
+        /// A context-dependent orange color.
+        case orange
+        
+        /// A context-dependent purple color.
+        case purple
+        
+        /// A context-dependent red color.
+        case red
+        
+        /// A context-dependent yellow color.
+        case yellow
+    }
+    
+    static var keyPaths: [String : AnyKeyPath] = [
+        "color": \PageColor._color,
+    ]
+
+    @available(*, deprecated, message: "Do not call directly. Required for 'AutomaticDirectiveConvertible'.")
+    init(originalMarkup: BlockDirective) {
+        self.originalMarkup = originalMarkup
+    }
+}

--- a/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderNode.spec.json
+++ b/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderNode.spec.json
@@ -1791,6 +1791,15 @@
                     }
                 }
             },
+            "TopicColor": {
+                "type": "object",
+                "properties": {
+                    "standardColorIdentifier": {
+                        "type": "string",
+                        "enum": ["blue", "gray", "green", "orange", "purple", "red", "yellow"]
+                    }
+                }
+            },
             "SymbolTag": {
                 "type": "object",
                 "required": [
@@ -2249,6 +2258,9 @@
                         "items": {
                             "$ref": "#/components/schemas/TopicImage"
                         }
+                    },
+                    "color": {
+                        "$ref": "#/components/schemas/TopicColor"
                     },
                     "customMetadata": {
                         "type": "object",

--- a/Sources/SwiftDocC/SwiftDocC.docc/Resources/ThemeSettings.spec.json
+++ b/Sources/SwiftDocC/SwiftDocC.docc/Resources/ThemeSettings.spec.json
@@ -479,6 +479,27 @@
                                     "secondary-label": {
                                         "$ref": "#/components/schemas/Color"
                                     },
+                                    "standard-blue-documentation-intro-fill": {
+                                        "$ref": "#/components/schemas/Color"
+                                    },
+                                    "standard-gray-documentation-intro-fill": {
+                                        "$ref": "#/components/schemas/Color"
+                                    },
+                                    "standard-green-documentation-intro-fill": {
+                                        "$ref": "#/components/schemas/Color"
+                                    },
+                                    "standard-orange-documentation-intro-fill": {
+                                        "$ref": "#/components/schemas/Color"
+                                    },
+                                    "standard-purple-documentation-intro-fill": {
+                                        "$ref": "#/components/schemas/Color"
+                                    },
+                                    "standard-red-documentation-intro-fill": {
+                                        "$ref": "#/components/schemas/Color"
+                                    },
+                                    "standard-yellow-documentation-intro-fill": {
+                                        "$ref": "#/components/schemas/Color"
+                                    },
                                     "step-background": {
                                         "$ref": "#/components/schemas/Color"
                                     },

--- a/Sources/docc/DocCDocumentation.docc/DocC.symbols.json
+++ b/Sources/docc/DocCDocumentation.docc/DocC.symbols.json
@@ -3077,6 +3077,184 @@
         },
         {
           "kind" : "typeIdentifier",
+          "spelling" : "PageColor"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "("
+        },
+        {
+          "kind" : "text",
+          "spelling" : "_ "
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "color"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Color"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ")"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "text" : "A directive that specifies an accent color for a given documentation page."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "Use the `PageColor` directive to provide a hint to the renderer as to how"
+          },
+          {
+            "text" : "the page should be accented with color. The renderer may use this color,"
+          },
+          {
+            "text" : "depending on the context, as a foundation for other colors used on the"
+          },
+          {
+            "text" : "page. For example, Swift-DocC-Render uses this color as the primary"
+          },
+          {
+            "text" : "background color of a page's introduction section and adjusts other"
+          },
+          {
+            "text" : "elements in the introduction section to account for the new background."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "This directive is only valid within a ``Metadata`` directive:"
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "```markdown"
+          },
+          {
+            "text" : "@Metadata {"
+          },
+          {
+            "text" : "    @PageColor(orange)"
+          },
+          {
+            "text" : "}"
+          },
+          {
+            "text" : "```"
+          },
+          {
+            "text" : "- Parameters:"
+          },
+          {
+            "text" : "  - color: A context-dependent, standard color."
+          },
+          {
+            "text" : "     **(required)**"
+          },
+          {
+            "text" : "     - term `blue`: A context-dependent blue color."
+          },
+          {
+            "text" : "     - term `gray`: A context-dependent gray color."
+          },
+          {
+            "text" : "     - term `green`: A context-dependent green color."
+          },
+          {
+            "text" : "     - term `orange`: A context-dependent orange color."
+          },
+          {
+            "text" : "     - term `purple`: A context-dependent purple color."
+          },
+          {
+            "text" : "     - term `red`: A context-dependent red color."
+          },
+          {
+            "text" : "     - term `yellow`: A context-dependent yellow color."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$PageColor"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$PageColor",
+            "spelling" : "PageColor"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "PageColor"
+          },
+          {
+            "kind" : "text",
+            "spelling" : "("
+          },
+          {
+            "kind" : "text",
+            "spelling" : "_ "
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "color"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "spelling" : "Color"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ")"
+          }
+        ],
+        "title" : "PageColor"
+      },
+      "pathComponents" : [
+        "PageColor"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
           "spelling" : "PageImage"
         },
         {

--- a/Sources/docc/DocCDocumentation.docc/Reference Syntax/API Reference Syntax/Metadata.md
+++ b/Sources/docc/DocCDocumentation.docc/Reference Syntax/API Reference Syntax/Metadata.md
@@ -28,15 +28,7 @@ Use the `Metadata` directive with the ``DisplayName`` directive to configure a s
 @Metadata {
     @DisplayName("Sloth Creator")
 }
-````
-
-### Contained Elements
-
-A metadata element must contain one of the following items:
-
-- term ``DocumentationExtension``: Defines whether the content in a documentation extension file amends or replaces in-source documentation. **(optional)**
-- term ``TechnologyRoot``: Configures a documentation page that's not associated with a particular framework to appear as a top-level page. **(optional)**
-- term ``DisplayName``: Configures a symbol's documentation page to use a custom display name. **(optional)**
+```
 
 ## Topics
 
@@ -53,6 +45,7 @@ A metadata element must contain one of the following items:
 - ``DisplayName``
 - ``PageImage``
 - ``PageKind``
+- ``PageColor``
 - ``CallToAction``
 
 ### Customizing the Languages of an Article

--- a/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorTests.swift
@@ -1149,7 +1149,7 @@ class RenderNodeTranslatorTests: XCTestCase {
         XCTAssertEqual(tabNavigator.tabs[2].content.count, 1)
     }
     
-    func testCustomPageImage() throws {
+    func testRenderNodeMetadata() throws {
          let (bundle, context) = try testBundleAndContext(named: "BookLikeContent")
          let reference = ResolvedTopicReference(
              bundleIdentifier: bundle.identifier,
@@ -1220,5 +1220,10 @@ class RenderNodeTranslatorTests: XCTestCase {
         XCTAssertEqual(roundTrippedArticle.metadata.customMetadata.keys.first, "country")
         XCTAssertEqual(roundTrippedArticle.metadata.customMetadata.values.count, 1)
         XCTAssertEqual(roundTrippedArticle.metadata.customMetadata.values.first, "Belgium")
+        
+        XCTAssertEqual(
+            roundTrippedArticle.metadata.color?.standardColorIdentifier,
+            "yellow"
+        )
      }
 }

--- a/Tests/SwiftDocCTests/Semantics/DirectiveInfrastructure/DirectiveIndexTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/DirectiveInfrastructure/DirectiveIndexTests.swift
@@ -36,6 +36,7 @@ class DirectiveIndexTests: XCTestCase {
                 "Links",
                 "Metadata",
                 "Options",
+                "PageColor",
                 "PageImage",
                 "PageKind",
                 "Redirected",

--- a/Tests/SwiftDocCTests/Semantics/DirectiveInfrastructure/DirectiveMirrorTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/DirectiveInfrastructure/DirectiveMirrorTests.swift
@@ -39,7 +39,7 @@ class DirectiveMirrorTests: XCTestCase {
         XCTAssertFalse(reflectedDirective.allowsMarkup)
         XCTAssert(reflectedDirective.arguments.isEmpty)
         
-        XCTAssertEqual(reflectedDirective.childDirectives.count, 9)
+        XCTAssertEqual(reflectedDirective.childDirectives.count, 10)
         
         XCTAssertEqual(
             reflectedDirective.childDirectives["DocumentationExtension"]?.propertyLabel,

--- a/Tests/SwiftDocCTests/Semantics/MetadataTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/MetadataTests.swift
@@ -311,6 +311,42 @@ class MetadataTests: XCTestCase {
         )
     }
     
+    func testPageColorSupport() throws {
+        do {
+            let (problems, metadata) = try parseMetadataFromSource(
+            """
+            # Article title
+            
+            @Metadata {
+                @PageColor(blue)
+            }
+            
+            The abstract of this article.
+            """
+            )
+            
+            XCTAssertEqual(problems, [])
+            XCTAssertEqual(metadata.pageColor, .blue)
+        }
+        
+        do {
+            let (problems, metadata) = try parseMetadataFromSource(
+            """
+            # Article title
+            
+            @Metadata {
+                @PageColor(green)
+            }
+            
+            The abstract of this article.
+            """
+            )
+            
+            XCTAssertEqual(problems, [])
+            XCTAssertEqual(metadata.pageColor, .green)
+        }
+    }
+    
     func parseMetadataFromSource(
         _ source: String,
         file: StaticString = #file,

--- a/Tests/SwiftDocCTests/Test Bundles/BookLikeContent.docc/MyArticle.md
+++ b/Tests/SwiftDocCTests/Test Bundles/BookLikeContent.docc/MyArticle.md
@@ -6,6 +6,7 @@ This is the abstract of my article. Nice!
     @PageImage(source: "plus", alt: "A plus icon.", purpose: icon)
     @PageImage(source: "figure1", alt: "An example figure.", purpose: card)
     @CustomMetadata(key: "country", value: "Belgium")
+    @PageColor(yellow)
 }
 
 @Row(numberOfColumns: 8) {

--- a/bin/preview-docs
+++ b/bin/preview-docs
@@ -76,7 +76,6 @@ case $FRAMEWORK in
       --fallback-display-name SwiftDocC \
       --fallback-bundle-identifier org.swift.SwiftDocC \
       --fallback-bundle-version 1.0.0 \
-      --diagnostic-level error \
       --additional-symbol-graph-dir "$SGFS_DIR" \
       --output-path "$DOCS_BUILD_DIR"
   ;;
@@ -103,7 +102,6 @@ case $FRAMEWORK in
       --fallback-display-name SwiftDocCUtilities \
       --fallback-bundle-identifier org.swift.SwiftDocCUtilities \
       --fallback-bundle-version 1.0.0 \
-      --diagnostic-level error \
       --additional-symbol-graph-dir "$SGFS_DIR" \
       --output-path $DOCS_BUILD_DIR
   ;;
@@ -113,7 +111,6 @@ case $FRAMEWORK in
     # Compile the documentation
     swift run docc $DOCC_CMD "$DOCC_ROOT/Sources/docc/DocCDocumentation.docc" \
       --experimental-enable-custom-templates \
-      --diagnostic-level error \
       --output-path $DOCS_BUILD_DIR
   ;;
   


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://106153042

## Summary

Adds a new `@PageColor` metadata directive that allows for customizing the color used to represent a given page.

`@PageColor` gives authors control over the color used when rendering a page – initially this will affect the background color Swift-DocC-Render uses in the page's introduction (hero) section.

## Example

    # What's New in SlothCreator

    @Metadata {
        @PageColor(blue)
    }

    ![A sloth on a tree wearing a fedora.](sloth-fedora)

    Let's check out what's new in SlothCreator!

    ...

## Details

### Declaration

```swift
@PageColor(_ color: Color)
```

### Overview

Use the `PageColor` directive to provide a hint to the Swift-DocC renderer as to what color should represent this page. The renderer will use this color, depending on the context, as a foundation for the other accent colors used in the page. For example, Swift-DocC-Render will use this color as the primary background color of a page’s introduction section and adjust the colors of the icon and text in the page’s introduction accordingly.

This directive is only valid within an `@Metadata` directive.


```swift
@Metadata {
    @PageColor(purple)
}
```

### Parameters

`@PageColor` accepts the following parameters:

*  `color`: An unnamed parameter that accepts one of the following pre-defined colors. Each color is context-dependent.
    * blue
    * gray
    * green
    * orange
    * purple
    * red
    * yellow

### Examples

The following screenshots show how Swift-DocC Render might interpret the given color inputs initially.

![Hero-yellow@2x](https://user-images.githubusercontent.com/6750147/228683082-03e26099-e943-4bcb-885f-bb45748dab1d.png)
![Hero-purple@2x](https://user-images.githubusercontent.com/6750147/228683090-31fabd2e-acfb-426d-885e-9719602e1fe7.png)
![Hero-green@2x](https://user-images.githubusercontent.com/6750147/228683091-16b73fd3-e39e-4579-8805-ccfc38cc1403.png)


Forums post: https://forums.swift.org/t/support-for-customizing-a-page-s-accent-color-in-swift-docc/64093

## Dependencies

Swift-DocC-Render PR TBD.

## Testing

Add `@PageColor` to the `@Metadata` directive in a Swift-DocC article or extension file and confirm that the resulting RenderNode includes a `color` metadata property.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
