### PR TITLE
Process `typeDetails` information from symbol graphs.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -42,7 +42,7 @@
         "repositoryURL": "https://github.com/apple/swift-docc-symbolkit",
         "state": {
           "branch": "main",
-          "revision": "ccbbd881d75d3ca503daf8cf3b5d78adbf647da9",
+          "revision": "53e5cb9b18222f66cb8d6fb684d7383e705e0936",
           "version": null
         }
       },

--- a/Tests/SwiftDocCTests/Test Bundles/DictionaryData.docc/dictionary.symbols.json
+++ b/Tests/SwiftDocCTests/Test Bundles/DictionaryData.docc/dictionary.symbols.json
@@ -34,6 +34,12 @@
       "targetFallback": null
     },
     {
+      "kind": "optionalMemberOf",
+      "source": "data:test:Artist@monthOfBirth",
+      "target": "data:test:Artist",
+      "targetFallback": null
+    },
+    {
       "kind": "memberOf",
       "source": "data:test:Artist@name",
       "target": "data:test:Artist",
@@ -168,6 +174,50 @@
       "declarationFragments": [
         {
           "kind": "text",
+          "spelling": "*"
+        }
+      ],
+      "identifier": {
+        "interfaceLanguage": "data",
+        "precise": "data:test:Artist@monthOfBirth"
+      },
+      "kind": {
+        "displayName": "Dictionary Key",
+        "identifier": "dictionaryKey"
+      },
+      "names": {
+        "title": "monthOfBirth"
+      },
+      "pathComponents": [
+        "Artist",
+        "monthOfBirth"
+      ],
+      "typeDetails": [
+        {
+          "baseType": "integer",
+          "fragments": [
+            {
+              "kind": "text",
+              "spelling": "integer"
+            }
+          ]
+        },
+        {
+          "baseType": "string",
+          "fragments": [
+            {
+              "kind": "text",
+              "spelling": "string"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "text",
           "spelling": "string"
         }
       ],
@@ -192,7 +242,11 @@
       "declarationFragments": [
         {
           "kind": "text",
-          "spelling": "string Genre"
+          "spelling": "string "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "Genre"
         }
       ],
       "identifier": {
@@ -218,6 +272,11 @@
       },
       "pathComponents": [
         "Genre"
+      ],
+      "typeDetails": [
+        {
+          "baseType": "string",
+        }
       ]
     },
     {

--- a/Tests/SwiftDocCTests/XCTestCase+AssertingTestData.swift
+++ b/Tests/SwiftDocCTests/XCTestCase+AssertingTestData.swift
@@ -22,7 +22,7 @@ extension XCTestCase {
         symbolKind expectedSymbolKind: String? = nil,
         title expectedTitle: String,
         navigatorTitle expectedNavigatorTitle: String?,
-        abstract expectedAbstract: String,
+        abstract expectedAbstract: String?,
         declarationTokens expectedDeclarationTokens: [String]?,
         endpointTokens expectedEndpointTokens: [String]? = nil,
         httpParameters expectedHTTPParameters: [String]? = nil,


### PR DESCRIPTION

Bug/issue #, if applicable: rdar://107432025

## Summary

Converts new `typeDetails` information in symbol graph into base-type details and allowed type declarations for `RenderProperty` entities, such as dictionary keys and HTTP parameters. This data is rendered on the page as part of the key or parameter documentation as a "Possible types" attribute, listing the individual types.


## Dependencies

Requires changes on `type_details` branch of pdwilson12/swift-docc-symbolkit tracked in https://github.com/apple/swift-docc-symbolkit/pull/56

## Testing

Build docc and preview the DictionaryData.docc fixture bundle.

Steps:
1. Run `docc preview` on the `DictionaryData.docc` fixture
2. View the `Artist` page and confirm "Possible types" entry of `monthOfBirth` key.
3. Modify the symbol graph for monthOfBirth key, adding/modifying the `typeDetails` entry and verify changes reflected on page.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
