### PR TITLE
[5.9] Process `typeDetails` information from symbol graphs

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -42,7 +42,7 @@
         "repositoryURL": "https://github.com/apple/swift-docc-symbolkit",
         "state": {
           "branch": "main",
-          "revision": "ccbbd881d75d3ca503daf8cf3b5d78adbf647da9",
+          "revision": "53e5cb9b18222f66cb8d6fb684d7383e705e0936",
           "version": null
         }
       },

--- a/Package.resolved
+++ b/Package.resolved
@@ -41,8 +41,8 @@
         "package": "SymbolKit",
         "repositoryURL": "https://github.com/apple/swift-docc-symbolkit",
         "state": {
-          "branch": "main",
-          "revision": "53e5cb9b18222f66cb8d6fb684d7383e705e0936",
+          "branch": "release/5.9",
+          "revision": "d42e3db1c0f97f4a3be9a4552f7003c2959268d5",
           "version": null
         }
       },

--- a/Package.swift
+++ b/Package.swift
@@ -118,7 +118,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(name: "swift-markdown", url: "https://github.com/apple/swift-markdown.git", .branch("main")),
         .package(name: "CLMDB", url: "https://github.com/apple/swift-lmdb.git", .branch("main")),
         .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "1.0.1")),
-        .package(name: "SymbolKit", url: "https://github.com/apple/swift-docc-symbolkit", .branch("main")),
+        .package(name: "SymbolKit", url: "https://github.com/apple/swift-docc-symbolkit", .branch("release/5.9")),
         .package(url: "https://github.com/apple/swift-crypto.git", .upToNextMinor(from: "1.1.2")),
     ]
     

--- a/Tests/SwiftDocCTests/Test Bundles/DictionaryData.docc/dictionary.symbols.json
+++ b/Tests/SwiftDocCTests/Test Bundles/DictionaryData.docc/dictionary.symbols.json
@@ -34,6 +34,12 @@
       "targetFallback": null
     },
     {
+      "kind": "optionalMemberOf",
+      "source": "data:test:Artist@monthOfBirth",
+      "target": "data:test:Artist",
+      "targetFallback": null
+    },
+    {
       "kind": "memberOf",
       "source": "data:test:Artist@name",
       "target": "data:test:Artist",
@@ -168,6 +174,50 @@
       "declarationFragments": [
         {
           "kind": "text",
+          "spelling": "*"
+        }
+      ],
+      "identifier": {
+        "interfaceLanguage": "data",
+        "precise": "data:test:Artist@monthOfBirth"
+      },
+      "kind": {
+        "displayName": "Dictionary Key",
+        "identifier": "dictionaryKey"
+      },
+      "names": {
+        "title": "monthOfBirth"
+      },
+      "pathComponents": [
+        "Artist",
+        "monthOfBirth"
+      ],
+      "typeDetails": [
+        {
+          "baseType": "integer",
+          "fragments": [
+            {
+              "kind": "text",
+              "spelling": "integer"
+            }
+          ]
+        },
+        {
+          "baseType": "string",
+          "fragments": [
+            {
+              "kind": "text",
+              "spelling": "string"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "text",
           "spelling": "string"
         }
       ],
@@ -192,7 +242,11 @@
       "declarationFragments": [
         {
           "kind": "text",
-          "spelling": "string Genre"
+          "spelling": "string "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "Genre"
         }
       ],
       "identifier": {
@@ -218,6 +272,11 @@
       },
       "pathComponents": [
         "Genre"
+      ],
+      "typeDetails": [
+        {
+          "baseType": "string",
+        }
       ]
     },
     {

--- a/Tests/SwiftDocCTests/XCTestCase+AssertingTestData.swift
+++ b/Tests/SwiftDocCTests/XCTestCase+AssertingTestData.swift
@@ -22,7 +22,7 @@ extension XCTestCase {
         symbolKind expectedSymbolKind: String? = nil,
         title expectedTitle: String,
         navigatorTitle expectedNavigatorTitle: String?,
-        abstract expectedAbstract: String,
+        abstract expectedAbstract: String?,
         declarationTokens expectedDeclarationTokens: [String]?,
         endpointTokens expectedEndpointTokens: [String]? = nil,
         httpParameters expectedHTTPParameters: [String]? = nil,


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift-docc/pull/529

Explanation: HTTP/REST requests and JSON dictionaries can define parameters and keys that are weakly typed, allowing for multiple possible value types, such as integer or string. This extends symbol graphs to call out those individual allowed types and show up on the rendered page.
Scope: Adds a new optional key to symbol graphs and converts that data to existing page structures used when rendering HTTP parameters and dictionary keys.
Radar: rdar://107432025
Risk: Low. Added key is optional.
Testing: Changes are covered by unit tests.
Reviewer: @QuietMisdreavus