### PR TITLE
Remove deprecated usages of 'layout' API of 'ContentAndMedia' in docs

### DIFF
--- a/Sources/docc/DocCDocumentation.docc/Reference Syntax/Tutorials Syntax/Top-Level Directives/Tutorial/Section.md
+++ b/Sources/docc/DocCDocumentation.docc/Reference Syntax/Tutorials Syntax/Top-Level Directives/Tutorial/Section.md
@@ -23,7 +23,7 @@ Use the `title` parameter to provide a name for the section. Then, use the ``Con
     ...
     
     @Section(title: "Add a customization view") {
-        @ContentAndMedia(layout: "horizontal") {
+        @ContentAndMedia {
             Add the ability for users to customize sloths and select their powers.
             
             @Image(source: 01-creating-section2.png, alt: "An outline of a sloth surrounded by four power type icons. The power type icons are arranged in the following order, clockwise from the top: fire, wind, lightning, and ice.")

--- a/Sources/docc/DocCDocumentation.docc/Reference Syntax/Tutorials Syntax/Top-Level Directives/Tutorial/Section/ContentAndMedia.md
+++ b/Sources/docc/DocCDocumentation.docc/Reference Syntax/Tutorials Syntax/Top-Level Directives/Tutorial/Section/ContentAndMedia.md
@@ -16,7 +16,7 @@ Use a `ContentAndMedia` directive within a ``Section`` or ``Stack`` directive to
     ...
     
     @Section(title: "Add a customization view") {
-        @ContentAndMedia(layout: "horizontal") {
+        @ContentAndMedia {
             Add the ability for users to customize sloths and select their powers.
             
             @Image(source: 01-creating-section2.png, alt: "An outline of a sloth surrounded by four power type icons. The power type icons are arranged in the following order, clockwise from the top: fire, wind, lightning, and ice.")

--- a/Sources/docc/DocCDocumentation.docc/Reference Syntax/Tutorials Syntax/Top-Level Directives/Tutorial/Section/Stack.md
+++ b/Sources/docc/DocCDocumentation.docc/Reference Syntax/Tutorials Syntax/Top-Level Directives/Tutorial/Section/Stack.md
@@ -16,22 +16,22 @@ Use the Stack directive to horizontally arrange between one and three groupings 
     ...
     
     @Section(title: "Add a customization view") {
-        @ContentAndMedia(layout: "horizontal") {
+        @ContentAndMedia {
             Add the ability for users to customize sloths and select their powers.
             
             @Image(source: 01-creating-section2.png, alt: "An outline of a sloth surrounded by four power type icons. The power type icons are arranged in the following order, clockwise from the top: fire, wind, lightning, and ice.")
         }
         
         @Stack {
-            @ContentAndMedia(layout: "horizontal") {
+            @ContentAndMedia {
                 ...
             }
 
-            @ContentAndMedia(layout: "horizontal") {            
+            @ContentAndMedia {            
                 ...            
             }
 
-            @ContentAndMedia(layout: "horizontal") {
+            @ContentAndMedia {
                 ...
             }
         

--- a/Sources/docc/DocCDocumentation.docc/Reference Syntax/Tutorials Syntax/Top-Level Directives/Tutorial/Section/Steps/Step/Step.md
+++ b/Sources/docc/DocCDocumentation.docc/Reference Syntax/Tutorials Syntax/Top-Level Directives/Tutorial/Section/Steps/Step/Step.md
@@ -20,7 +20,7 @@ Use the `Step` directive to define a single task the reader performs within a se
         }
         
         @Section(title: "Create a new folder and add SlothCreator") {
-            @ContentAndMedia(layout: "horizontal") {
+            @ContentAndMedia {
                 
                 ...
                 

--- a/Sources/docc/DocCDocumentation.docc/Reference Syntax/Tutorials Syntax/Top-Level Directives/Tutorial/Section/Steps/Steps.md
+++ b/Sources/docc/DocCDocumentation.docc/Reference Syntax/Tutorials Syntax/Top-Level Directives/Tutorial/Section/Steps/Steps.md
@@ -20,7 +20,7 @@ Each individual step contains instructional text along with either a code listin
     ...
     
     @Section(title: "Create a Swift Package") {
-        @ContentAndMedia(layout: "horizontal") {
+        @ContentAndMedia {
 
             ...
 

--- a/Sources/docc/DocCDocumentation.docc/Reference Syntax/Tutorials Syntax/Top-Level Directives/Tutorial/Tutorial.md
+++ b/Sources/docc/DocCDocumentation.docc/Reference Syntax/Tutorials Syntax/Top-Level Directives/Tutorial/Tutorial.md
@@ -29,7 +29,7 @@ Use a text editor to add a Tutorial file to your documentation catalog and ensur
     }
     
     @Section(title: "<#text#>") {
-        @ContentAndMedia(layout: horizontal) {
+        @ContentAndMedia {
             <#text#>
             
             @Image(source: <#file#>, alt: "<#accessible description#>")
@@ -112,7 +112,7 @@ Define sections using the ``Section`` directive. You can optionally start with d
     }
     
     @Section(title: "Create a Swift Package in a new directory") {
-        @ContentAndMedia(layout: "horizontal") {
+        @ContentAndMedia {
             
             ...
             
@@ -146,7 +146,7 @@ Define sections using the ``Section`` directive. You can optionally start with d
     }
     
     @Section(title: "Add a customization view") {
-        @ContentAndMedia(layout: "horizontal") {
+        @ContentAndMedia {
 
             ...
 
@@ -174,7 +174,7 @@ At the end of a tutorial page, you can optionally use an ``Assessments`` directi
     }
     
     @Section(title: "Create a new project and add SlothCreator") {
-        @ContentAndMedia(layout: "horizontal") {
+        @ContentAndMedia {
             
             ...
 

--- a/Sources/docc/DocCDocumentation.docc/Reference Syntax/Tutorials Syntax/building-an-interactive-tutorial.md
+++ b/Sources/docc/DocCDocumentation.docc/Reference Syntax/Tutorials Syntax/building-an-interactive-tutorial.md
@@ -69,7 +69,7 @@ Tutorial pages provide instructions that walk through using your APIs in realist
     }
     
     @Section(title: "Add the name of your section here.") {
-        @ContentAndMedia(layout: horizontal) {
+        @ContentAndMedia {
             Add engaging section text here.
             
             @Image(source: "section-image-filename-here.jpg", alt: "Add an accessible description for your image here.")    
@@ -103,7 +103,7 @@ Replace the placeholders with your custom content. Use the ``Intro`` directive t
     }
     
     @Section(title: "Add a section title here") {
-        @ContentAndMedia(layout: "horizontal") {
+        @ContentAndMedia {
             Add some content here to introduce the steps that follow.
             
             @Image(source: "section-image-filename.png", alt: "Add an accessible description for your image here.")

--- a/Tests/SwiftDocCTests/LinkTargets/LinkDestinationSummaryTests.swift
+++ b/Tests/SwiftDocCTests/LinkTargets/LinkDestinationSummaryTests.swift
@@ -49,7 +49,7 @@ class ExternalLinkableTests: XCTestCase {
                    }
                    
                    @Section(title: "Create a New AR Project 💻") {
-                      @ContentAndMedia(layout: vertical) {
+                      @ContentAndMedia {
                          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
                          ut labore et dolore magna aliqua. Phasellus faucibus scelerisque eleifend donec pretium.
 

--- a/Tests/SwiftDocCTests/LinkTargets/LinkDestinationSummaryTests.swift
+++ b/Tests/SwiftDocCTests/LinkTargets/LinkDestinationSummaryTests.swift
@@ -49,7 +49,7 @@ class ExternalLinkableTests: XCTestCase {
                    }
                    
                    @Section(title: "Create a New AR Project 💻") {
-                      @ContentAndMedia {
+                      @ContentAndMedia(layout: vertical) {
                          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
                          ut labore et dolore magna aliqua. Phasellus faucibus scelerisque eleifend donec pretium.
 


### PR DESCRIPTION
<!--
If you're opening a PR to cherry-pick a change for a release branch, use this template instead:
https://github.com/apple/swift-docc/blob/main/.github/PULL_REQUEST_TEMPLATE/CHERRY_PICK.md
-->

Bug/issue #, if applicable: None.

## Summary

_Provide a description of what your PR addresses, explaining the expected user experience. 
Also, provide an overview of your implementation._

Since 'layout' init parameter of 'ContentAndMedia' is deprecated by https://github.com/apple/swift-docc/blob/f7cc54ab64eeebe06d4ca721cc7ac78c2da6f545/Sources/SwiftDocC/Semantics/ContentAndMedia.swift#L86

We should remove the usages of this parameter in our documents and tests

## Dependencies

_Describe any dependencies this PR might have, such as an associated branch in another repository._

None.

## Testing

_Describe how a reviewer can test the functionality of your PR. Provide test content to test with if
applicable._

Steps:
1. _Provide setup instructions._
2. _Explain in detail how the functionality can be tested._

None.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
