### PR TITLE
Fix rendering issue for links with special characters

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -1003,6 +1003,9 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
     /// This allows convenient access to other symbol's documentation nodes while building relationships between symbols.
     private(set) var symbolIndex = [String: DocumentationNode]()
     
+    /// A lookup of resolved references based on the reference's absolute string.
+    private(set) var referenceIndex = [String: ResolvedTopicReference]()
+    
     private func nodeWithInitializedContent(reference: ResolvedTopicReference, matches: [DocumentationContext.SemanticResult<Article>]?) -> DocumentationNode {
         precondition(documentationCache.keys.contains(reference))
         
@@ -2311,6 +2314,14 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
         topicGraphGlobalAnalysis()
         
         preResolveModuleNames()
+        
+        referenceIndex.reserveCapacity(knownIdentifiers.count + nodeAnchorSections.count)
+        for reference in knownIdentifiers {
+            referenceIndex[reference.absoluteString] = reference
+        }
+        for reference in nodeAnchorSections.keys {
+            referenceIndex[reference.absoluteString] = reference
+        }
     }
     
     /// Given a list of topics that have been automatically curated, checks if a topic has been additionally manually curated

--- a/Sources/SwiftDocC/Infrastructure/DocumentationCurator.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationCurator.swift
@@ -38,7 +38,7 @@ struct DocumentationCurator {
         }
         
         // Optimization for absolute links.
-        if let cached = context.documentationCacheBasedLinkResolver.referenceFor(absoluteSymbolPath: destination, parent: resolved) {
+        if let cached = context.referenceIndex[destination] {
             return cached
         }
         

--- a/Sources/SwiftDocC/Model/Identifier.swift
+++ b/Sources/SwiftDocC/Model/Identifier.swift
@@ -623,7 +623,7 @@ public struct ResourceReference: Hashable {
 /// If this step is not performed, the disallowed characters are instead percent escape encoded instead which is less readable.
 /// For example, a path like `"hello world/example project"` is converted to `"hello-world/example-project"`
 /// instead of `"hello%20world/example%20project"`.
-func urlReadablePath(_ path: String) -> String {
+func urlReadablePath<S: StringProtocol>(_ path: S) -> String {
     return path.components(separatedBy: .urlPathNotAllowed).joined(separator: "-")
 }
 
@@ -639,7 +639,7 @@ private extension CharacterSet {
 ///
 /// If this step is not performed, the disallowed characters are instead percent escape encoded, which is less readable.
 /// For example, a fragment like `"#hello world"` is converted to `"#hello-world"` instead of `"#hello%20world"`.
-func urlReadableFragment(_ fragment: String) -> String {
+func urlReadableFragment<S: StringProtocol>(_ fragment: S) -> String {
     var fragment = fragment
         // Trim leading/trailing whitespace
         .trimmingCharacters(in: .whitespaces)

--- a/Sources/SwiftDocC/Model/Rendering/RenderContentCompiler.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderContentCompiler.swift
@@ -192,6 +192,11 @@ struct RenderContentCompiler: MarkupVisitor {
     }
     
     mutating func resolveTopicReference(_ destination: String) -> ResolvedTopicReference? {
+        if let cached = context.referenceIndex[destination] {
+            collectedTopicReferences.append(cached)
+            return cached
+        }
+        
         guard let validatedURL = ValidatedURL(parsingAuthoredLink: destination) else {
             return nil
         }
@@ -215,7 +220,7 @@ struct RenderContentCompiler: MarkupVisitor {
     }
 
     func resolveSymbolReference(destination: String) -> ResolvedTopicReference? {
-        if let cached = context.documentationCacheBasedLinkResolver.referenceFor(absoluteSymbolPath: destination, parent: identifier) {
+        if let cached = context.referenceIndex[destination] {
             return cached
         }
 

--- a/Sources/SwiftDocC/Model/Rendering/RenderContentCompiler.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderContentCompiler.swift
@@ -175,9 +175,23 @@ struct RenderContentCompiler: MarkupVisitor {
             useOverriding = false
         } else if let overridingTitle = overridingTitle,
                   overridingTitle.hasPrefix(ResolvedTopicReference.urlScheme + ":"),
-                  destination.hasPrefix(ResolvedTopicReference.urlScheme + "://"),
-                  destination.hasSuffix(overridingTitle.dropFirst((ResolvedTopicReference.urlScheme + ":").count)) { // If the link is a transformed doc link, we don't use overriding info
-            useOverriding = false
+                  destination.hasPrefix(ResolvedTopicReference.urlScheme + "://")
+        {
+            // The overriding title looks like a documentation link. Escape it like a resolved reference string to compare it with the destination.
+            let withoutScheme = overridingTitle.dropFirst((ResolvedTopicReference.urlScheme + ":").count)
+            if destination.hasSuffix(withoutScheme) {
+                useOverriding = false
+            } else {
+                let escapedTitle: String
+                if let fragmentIndex = withoutScheme.firstIndex(of: "#") {
+                    let escapedFragment = withoutScheme[fragmentIndex...].dropFirst().addingPercentEncoding(withAllowedCharacters: .urlFragmentAllowed) ?? ""
+                    escapedTitle = "\(urlReadablePath(withoutScheme[..<fragmentIndex]))#\(escapedFragment)"
+                } else {
+                    escapedTitle = urlReadablePath(withoutScheme)
+                }
+                
+                useOverriding = !destination.hasSuffix(escapedTitle) // If the link is a transformed doc link, we don't use overriding info
+            }
         } else {
             useOverriding = true
         }

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -544,7 +544,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
             // This is an external link
             let externalLinkIdentifier = RenderReferenceIdentifier(forExternalLink: link.absoluteString)
             if linkReferences.keys.contains(externalLinkIdentifier.identifier) {
-                // If we've already seen this link, return the existing reference with an overriden title.
+                // If we've already seen this link, return the existing reference with an overridden title.
                 action = RenderInlineContent.reference(identifier: externalLinkIdentifier,
                                                        isActive: true,
                                                        overridingTitle: overridingTitle,

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -534,8 +534,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
         
         let action: RenderInlineContent
         // We expect, at this point of the rendering, this API to be called with valid URLs, otherwise crash.
-        let unresolved = UnresolvedTopicReference(topicURL: ValidatedURL(link)!)
-        if case let .success(resolved) = context.resolve(.unresolved(unresolved), in: bundle.rootReference) {
+        if let resolved = context.referenceIndex[link.absoluteString] {
             action = RenderInlineContent.reference(identifier: RenderReferenceIdentifier(resolved.absoluteString),
                                                    isActive: true,
                                                    overridingTitle: overridingTitle,

--- a/Sources/SwiftDocC/Semantics/MarkupReferenceResolver.swift
+++ b/Sources/SwiftDocC/Semantics/MarkupReferenceResolver.swift
@@ -118,7 +118,7 @@ struct MarkupReferenceResolver: MarkupRewriter {
     }
 
     mutating func resolveAbsoluteSymbolLink(unresolvedDestination: String, elementRange range: SourceRange?) -> ResolvedTopicReference? {
-        if let cached = context.documentationCacheBasedLinkResolver.referenceFor(absoluteSymbolPath: unresolvedDestination, parent: rootReference) {
+        if let cached = context.referenceIndex[unresolvedDestination] {
             guard context.topicGraph.isLinkable(cached) == true else {
                 problems.append(disabledLinkDestinationProblem(reference: cached, source: source, range: range, severity: .warning))
                 return nil

--- a/Sources/SwiftDocC/Semantics/MarkupReferenceResolver.swift
+++ b/Sources/SwiftDocC/Semantics/MarkupReferenceResolver.swift
@@ -113,7 +113,12 @@ struct MarkupReferenceResolver: MarkupRewriter {
             return link
         }
         var link = link
+        let wasAutoLink = link.isAutolink
         link.destination = resolvedURL.absoluteString
+        if wasAutoLink {
+            link.replaceChildrenInRange(0..<link.childCount, with: [Text(resolvedURL.absoluteString)])
+            assert(link.isAutolink)
+        }
         return link
     }
 

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -1668,6 +1668,8 @@ let expected = """
     }
     
     func testSpecialCharactersInLinks() throws {
+        try XCTSkipUnless(LinkResolutionMigrationConfiguration.shouldUseHierarchyBasedLinkResolver)
+        
         let originalSymbolGraph = Bundle.module.url(forResource: "TestBundle", withExtension: "docc", subdirectory: "Test Bundles")!.appendingPathComponent("mykit-iOS.symbols.json")
         
         let testBundle = Folder(name: "special-characters.docc", content: [

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -1753,7 +1753,7 @@ let expected = """
         
         
         let contentSection = try XCTUnwrap(renderNode.primaryContentSections.first as? ContentRenderSection)
-        let lists = contentSection.content.compactMap({ content in
+        let lists: [RenderBlockContent.UnorderedList] = contentSection.content.compactMap({ (content: RenderBlockContent) -> RenderBlockContent.UnorderedList? in
             if case let .unorderedList(list) = content {
                 return list
             } else {


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://85531439

## Summary

Fix an issue where symbol links or documentation links containing special characters resolved successfully but didn't render as expected on the page.

There are two parts to this fix:
- Allow any previously resolved reference to be looked up without resolving it again. I do this because `MarkupReferenceResolver` replaces the links original destination with the absolute string of the resolves reference but the resolved reference replaces non-path characters with "-" resulting in potential ambiguity when re-resolving the link.
- Preserve the `isAutolink` attribute of `Link` values when updating their destination with a new resolved `destination`

## Dependencies

None.

## Testing

- Use one or more special characters—for example `π` or 😃—in an element that can be linked to. This can be either in a symbol name, article file name, or heading. 
  See for example [this unit test][1].
- Write a symbol link to the symbol, article, or heading containing the special character.
   _Expected:_ The link should resolve and render with its title as the link text
- Also curate the symbol, article, or heading containing the special character.
_Expected:_ The link should resolve and render with its title as the link text

[1]: https://github.com/apple/swift-docc/pull/532/files#diff-9b0aec6c7b0be499b4e872a4787cf47cb210416da4acccd0e6795b1e809373e8R1673-R1711

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
