### PR TITLE
update branch dependencies to release/5.9

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
         "package": "cmark-gfm",
         "repositoryURL": "https://github.com/apple/swift-cmark.git",
         "state": {
-          "branch": "gfm",
-          "revision": "eb9a6a357b6816c68f4b194eaa5b67f3cd1fa5c3",
+          "branch": "release/5.9",
+          "revision": "86aeb491675de6f077a3a6df6cbcac1a25dcbee1",
           "version": null
         }
       },
@@ -50,7 +50,7 @@
         "package": "CLMDB",
         "repositoryURL": "https://github.com/apple/swift-lmdb.git",
         "state": {
-          "branch": "main",
+          "branch": "release/5.9",
           "revision": "584941b1236b15bad74d8163785d389c028b1ad8",
           "version": null
         }
@@ -59,8 +59,8 @@
         "package": "swift-markdown",
         "repositoryURL": "https://github.com/apple/swift-markdown.git",
         "state": {
-          "branch": "main",
-          "revision": "36b71b380ca9cb7497fc24416f8b77721eaf7330",
+          "branch": "release/5.9",
+          "revision": "bbeb362919d903eb722c913ad49a1b23d27bdc00",
           "version": null
         }
       },

--- a/Package.swift
+++ b/Package.swift
@@ -115,8 +115,8 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     // Building standalone, so fetch all dependencies remotely.
     package.dependencies += [
         .package(url: "https://github.com/apple/swift-nio.git", .upToNextMinor(from: "2.31.2")),
-        .package(name: "swift-markdown", url: "https://github.com/apple/swift-markdown.git", .branch("main")),
-        .package(name: "CLMDB", url: "https://github.com/apple/swift-lmdb.git", .branch("main")),
+        .package(name: "swift-markdown", url: "https://github.com/apple/swift-markdown.git", .branch("release/5.9")),
+        .package(name: "CLMDB", url: "https://github.com/apple/swift-lmdb.git", .branch("release/5.9")),
         .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "1.0.1")),
         .package(name: "SymbolKit", url: "https://github.com/apple/swift-docc-symbolkit", .branch("release/5.9")),
         .package(url: "https://github.com/apple/swift-crypto.git", .upToNextMinor(from: "1.1.2")),


### PR DESCRIPTION
- **Explanation**: This PR updates the branch dependencies of Swift-Markdown and swift-lmdb to their respective `release/5.9` branches.
- **Scope**: Ensures that the 5.9 release of Swift-DocC doesn't accidentally integrate with unintended code from these projects' `main` branches.
- **GitHub Issue**: None
- **Risk**: Low. These repos should be very close in code content with each other, if not identical.
- **Testing**: `bin/test` passes.