### PR TITLE
[ConvertService] Support resolving images referenced in content

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -2832,13 +2832,16 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
     public func identifier(forAssetName name: String, in parent: ResolvedTopicReference) -> String? {
         let bundleIdentifier = parent.bundleIdentifier
         if let assetManager = assetManagers[bundleIdentifier] {
-            return assetManager.bestKey(forAssetName: name)
-        } else {
-            if _externalAssetResolvers[bundleIdentifier]?._resolveExternalAsset(named: name, bundleIdentifier: parent.bundleIdentifier) != nil {
-                return name
-            } else {
-                return nil
+            if let localName = assetManager.bestKey(forAssetName: name) {
+                return localName
+            } else if let fallbackAssetManager = fallbackAssetResolvers[bundleIdentifier] {
+                return fallbackAssetManager.resolve(assetNamed: name, bundleIdentifier: bundleIdentifier) != nil ? name : nil
             }
+            return nil
+        } else if _externalAssetResolvers[bundleIdentifier]?._resolveExternalAsset(named: name, bundleIdentifier: parent.bundleIdentifier) != nil {
+            return name
+        } else {
+            return nil
         }
     }
 

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -87,7 +87,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
         let mediaReference = step.media.map { visit($0) } as? RenderReferenceIdentifier
         let codeReference = step.code.map { visitCode($0) } as? RenderReferenceIdentifier
         
-        let previewReference = step.code?.preview.map {
+        let previewReference = step.code?.preview.flatMap {
             createAndRegisterRenderReference(forMedia: $0.source, altText: ($0 as? ImageMedia)?.altText)
         }
         
@@ -262,8 +262,8 @@ public struct RenderNodeTranslator: SemanticVisitor {
         section.video = intro.video.map { visit($0) } as? RenderReferenceIdentifier
         
         // Set the Intro's background image to the video's poster image.
-        section.backgroundImage = intro.video?.poster.map { createAndRegisterRenderReference(forMedia: $0) }
-            ?? intro.image.map { createAndRegisterRenderReference(forMedia: $0.source) }
+        section.backgroundImage = intro.video?.poster.flatMap { createAndRegisterRenderReference(forMedia: $0) }
+            ?? intro.image.flatMap { createAndRegisterRenderReference(forMedia: $0.source) }
         
         return section
     }
@@ -726,12 +726,11 @@ public struct RenderNodeTranslator: SemanticVisitor {
         }
        
         if let pageImages = documentationNode.metadata?.pageImages {
-            node.metadata.images = pageImages.map { pageImage -> TopicImage in
+            node.metadata.images = pageImages.compactMap { pageImage -> TopicImage? in
                 let renderReference = createAndRegisterRenderReference(forMedia: pageImage.source)
-                return TopicImage(
-                    pageImagePurpose: pageImage.purpose,
-                    identifier: renderReference
-                )
+                return renderReference.map {
+                    TopicImage(pageImagePurpose: pageImage.purpose, identifier: $0)
+                }
             }
         }
 
@@ -796,8 +795,9 @@ public struct RenderNodeTranslator: SemanticVisitor {
                         overridingTitle: callToAction.buttonLabel,
                         overridingTitleInlineContent: nil))
                 externalLocationReferences[url.description] = ExternalLocationReference(identifier: downloadIdentifier)
-            } else if let fileReference = callToAction.file {
-                let downloadIdentifier = createAndRegisterRenderReference(forMedia: fileReference, assetContext: .download)
+            } else if let fileReference = callToAction.file,
+                      let downloadIdentifier = createAndRegisterRenderReference(forMedia: fileReference, assetContext: .download)
+            {
                 node.sampleDownload = .init(action: .reference(
                     identifier: downloadIdentifier,
                     isActive: true,
@@ -1234,12 +1234,11 @@ public struct RenderNodeTranslator: SemanticVisitor {
         node.metadata.navigatorTitleVariants = contentRenderer.navigatorFragments(for: documentationNode)
         
         if let pageImages = documentationNode.metadata?.pageImages {
-            node.metadata.images = pageImages.map { pageImage -> TopicImage in
+            node.metadata.images = pageImages.compactMap { pageImage -> TopicImage? in
                 let renderReference = createAndRegisterRenderReference(forMedia: pageImage.source)
-                return TopicImage(
-                    pageImagePurpose: pageImage.purpose,
-                    identifier: renderReference
-                )
+                return renderReference.map {
+                    TopicImage(pageImagePurpose: pageImage.purpose, identifier: $0)
+                }
             }
         }
 
@@ -1584,63 +1583,68 @@ public struct RenderNodeTranslator: SemanticVisitor {
     }
 
     /// Creates a render reference for the given media and registers the reference to include it in the `references` dictionary.
-    mutating func createAndRegisterRenderReference(forMedia media: ResourceReference?, poster: ResourceReference? = nil, altText: String? = nil, assetContext: DataAsset.Context = .display) -> RenderReferenceIdentifier {
-        var mediaReference = RenderReferenceIdentifier("")
+    mutating func createAndRegisterRenderReference(forMedia media: ResourceReference?, poster: ResourceReference? = nil, altText: String? = nil, assetContext: DataAsset.Context = .display) -> RenderReferenceIdentifier? {
         guard let oldMedia = media,
-              let path = context.identifier(forAssetName: oldMedia.path, in: identifier) else { return mediaReference }
-        
-        let media = ResourceReference(bundleIdentifier: oldMedia.bundleIdentifier, path: path)
-        let fileExtension = NSString(string: media.path).pathExtension
-        
-        func resolveAsset() -> DataAsset? {
-            renderContext?.store.content(
-                forAssetNamed: media.path, bundleIdentifier: identifier.bundleIdentifier)
-            ?? context.resolveAsset(named: media.path, in: identifier)
+              let mediaIdentifier = context.identifier(forAssetName: oldMedia.path, in: identifier) else {
+            return nil
         }
         
+        let media = ResourceReference(bundleIdentifier: oldMedia.bundleIdentifier, path: mediaIdentifier)
+        guard let resolvedAssets = renderContext?.store.content(forAssetNamed: media.path, bundleIdentifier: identifier.bundleIdentifier)
+                                ?? context.resolveAsset(named: media.path, in: identifier)
+        else {
+            return nil
+        }
+        
+        let fileExtension: String = {
+            let identifierFileExtension = NSString(string: media.path).pathExtension
+            if !identifierFileExtension.isEmpty {
+                return identifierFileExtension
+            }
+            return resolvedAssets.data(bestMatching: DataTraitCollection()).url.pathExtension
+        }()
+        
         // Check if media is a supported image.
-        if DocumentationContext.isFileExtension(fileExtension, supported: .image),
-            let resolvedImages = resolveAsset()
-        {
-            mediaReference = RenderReferenceIdentifier(media.path)
+        if DocumentationContext.isFileExtension(fileExtension, supported: .image) {
+            let mediaReference = RenderReferenceIdentifier(media.path)
             
             imageReferences[media.path] = ImageReference(
                 identifier: mediaReference,
                 // If no alt text has been provided and this image has been registered previously, use the registered alt text.
                 altText: altText ?? imageReferences[media.path]?.altText,
-                imageAsset: resolvedImages
+                imageAsset: resolvedAssets
             )
+            return mediaReference
         }
         
-        if DocumentationContext.isFileExtension(fileExtension, supported: .video),
-           let resolvedVideos = resolveAsset()
-        {
-            mediaReference = RenderReferenceIdentifier(media.path)
-            let poster = poster.map { createAndRegisterRenderReference(forMedia: $0) }
-            videoReferences[media.path] = VideoReference(identifier: mediaReference, altText: altText, videoAsset: resolvedVideos, poster: poster)
+        if DocumentationContext.isFileExtension(fileExtension, supported: .video) {
+            let mediaReference = RenderReferenceIdentifier(media.path)
+            let poster = poster.flatMap { createAndRegisterRenderReference(forMedia: $0) }
+            videoReferences[media.path] = VideoReference(identifier: mediaReference, altText: altText, videoAsset: resolvedAssets, poster: poster)
+            return mediaReference
         }
         
-        if assetContext == DataAsset.Context.download, let resolvedDownload = resolveAsset() {
+        if assetContext == DataAsset.Context.download {
+            let mediaReference = RenderReferenceIdentifier(media.path)
             // Create a download reference if possible.
             let downloadReference: DownloadReference
-            do {            
-                mediaReference = RenderReferenceIdentifier(media.path)
-                let downloadURL = resolvedDownload.variants.first!.value
+            do {
+                let downloadURL = resolvedAssets.variants.first!.value
                 let downloadData = try context.dataProvider.contentsOfURL(downloadURL, in: bundle)
                 downloadReference = DownloadReference(identifier: mediaReference,
                     renderURL: downloadURL,
                     checksum: Checksum.sha512(of: downloadData))
             } catch {
                 // It seems this is the way to error out of here.
-                return mediaReference
+                return nil
             }
 
             // Add the file to the download references.
-            mediaReference = RenderReferenceIdentifier(media.path)
             downloadReferences[media.path] = downloadReference
+            return mediaReference
         }
 
-        return mediaReference
+        return nil
     }
     
     var context: DocumentationContext

--- a/Tests/SwiftDocCTests/DocumentationService/ConvertService/ConvertServiceTests.swift
+++ b/Tests/SwiftDocCTests/DocumentationService/ConvertService/ConvertServiceTests.swift
@@ -696,6 +696,243 @@ class ConvertServiceTests: XCTestCase {
             )
         }
     }
+
+    func testConvertArticleWithImageReferencesAndDetailedGridLinks() throws {
+        let articleData = try XCTUnwrap("""
+            # First article
+            
+            Link to another article which has page images.
+            
+            @Links(visualStyle: detailedGrid) {
+                - <doc:Second-article>
+            }
+            
+            @Metadata {
+                @PageImage(purpose: card, source: "first-page-card-image")
+                @PageImage(purpose: icon, source: "first-page-icon-image")
+            }
+            
+            ![A markdown image](first-page-markdown-image)
+            
+            @Image(source: "first-page-directive-image", alt: "A directive image")
+            """.data(using: .utf8))
+        
+        let request = ConvertRequest(
+            bundleInfo: testBundleInfo,
+            externalIDsToConvert: nil,
+            documentPathsToConvert: nil,
+            symbolGraphs: [],
+            knownDisambiguatedSymbolPathComponents: nil,
+            markupFiles: [articleData],
+            miscResourceURLs: []
+        )
+        
+        let server = DocumentationServer()
+        
+        let expectedAssetNames = [
+            "second-page-card-image",
+            "second-page-icon-image",
+            "first-page-card-image",
+            "first-page-icon-image",
+            "first-page-markdown-image",
+            "first-page-directive-image",
+        ]
+        
+        let mockLinkResolvingService = LinkResolvingService { message in
+            XCTAssertEqual(message.type, "resolve-reference")
+            XCTAssert(message.identifier.hasPrefix("SwiftDocC"))
+            do {
+                let payload = try XCTUnwrap(message.payload)
+                let request = try JSONDecoder()
+                    .decode(
+                        ConvertRequestContextWrapper<OutOfProcessReferenceResolver.Request>.self,
+                        from: payload
+                    )
+                
+                XCTAssertEqual(request.convertRequestIdentifier, "test-identifier")
+                
+                switch request.payload {
+                case .topic(let url):
+                    guard url.absoluteString == "doc://identifier/Second-article" else {
+                        XCTFail("Unexpected topic request: \(url.absoluteString.singleQuoted)")
+                        return nil
+                    }
+                    
+                    let testSymbolInformationResponse = OutOfProcessReferenceResolver
+                        .ResolvedInformation(
+                            kind: .article,
+                            url: url,
+                            title: "Second article",
+                            abstract: "An article with page image metadata.",
+                            language: .swift,
+                            availableLanguages: [.swift, .objectiveC],
+                            platforms: [],
+                            declarationFragments: nil,
+                            topicImages: [
+                                .init(pageImagePurpose: .card, identifier: RenderReferenceIdentifier("second-page-card-image")),
+                                .init(pageImagePurpose: .icon, identifier: RenderReferenceIdentifier("second-page-icon-image")),
+                            ],
+                            references: nil
+                        )
+                    
+                    let payloadData = OutOfProcessReferenceResolver.Response
+                        .resolvedInformation(testSymbolInformationResponse)
+                    
+                    return DocumentationServer.Message(
+                        type: "resolve-reference-response",
+                        payload: try JSONEncoder().encode(payloadData)
+                    )
+                    
+                case .symbol(let preciseIdentifier):
+                    XCTFail("Unexpected symbol request: \(preciseIdentifier)")
+                    return nil
+                    
+                case .asset(let assetReference):
+                    switch (assetReference.assetName, assetReference.bundleIdentifier) {
+                    case (let assetName, "identifier") where expectedAssetNames.contains(assetName):
+                        var asset = DataAsset()
+                        asset.register(
+                            URL(string: "docs-media:///path/to/\(assetName).png")!,
+                            with: DataTraitCollection(
+                                userInterfaceStyle: .light,
+                                displayScale: .double
+                            )
+                        )
+                        
+                        return DocumentationServer.Message(
+                            type: "resolve-reference-response",
+                            payload: try JSONEncoder().encode(
+                                OutOfProcessReferenceResolver.Response
+                                    .asset(asset)
+                            )
+                        )
+
+                    default:
+                        XCTFail("Unexpected asset resolution request for '\(assetReference)'")
+                        return nil
+                    }
+                }
+            } catch {
+                XCTFail(error.localizedDescription)
+                return nil
+            }
+        }
+        
+        server.register(service: mockLinkResolvingService)
+        
+        try processAndAssert(request: request, linkResolvingServer: server) { message in
+            XCTAssertEqual(message.type, "convert-response")
+            XCTAssertEqual(message.identifier, "test-identifier-response")
+            
+            let response = try JSONDecoder().decode(
+                ConvertResponse.self, from: XCTUnwrap(message.payload)
+            )
+            
+            XCTAssertEqual(response.renderNodes.count, 1)
+            let data = try XCTUnwrap(response.renderNodes.first)
+            let renderNode = try JSONDecoder().decode(RenderNode.self, from: data)
+            
+            XCTAssertEqual(
+                renderNode.metadata.externalID,
+                nil
+            )
+            
+            XCTAssertEqual(renderNode.kind, .article)
+            
+            XCTAssertEqual(renderNode.abstract?.count, 1)
+            
+            XCTAssertEqual(
+                renderNode.abstract?.first,
+                .text("Link to another article which has page images.")
+            )
+            
+            XCTAssertEqual(
+                renderNode.metadata.images.map(\.identifier.identifier).sorted(),
+                ["first-page-card-image", "first-page-icon-image"]
+            )
+            
+            XCTAssertEqual(
+                renderNode.references.keys.sorted(),
+                (["doc://identifier/Second-article"] + expectedAssetNames).sorted()
+            )
+            
+            let articleReference = try XCTUnwrap(renderNode.references["doc://identifier/Second-article"] as? TopicRenderReference)
+            XCTAssertEqual(articleReference.title, "Second article")
+            XCTAssertEqual(articleReference.abstract.plainText, "An article with page image metadata.")
+            XCTAssertEqual(articleReference.images.sorted(by: \.identifier.identifier), [
+                TopicImage(type: .card, identifier: RenderReferenceIdentifier("second-page-card-image")),
+                TopicImage(type: .icon, identifier: RenderReferenceIdentifier("second-page-icon-image")),
+            ])
+            
+            let firstCardImageReference = try XCTUnwrap(renderNode.references["first-page-card-image"] as? ImageReference)
+            XCTAssertEqual(firstCardImageReference.asset, DataAsset(
+                variants: [
+                    DataTraitCollection(userInterfaceStyle: .light, displayScale: .double): URL(string: "docs-media:///path/to/first-page-card-image.png")!,
+                ],
+                metadata: [
+                    URL(string: "docs-media:///path/to/first-page-card-image.png")!: DataAsset.Metadata(svgID: nil),
+                ],
+                context: .display
+            ))
+            
+            let firstIconImageReference = try XCTUnwrap(renderNode.references["first-page-icon-image"] as? ImageReference)
+            XCTAssertEqual(firstIconImageReference.asset, DataAsset(
+                variants: [
+                    DataTraitCollection(userInterfaceStyle: .light, displayScale: .double): URL(string: "docs-media:///path/to/first-page-icon-image.png")!,
+                ],
+                metadata: [
+                    URL(string: "docs-media:///path/to/first-page-icon-image.png")!: DataAsset.Metadata(svgID: nil),
+                ],
+                context: .display
+            ))
+            
+            let secondCardImageReference = try XCTUnwrap(renderNode.references["second-page-card-image"] as? ImageReference)
+            XCTAssertEqual(secondCardImageReference.asset, DataAsset(
+                variants: [
+                    DataTraitCollection(userInterfaceStyle: .light, displayScale: .double): URL(string: "docs-media:///path/to/second-page-card-image.png")!,
+                ],
+                metadata: [
+                    URL(string: "docs-media:///path/to/second-page-card-image.png")!: DataAsset.Metadata(svgID: nil),
+                ],
+                context: .display
+            ))
+            
+            let secondIconImageReference = try XCTUnwrap(renderNode.references["second-page-icon-image"] as? ImageReference)
+            XCTAssertEqual(secondIconImageReference.asset, DataAsset(
+                variants: [
+                    DataTraitCollection(userInterfaceStyle: .light, displayScale: .double): URL(string: "docs-media:///path/to/second-page-icon-image.png")!,
+                ],
+                metadata: [
+                    URL(string: "docs-media:///path/to/second-page-icon-image.png")!: DataAsset.Metadata(svgID: nil),
+                ],
+                context: .display
+            ))
+            
+            let firstMarkdownImageReference = try XCTUnwrap(renderNode.references["first-page-markdown-image"] as? ImageReference)
+            XCTAssertEqual(firstMarkdownImageReference.asset, DataAsset(
+                variants: [
+                    DataTraitCollection(userInterfaceStyle: .light, displayScale: .double): URL(string: "docs-media:///path/to/first-page-markdown-image.png")!,
+                ],
+                metadata: [
+                    URL(string: "docs-media:///path/to/first-page-markdown-image.png")!: DataAsset.Metadata(svgID: nil),
+                ],
+                context: .display
+            ))
+            XCTAssertEqual(firstMarkdownImageReference.altText, "A markdown image")
+            
+            let firstDirectiveImageReference = try XCTUnwrap(renderNode.references["first-page-directive-image"] as? ImageReference)
+            XCTAssertEqual(firstDirectiveImageReference.asset, DataAsset(
+                variants: [
+                    DataTraitCollection(userInterfaceStyle: .light, displayScale: .double): URL(string: "docs-media:///path/to/first-page-directive-image.png")!,
+                ],
+                metadata: [
+                    URL(string: "docs-media:///path/to/first-page-directive-image.png")!: DataAsset.Metadata(svgID: nil),
+                ],
+                context: .display
+            ))
+            XCTAssertEqual(firstDirectiveImageReference.altText, "A directive image")
+        }
+    }
     
     func testConvertSingleTutorial() throws {
         let tutorialFile = Bundle.module.url(

--- a/Tests/SwiftDocCTests/DocumentationService/Models/DocumentationServerTests.swift
+++ b/Tests/SwiftDocCTests/DocumentationService/Models/DocumentationServerTests.swift
@@ -48,18 +48,24 @@ class DocumentationServerTests: XCTestCase {
         let server = DocumentationServer()
         
         let expectedMessage = DocumentationServer.Message(
-            type: .init(rawValue: "type"),
+            type: .init(rawValue: "type-1"),
             payload: "payload".data(using: .utf8)!
         )
+        XCTAssertTrue(TestServiceA.handlingTypes.contains(expectedMessage.type))
         
-        let expectation = XCTestExpectation()
+        let messageExpectation = XCTestExpectation(description: "service received message")
+        let responseExpectation = XCTestExpectation(description: "server received response")
         
         server.register(service: TestServiceA(onProcess: { message in
             XCTAssertEqual(message, expectedMessage)
-            expectation.fulfill()
+            messageExpectation.fulfill()
         }))
         
-        XCTWaiter().wait(for: [expectation], timeout: 1.0)
+        processAndAssert(server, withMessage: expectedMessage, satisfies: { data in
+            responseExpectation.fulfill()
+        })
+        
+        wait(for: [messageExpectation, responseExpectation], timeout: 1.0)
     }
     
     func testReturnsInvalidMessageErrorWhenGivenAnInvalidMessage() throws {

--- a/Tests/SwiftDocCTests/DocumentationService/Models/DocumentationServerTests.swift
+++ b/Tests/SwiftDocCTests/DocumentationService/Models/DocumentationServerTests.swift
@@ -100,6 +100,9 @@ class DocumentationServerTests: XCTestCase {
         let expectation = XCTestExpectation(description: "Completion closure called")
         
         server.process(message, completion: { data in
+            defer {
+                expectation.fulfill()
+            }
             do {
                 try assertion(data)
             } catch {
@@ -107,7 +110,7 @@ class DocumentationServerTests: XCTestCase {
             }
         })
         
-        XCTWaiter().wait(for: [expectation], timeout: 1.0)
+        wait(for: [expectation], timeout: 1.0)
     }
 
     func assertIsErrorMessageWithIdentifier(_ identifier: String, messageData: Data) {


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://107531364

## Summary

This enables convert service requests to resolve assets that are references in the content. This required two changes:
- Allow the fallback asset resolve to look for an asset identifier when the local asset manager didn't find one.
- When rendering the image, get the file extension from the asset's url instead of from the asset identifier.

This PR also removes unnecessary empty media references when an asset didn't render anything.

## Dependencies

None

## Testing

In a client that uses` ConvertService`:
- Verify that passing an article with image references (either using `![]()`, `@Image`, or `@PageImage`) result in DocC returning a render node with image references for those images. 
- Add another article with `@PageImage` images and link it with `@Links(visualStyle: detailedGrid)` and verify that DocC returns a image references for the second article's page images.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary
