### PR TITLE
Disfavor default implementations and synthesized symbols in link collisions

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
@@ -108,6 +108,7 @@ struct PathHierarchy {
                 } else {
                     let node = Node(symbol: symbol)
                     // Disfavor synthesized symbols when they collide with other symbol with the same path.
+                    // FIXME: Get information about synthesized symbols from SymbolKit https://github.com/apple/swift-docc-symbolkit/issues/58
                     node.isDisfavoredInCollision = symbol.identifier.precise.contains("::SYNTHESIZED::")
                     nodes[id] = node
                     allNodes[id, default: []].append(node)


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://98781530

## Summary

This adds basic handling of collisions to deprioritize synthesized symbols and default implementations of protocol requirements. 

It's more likely that the developer intended to link to the other symbol so the hierarchy based resolver will resolve the ambiguous link the to that symbol. 

## Dependencies

None.

## Testing

- Create a public protocol with some protocol requirements and also add a public default implementation of it. 
- Write a symbol link to without disambiguation to the protocol requirement. For example:
```
/// These two links should resolve:
///
/// - ``Something/doSomething()``
/// - ``doSomething()``
public protocol Something {
    func doSomething()
}
public extension Something {
    func doSomething() {}
}
```

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary
