### PR TITLE
drop an "Extended Symbol" page when its children are curated elsewhere

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -2398,8 +2398,13 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
             trimEmptyExtendedSymbolPages(under: child)
         }
 
-        // Finally, if this node was left with no children, remove it from the topic graph.
-        if let node = topicGraph.nodeWithReference(nodeReference), node.kind.isExtendedSymbolKind, topicGraph[node].isEmpty {
+        // Finally, if this node was left with no children and does not have an extension file,
+        // remove it from the topic graph.
+        if let node = topicGraph.nodeWithReference(nodeReference),
+           node.kind.isExtendedSymbolKind,
+           topicGraph[node].isEmpty,
+           documentationExtensionURL(for: nodeReference) == nil
+        {
             topicGraph.removeEdges(to: node)
             topicGraph.removeEdges(from: node)
             topicGraph.edges.removeValue(forKey: nodeReference)

--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -2415,6 +2415,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
                 kind: node.kind,
                 source: node.source,
                 title: node.title,
+                isResolvable: false, // turn isResolvable off to prevent a link from being made
                 isVirtual: true, // set isVirtual to keep it from generating a page later on
                 isEmptyExtension: true
             ))

--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -2400,7 +2400,19 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
 
         // Finally, if this node was left with no children, remove it from the topic graph.
         if let node = topicGraph.nodeWithReference(nodeReference), node.kind.isExtendedSymbolKind, topicGraph[node].isEmpty {
-            topicGraph.removeNode(node)
+            topicGraph.removeEdges(to: node)
+            topicGraph.removeEdges(from: node)
+            topicGraph.edges.removeValue(forKey: nodeReference)
+            topicGraph.reverseEdges.removeValue(forKey: nodeReference)
+
+            topicGraph.replaceNode(node, with: .init(
+                reference: node.reference,
+                kind: node.kind,
+                source: node.source,
+                title: node.title,
+                isVirtual: true, // set isVirtual to keep it from generating a page later on
+                isEmptyExtension: true
+            ))
         }
     }
     

--- a/Sources/SwiftDocC/Infrastructure/Topic Graph/TopicGraph.swift
+++ b/Sources/SwiftDocC/Infrastructure/Topic Graph/TopicGraph.swift
@@ -205,6 +205,7 @@ struct TopicGraph {
         removeEdges(from: node)
         removeEdges(to: node)
         edges.removeValue(forKey: node.reference)
+        reverseEdges.removeValue(forKey: node.reference)
 
         // Finally, remove the node reference itself
         nodes.removeValue(forKey: node.reference)

--- a/Sources/SwiftDocC/Model/Kind.swift
+++ b/Sources/SwiftDocC/Model/Kind.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -204,4 +204,14 @@ extension DocumentationNode.Kind {
         // Other
         .keyword, .restAPI, .tag, .propertyList, .object
     ]
+
+    /// Returns whether this symbol kind is a synthetic "Extended Symbol" symbol kind.
+    public var isExtendedSymbolKind: Bool {
+        switch self {
+        case .extendedClass, .extendedModule, .extendedProtocol, .extendedStructure, .extendedEnumeration, .unknownExtendedType:
+            return true
+        default:
+            return false
+        }
+    }
 }

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -1383,9 +1383,20 @@ public struct RenderNodeTranslator: SemanticVisitor {
                         let resolver = LinkTitleResolver(context: context, source: resolved.url)
                         let resolvedTitle = resolver.title(for: node)
                         destinationsMap[destination] = resolvedTitle?[trait]
-                        
-                        // Add relationship to render references
-                        collectedTopicReferences.append(resolved)
+
+                        let dropLink = context.topicGraph.nodeWithReference(resolved)?.isEmptyExtension ?? false
+
+                        if !dropLink {
+                            // Add relationship to render references
+                            collectedTopicReferences.append(resolved)
+                        } else if let topicUrl = ValidatedURL(resolved.url) {
+                            // If the topic isn't linkable (e.g. an extended type), then we shouldn't
+                            // add a resolved relationship - deconstruct the resolved reference so
+                            // we can still display it, though
+                            let title = resolvedTitle?[trait] ?? resolved.lastPathComponent
+                            let reference = UnresolvedTopicReference(topicURL: topicUrl, title: title)
+                            collectedUnresolvedTopicReferences.append(reference)
+                        }
 
                     case .unresolved(let unresolved), .resolved(.failure(let unresolved, _)):
                         // Try creating a render reference anyway

--- a/Sources/SwiftDocC/Semantics/MarkupReferenceResolver.swift
+++ b/Sources/SwiftDocC/Semantics/MarkupReferenceResolver.swift
@@ -26,6 +26,11 @@ fileprivate func unknownSnippetSliceProblem(snippetPath: String, slice: String, 
     return Problem(diagnostic: diagnostic, possibleSolutions: [])
 }
 
+fileprivate func removedLinkDestinationProblem(reference: ResolvedTopicReference, source: URL?, range: SourceRange?, severity: DiagnosticSeverity) -> Problem {
+    let diagnostic = Diagnostic(source: source, severity: severity, range: range, identifier: "org.swift.docc.removedExtensionLinkDestination", summary: "The topic \(reference.path.singleQuoted) is an empty extension page and cannot be linked to.", explanation: "This extension symbol has had all its children curated and has been removed.")
+    return Problem(diagnostic: diagnostic, possibleSolutions: [])
+}
+
 /**
  Rewrites a ``Markup`` tree to resolve ``UnresolvedTopicReference`s using a ``DocumentationContext``.
  */
@@ -56,8 +61,11 @@ struct MarkupReferenceResolver: MarkupRewriter {
             // If the linked node is part of the topic graph,
             // verify that linking to it is enabled, else return `nil`.
             if let node = context.topicGraph.nodeWithReference(resolved) {
-                guard context.topicGraph.isLinkable(node.reference) else {
+                if !context.topicGraph.isLinkable(node.reference) {
                     problems.append(disabledLinkDestinationProblem(reference: resolved, source: source, range: range, severity: severity))
+                    return nil
+                } else if node.isEmptyExtension {
+                    problems.append(removedLinkDestinationProblem(reference: resolved, source: source, range: range, severity: severity))
                     return nil
                 }
             }

--- a/Sources/SwiftDocC/Semantics/MarkupReferenceResolver.swift
+++ b/Sources/SwiftDocC/Semantics/MarkupReferenceResolver.swift
@@ -27,8 +27,16 @@ fileprivate func unknownSnippetSliceProblem(snippetPath: String, slice: String, 
 }
 
 fileprivate func removedLinkDestinationProblem(reference: ResolvedTopicReference, source: URL?, range: SourceRange?, severity: DiagnosticSeverity) -> Problem {
+    var solutions = [Solution]()
+    if let range = range, reference.pathComponents.count > 3 {
+        // The first three path components are "/", "documentation", and the module name, so drop those
+        let pathRemainder = reference.pathComponents[3...]
+        solutions.append(.init(summary: "Use a plain code span instead of a symbol link", replacements: [
+            .init(range: range, replacement: "`\(pathRemainder.joined(separator: "/"))`")
+        ]))
+    }
     let diagnostic = Diagnostic(source: source, severity: severity, range: range, identifier: "org.swift.docc.removedExtensionLinkDestination", summary: "The topic \(reference.path.singleQuoted) is an empty extension page and cannot be linked to.", explanation: "This extension symbol has had all its children curated and has been removed.")
-    return Problem(diagnostic: diagnostic, possibleSolutions: [])
+    return Problem(diagnostic: diagnostic, possibleSolutions: solutions)
 }
 
 /**

--- a/Sources/SwiftDocC/Semantics/MarkupReferenceResolver.swift
+++ b/Sources/SwiftDocC/Semantics/MarkupReferenceResolver.swift
@@ -69,11 +69,11 @@ struct MarkupReferenceResolver: MarkupRewriter {
             // If the linked node is part of the topic graph,
             // verify that linking to it is enabled, else return `nil`.
             if let node = context.topicGraph.nodeWithReference(resolved) {
-                if !context.topicGraph.isLinkable(node.reference) {
-                    problems.append(disabledLinkDestinationProblem(reference: resolved, source: source, range: range, severity: severity))
-                    return nil
-                } else if node.isEmptyExtension {
+                if node.isEmptyExtension {
                     problems.append(removedLinkDestinationProblem(reference: resolved, source: source, range: range, severity: severity))
+                    return nil
+                } else if !context.topicGraph.isLinkable(node.reference) {
+                    problems.append(disabledLinkDestinationProblem(reference: resolved, source: source, range: range, severity: severity))
                     return nil
                 }
             }

--- a/Tests/SwiftDocCTests/Infrastructure/ReferenceResolverTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/ReferenceResolverTests.swift
@@ -436,7 +436,12 @@ class ReferenceResolverTests: XCTestCase {
         }
 
         // Make sure that linking to `Swift/Array` raises a diagnostic about the page having been removed
-        XCTAssert(context.problems.contains(where: { $0.diagnostic.identifier == "org.swift.docc.removedExtensionLinkDestination"}))
+        let diagnostic = try XCTUnwrap(context.problems.first(where: { $0.diagnostic.identifier == "org.swift.docc.removedExtensionLinkDestination"}))
+        XCTAssertEqual(diagnostic.possibleSolutions.count, 1)
+        let solution = try XCTUnwrap(diagnostic.possibleSolutions.first)
+        XCTAssertEqual(solution.replacements.count, 1)
+        let replacement = try XCTUnwrap(solution.replacements.first)
+        XCTAssertEqual(replacement.replacement, "`Swift/Array`")
 
         // Also make sure that the extension pages are still gone
         let extendedModule = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ModuleWithSingleExtension/Swift", sourceLanguage: .swift)

--- a/Tests/SwiftDocCTests/Infrastructure/ReferenceResolverTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/ReferenceResolverTests.swift
@@ -449,6 +449,18 @@ class ReferenceResolverTests: XCTestCase {
 
         let extendedStructure = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ModuleWithSingleExtension/Swift/Array", sourceLanguage: .swift)
         XCTAssertFalse(context.knownPages.contains(where: { $0 == extendedStructure }))
+
+        // Load the RenderNode for the root article and make sure that the `Swift/Array` symbol link
+        // is not rendered as a link
+        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ModuleWithSingleExtension", sourceLanguage: .swift))
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode
+
+        XCTAssertEqual(renderNode.abstract, [
+            .text("This is a test module with an extension to "),
+            .codeVoice(code: "Swift/Array"),
+            .text(".")
+        ])
     }
 
     func testCuratedExtensionWithDanglingReferenceToFragment() throws {

--- a/Tests/SwiftDocCTests/Test Bundles/ModuleWithConformanceAndExtension.docc/Info.plist
+++ b/Tests/SwiftDocCTests/Test Bundles/ModuleWithConformanceAndExtension.docc/Info.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleVersion</key>
+	<string>0.1.0</string>
+	<key>CFBundleIdentifier</key>
+	<string>org.swift.docc.example</string>
+	<key>CFBundleDisplayName</key>
+	<string>Module with Conformance and Extension</string>
+	<key>CFBundleName</key>
+	<string>ModuleWithConformanceAndExtension</string>
+</dict>
+</plist>

--- a/Tests/SwiftDocCTests/Test Bundles/ModuleWithConformanceAndExtension.docc/ModuleWithConformanceAndExtension.md
+++ b/Tests/SwiftDocCTests/Test Bundles/ModuleWithConformanceAndExtension.docc/ModuleWithConformanceAndExtension.md
@@ -1,0 +1,13 @@
+# ``ModuleWithConformanceAndExtension``
+
+This test bundle contains symbol graphs which define a protocol (`MyProtocol`) and a conformance of
+`Bool` to that protocol. It also extends `Bool` with a new property. By curating the property below,
+the "Extended Symbol" pages for `Bool` and `Swift` should disappear. As well, the conformance of
+`Bool` to `MyProtocol` should still appear on `MyProtocol`'s page, but the link should not be live.
+
+## Topics
+
+- ``MyProtocol``
+- ``Swift/Bool/asdf``
+
+<!-- Copyright (c) 2023 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Tests/SwiftDocCTests/Test Bundles/ModuleWithConformanceAndExtension.docc/ModuleWithConformanceAndExtension.symbols.json
+++ b/Tests/SwiftDocCTests/Test Bundles/ModuleWithConformanceAndExtension.docc/ModuleWithConformanceAndExtension.symbols.json
@@ -1,0 +1,85 @@
+{
+    "metadata": {
+        "formatVersion": {
+            "major": 0,
+            "minor": 6,
+            "patch": 0
+        },
+        "generator": "Swift 5.9"
+    },
+    "module": {
+        "name": "ModuleWithConformanceAndExtension",
+        "platform": {
+            "architecture": "x86_64",
+            "vendor": "apple",
+            "operatingSystem": {
+                "name": "macosx",
+                "minimumVersion": {
+                    "major": 12,
+                    "minor": 4
+                }
+            }
+        }
+    },
+    "symbols": [
+        {
+            "kind": {
+                "identifier": "swift.protocol",
+                "displayName": "Protocol"
+            },
+            "identifier": {
+                "precise": "s:9ModuleWithConformanceAndExtension10MyProtocolP",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "MyProtocol"
+            ],
+            "names": {
+                "title": "MyProtocol",
+                "navigator": [
+                    {
+                        "kind": "identifier",
+                        "spelling": "MyProtocol"
+                    }
+                ],
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "protocol"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "MyProtocol"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "protocol"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "MyProtocol"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file://path/to/ModuleWithConformanceAndExtension.swift",
+                "position": {
+                    "line": 9,
+                    "character": 16
+                }
+            }
+        }
+    ],
+    "relationships": []
+}

--- a/Tests/SwiftDocCTests/Test Bundles/ModuleWithConformanceAndExtension.docc/ModuleWithConformanceAndExtension@Swift.symbols.json
+++ b/Tests/SwiftDocCTests/Test Bundles/ModuleWithConformanceAndExtension.docc/ModuleWithConformanceAndExtension@Swift.symbols.json
@@ -1,0 +1,266 @@
+{
+    "metadata": {
+        "formatVersion": {
+            "major": 0,
+            "minor": 6,
+            "patch": 0
+        },
+        "generator": "Swift 5.9"
+    },
+    "module": {
+        "name": "ModuleWithConformanceAndExtension",
+        "platform": {
+            "architecture": "x86_64",
+            "vendor": "apple",
+            "operatingSystem": {
+                "name": "macosx",
+                "minimumVersion": {
+                    "major": 12,
+                    "minor": 4
+                }
+            }
+        }
+    },
+    "symbols": [
+        {
+            "kind": {
+                "identifier": "swift.extension",
+                "displayName": "Extension"
+            },
+            "identifier": {
+                "precise": "s:e:s:Sb9ModuleWithConformanceAndExtensionE4asdfSSvp",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "Bool"
+            ],
+            "names": {
+                "title": "Bool",
+                "navigator": [
+                    {
+                        "kind": "identifier",
+                        "spelling": "Bool"
+                    }
+                ],
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "extension"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Bool",
+                        "preciseIdentifier": "s:Sb"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "Swift",
+                "typeKind": "swift.struct"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "extension"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Bool",
+                    "preciseIdentifier": "s:Sb"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file://path/to/ModuleWithConformanceAndExtension.swift",
+                "position": {
+                    "line": 13,
+                    "character": 7
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.extension",
+                "displayName": "Extension"
+            },
+            "identifier": {
+                "precise": "s:e:s:Sbs:9ModuleWithConformanceAndExtension10MyProtocolP",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "Bool"
+            ],
+            "names": {
+                "title": "Bool",
+                "navigator": [
+                    {
+                        "kind": "identifier",
+                        "spelling": "Bool"
+                    }
+                ],
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "extension"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Bool",
+                        "preciseIdentifier": "s:Sb"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "Swift",
+                "typeKind": "swift.struct"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "extension"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Bool",
+                    "preciseIdentifier": "s:Sb"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file://path/to/ModuleWithConformanceAndExtension.swift",
+                "position": {
+                    "line": 11,
+                    "character": 0
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.property",
+                "displayName": "Instance Property"
+            },
+            "identifier": {
+                "precise": "s:Sb9ModuleWithConformanceAndExtensionE4asdfSSvp",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "Bool",
+                "asdf"
+            ],
+            "names": {
+                "title": "asdf",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "var"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "asdf"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ": "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "String",
+                        "preciseIdentifier": "s:SS"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "Swift",
+                "typeKind": "swift.struct"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "var"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "asdf"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "String",
+                    "preciseIdentifier": "s:SS"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " { "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "get"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " }"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file://path/to/ModuleWithConformanceAndExtension.swift",
+                "position": {
+                    "line": 14,
+                    "character": 8
+                }
+            }
+        }
+    ],
+    "relationships": [
+        {
+            "kind": "extensionTo",
+            "source": "s:e:s:Sb9ModuleWithConformanceAndExtensionE4asdfSSvp",
+            "target": "s:Sb",
+            "targetFallback": "Swift.Bool"
+        },
+        {
+            "kind": "extensionTo",
+            "source": "s:e:s:Sbs:9ModuleWithConformanceAndExtension10MyProtocolP",
+            "target": "s:Sb",
+            "targetFallback": "Swift.Bool"
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:Sb9ModuleWithConformanceAndExtensionE4asdfSSvp",
+            "target": "s:e:s:Sb9ModuleWithConformanceAndExtensionE4asdfSSvp",
+            "targetFallback": "Swift.Bool"
+        },
+        {
+            "kind": "conformsTo",
+            "source": "s:e:s:Sbs:9ModuleWithConformanceAndExtension10MyProtocolP",
+            "target": "s:9ModuleWithConformanceAndExtension10MyProtocolP"
+        }
+    ]
+}

--- a/Tests/SwiftDocCTests/Test Bundles/ModuleWithSingleExtension.docc/Info.plist
+++ b/Tests/SwiftDocCTests/Test Bundles/ModuleWithSingleExtension.docc/Info.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleVersion</key>
+	<string>0.1.0</string>
+	<key>CFBundleIdentifier</key>
+	<string>org.swift.docc.example</string>
+	<key>CFBundleDisplayName</key>
+	<string>Module with Single Extension</string>
+	<key>CFBundleName</key>
+	<string>ModuleWithSingleExtension</string>
+</dict>
+</plist>

--- a/Tests/SwiftDocCTests/Test Bundles/ModuleWithSingleExtension.docc/ModuleWithSingleExtension.md
+++ b/Tests/SwiftDocCTests/Test Bundles/ModuleWithSingleExtension.docc/ModuleWithSingleExtension.md
@@ -1,0 +1,11 @@
+# ``ModuleWithSingleExtension``
+
+This module contains an extension to Swift's Array type, and en empty enum to curate it into.
+
+## Overview
+
+The purpose of this test fixture is to ensure that when extension symbols are curated outside of
+their default location of their extended module/symbol, that an empty module/symbol page isn't left
+behind to confuse readers.
+
+<!-- Copyright (c) 2023 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Tests/SwiftDocCTests/Test Bundles/ModuleWithSingleExtension.docc/ModuleWithSingleExtension.symbols.json
+++ b/Tests/SwiftDocCTests/Test Bundles/ModuleWithSingleExtension.docc/ModuleWithSingleExtension.symbols.json
@@ -1,0 +1,156 @@
+{
+    "metadata": {
+        "formatVersion": {
+            "major": 0,
+            "minor": 6,
+            "patch": 0
+        },
+        "generator": "Swift 5.9"
+    },
+    "module": {
+        "name": "ModuleWithSingleExtension",
+        "platform": {
+            "architecture": "x86_64",
+            "vendor": "apple",
+            "operatingSystem": {
+                "name": "macosx",
+                "minimumVersion": {
+                    "major": 12,
+                    "minor": 4
+                }
+            }
+        }
+    },
+    "symbols": [
+        {
+            "kind": {
+                "identifier": "swift.enum",
+                "displayName": "Enumeration"
+            },
+            "identifier": {
+                "precise": "s:9ModuleWithSingleExtension11MyNamespaceO",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "MyNamespace"
+            ],
+            "names": {
+                "title": "MyNamespace",
+                "navigator": [
+                    {
+                        "kind": "identifier",
+                        "spelling": "MyNamespace"
+                    }
+                ],
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "enum"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "MyNamespace"
+                    }
+                ]
+            },
+            "docComment": {
+                "uri": "file://path/to/ModuleWithSingleExtension.swift",
+                "module": "ModuleWithSingleExtension",
+                "lines": [
+                    {
+                        "range": {
+                            "start": {
+                                "line": 9,
+                                "character": 4
+                            },
+                            "end": {
+                                "line": 9,
+                                "character": 33
+                            }
+                        },
+                        "text": "a namespace for organization."
+                    },
+                    {
+                        "range": {
+                            "start": {
+                                "line": 10,
+                                "character": 3
+                            },
+                            "end": {
+                                "line": 10,
+                                "character": 3
+                            }
+                        },
+                        "text": ""
+                    },
+                    {
+                        "range": {
+                            "start": {
+                                "line": 11,
+                                "character": 4
+                            },
+                            "end": {
+                                "line": 11,
+                                "character": 13
+                            }
+                        },
+                        "text": "## Topics"
+                    },
+                    {
+                        "range": {
+                            "start": {
+                                "line": 12,
+                                "character": 3
+                            },
+                            "end": {
+                                "line": 12,
+                                "character": 3
+                            }
+                        },
+                        "text": ""
+                    },
+                    {
+                        "range": {
+                            "start": {
+                                "line": 13,
+                                "character": 4
+                            },
+                            "end": {
+                                "line": 13,
+                                "character": 26
+                            }
+                        },
+                        "text": "- ``Swift/Array/asdf``"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "enum"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "MyNamespace"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file://path/to/ModuleWithSingleExtension.swift",
+                "position": {
+                    "line": 14,
+                    "character": 12
+                }
+            }
+        }
+    ],
+    "relationships": []
+}

--- a/Tests/SwiftDocCTests/Test Bundles/ModuleWithSingleExtension.docc/ModuleWithSingleExtension@Swift.symbols.json
+++ b/Tests/SwiftDocCTests/Test Bundles/ModuleWithSingleExtension.docc/ModuleWithSingleExtension@Swift.symbols.json
@@ -1,0 +1,200 @@
+{
+    "metadata": {
+        "formatVersion": {
+            "major": 0,
+            "minor": 6,
+            "patch": 0
+        },
+        "generator": "Swift 5.9"
+    },
+    "module": {
+        "name": "ModuleWithSingleExtension",
+        "platform": {
+            "architecture": "x86_64",
+            "vendor": "apple",
+            "operatingSystem": {
+                "name": "macosx",
+                "minimumVersion": {
+                    "major": 12,
+                    "minor": 4
+                }
+            }
+        }
+    },
+    "symbols": [
+        {
+            "kind": {
+                "identifier": "swift.extension",
+                "displayName": "Extension"
+            },
+            "identifier": {
+                "precise": "s:e:s:Sa9ModuleWithSingleExtensionE4asdfSivp",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "Array"
+            ],
+            "names": {
+                "title": "Array",
+                "navigator": [
+                    {
+                        "kind": "identifier",
+                        "spelling": "Array"
+                    }
+                ],
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "extension"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Array",
+                        "preciseIdentifier": "s:Sa"
+                    }
+                ]
+            },
+            "swiftGenerics": {
+                "parameters": [
+                    {
+                        "name": "Element",
+                        "index": 0,
+                        "depth": 0
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "Swift",
+                "typeKind": "swift.struct"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "extension"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Array",
+                    "preciseIdentifier": "s:Sa"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file://path/to/ModuleWithSingleExtension.swift",
+                "position": {
+                    "line": 16,
+                    "character": 7
+                }
+            }
+        },
+        {
+            "kind": {
+                "identifier": "swift.property",
+                "displayName": "Instance Property"
+            },
+            "identifier": {
+                "precise": "s:Sa9ModuleWithSingleExtensionE4asdfSivp",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "Array",
+                "asdf"
+            ],
+            "names": {
+                "title": "asdf",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "var"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "asdf"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ": "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Int",
+                        "preciseIdentifier": "s:Si"
+                    }
+                ]
+            },
+            "swiftExtension": {
+                "extendedModule": "Swift",
+                "typeKind": "swift.struct"
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "var"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "asdf"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Int",
+                    "preciseIdentifier": "s:Si"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " { "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "get"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " }"
+                }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file://path/to/ModuleWithSingleExtension.swift",
+                "position": {
+                    "line": 17,
+                    "character": 6
+                }
+            }
+        }
+    ],
+    "relationships": [
+        {
+            "kind": "extensionTo",
+            "source": "s:e:s:Sa9ModuleWithSingleExtensionE4asdfSivp",
+            "target": "s:Sa",
+            "targetFallback": "Swift.Array"
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:Sa9ModuleWithSingleExtensionE4asdfSivp",
+            "target": "s:e:s:Sa9ModuleWithSingleExtensionE4asdfSivp",
+            "targetFallback": "Swift.Array"
+        }
+    ]
+}


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://107729630

## Summary

When Swift-DocC gets symbol graphs with extension block symbols, it creates "Extended Module/Class/Structure/etc" symbols to automatically curate the extension symbols into. However, if the extension symbols are then curated in the rest of the documentation hierarchy, these extra symbols are left in the topic graph and create empty pages that don't need to be there. This PR adds a pass to `DocumentationContext.register(_:)` to drop these symbols if all their children have been curated elsewhere. (This pass is done recursively, so "Extended Module" pages will drop if all their child "Extended Class/Structure/etc" pages are also dropped.)

## Dependencies

None

## Testing

The following code was used to test this functionality:

```swift
/// a namespace for organization.
///
/// ## Topics
///
/// - ``Swift/Array/asdf``
public enum MyNamespace {}

public extension Array {
  var asdf: Int { count }
}
```

Steps:
1. Build a symbol graph for the above code that includes extension block symbols. (The code above was used to create the `ModuleWithSingleExtension` test fixture added in this PR, which can be used as a shortcut.)
2. Add the resulting symbol graphs to a documentation catalog and generate documentation.
3. Ensure that the resulting documentation doesn't contain the "Extended Module" page for `Swift`, nor the "Extended Structure" page for `Array`.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ n/a ] Updated documentation if necessary
