### PR TITLE
[5.9] Store only the resolved reference in DocumentationContext.symbolIndex

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/CoverageDataEntry.swift
+++ b/Sources/SwiftDocC/Infrastructure/CoverageDataEntry.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -371,9 +371,7 @@ extension CoverageDataEntry {
                 )
                 let total = children.count
                 let documented = children.filter {
-                    (context.symbolIndex[$0.reference.description]?.semantic as? Symbol)?
-                        .abstractSection
-                        != nil
+                    (context.nodeWithSymbolIdentifier($0.reference.description)?.semantic as? Symbol)?.abstractSection != nil
                 }.count
 
                 if total == 0 {

--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -587,7 +587,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
                             // If the two symbols are coming from different modules,
                             // regardless if they are in the same bundle
                             // (for example Foundation and SwiftUI), skip link resolving.
-                            if let originSymbol = symbolIndex[semantic.origin!.identifier]?.semantic as? Symbol,
+                            if let originSymbol = nodeWithSymbolIdentifier(semantic.origin!.identifier)?.semantic as? Symbol,
                                originSymbol.moduleReference != semantic.moduleReference {
                                 continue
                             }
@@ -601,7 +601,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
                     if let semantic = documentationNode.semantic as? Symbol,
                         semantic.origin != nil,
                         let originNode = symbolIndex[semantic.origin!.identifier] {
-                        inheritanceParentReference = originNode.reference
+                        inheritanceParentReference = originNode
                     } else {
                         inheritanceParentReference = nil
                     }
@@ -652,7 +652,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
         for result in results.sync({ $0 }) {
             documentationCache[result.reference] = result.node
             if let preciseIdentifier = result.node.symbol?.identifier.precise {
-                symbolIndex[preciseIdentifier] = result.node
+                symbolIndex[preciseIdentifier] = result.reference
             }
             diagnosticEngine.emit(result.problems)
         }
@@ -998,10 +998,16 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
         }
     }
     
-    /// A lookup of symbol documentation nodes based on the symbol's precise identifier.
+    /// A lookup of topic references for symbol documentation nodes based on the symbol's precise identifier.
     ///
-    /// This allows convenient access to other symbol's documentation nodes while building relationships between symbols.
-    private(set) var symbolIndex = [String: DocumentationNode]()
+    /// To access the symbol's documentation node use ``nodeWithSymbolIdentifier(_:)`` instead.
+    private(set) var symbolIndex = [String: ResolvedTopicReference]()
+    
+    /// Looks up a symbol documentation node based on the symbol's precise identifier.
+    func nodeWithSymbolIdentifier(_ preciseIdentifier: String) -> DocumentationNode? {
+        guard let reference = symbolIndex[preciseIdentifier] else { return nil }
+        return documentationCache[reference]
+    }
     
     private func nodeWithInitializedContent(reference: ResolvedTopicReference, matches: [DocumentationContext.SemanticResult<Article>]?) -> DocumentationNode {
         precondition(documentationCache.keys.contains(reference))
@@ -1062,7 +1068,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
         // Filter only parent <-> child edges
         switch edge.kind {
         case .memberOf, .requirementOf, .declaredIn, .inContextOf:
-            guard let parentRef = symbolIndex[edge.target]?.reference, let childRef = symbolIndex[edge.source]?.reference else {
+            guard let parentRef = symbolIndex[edge.target], let childRef = symbolIndex[edge.source] else {
             return nil
             }
             return (parentRef, childRef)
@@ -1132,7 +1138,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
         let symbolData = result.0
         topicGraph.addNode(symbolData.topicGraphNode)
         documentationCache[symbolData.reference] = symbolData.node
-        symbolIndex[symbolData.preciseIdentifier] = symbolData.node
+        symbolIndex[symbolData.preciseIdentifier] = symbolData.reference
         
         for anchor in result.0.node.anchorSections {
             nodeAnchorSections[anchor.reference] = anchor
@@ -1275,8 +1281,8 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
                     for symbol in unifiedSymbolGraph.symbols.values where symbol.defaultSymbol!.pathComponents.count == 1 {
                         try symbolIndex[symbol.uniqueIdentifier].map({
                             // If merging symbol graph extension there can be repeat symbols, don't add them again.
-                            guard (try? symbolsURLHierarchy.parent(of: $0.reference)) == nil else { return }
-                            try symbolsURLHierarchy.add($0.reference, parent: moduleReference)
+                            guard (try? symbolsURLHierarchy.parent(of: $0)) == nil else { return }
+                            try symbolsURLHierarchy.add($0, parent: moduleReference)
                         })
                     }
                 }
@@ -1397,7 +1403,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
                         let hierarchyBasedReferences = hierarchyBasedLinkResolver!.referencesForSymbols(in: symbolGraphLoader.unifiedGraphs, bundle: bundle, context: self)
                         
                         for (usr, hierarchyBasedReference) in hierarchyBasedReferences {
-                            guard let cacheBasedMainReference = symbolIndex[usr.precise]?.reference.path else {
+                            guard let cacheBasedMainReference = symbolIndex[usr.precise]?.path else {
                                 linkResolutionMismatches.missingPathsInCacheBasedLinkResolver.append(hierarchyBasedReference.path)
                                 continue
                             }
@@ -1406,11 +1412,11 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
                                 linkResolutionMismatches.pathsWithMismatchedDisambiguation[hierarchyBasedReference.path] = cacheBasedMainReference
                             }
                         }
-                        for (usr, node) in symbolIndex {
-                            guard let kind = node.symbol?.kind.identifier, kind.symbolGeneratesPage(),
+                        for (usr, reference) in symbolIndex {
+                            guard let kind = documentationCache[reference]?.symbol?.kind.identifier, kind.symbolGeneratesPage(),
                                   !hierarchyBasedReferences.keys.contains(where: { $0.precise == usr })
                             else { continue }
-                            linkResolutionMismatches.missingPathsInHierarchyBasedLinkResolver.append(node.reference.path)
+                            linkResolutionMismatches.missingPathsInHierarchyBasedLinkResolver.append(reference.path)
                         }
                     }
                 }
@@ -1425,9 +1431,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
 
             // Parse and prepare the nodes' content concurrently.
             let updatedNodes: [(node: DocumentationNode, matchedArticleURL: URL?)] = Array(symbolIndex.values)
-                .concurrentPerform { node, results in
-                    let finalReference = node.reference
-                    
+                .concurrentPerform { finalReference, results in
                     // Match the symbol's documentation extension and initialize the node content.
                     let matches = uncuratedDocumentationExtensions[finalReference]
                     let updatedNode = nodeWithInitializedContent(reference: finalReference, matches: matches)
@@ -1447,8 +1451,8 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
                 }
                 // Update cache and lookup indexes with the updated node value
                 documentationCache[reference] = updatedNode
-                if let symbol = documentationCache[reference]!.symbol {
-                    symbolIndex[symbol.identifier.precise] = documentationCache[reference]!
+                if let symbol = updatedNode.symbol {
+                    symbolIndex[symbol.identifier.precise] = reference
                 }
                 if let url = matchedArticleURL {
                     documentLocationMap[url] = reference
@@ -1458,7 +1462,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
             }
 
             // Resolve any external references first
-            try preResolveExternalLinks(references: Array(moduleReferences.values) + combinedSymbols.keys.compactMap({ symbolIndex[$0]?.reference }), bundle: bundle)
+            try preResolveExternalLinks(references: Array(moduleReferences.values) + combinedSymbols.keys.compactMap({ symbolIndex[$0] }), bundle: bundle)
             
             // Look up and add symbols that are _referenced_ in the symbol graph but don't exist in the symbol graph.
             try resolveExternalSymbols(in: combinedSymbols, relationships: combinedRelationships)
@@ -1513,6 +1517,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
                     selector: selector,
                     in: bundle,
                     symbolIndex: &symbolIndex,
+                    documentationCache: documentationCache,
                     engine: diagnosticEngine
                 )
             case .defaultImplementationOf:
@@ -1522,7 +1527,9 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
                     selector: selector,
                     in: bundle,
                     context: self,
-                    symbolIndex: &symbolIndex, engine: diagnosticEngine
+                    symbolIndex: &symbolIndex,
+                    documentationCache: documentationCache,
+                    engine: diagnosticEngine
                 )
             case .inheritsFrom:
                 // Build ancestor <-> offspring relationships.
@@ -1531,6 +1538,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
                     selector: selector,
                     in: bundle,
                     symbolIndex: &symbolIndex,
+                    documentationCache: documentationCache,
                     engine: diagnosticEngine
                 )
             case .requirementOf:
@@ -1540,6 +1548,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
                     selector: selector,
                     in: bundle,
                     symbolIndex: &symbolIndex,
+                    documentationCache: documentationCache,
                     engine: diagnosticEngine
                 )
             case .optionalRequirementOf:
@@ -1549,6 +1558,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
                     selector: selector,
                     in: bundle,
                     symbolIndex: &symbolIndex,
+                    documentationCache: documentationCache,
                     engine: diagnosticEngine
                 )
             default:
@@ -1570,7 +1580,10 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
         
         for edge in relationships {
             if edge.kind == .memberOf || edge.kind == .optionalMemberOf {
-                if let source = symbolIndex[edge.source], let target = symbolIndex[edge.target], let sourceSymbol = source.symbol {
+                if let source = nodeWithSymbolIdentifier(edge.source), let target = nodeWithSymbolIdentifier(edge.target),
+//                   let source = documentationCache[sourceRef], let target = documentationCache[targetRef],
+                   let sourceSymbol = source.symbol
+                {
                     switch (source.kind, target.kind) {
                     case (.dictionaryKey, .dictionary):
                         let dictionaryKey = DictionaryKey(name: sourceSymbol.title, contents: [], symbol: sourceSymbol, required: (edge.kind == .memberOf))
@@ -1617,7 +1630,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
         
         // Merge in all the dictionary keys for each target into their section variants.
         keysByTarget.forEach { targetIdentifier, keys in
-            let target = symbolIndex[targetIdentifier]
+            let target = nodeWithSymbolIdentifier(targetIdentifier)
             if let semantic = target?.semantic as? Symbol {
                 let keys = keys.sorted { $0.name < $1.name }
                 if semantic.dictionaryKeysSectionVariants[trait] == nil {
@@ -1630,7 +1643,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
         
         // Merge in all the parameters for each target into their section variants.
         parametersByTarget.forEach { targetIdentifier, parameters in
-            let target = symbolIndex[targetIdentifier]
+            let target = nodeWithSymbolIdentifier(targetIdentifier)
             if let semantic = target?.semantic as? Symbol {
                 let parameters = parameters.sorted { $0.name < $1.name }
                 if semantic.httpParametersSectionVariants[trait] == nil {
@@ -1643,7 +1656,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
         
         // Merge in the body for each target into their section variants.
         bodyByTarget.forEach { targetIdentifier, body in
-            let target = symbolIndex[targetIdentifier]
+            let target = nodeWithSymbolIdentifier(targetIdentifier)
             if let semantic = target?.semantic as? Symbol {
                 // Add any body parameters to existing body record
                 var localBody = body
@@ -1660,7 +1673,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
         
         // Merge in all the responses for each target into their section variants.
         responsesByTarget.forEach { targetIdentifier, responses in
-            let target = symbolIndex[targetIdentifier]
+            let target = nodeWithSymbolIdentifier(targetIdentifier)
             if let semantic = target?.semantic as? Symbol {
                 let responses = responses.sorted { $0.statusCode < $1.statusCode }
                 if semantic.httpResponsesSectionVariants[trait] == nil {
@@ -1711,7 +1724,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
         for symbolIdentifier in symbolsToResolve {
             do {
                 let symbolNode = try symbolResolver.symbolEntity(withPreciseIdentifier: symbolIdentifier)
-                symbolIndex[symbolIdentifier] = symbolNode
+                symbolIndex[symbolIdentifier] = symbolNode.reference
                 
                 // Keep track of which symbols were added to the topic graph from external sources so that their pages are not rendered.
                 externallyResolvedSymbols.insert(symbolNode.reference)
@@ -1742,7 +1755,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
                 return
             }
             
-            guard let existingNode = symbolIndex[symbol.uniqueIdentifier], existingNode.semantic is Symbol else {
+            guard let existingNode =  nodeWithSymbolIdentifier(symbol.uniqueIdentifier), existingNode.semantic is Symbol else {
                 // New symbols that didn't exist in the previous graphs should be added.
                 guard let references = references[symbol.defaultIdentifier], let reference = references.first else {
                     fatalError("Symbol with identifier '\(symbol.uniqueIdentifier)' has no reference. A symbol will always have at least one reference.")
@@ -2294,7 +2307,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
         emitWarningsForUncuratedTopics()
         
         if let hierarchyBasedLinkResolver = hierarchyBasedLinkResolver {
-            hierarchyBasedLinkResolver.addAnchorForSymbols(symbolIndex: symbolIndex)
+            hierarchyBasedLinkResolver.addAnchorForSymbols(symbolIndex: symbolIndex, documentationCache: documentationCache)
         }
         
         // Fifth, resolve links in nodes that are added solely via curation

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/DocumentationCacheBasedLinkResolver.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/DocumentationCacheBasedLinkResolver.swift
@@ -511,7 +511,7 @@ final class DocumentationCacheBasedLinkResolver {
     /// Method called when walking the symbol url tree that checks if a parent of a symbol has had its
     /// path modified during loading the symbol graph. If that's the case the method replaces
     /// `reference` with an updated reference with a correct reference path.
-    func updateNodeWithReferenceIfCollisionChild(_ reference: ResolvedTopicReference, symbolsURLHierarchy: inout BidirectionalTree<ResolvedTopicReference>, symbolIndex: inout [String: DocumentationNode], context: DocumentationContext) throws {
+    func updateNodeWithReferenceIfCollisionChild(_ reference: ResolvedTopicReference, symbolsURLHierarchy: inout BidirectionalTree<ResolvedTopicReference>, symbolIndex: inout [String: ResolvedTopicReference], context: DocumentationContext) throws {
         let newReference = try currentReferenceFor(reference: reference, symbolsURLHierarchy: &symbolsURLHierarchy)
         guard newReference != reference else { return }
         
@@ -523,7 +523,7 @@ final class DocumentationCacheBasedLinkResolver {
         // Rewrite the symbol index
         if let symbolIdentifier = documentationNode?.symbol?.identifier {
             symbolIndex.removeValue(forKey: symbolIdentifier.precise)
-            symbolIndex[symbolIdentifier.precise] = documentationNode
+            symbolIndex[symbolIdentifier.precise] = newReference
         }
         
         // Replace the topic graph node

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
@@ -1113,7 +1113,7 @@ private extension PathHierarchy.Node {
             if let fragments = symbol[mixin: SymbolGraph.Symbol.DeclarationFragments.self]?.declarationFragments {
                 return fragments.map(\.spelling).joined().split(whereSeparator: { $0.isWhitespace || $0.isNewline }).joined(separator: " ")
             }
-            return context.symbolIndex[symbol.identifier.precise]!.name.description
+            return context.nodeWithSymbolIdentifier(symbol.identifier.precise)!.name.description
         }
         // This only gets called for PathHierarchy error messages, so hierarchyBasedLinkResolver is never nil.
         let reference = context.hierarchyBasedLinkResolver!.resolvedReferenceMap[identifier]!

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchyBasedLinkResolver.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchyBasedLinkResolver.swift
@@ -73,12 +73,12 @@ final class PathHierarchyBasedLinkResolver {
     }
     
     /// Map the resolved identifiers to resolved topic references for all symbols in the given symbol index.
-    func addMappingForSymbols(symbolIndex: [String: DocumentationNode]) {
+    func addMappingForSymbols(symbolIndex: [String: ResolvedTopicReference]) {
         for (id, node) in pathHierarchy.lookup {
-            guard let symbol = node.symbol, let node = symbolIndex[symbol.identifier.precise] else {
+            guard let symbol = node.symbol, let reference = symbolIndex[symbol.identifier.precise] else {
                 continue
             }
-            resolvedReferenceMap[id] = node.reference
+            resolvedReferenceMap[id] = reference
         }
     }
     
@@ -164,9 +164,9 @@ final class PathHierarchyBasedLinkResolver {
     }
     
     /// Adds the headings for all symbols in the symbol index to the path hierarchy.
-    func addAnchorForSymbols(symbolIndex: [String: DocumentationNode]) {
+    func addAnchorForSymbols(symbolIndex: [String: ResolvedTopicReference], documentationCache: [ResolvedTopicReference: DocumentationNode]) {
         for (id, node) in pathHierarchy.lookup {
-            guard let symbol = node.symbol, let node = symbolIndex[symbol.identifier.precise] else { continue }
+            guard let symbol = node.symbol, let reference = symbolIndex[symbol.identifier.precise], let node = documentationCache[reference] else { continue }
             addAnchors(node.anchorSections, to: id)
         }
     }

--- a/Sources/SwiftDocC/Infrastructure/Symbol Graph/GeneratedDocumentationTopics.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Graph/GeneratedDocumentationTopics.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -255,14 +255,15 @@ enum GeneratedDocumentationTopics {
                // Check that there is origin information (i.e. the symbol is inherited)
                let origin = relationship.mixins[SymbolGraph.Relationship.SourceOrigin.mixinKey] as? SymbolGraph.Relationship.SourceOrigin,
                // Resolve the containing type
-               let parent = context.symbolIndex[relationship.target],
+               let parent = context.nodeWithSymbolIdentifier(relationship.target),
                // Resolve the child
-               let child = context.symbolIndex[relationship.source],
+               let child = context.nodeWithSymbolIdentifier(relationship.source),
                // Get the child symbol
                let childSymbol = child.symbol,
                // Get the swift extension data
-               let extends = childSymbol.mixins[SymbolGraph.Symbol.Swift.Extension.mixinKey] as? SymbolGraph.Symbol.Swift.Extension {
-                let originSymbol = context.symbolIndex[origin.identifier]?.symbol
+               let extends = childSymbol.mixins[SymbolGraph.Symbol.Swift.Extension.mixinKey] as? SymbolGraph.Symbol.Swift.Extension
+            {
+                let originSymbol = context.nodeWithSymbolIdentifier(origin.identifier)?.symbol
                 
                 // Add the inherited symbol to the index.
                 try inheritanceIndex.add(child.reference, to: parent.reference, childSymbol: childSymbol, originDisplayName: origin.displayName, originSymbol: originSymbol, extendedModuleName: extends.extendedModule)

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -1751,7 +1751,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
             // Create a reference if one found
             var reference: ResolvedTopicReference?
             if let preciseIdentifier = token.preciseIdentifier,
-               let resolved = self.context.symbolIndex[preciseIdentifier]?.reference {
+               let resolved = self.context.symbolIndex[preciseIdentifier] {
                 reference = resolved
                 
                 // Add relationship to render references

--- a/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/DeclarationsSectionTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/DeclarationsSectionTranslator.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -33,7 +33,7 @@ struct DeclarationsSectionTranslator: RenderSectionTranslator {
                     // Create a reference if one found
                     var reference: ResolvedTopicReference?
                     if let preciseIdentifier = token.preciseIdentifier,
-                       let resolved = renderNodeTranslator.context.symbolIndex[preciseIdentifier]?.reference {
+                       let resolved = renderNodeTranslator.context.symbolIndex[preciseIdentifier] {
                         reference = resolved
                         
                         // Add relationship to render references

--- a/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/HTTPBodySectionTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/HTTPBodySectionTranslator.swift
@@ -33,7 +33,7 @@ struct HTTPBodySectionTranslator: RenderSectionTranslator {
                 // Create a reference if one found
                 var reference: ResolvedTopicReference?
                 if let preciseIdentifier = token.preciseIdentifier,
-                   let resolved = renderNodeTranslator.context.symbolIndex[preciseIdentifier]?.reference {
+                   let resolved = renderNodeTranslator.context.symbolIndex[preciseIdentifier] {
                     reference = resolved
                     
                     // Add relationship to render references

--- a/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/HTTPResponsesSectionTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/HTTPResponsesSectionTranslator.swift
@@ -48,7 +48,7 @@ struct HTTPResponsesSectionTranslator: RenderSectionTranslator {
                     // Create a reference if one found
                     var reference: ResolvedTopicReference?
                     if let preciseIdentifier = token.preciseIdentifier,
-                       let resolved = renderNodeTranslator.context.symbolIndex[preciseIdentifier]?.reference {
+                       let resolved = renderNodeTranslator.context.symbolIndex[preciseIdentifier] {
                         reference = resolved
                         
                         // Add relationship to render references

--- a/Tests/SwiftDocCTests/Converter/DocumentationContextConverterTests.swift
+++ b/Tests/SwiftDocCTests/Converter/DocumentationContextConverterTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -45,7 +45,7 @@ class DocumentationContextConverterTests: XCTestCase {
         let renderContext = RenderContext(documentationContext: context, bundle: bundle)
         
         let fillIntroducedSymbolNode = try XCTUnwrap(
-            context.symbolIndex["s:14FillIntroduced19macOSOnlyDeprecatedyyF"]
+            context.nodeWithSymbolIdentifier("s:14FillIntroduced19macOSOnlyDeprecatedyyF")
         )
         
         do {
@@ -77,7 +77,7 @@ class DocumentationContextConverterTests: XCTestCase {
         let renderContext = RenderContext(documentationContext: context, bundle: bundle)
         
         let fillIntroducedSymbolNode = try XCTUnwrap(
-            context.symbolIndex["s:14FillIntroduced19macOSOnlyDeprecatedyyF"]
+            context.nodeWithSymbolIdentifier("s:14FillIntroduced19macOSOnlyDeprecatedyyF")
         )
         
         do {

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -749,7 +749,7 @@ class DocumentationContextTests: XCTestCase {
         XCTAssertFalse(context.symbolIndex.isEmpty)
         
         // MyClass is loaded
-        guard let myClass = context.symbolIndex["s:5MyKit0A5ClassC"] else {
+        guard let myClass = context.nodeWithSymbolIdentifier("s:5MyKit0A5ClassC") else {
             XCTFail("`MyClass` not found in symbol graph")
             return
         }
@@ -820,7 +820,7 @@ class DocumentationContextTests: XCTestCase {
         //
         
         // MyProtocol is loaded
-        guard let myProtocol = context.symbolIndex["s:5MyKit0A5ProtocolP"],
+        guard let myProtocol = context.nodeWithSymbolIdentifier("s:5MyKit0A5ProtocolP"),
             let myProtocolSymbol = myProtocol.semantic as? Symbol else {
             XCTFail("`MyProtocol` not found in symbol graph")
             return
@@ -995,7 +995,7 @@ class DocumentationContextTests: XCTestCase {
         try workspace.registerProvider(dataProvider)
         
         // MyClass is loaded
-        guard let myClass = context.symbolIndex["s:5MyKit0A5ClassC"],
+        guard let myClass = context.nodeWithSymbolIdentifier("s:5MyKit0A5ClassC"),
             let myClassSymbol = myClass.semantic as? Symbol else {
             XCTFail("`MyClass` not found in symbol graph")
             return
@@ -1092,7 +1092,7 @@ class DocumentationContextTests: XCTestCase {
         try workspace.registerProvider(dataProvider)
         
         // SideClass is loaded
-        guard let sideClass = context.symbolIndex["s:7SideKit0A5ClassC"],
+        guard let sideClass = context.nodeWithSymbolIdentifier("s:7SideKit0A5ClassC"),
             let sideClassSymbol = sideClass.semantic as? Symbol else {
             XCTFail("`SideClass` not found in symbol graph")
             return
@@ -1129,7 +1129,7 @@ class DocumentationContextTests: XCTestCase {
         try workspace.registerProvider(dataProvider)
         
         // MyClass is loaded
-        guard let myClass = context.symbolIndex["s:5MyKit0A5ClassC"],
+        guard let myClass = context.nodeWithSymbolIdentifier("s:5MyKit0A5ClassC"),
             let myClassSymbol = myClass.semantic as? Symbol else {
             XCTFail("`MyClass` not found in symbol graph")
             return
@@ -1933,12 +1933,12 @@ let expected = """
         XCTAssertNoThrow(try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/SideKit/SideClass/Test-swift.enum/NestedEnum-swift.enum/path", sourceLanguage: .swift)))
         
         // Verify that the symbol index has been updated with the rewritten collision-corrected symbol paths
-        XCTAssertEqual(context.symbolIndex["s:7SideKit0A5ClassC10testnEE"]?.reference.path, "/documentation/SideKit/SideClass/Test-swift.enum/nestedEnum-swift.property")
-        XCTAssertEqual(context.symbolIndex["s:7SideKit0A5ClassC10testEE"]?.reference.path, "/documentation/SideKit/SideClass/Test-swift.enum/NestedEnum-swift.enum")
-        XCTAssertEqual(context.symbolIndex["s:7SideKit0A5ClassC10tEstPP"]?.reference.path, "/documentation/SideKit/SideClass/Test-swift.enum/NestedEnum-swift.enum/path")
+        XCTAssertEqual(context.symbolIndex["s:7SideKit0A5ClassC10testnEE"]?.path, "/documentation/SideKit/SideClass/Test-swift.enum/nestedEnum-swift.property")
+        XCTAssertEqual(context.symbolIndex["s:7SideKit0A5ClassC10testEE"]?.path, "/documentation/SideKit/SideClass/Test-swift.enum/NestedEnum-swift.enum")
+        XCTAssertEqual(context.symbolIndex["s:7SideKit0A5ClassC10tEstPP"]?.path, "/documentation/SideKit/SideClass/Test-swift.enum/NestedEnum-swift.enum/path")
         
-        XCTAssertEqual(context.symbolIndex["s:5MyKit0A5MyProtocol0Afunc()"]?.reference.path, "/documentation/SideKit/SideProtocol/func()-6ijsi")
-        XCTAssertEqual(context.symbolIndex["s:5MyKit0A5MyProtocol0Afunc()DefaultImp"]?.reference.path, "/documentation/SideKit/SideProtocol/func()-2dxqn")
+        XCTAssertEqual(context.symbolIndex["s:5MyKit0A5MyProtocol0Afunc()"]?.path, "/documentation/SideKit/SideProtocol/func()-6ijsi")
+        XCTAssertEqual(context.symbolIndex["s:5MyKit0A5MyProtocol0Afunc()DefaultImp"]?.path, "/documentation/SideKit/SideProtocol/func()-2dxqn")
     }
 
     func testResolvingArticleLinkBeforeCuratingIt() throws {
@@ -2405,7 +2405,7 @@ let expected = """
             XCTAssertEqual(problem.diagnostic.range?.lowerBound.column, 23)
         }
 
-        let functionNode = try XCTUnwrap(context.symbolIndex["s:7SideKit0A5ClassC10myFunctionyyF"])
+        let functionNode = try XCTUnwrap(context.nodeWithSymbolIdentifier("s:7SideKit0A5ClassC10myFunctionyyF"))
         XCTAssertEqual(functionNode.docChunks.count, 2)
         let docCommentChunks = functionNode.docChunks.compactMap { chunk -> DocumentationNode.DocumentationChunk? in
             switch chunk.source {
@@ -3015,7 +3015,7 @@ let expected = """
             let unresolved = TopicReference.unresolved(.init(topicURL: try XCTUnwrap(ValidatedURL(parsingExact: "doc:Test"))))
             let expected = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/Test-Bundle/Test", sourceLanguage: .swift)
             
-            let symbolReference = try XCTUnwrap(context.symbolIndex["s:12Minimal_docs4TestV"]?.reference)
+            let symbolReference = try XCTUnwrap(context.symbolIndex["s:12Minimal_docs4TestV"])
             
             // Resolve from various locations in the bundle
             for parent in [bundle.rootReference, bundle.documentationRootReference, bundle.tutorialsRootReference, symbolReference] {
@@ -3211,7 +3211,7 @@ let expected = """
         let (bundle, context) = try testBundleAndContext(named: "BundleWithExecutableModuleKind")
         XCTAssertEqual(bundle.info.defaultModuleKind, "Executable")
         
-        let moduleSymbol = try XCTUnwrap(context.symbolIndex["ExampleDocumentedExecutable"]?.symbol)
+        let moduleSymbol = try XCTUnwrap(context.nodeWithSymbolIdentifier("ExampleDocumentedExecutable")?.symbol)
         XCTAssertEqual(moduleSymbol.kind.identifier.identifier, "module")
         XCTAssertEqual(moduleSymbol.kind.displayName, "Executable")
     }
@@ -3280,8 +3280,8 @@ let expected = """
         )
         
         let symbolsInSymbolIndex = Set(
-            context.symbolIndex.values.compactMap { node -> ObjectIdentifier? in
-                guard let symbol = node.semantic as? Symbol else {
+            context.symbolIndex.values.compactMap { reference -> ObjectIdentifier? in
+                guard let symbol = context.documentationCache[reference]?.semantic as? Symbol else {
                     XCTFail("Node in symbolIndex doesn't have a symbol.")
                     return nil
                 }
@@ -3294,6 +3294,25 @@ let expected = """
             symbolsInSymbolIndex,
             "Expected the symbol instances in the documentationCache and symbolIndex dictionaries to be the same"
         )
+    }
+    
+    func testAllReferencesInSymbolsIndexExistInDocumentationCache() throws {
+        let (_, context) = try testBundleAndContext(named: "TestBundle")
+        
+        let referencesInSymbolIndex = Set(context.symbolIndex.values)
+        let referencesInDocumentationCache = Set(context.documentationCache.keys)
+        
+        let extraReferencesInSymbolIndex = referencesInSymbolIndex.subtracting(referencesInDocumentationCache)
+        XCTAssert(extraReferencesInSymbolIndex.isEmpty, "Some symbols in the symbol index don't exist in the documentation cache: \(extraReferencesInSymbolIndex.map(\.path).sorted())")
+
+        
+        var referencesToSymbolsInDocumentationCache = Set<ResolvedTopicReference>()
+        for (reference, node) in context.documentationCache where node.semantic is Symbol {
+            referencesToSymbolsInDocumentationCache.insert(reference)
+        }
+            
+        let missingReferencesInSymbolIndex = referencesToSymbolsInDocumentationCache.subtracting(referencesInSymbolIndex)
+        XCTAssert(missingReferencesInSymbolIndex.isEmpty, "Some symbol references in the documentation cache don't exist in the symbol index: \(missingReferencesInSymbolIndex.map(\.path).sorted())")
     }
     
     func testDocumentationExtensionURLForReferenceReturnsURLForSymbolReference() throws {

--- a/Tests/SwiftDocCTests/Infrastructure/InheritIntroducedAvailabilityTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/InheritIntroducedAvailabilityTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -52,7 +52,7 @@ class InheritIntroducedAvailabilityTests: XCTestCase {
     /// the macOS version in the Info.plist
     func testMacOSOnlyDeprecated() {
         let macOSOnlyDeprecated =
-            context.symbolIndex["s:14FillIntroduced19macOSOnlyDeprecatedyyF"]!
+            context.nodeWithSymbolIdentifier("s:14FillIntroduced19macOSOnlyDeprecatedyyF")!
                 .symbol!.availability!.availability.first {
             $0.domain?.rawValue == PlatformName.macOS.rawValue
         }!
@@ -69,7 +69,7 @@ class InheritIntroducedAvailabilityTests: XCTestCase {
     func testMacOSOnlyIntroduced() {
         // Don't overwrite existing `macOS, introduced: 10.15`
         let macOSOnlyIntroduced =
-            context.symbolIndex["s:14FillIntroduced09macOSOnlyB0yyF"]!
+            context.nodeWithSymbolIdentifier("s:14FillIntroduced09macOSOnlyB0yyF")!
                 .symbol!.availability!.availability.first {
             $0.domain?.rawValue == PlatformName.macOS.rawValue
         }!
@@ -82,7 +82,7 @@ class InheritIntroducedAvailabilityTests: XCTestCase {
     /// the iOS version in the Info.plist
     func testiOSOnlyDeprecated() {
         let iOSOnlyDeprecated =
-            context.symbolIndex["s:14FillIntroduced17iOSOnlyDeprecatedyyF"]!
+            context.nodeWithSymbolIdentifier("s:14FillIntroduced17iOSOnlyDeprecatedyyF")!
                 .symbol!.availability!.availability.first {
             $0.domain?.rawValue == PlatformName.iOS.rawValue
         }!
@@ -99,7 +99,7 @@ class InheritIntroducedAvailabilityTests: XCTestCase {
     func testiOSOnlyIntroduced() {
         // Don't overwrite existing `macOS, introduced: 10.15`
         let iOSOnlyIntroduced =
-            context.symbolIndex["s:14FillIntroduced07iOSOnlyB0yyF"]!
+            context.nodeWithSymbolIdentifier("s:14FillIntroduced07iOSOnlyB0yyF")!
                 .symbol!.availability!.availability.first {
             $0.domain?.rawValue == PlatformName.iOS.rawValue
         }!
@@ -112,7 +112,7 @@ class InheritIntroducedAvailabilityTests: XCTestCase {
     /// the iOS version in the Info.plist via a fallback mechanism.
     func testCatalystOnlyDeprecated() {
         let catalystOnlyDeprecated =
-            context.symbolIndex["s:14FillIntroduced25macCatalystOnlyDeprecatedyyF"]!
+            context.nodeWithSymbolIdentifier("s:14FillIntroduced25macCatalystOnlyDeprecatedyyF")!
                 .symbol!.availability!.availability.first {
             $0.domain?.rawValue == PlatformName.catalyst.rawValue
         }!
@@ -129,7 +129,7 @@ class InheritIntroducedAvailabilityTests: XCTestCase {
     func testCatalystOnlyIntroduced() {
         // Don't overwrite existing `macOS, introduced: 10.15`
         let catalystOnlyIntroduced =
-            context.symbolIndex["s:14FillIntroduced015macCatalystOnlyB0yyF"]!
+            context.nodeWithSymbolIdentifier("s:14FillIntroduced015macCatalystOnlyB0yyF")!
                 .symbol!.availability!.availability.first {
             $0.domain?.rawValue == PlatformName.catalyst.rawValue
         }!
@@ -156,7 +156,7 @@ class InheritIntroducedAvailabilityTests: XCTestCase {
         /// @available(tvOS, unavailable)
         /// @available(watchOS, unavailable)
         /// ```
-        let iOSMacOSOnly = context.symbolIndex["s:14FillIntroduced12iOSMacOSOnlyyyF"]!
+        let iOSMacOSOnly = context.nodeWithSymbolIdentifier("s:14FillIntroduced12iOSMacOSOnlyyyF")!
 
         /// These domains should not have had an `introduced` version added.
         let domainsThatShouldntHaveIntroduced = Set([

--- a/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
@@ -1294,7 +1294,7 @@ class PathHierarchyTests: XCTestCase {
             XCTAssertEqual(tree.caseInsensitiveDisambiguatedPaths()["s:5MyKit0A5ClassC10myFunctionyyF"],
                            "/MyKit/MyClass/myFunction()")
             
-            XCTAssertEqual(context.symbolIndex["s:5MyKit0A5ClassC10myFunctionyyF"]?.reference.path,
+            XCTAssertEqual(context.symbolIndex["s:5MyKit0A5ClassC10myFunctionyyF"]?.path,
                            "/documentation/MyKit/MyClass/myFunction()")
         }
         
@@ -1313,7 +1313,7 @@ class PathHierarchyTests: XCTestCase {
             XCTAssertEqual(tree.caseInsensitiveDisambiguatedPaths()["s:5MyKit0A5ClassC10myFunctionyyF"],
                            "/MyKit/MyClass-class/myFunction()")
             
-            XCTAssertEqual(context.symbolIndex["s:5MyKit0A5ClassC10myFunctionyyF"]?.reference.path,
+            XCTAssertEqual(context.symbolIndex["s:5MyKit0A5ClassC10myFunctionyyF"]?.path,
                            "/documentation/MyKit/MyClass-swift.class/myFunction()")
         }
         
@@ -1334,7 +1334,7 @@ class PathHierarchyTests: XCTestCase {
             XCTAssertEqual(tree.caseInsensitiveDisambiguatedPaths()["s:5MyKit0A5ClassC10myFunctionyyF"],
                            "/MyKit/MyClass-class-hash/myFunction()")
             
-            XCTAssertEqual(context.symbolIndex["s:5MyKit0A5ClassC10myFunctionyyF"]?.reference.path,
+            XCTAssertEqual(context.symbolIndex["s:5MyKit0A5ClassC10myFunctionyyF"]?.path,
                            "/documentation/MyKit/MyClass-swift.class-hash/myFunction()")
         }
     }

--- a/Tests/SwiftDocCTests/Infrastructure/ReferenceResolverTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/ReferenceResolverTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -501,7 +501,7 @@ class ReferenceResolverTests: XCTestCase {
         
         var resolver = ReferenceResolver(context: context, bundle: bundle, source: nil)
         
-        let symbol = try XCTUnwrap(context.symbolIndex["s:5MyKit0A5ClassC"]?.semantic as? Symbol)
+        let symbol = try XCTUnwrap(context.nodeWithSymbolIdentifier("s:5MyKit0A5ClassC")?.semantic as? Symbol)
         
         /// Verifies the given assertion on a variants property of the given symbols.
         func assertSymbolVariants<Variant>(

--- a/Tests/SwiftDocCTests/Infrastructure/Symbol Link Resolution/AbsoluteSymbolLinkTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/Symbol Link Resolution/AbsoluteSymbolLinkTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -523,7 +523,7 @@ class AbsoluteSymbolLinkTests: XCTestCase {
         XCTAssertEqual(expectedDescriptions.count, context.symbolIndex.count)
         
         let validatedSymbolLinkDescriptions = context.symbolIndex.values
-            .map(\.reference.url.absoluteString)
+            .map(\.url.absoluteString)
             .sorted()
             .compactMap(AbsoluteSymbolLink.init(string:))
             .map(\.description)
@@ -871,7 +871,7 @@ class AbsoluteSymbolLinkTests: XCTestCase {
         XCTAssertEqual(expectedDescriptions.count, context.symbolIndex.count)
         
         let validatedSymbolLinkDescriptions = context.symbolIndex.values
-            .map(\.reference.url.absoluteString)
+            .map(\.url.absoluteString)
             .sorted()
             .compactMap(AbsoluteSymbolLink.init(string:))
             .map(\.description)
@@ -890,7 +890,7 @@ class AbsoluteSymbolLinkTests: XCTestCase {
         )
         
         let bundlePathComponents = context.symbolIndex.values
-            .flatMap(\.reference.pathComponents)
+            .flatMap(\.pathComponents)
         
         
         bundlePathComponents.forEach { component in

--- a/Tests/SwiftDocCTests/Infrastructure/SymbolGraph/SymbolGraphLoaderTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/SymbolGraph/SymbolGraphLoaderTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -179,7 +179,7 @@ class SymbolGraphLoaderTests: XCTestCase {
             // to simulate the loading order we want to test.
             let (_, _, context) = try testBundleCopy(iOSSymbolGraphName: "faux@MyKit.symbols.json", catalystSymbolGraphName: "MyKit.symbols.json")
 
-            guard let availability = (context.symbolIndex["s:5MyKit0A5ClassC"]?.semantic as? Symbol)?.availability?.availability else {
+            guard let availability = (context.nodeWithSymbolIdentifier("s:5MyKit0A5ClassC")?.semantic as? Symbol)?.availability?.availability else {
                 XCTFail("Did not find availability for symbol 's:5MyKit0A5ClassC'")
                 return
             }
@@ -199,7 +199,7 @@ class SymbolGraphLoaderTests: XCTestCase {
             // to simulate the loading order we want to test.
             let (_, _, context) = try testBundleCopy(iOSSymbolGraphName: "MyKit.symbols.json", catalystSymbolGraphName: "faux@MyKit.symbols.json")
             
-            guard let availability = (context.symbolIndex["s:5MyKit0A5ClassC"]?.semantic as? Symbol)?.availability?.availability else {
+            guard let availability = (context.nodeWithSymbolIdentifier("s:5MyKit0A5ClassC")?.semantic as? Symbol)?.availability?.availability else {
                 XCTFail("Did not find availability for symbol 's:5MyKit0A5ClassC'")
                 return
             }

--- a/Tests/SwiftDocCTests/Infrastructure/SymbolGraph/SymbolGraphRelationshipsBuilderTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/SymbolGraph/SymbolGraphRelationshipsBuilderTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -15,7 +15,13 @@ import XCTest
 
 class SymbolGraphRelationshipsBuilderTests: XCTestCase {
     
-    private func createSymbols(in symbolIndex: inout [String: DocumentationNode], bundle: DocumentationBundle, sourceType: SymbolGraph.Symbol.Kind, targetType: SymbolGraph.Symbol.Kind) -> SymbolGraph.Relationship {
+    private func createSymbols(
+        in symbolIndex: inout [String: ResolvedTopicReference],
+        documentationCache: inout [ResolvedTopicReference: DocumentationNode],
+        bundle: DocumentationBundle,
+        sourceType: SymbolGraph.Symbol.Kind,
+        targetType: SymbolGraph.Symbol.Kind
+    ) -> SymbolGraph.Relationship {
         let sourceIdentifier = SymbolGraph.Symbol.Identifier(precise: "A", interfaceLanguage: SourceLanguage.swift.id)
         let targetIdentifier = SymbolGraph.Symbol.Identifier(precise: "B", interfaceLanguage: SourceLanguage.swift.id)
         
@@ -28,8 +34,10 @@ class SymbolGraphRelationshipsBuilderTests: XCTestCase {
         let targetSymbol = SymbolGraph.Symbol(identifier: targetIdentifier, names: SymbolGraph.Symbol.Names(title: "B", navigator: nil, subHeading: nil, prose: nil), pathComponents: ["MyKit", "B"], docComment: nil, accessLevel: .init(rawValue: "public"), kind: targetType, mixins: [:])
         
         let engine = DiagnosticEngine()
-        symbolIndex["A"] = DocumentationNode(reference: sourceRef, symbol: sourceSymbol, platformName: "macOS", moduleReference: moduleRef, article: nil, engine: engine)
-        symbolIndex["B"] = DocumentationNode(reference: targetRef, symbol: targetSymbol, platformName: "macOS", moduleReference: moduleRef, article: nil, engine: engine)
+        symbolIndex["A"] = sourceRef
+        symbolIndex["B"] = targetRef
+        documentationCache[sourceRef] = DocumentationNode(reference: sourceRef, symbol: sourceSymbol, platformName: "macOS", moduleReference: moduleRef, article: nil, engine: engine)
+        documentationCache[targetRef] = DocumentationNode(reference: targetRef, symbol: targetSymbol, platformName: "macOS", moduleReference: moduleRef, article: nil, engine: engine)
         XCTAssert(engine.problems.isEmpty)
         
         return SymbolGraph.Relationship(source: sourceIdentifier.precise, target: targetIdentifier.precise, kind: .defaultImplementationOf, targetFallback: nil)
@@ -39,30 +47,32 @@ class SymbolGraphRelationshipsBuilderTests: XCTestCase {
     
     func testImplementsRelationship() throws {
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
-        var symbolIndex = [String: DocumentationNode]()
+        var symbolIndex = [String: ResolvedTopicReference]()
+        var documentationCache = [ResolvedTopicReference: DocumentationNode]()
         let engine = DiagnosticEngine()
         
-        let edge = createSymbols(in: &symbolIndex, bundle: bundle, sourceType: .init(parsedIdentifier: .class, displayName: "Class"), targetType: .init(parsedIdentifier: .protocol, displayName: "Protocol"))
+        let edge = createSymbols(in: &symbolIndex, documentationCache: &documentationCache, bundle: bundle, sourceType: .init(parsedIdentifier: .class, displayName: "Class"), targetType: .init(parsedIdentifier: .protocol, displayName: "Protocol"))
         
         // Adding the relationship
-        SymbolGraphRelationshipsBuilder.addImplementationRelationship(edge: edge, selector: swiftSelector, in: bundle, context: context, symbolIndex: &symbolIndex, engine: engine)
+        SymbolGraphRelationshipsBuilder.addImplementationRelationship(edge: edge, selector: swiftSelector, in: bundle, context: context, symbolIndex: &symbolIndex, documentationCache: documentationCache, engine: engine)
         
         // Test default implementation was added
-        XCTAssertFalse((symbolIndex["B"]!.semantic as! Symbol).defaultImplementations.implementations.isEmpty)
+        XCTAssertFalse((documentationCache[symbolIndex["B"]!]!.semantic as! Symbol).defaultImplementations.implementations.isEmpty)
     }
 
     func testConformsRelationship() throws {
         let bundle = try testBundle(named: "TestBundle")
-        var symbolIndex = [String: DocumentationNode]()
+        var symbolIndex = [String: ResolvedTopicReference]()
+        var documentationCache = [ResolvedTopicReference: DocumentationNode]()
         let engine = DiagnosticEngine()
         
-        let edge = createSymbols(in: &symbolIndex, bundle: bundle, sourceType: .init(parsedIdentifier: .class, displayName: "Class"), targetType: .init(parsedIdentifier: .protocol, displayName: "Protocol"))
+        let edge = createSymbols(in: &symbolIndex, documentationCache: &documentationCache, bundle: bundle, sourceType: .init(parsedIdentifier: .class, displayName: "Class"), targetType: .init(parsedIdentifier: .protocol, displayName: "Protocol"))
         
         // Adding the relationship
-        SymbolGraphRelationshipsBuilder.addConformanceRelationship(edge: edge, selector: swiftSelector, in: bundle, symbolIndex: &symbolIndex, engine: engine)
+        SymbolGraphRelationshipsBuilder.addConformanceRelationship(edge: edge, selector: swiftSelector, in: bundle, symbolIndex: &symbolIndex, documentationCache: documentationCache, engine: engine)
         
         // Test default conforms to was added
-        guard let conformsTo = (symbolIndex["A"]!.semantic as! Symbol).relationships.groups.first(where: { group -> Bool in
+        guard let conformsTo = (documentationCache[symbolIndex["A"]!]!.semantic as! Symbol).relationships.groups.first(where: { group -> Bool in
             return group.kind == RelationshipsGroup.Kind.conformsTo
         }) else {
             XCTFail("Conforms to group not added")
@@ -71,7 +81,7 @@ class SymbolGraphRelationshipsBuilderTests: XCTestCase {
         XCTAssertEqual(conformsTo.destinations.first?.url?.absoluteString, "doc://org.swift.docc.example/documentation/MyKit/B")
         
         // Test default conformance was added
-        guard let conforming = (symbolIndex["B"]!.semantic as! Symbol).relationships.groups.first(where: { group -> Bool in
+        guard let conforming = (documentationCache[symbolIndex["B"]!]!.semantic as! Symbol).relationships.groups.first(where: { group -> Bool in
             return group.kind == RelationshipsGroup.Kind.conformingTypes
         }) else {
             XCTFail("Conforming types not added")
@@ -82,16 +92,17 @@ class SymbolGraphRelationshipsBuilderTests: XCTestCase {
 
     func testInheritanceRelationship() throws {
         let bundle = try testBundle(named: "TestBundle")
-        var symbolIndex = [String: DocumentationNode]()
+        var symbolIndex = [String: ResolvedTopicReference]()
+        var documentationCache = [ResolvedTopicReference: DocumentationNode]()
         let engine = DiagnosticEngine()
         
-        let edge = createSymbols(in: &symbolIndex, bundle: bundle, sourceType: .init(parsedIdentifier: .class, displayName: "Class"), targetType: .init(parsedIdentifier: .protocol, displayName: "Protocol"))
+        let edge = createSymbols(in: &symbolIndex, documentationCache: &documentationCache,bundle: bundle, sourceType: .init(parsedIdentifier: .class, displayName: "Class"), targetType: .init(parsedIdentifier: .protocol, displayName: "Protocol"))
         
         // Adding the relationship
-        SymbolGraphRelationshipsBuilder.addInheritanceRelationship(edge: edge, selector: swiftSelector, in: bundle, symbolIndex: &symbolIndex, engine: engine)
+        SymbolGraphRelationshipsBuilder.addInheritanceRelationship(edge: edge, selector: swiftSelector, in: bundle, symbolIndex: &symbolIndex, documentationCache: documentationCache, engine: engine)
         
         // Test inherits was added
-        guard let inherits = (symbolIndex["A"]!.semantic as! Symbol).relationships.groups.first(where: { group -> Bool in
+        guard let inherits = (documentationCache[symbolIndex["A"]!]!.semantic as! Symbol).relationships.groups.first(where: { group -> Bool in
             return group.kind == RelationshipsGroup.Kind.inheritsFrom
         }) else {
             XCTFail("Inherits from not added")
@@ -99,8 +110,8 @@ class SymbolGraphRelationshipsBuilderTests: XCTestCase {
         }
         XCTAssertEqual(inherits.destinations.first?.url?.absoluteString, "doc://org.swift.docc.example/documentation/MyKit/B")
         
-        // Test decendants were added
-        guard let inherited = (symbolIndex["B"]!.semantic as! Symbol).relationships.groups.first(where: { group -> Bool in
+        // Test descendants were added
+        guard let inherited = (documentationCache[symbolIndex["B"]!]!.semantic as! Symbol).relationships.groups.first(where: { group -> Bool in
             return group.kind == RelationshipsGroup.Kind.inheritedBy
         }) else {
             XCTFail("Inherited by types not added")
@@ -111,7 +122,8 @@ class SymbolGraphRelationshipsBuilderTests: XCTestCase {
     
     func testInheritanceRelationshipFromOtherFramework() throws {
         let bundle = try testBundle(named: "TestBundle")
-        var symbolIndex = [String: DocumentationNode]()
+        var symbolIndex = [String: ResolvedTopicReference]()
+        var documentationCache = [ResolvedTopicReference: DocumentationNode]()
         let engine = DiagnosticEngine()
         
         let sourceIdentifier = SymbolGraph.Symbol.Identifier(precise: "A", interfaceLanguage: SourceLanguage.swift.id)
@@ -122,14 +134,15 @@ class SymbolGraphRelationshipsBuilderTests: XCTestCase {
         
         let sourceSymbol = SymbolGraph.Symbol(identifier: sourceIdentifier, names: SymbolGraph.Symbol.Names(title: "A", navigator: nil, subHeading: nil, prose: nil), pathComponents: ["MyKit", "A"], docComment: nil, accessLevel: .init(rawValue: "public"), kind: SymbolGraph.Symbol.Kind(parsedIdentifier: .class, displayName: "Class"), mixins: [:])
         
-        symbolIndex["A"] = DocumentationNode(reference: sourceRef, symbol: sourceSymbol, platformName: "macOS", moduleReference: moduleRef, article: nil, engine: engine)
+        symbolIndex["A"] = sourceRef
+        documentationCache[sourceRef] = DocumentationNode(reference: sourceRef, symbol: sourceSymbol, platformName: "macOS", moduleReference: moduleRef, article: nil, engine: engine)
         XCTAssert(engine.problems.isEmpty)
         
         let edge = SymbolGraph.Relationship(source: sourceIdentifier.precise, target: targetIdentifier.precise, kind: .inheritsFrom, targetFallback: "MyOtherKit.B")
         
-        SymbolGraphRelationshipsBuilder.addInheritanceRelationship(edge: edge, selector: swiftSelector, in: bundle, symbolIndex: &symbolIndex, engine: engine)
+        SymbolGraphRelationshipsBuilder.addInheritanceRelationship(edge: edge, selector: swiftSelector, in: bundle, symbolIndex: &symbolIndex, documentationCache: documentationCache, engine: engine)
         
-        let relationships = (symbolIndex["A"]!.semantic as! Symbol).relationships
+        let relationships = (documentationCache[symbolIndex["A"]!]!.semantic as! Symbol).relationships
         guard let inheritsShouldHaveFallback = relationships.groups.first(where: { group -> Bool in
             return group.kind == RelationshipsGroup.Kind.inheritsFrom
         }) else {
@@ -144,29 +157,31 @@ class SymbolGraphRelationshipsBuilderTests: XCTestCase {
     
     func testRequirementRelationship() throws {
         let bundle = try testBundle(named: "TestBundle")
-        var symbolIndex = [String: DocumentationNode]()
+        var symbolIndex = [String: ResolvedTopicReference]()
+        var documentationCache = [ResolvedTopicReference: DocumentationNode]()
         let engine = DiagnosticEngine()
         
-        let edge = createSymbols(in: &symbolIndex, bundle: bundle, sourceType: .init(parsedIdentifier: .method, displayName: "Method"), targetType: .init(parsedIdentifier: .protocol, displayName: "Protocol"))
+        let edge = createSymbols(in: &symbolIndex, documentationCache: &documentationCache,bundle: bundle, sourceType: .init(parsedIdentifier: .method, displayName: "Method"), targetType: .init(parsedIdentifier: .protocol, displayName: "Protocol"))
         
         // Adding the relationship
-        SymbolGraphRelationshipsBuilder.addRequirementRelationship(edge: edge, selector: swiftSelector, in: bundle, symbolIndex: &symbolIndex, engine: engine)
+        SymbolGraphRelationshipsBuilder.addRequirementRelationship(edge: edge, selector: swiftSelector, in: bundle, symbolIndex: &symbolIndex, documentationCache: documentationCache, engine: engine)
         
         // Test default implementation was added
-        XCTAssertTrue((symbolIndex["A"]!.semantic as! Symbol).isRequired)
+        XCTAssertTrue((documentationCache[symbolIndex["A"]!]!.semantic as! Symbol).isRequired)
     }
     
     func testOptionalRequirementRelationship() throws {
         let bundle = try testBundle(named: "TestBundle")
-        var symbolIndex = [String: DocumentationNode]()
+        var symbolIndex = [String: ResolvedTopicReference]()
+        var documentationCache = [ResolvedTopicReference: DocumentationNode]()
         let engine = DiagnosticEngine()
         
-        let edge = createSymbols(in: &symbolIndex, bundle: bundle, sourceType: .init(parsedIdentifier: .method, displayName: "Method"), targetType: .init(parsedIdentifier: .protocol, displayName: "Protocol"))
+        let edge = createSymbols(in: &symbolIndex, documentationCache: &documentationCache,bundle: bundle, sourceType: .init(parsedIdentifier: .method, displayName: "Method"), targetType: .init(parsedIdentifier: .protocol, displayName: "Protocol"))
         
         // Adding the relationship
-        SymbolGraphRelationshipsBuilder.addOptionalRequirementRelationship(edge: edge, selector: swiftSelector, in: bundle, symbolIndex: &symbolIndex, engine: engine)
+        SymbolGraphRelationshipsBuilder.addOptionalRequirementRelationship(edge: edge, selector: swiftSelector, in: bundle, symbolIndex: &symbolIndex, documentationCache: documentationCache, engine: engine)
         
         // Test default implementation was added
-        XCTAssertFalse((symbolIndex["A"]!.semantic as! Symbol).isRequired)
+        XCTAssertFalse((documentationCache[symbolIndex["A"]!]!.semantic as! Symbol).isRequired)
     }
 }

--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
@@ -1287,7 +1287,7 @@ class SemaToRenderNodeTests: XCTestCase {
         XCTAssertFalse(context.symbolIndex.isEmpty)
         
         // MyProtocol is loaded
-        guard let myProtocol = context.symbolIndex["s:5MyKit0A5ProtocolP"],
+        guard let myProtocol = context.nodeWithSymbolIdentifier("s:5MyKit0A5ProtocolP"),
               let myProtocolSymbol = myProtocol.semantic as? Symbol else {
             XCTFail("`MyProtocol` not found in symbol graph")
             return
@@ -1295,12 +1295,12 @@ class SemaToRenderNodeTests: XCTestCase {
         
         // Verify that various symbols that exist are referenced in the symbol graph file have been resolved and added to the symbol index
         
-        XCTAssertNotNil(context.symbolIndex["p:hPP"], "External symbol from declaration was resolved and added to the index")
-        XCTAssertNotNil(context.symbolIndex["s:Si"], "External symbol from declaration was resolved and added to the index")
-        XCTAssertNotNil(context.symbolIndex["s:10Foundation3URLV"], "External symbol from declaration was resolved and added to the index")
-        XCTAssertNotNil(context.symbolIndex["s:10Foundation4DataV"], "External symbol from declaration was resolved and added to the index")
+        XCTAssertNotNil(context.nodeWithSymbolIdentifier("p:hPP"), "External symbol from declaration was resolved and added to the index")
+        XCTAssertNotNil(context.nodeWithSymbolIdentifier("s:Si"), "External symbol from declaration was resolved and added to the index")
+        XCTAssertNotNil(context.nodeWithSymbolIdentifier("s:10Foundation3URLV"), "External symbol from declaration was resolved and added to the index")
+        XCTAssertNotNil(context.nodeWithSymbolIdentifier("s:10Foundation4DataV"), "External symbol from declaration was resolved and added to the index")
         
-        XCTAssertNotNil(context.symbolIndex["s:5Foundation0A5NSCodableP"], "External symbol from symbol graph relationship was resolved and added to the index")
+        XCTAssertNotNil(context.nodeWithSymbolIdentifier("s:5Foundation0A5NSCodableP"), "External symbol from symbol graph relationship was resolved and added to the index")
         
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: myProtocol.reference, source: nil)
 

--- a/Tests/SwiftDocCTests/Semantics/SymbolTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/SymbolTests.swift
@@ -523,7 +523,7 @@ class SymbolTests: XCTestCase {
         let (_, _, context) = try testBundleAndContext(copying: "TestBundle") { url in
             try? FileManager.default.copyItem(at: deckKitSymbolGraph, to: url.appendingPathComponent("DeckKit.symbols.json"))
         }
-        let symbol = try XCTUnwrap(context.symbolIndex["c:objc(cs)PlayingCard(cm)newWithRank:ofSuit:"]?.semantic as? Symbol)
+        let symbol = try XCTUnwrap(context.nodeWithSymbolIdentifier("c:objc(cs)PlayingCard(cm)newWithRank:ofSuit:")?.semantic as? Symbol)
 
         XCTAssertEqual(symbol.abstract?.format(), "Allocate and initialize a new card with the given rank and suit.")
 
@@ -1143,7 +1143,7 @@ class SymbolTests: XCTestCase {
             try newGraphData.write(to: url.appendingPathComponent("mykit-iOS.symbols.json"))
         }
         
-        guard let original = context.symbolIndex[myFunctionUSR], let symbol = original.symbol, let symbolSemantic = original.semantic as? Symbol else {
+        guard let original = context.nodeWithSymbolIdentifier(myFunctionUSR), let symbol = original.symbol, let symbolSemantic = original.semantic as? Symbol else {
             XCTFail("Couldn't find the expected symbol", file: (file), line: line)
             enum TestHelperError: Error { case missingExpectedMyFuctionSymbol }
             throw TestHelperError.missingExpectedMyFuctionSymbol


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift-docc/pull/543

- **Explanation**: Reduce peak memory usage by ~1.5% by looking up documentation nodes in the context instead of storing them directly in the symbol index. 
- **Scope**: Peak memory usage
- **Radar**: rdar://106654403
- **Risk**: Low. 
- **Testing**: Automated testing and some manual testing verify that output and other behavior is unchanged.
- **Reviewer**: @franklinsch 

My main reason for suggesting we cherry pick this change is to have similar code on main and release/5.9 to minimize conflicts when cherry picking other changes from main. 