### PR TITLE
Fix inverse logic in hierarchy based link resolver environment opt-out

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/LinkResolutionMigration.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/LinkResolutionMigration.swift
@@ -24,11 +24,15 @@ enum LinkResolutionMigrationConfiguration {
         let defaultsKey = "DocCUseHierarchyBasedLinkResolver"
         let environmentKey = "DOCC_USE_HIERARCHY_BASED_LINK_RESOLVER"
         
+        if let environmentValue = ProcessInfo.processInfo.environment[environmentKey] {
+            switch environmentValue.uppercased() {
+            case "NO", "FALSE", "0": return false
+            case "YES", "TRUE", "1": return true
+            default: break
+            }
+        }
         if UserDefaults.standard.object(forKey: defaultsKey) != nil {
             return UserDefaults.standard.bool(forKey: defaultsKey)
-        }
-        if let environmentValue = ProcessInfo.processInfo.environment[environmentKey] {
-            return environmentValue != "NO"
         }
         return true
     }()

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/LinkResolutionMigration.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/LinkResolutionMigration.swift
@@ -28,7 +28,7 @@ enum LinkResolutionMigrationConfiguration {
             return UserDefaults.standard.bool(forKey: defaultsKey)
         }
         if let environmentValue = ProcessInfo.processInfo.environment[environmentKey] {
-            return environmentValue == "NO"
+            return environmentValue != "NO"
         }
         return true
     }()


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

This fixes an issue where the opt-logic for the new link resolver was inverted. 

## Dependencies

None.

## Testing

- Run `swift run docc convert /path/to/SomeBundle.docc` with `DOCC_USE_HIERARCHY_BASED_LINK_RESOLVER=YES`.
DocC should use the hierarchy based resolver.
- Run `swift run docc convert /path/to/SomeBundle.docc` without `DOCC_USE_HIERARCHY_BASED_LINK_RESOLVER` set.
DocC should use the hierarchy based resolver.
- Run `swift run docc convert /path/to/SomeBundle.docc` with `DOCC_USE_HIERARCHY_BASED_LINK_RESOLVER=NO`.
DocC shouldn't use the hierarchy based resolver.
## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- ~[ ] Added tests~
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
