### PR TITLE
Correctly set page color metadata for symbol pages

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -1245,6 +1245,10 @@ public struct RenderNodeTranslator: SemanticVisitor {
                 )
             }
         }
+        
+        if let pageColor = documentationNode.metadata?.pageColor {
+            node.metadata.color = TopicColor(standardColorIdentifier: pageColor.rawValue)
+        }
 
         var metadataCustomDictionary : [String: String] = [:]
         if let customMetadatas = documentationNode.metadata?.customMetadata {

--- a/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorTests.swift
@@ -1226,4 +1226,25 @@ class RenderNodeTranslatorTests: XCTestCase {
             "yellow"
         )
      }
+    
+    func testPageColorMetadataInSymbolExtension() throws {
+        let (bundle, context) = try testBundleAndContext(named: "MixedManualAutomaticCuration")
+        let reference = ResolvedTopicReference(
+            bundleIdentifier: bundle.identifier,
+            path: "/documentation/TestBed",
+            sourceLanguage: .swift
+        )
+        let symbol = try XCTUnwrap(context.entity(with: reference).semantic as? Symbol)
+        var translator = RenderNodeTranslator(
+            context: context,
+            bundle: bundle,
+            identifier: reference,
+            source: nil
+        )
+        let renderNode = try XCTUnwrap(translator.visitSymbol(symbol) as? RenderNode)
+   
+        let encodedSymbol = try JSONEncoder().encode(renderNode)
+        let roundTrippedSymbol = try JSONDecoder().decode(RenderNode.self, from: encodedSymbol)
+        XCTAssertEqual(roundTrippedSymbol.metadata.color?.standardColorIdentifier, "purple")
+    }
 }

--- a/Tests/SwiftDocCTests/Test Bundles/MixedManualAutomaticCuration.docc/TestBed.md
+++ b/Tests/SwiftDocCTests/Test Bundles/MixedManualAutomaticCuration.docc/TestBed.md
@@ -1,5 +1,9 @@
 # ``TestBed``
 
+@Metadata {
+    @PageColor(purple)
+}
+
 TestBed framework.
 
 TestBed content.


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://107962126

## Summary

Fixes a bug where the `@PageColor` metadata directive was ignored when used on symbol pages.

## Testing

Add:

```
@Metadata {
   @PageColor(purple)
}
```

to a symbol page and confirm that the page renders as expected.

<img width="1402" alt="Screenshot 2023-04-12 at 5 09 15 PM" src="https://user-images.githubusercontent.com/6750147/231612910-a5aa7eaa-0910-4895-8ff6-164f48d5fbe4.png">

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
