### PR TITLE
[5.9] Correctly set page color for symbol pages

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -1246,6 +1246,10 @@ public struct RenderNodeTranslator: SemanticVisitor {
                 )
             }
         }
+        
+        if let pageColor = documentationNode.metadata?.pageColor {
+            node.metadata.color = TopicColor(standardColorIdentifier: pageColor.rawValue)
+        }
 
         var metadataCustomDictionary : [String: String] = [:]
         if let customMetadatas = documentationNode.metadata?.customMetadata {

--- a/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorTests.swift
@@ -1226,4 +1226,25 @@ class RenderNodeTranslatorTests: XCTestCase {
             "yellow"
         )
      }
+    
+    func testPageColorMetadataInSymbolExtension() throws {
+        let (bundle, context) = try testBundleAndContext(named: "MixedManualAutomaticCuration")
+        let reference = ResolvedTopicReference(
+            bundleIdentifier: bundle.identifier,
+            path: "/documentation/TestBed",
+            sourceLanguage: .swift
+        )
+        let symbol = try XCTUnwrap(context.entity(with: reference).semantic as? Symbol)
+        var translator = RenderNodeTranslator(
+            context: context,
+            bundle: bundle,
+            identifier: reference,
+            source: nil
+        )
+        let renderNode = try XCTUnwrap(translator.visitSymbol(symbol) as? RenderNode)
+   
+        let encodedSymbol = try JSONEncoder().encode(renderNode)
+        let roundTrippedSymbol = try JSONDecoder().decode(RenderNode.self, from: encodedSymbol)
+        XCTAssertEqual(roundTrippedSymbol.metadata.color?.standardColorIdentifier, "purple")
+    }
 }

--- a/Tests/SwiftDocCTests/Test Bundles/MixedManualAutomaticCuration.docc/TestBed.md
+++ b/Tests/SwiftDocCTests/Test Bundles/MixedManualAutomaticCuration.docc/TestBed.md
@@ -1,5 +1,9 @@
 # ``TestBed``
 
+@Metadata {
+    @PageColor(purple)
+}
+
 TestBed framework.
 
 TestBed content.


### PR DESCRIPTION
- **Explanation**: Fixes a bug with the new `@PageColor` metadata directive where the directive was ignored when used on symbols page.
- **Scope**: Small in scope. Targeted change fixes render node conversion for symbol pages.
- **Issue**: rdar://107962126
- **Risk**: Low risk.
- **Testing**: End to end testing with Swift-DocC-Render. Additional unit tests have been added.
- **Original PR:** #549
- **Reviewers**: @franklinsch 