### PR TITLE
[5.9] Fix test that took seconds to type check

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,6 +12,10 @@
 import PackageDescription
 import class Foundation.ProcessInfo
 
+let swiftSettings: [SwiftSetting] = [
+    .unsafeFlags(["-Xfrontend", "-warn-long-expression-type-checking=1000"], .when(configuration: .debug)),
+]
+
 let package = Package(
     name: "SwiftDocC",
     platforms: [
@@ -41,7 +45,9 @@ let package = Package(
                 "SymbolKit",
                 "CLMDB",
                 .product(name: "Crypto", package: "swift-crypto"),
-            ]),
+            ],
+            swiftSettings: swiftSettings
+        ),
         .testTarget(
             name: "SwiftDocCTests",
             dependencies: [
@@ -53,7 +59,9 @@ let package = Package(
                 .copy("Test Bundles"),
                 .copy("Converter/Converter Fixtures"),
                 .copy("Rendering/Rendering Fixtures"),
-            ]),
+            ],
+            swiftSettings: swiftSettings
+        ),
         
         // Command-line tool library
         .target(
@@ -62,7 +70,9 @@ let package = Package(
                 "SwiftDocC",
                 .product(name: "NIOHTTP1", package: "swift-nio"),
                 .product(name: "ArgumentParser", package: "swift-argument-parser")
-            ]),
+            ],
+            swiftSettings: swiftSettings
+        ),
         .testTarget(
             name: "SwiftDocCUtilitiesTests",
             dependencies: [
@@ -73,21 +83,26 @@ let package = Package(
             resources: [
                 .copy("Test Resources"),
                 .copy("Test Bundles"),
-            ]),
-        
+            ],
+            swiftSettings: swiftSettings
+        ),
         // Test utility library
         .target(
             name: "SwiftDocCTestUtilities",
             dependencies: [
                 "SymbolKit"
-            ]),
+            ],
+            swiftSettings: swiftSettings
+        ),
 
         // Command-line tool
         .executableTarget(
             name: "docc",
             dependencies: [
                 "SwiftDocCUtilities",
-            ]),
+            ],
+            swiftSettings: swiftSettings
+        ),
 
         // Test app for SwiftDocCUtilities
         .executableTarget(
@@ -95,14 +110,17 @@ let package = Package(
             dependencies: [
                 "SwiftDocCUtilities",
             ],
-            path: "Tests/signal-test-app"),
+            path: "Tests/signal-test-app",
+            swiftSettings: swiftSettings
+        ),
 
         .executableTarget(
             name: "generate-symbol-graph",
             dependencies: [
                 "SwiftDocC",
                 "SymbolKit",
-            ]
+            ],
+            swiftSettings: swiftSettings
         ),
         
     ]

--- a/Tests/SwiftDocCUtilitiesTests/ArgumentParsing/ConvertSubcommandSourceRepositoryTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ArgumentParsing/ConvertSubcommandSourceRepositoryTests.swift
@@ -142,12 +142,18 @@ class ConvertSubcommandSourceRepositoryTests: XCTestCase {
     ) throws {
         setenv(TemplateOption.environmentVariableKey, testTemplateURL.path, 1)
         
-        let convertOptions = try Docc.Convert.parse(
-            [testBundleURL.path]
-                + (checkoutPath.map { ["--checkout-path", $0] } ?? [])
-                + (sourceService.map { ["--source-service", $0] } ?? [])
-                + (sourceServiceBaseURL.map { ["--source-service-base-url", $0] } ?? [])
-        )
+        var arguments: [String] = [testBundleURL.path]
+        if let checkoutPath = checkoutPath {
+            arguments.append(contentsOf: ["--checkout-path", checkoutPath])
+        }
+        if let sourceService = sourceService {
+            arguments.append(contentsOf: ["--source-service", sourceService])
+        }
+        if let sourceServiceBaseURL = sourceServiceBaseURL {
+            arguments.append(contentsOf: ["--source-service-base-url", sourceServiceBaseURL])
+        }
+        
+        let convertOptions = try Docc.Convert.parse(arguments)
         
         let result = try ConvertAction(fromConvertCommand: convertOptions)
         try assertion?(result)


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift-docc/pull/547

- **Explanation**: This fixed an issue where one expression in a test was very slow to type check. In some cases this resulted in an error about the compiler being unable to type check this expression in a reasonable time.
- **Scope**: _Possible_ error about slow type checking during builds of test targets.
- **Radar**: rdar://107960794
- **Risk**: Low. 
- **Testing**: This change was verified manually. Debug builds opt in to warnings about slow type checking to avoid similar issues in the future.
- **Reviewer**: @franklinsch 

Note: the only reason for suggesting that we cherry pick this is to avoid _potential_ compiler errors about type checking taking unreasonably long.