### PR TITLE
Render extended symbol pages with their extended module

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -1176,6 +1176,8 @@ public struct RenderNodeTranslator: SemanticVisitor {
 
         if let crossImportOverlayModule = symbol.crossImportOverlayModule {
             node.metadata.modulesVariants = VariantCollection(defaultValue: [RenderMetadata.Module(name: crossImportOverlayModule.declaringModule, relatedModules: crossImportOverlayModule.bystanderModules)])
+        } else if let extendedModule = symbol.extendedModule, extendedModule != moduleName.displayName {
+            node.metadata.modulesVariants = VariantCollection(defaultValue: [RenderMetadata.Module(name: moduleName.displayName, relatedModules: [extendedModule])])
         } else {
             node.metadata.modulesVariants = VariantCollection(defaultValue: [RenderMetadata.Module(name: moduleName.displayName, relatedModules: nil)]
             )

--- a/Tests/SwiftDocCTests/Rendering/RenderMetadataTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/RenderMetadataTests.swift
@@ -142,6 +142,21 @@ class RenderMetadataTests: XCTestCase {
         XCTAssertEqual(renderNode.metadata.modules?.first?.name, "OverlayTest")
         XCTAssertEqual(renderNode.metadata.modules?.first?.relatedModules, ["BaseKit"])
     }
+
+    func testRendersExtensionSymbolsWithBystanderModules() throws {
+        let (_, bundle, context) = try testBundleAndContext(copying: "BundleWithRelativePathAmbiguity") { root in
+            // We don't want the external target to be part of the archive as that is not
+            // officially supported yet.
+            try FileManager.default.removeItem(at: root.appendingPathComponent("Dependency.symbols.json"))
+        }
+
+        // Get a translated render node
+        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/BundleWithRelativePathAmbiguity/Dependency/AmbiguousType", sourceLanguage: .swift))
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode
+        XCTAssertEqual(renderNode.metadata.modules?.first?.name, "BundleWithRelativePathAmbiguity")
+        XCTAssertEqual(renderNode.metadata.modules?.first?.relatedModules, ["Dependency"])
+    }
     
     func testEmitsTitleVariantsDuringEncoding() throws {
         var metadata = RenderMetadata()


### PR DESCRIPTION
Issue: rdar://107729534

## Summary

For bundles with extension block symbols, it can be a bit confusing to understand which module is actually needed to use an extension symbol. This PR adds context to these symbols by adding the extended module as a "related module" to the RenderNode, which renders both the owning module and the extended module to be shown in the rendered page.

(Note that this doesn't work for bundles without extension block symbols, due to inconsistencies in the Swift symbol graph. This is noted in the symbol graph loader as being connected to rdar://63200368. An interim fix will likely need to land in SymbolKit, since the module name processing code mainly happens there now.)

## Dependencies

None

## Testing

Steps:
1. Convert docs for the `Tests/SwiftDocCTests/Test Bundles/BundleWithRelativePathAmbiguity.docc` bundle.
3. Ensure that the page for `Dependency.AmbiguousType.foo()` has both `BundleWithRelativePathAmbiguity` and `Dependency` in its page header.

## Checklist

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ n/a ] Updated documentation if necessary
