### PR TITLE
add the extending module as a related module for extension symbols

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -1176,6 +1176,8 @@ public struct RenderNodeTranslator: SemanticVisitor {
 
         if let crossImportOverlayModule = symbol.crossImportOverlayModule {
             node.metadata.modulesVariants = VariantCollection(defaultValue: [RenderMetadata.Module(name: crossImportOverlayModule.declaringModule, relatedModules: crossImportOverlayModule.bystanderModules)])
+        } else if let extendedModule = symbol.extendedModule, extendedModule != moduleName.displayName {
+            node.metadata.modulesVariants = VariantCollection(defaultValue: [RenderMetadata.Module(name: moduleName.displayName, relatedModules: [extendedModule])])
         } else {
             node.metadata.modulesVariants = VariantCollection(defaultValue: [RenderMetadata.Module(name: moduleName.displayName, relatedModules: nil)]
             )

--- a/Tests/SwiftDocCTests/Rendering/RenderMetadataTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/RenderMetadataTests.swift
@@ -142,6 +142,21 @@ class RenderMetadataTests: XCTestCase {
         XCTAssertEqual(renderNode.metadata.modules?.first?.name, "OverlayTest")
         XCTAssertEqual(renderNode.metadata.modules?.first?.relatedModules, ["BaseKit"])
     }
+
+    func testRendersExtensionSymbolsWithBystanderModules() throws {
+        let (_, bundle, context) = try testBundleAndContext(copying: "BundleWithRelativePathAmbiguity") { root in
+            // We don't want the external target to be part of the archive as that is not
+            // officially supported yet.
+            try FileManager.default.removeItem(at: root.appendingPathComponent("Dependency.symbols.json"))
+        }
+
+        // Get a translated render node
+        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/BundleWithRelativePathAmbiguity/Dependency/AmbiguousType", sourceLanguage: .swift))
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode
+        XCTAssertEqual(renderNode.metadata.modules?.first?.name, "BundleWithRelativePathAmbiguity")
+        XCTAssertEqual(renderNode.metadata.modules?.first?.relatedModules, ["Dependency"])
+    }
     
     func testEmitsTitleVariantsDuringEncoding() throws {
         var metadata = RenderMetadata()


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift-docc/pull/557

- **Explanation**: Reduces ambiguity of extension symbols by ensuring that both the containing module and the extended module's names are included on the rendered pages of these symbols.
- **Scope**: Affects documentation bundles with extension block symbols.
- **Issue**: rdar://107729534
- **Risk**: Very low. The change only adds additional metadata for extension symbols; other documentation builds are unaffected.
- **Testing**: Automated tests have been added; the change was also manually tested by running on ArgumentParser.
- **Reviewer**: @ethan-kusters 
