### PR TITLE
Match documentation extensions to symbols using link resolver

### DIFF
--- a/Sources/SwiftDocC/DocumentationService/Convert/ConvertService.swift
+++ b/Sources/SwiftDocC/DocumentationService/Convert/ConvertService.swift
@@ -252,9 +252,7 @@ public struct ConvertService: DocumentationService {
         baseReferenceStore: RenderReferenceStore?
     ) -> RenderReferenceStore {
         let uncuratedArticles = context.uncuratedArticles.map { ($0, isDocumentationExtensionContent: false) }
-        let uncuratedDocumentationExtensions = context.uncuratedDocumentationExtensions.flatMap { reference, articles in
-            articles.map { article in ((reference, article), isDocumentationExtensionContent: true) }
-        }
+        let uncuratedDocumentationExtensions = context.uncuratedDocumentationExtensions.map { ($0, isDocumentationExtensionContent: true) }
         let topicContent = (uncuratedArticles + uncuratedDocumentationExtensions)
             .compactMap { (value, isDocumentationExtensionContent) -> (ResolvedTopicReference, RenderReferenceStore.TopicContent)? in
                 let (topicReference, article) = value

--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -1337,9 +1337,18 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
                 }
                 
                 if LinkResolutionMigrationConfiguration.shouldUseHierarchyBasedLinkResolver {
-                    // TODO: Resolve the link relative to the module https://github.com/apple/swift-docc/issues/516
+                    // If there's a single module then resolve relative to the module symbol. Otherwise resolve relative to the bundle root.
+                    // This means that links can omit the module name if there's only one module but need to start with the module name if there are multiple modules.
+                    let rootReference: ResolvedTopicReference
+                    let moduleReferences = hierarchyBasedLinkResolver!.modules()
+                    if moduleReferences.count == 1 {
+                        rootReference = moduleReferences.first!
+                    } else {
+                        rootReference = bundle.rootReference
+                    }
+                    
                     let reference = TopicReference.unresolved(.init(topicURL: url))
-                    switch resolve(reference, in: bundle.rootReference, fromSymbolLink: true) {
+                    switch resolve(reference, in: rootReference, fromSymbolLink: true) {
                     case .success(let resolved):
                         uncuratedDocumentationExtensions[resolved, default: []].append(documentationExtension)
                     case .failure(_, _):

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchyBasedLinkResolver.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchyBasedLinkResolver.swift
@@ -63,6 +63,11 @@ final class PathHierarchyBasedLinkResolver {
         return pathHierarchy.topLevelSymbols().map { resolvedReferenceMap[$0]! }
     }
     
+    /// Returns a list of all module symbols.
+    func modules() -> [ResolvedTopicReference] {
+        return pathHierarchy.modules.values.map { resolvedReferenceMap[$0.identifier]! }
+    }
+    
     // MARK: - Adding non-symbols
     
     /// Map the resolved identifiers to resolved topic references for a given bundle's article, tutorial, and technology root pages.

--- a/Sources/SwiftDocC/Infrastructure/Symbol Graph/GeneratedDocumentationTopics.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Graph/GeneratedDocumentationTopics.swift
@@ -160,7 +160,7 @@ enum GeneratedDocumentationTopics {
         var collectionArticle: Article
         
         // Find matching doc extension or create an empty article.
-        if let docExtensionMatch = context.uncuratedDocumentationExtensions[collectionReference]?.first?.value {
+        if let docExtensionMatch = context.uncuratedDocumentationExtensions[collectionReference]?.value {
             collectionArticle = docExtensionMatch
             collectionArticle.title = Heading(level: 1, Text(title))
             context.uncuratedDocumentationExtensions.removeValue(forKey: collectionReference)

--- a/Tests/SwiftDocCTests/DocumentationService/ConvertService/ConvertServiceTests.swift
+++ b/Tests/SwiftDocCTests/DocumentationService/ConvertService/ConvertServiceTests.swift
@@ -1224,12 +1224,7 @@ class ConvertServiceTests: XCTestCase {
                 XCTAssertEqual(
                     Set(referenceStore.topics.keys.map(\.path)),
                     [
-                        // Documentation extension files:
-                        "/documentation/MyKit",
-                        "/documentation/SideKit",
-                        "/documentation/MyKit/MyClass",
-                        "/documentation/MyKit/MyProtocol",
-                        "/documentation/SideKit/SideClass/init()",
+                        // This bundle doesn't contain any symbol graphs so documentation extensions can't match with any symbols
                         
                         // Articles and tutorials:
                         "/tutorials/TestOverview",
@@ -1244,14 +1239,6 @@ class ConvertServiceTests: XCTestCase {
                         "/tutorials/Test-Bundle/TutorialMediaWithSpaces",
                         "/documentation/Test-Bundle/Default-Code-Listing-Syntax",
                     ]
-                )
-            
-                try self.assertReferenceStoreContains(
-                    referenceStore: referenceStore,
-                    topicPath: "/documentation/MyKit/MyClass",
-                    source: testBundleURL.appendingPathComponent("documentation/myclass.md"),
-                    title: "doc:MyKit/MyClass",
-                    isDocumentationExtensionContent: true
                 )
                 
                 try self.assertReferenceStoreContains(

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContext+RootPageTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContext+RootPageTests.swift
@@ -88,10 +88,12 @@ class DocumentationContext_RootPageTests: XCTestCase {
         try workspace.registerProvider(dataProvider)
         
         // Verify that we emit a warning when trying to make a symbol a root page
-        XCTAssertTrue(context.problems.contains(where: { problem -> Bool in
-            return problem.diagnostic.identifier == "org.swift.docc.UnexpectedTechnologyRoot"
-                && problem.diagnostic.source?.path == "ReleaseNotes/MyClass"
-        }))
+        let technologyRootProblem = try XCTUnwrap(context.problems.first(where: { $0.diagnostic.identifier == "org.swift.docc.UnexpectedTechnologyRoot" }))
+        XCTAssertEqual(technologyRootProblem.diagnostic.source, tempFolderURL.appendingPathComponent("no-sgf-test.docc").appendingPathComponent("MyClass.md"))
+        XCTAssertEqual(technologyRootProblem.diagnostic.range?.lowerBound.line, 3)
+        let solution = try XCTUnwrap(technologyRootProblem.possibleSolutions.first)
+        XCTAssertEqual(solution.replacements.first?.range.lowerBound.line, 3)
+        XCTAssertEqual(solution.replacements.first?.range.upperBound.line, 3)
     }
     
 }

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -3041,6 +3041,51 @@ let expected = """
         }
     }
     
+    func testMatchesDocumentationExtensionsRelativeToModule() throws {
+        try XCTSkipUnless(LinkResolutionMigrationConfiguration.shouldUseHierarchyBasedLinkResolver)
+        
+        let (_, bundle, context) = try testBundleAndContext(copying: "MixedLanguageFrameworkWithLanguageRefinements") { url in
+            // Top level symbols, omitting the module name
+            try """
+            # ``MyStruct/myStructProperty``
+            
+            @Metadata {
+              @DocumentationExtension(mergeBehavior: override)
+            }
+            
+            my struct property
+            """.write(to: url.appendingPathComponent("struct-property.md"), atomically: true, encoding: .utf8)
+            
+            try """
+            # ``MyTypeAlias``
+            
+            @Metadata {
+              @DocumentationExtension(mergeBehavior: override)
+            }
+            
+            my type alias
+            """.write(to: url.appendingPathComponent("alias.md"), atomically: true, encoding: .utf8)
+        }
+        
+        do {
+            // The resolved reference needs more disambiguation than the documentation extension link did.
+            let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MixedFramework/MyStruct/myStructProperty", sourceLanguage: .swift)
+            
+            let node = try context.entity(with: reference)
+            let symbol = try XCTUnwrap(node.semantic as? Symbol)
+            XCTAssertEqual(symbol.abstract?.plainText, "my struct property", "The abstract should be from the overriding documentation extension.")
+        }
+        
+        do {
+            // The resolved reference needs more disambiguation than the documentation extension link did.
+            let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MixedFramework/MyTypeAlias", sourceLanguage: .swift)
+            
+            let node = try context.entity(with: reference)
+            let symbol = try XCTUnwrap(node.semantic as? Symbol)
+            XCTAssertEqual(symbol.abstract?.plainText, "my type alias", "The abstract should be from the overriding documentation extension.")
+        }
+    }
+    
     func testAutomaticallyCuratesArticles() throws {
         let articleOne = TextFile(name: "Article1.md", utf8Content: """
             # Article 1


### PR DESCRIPTION
Bug/issue #, if applicable: 
- rdar://108392613 #561
- rdar://76252171 #516 
- rdar://108392639 #560

## Summary

This uses the link resolver to match documentation extensions with symbols. This allows for using link resolution features in documentation extension title links. For example:

- Documentation extension title links can now omit disambiguation when the colliding paths have different capitalization
- Documentation extension title links can now contain special characters
- Documentation extension title links can now omit the leading module name when the bundle only contains one module
- Documentation extension title links can now use Swift _or_ Objective-C symbol names to extend the documentation for a symbol that's available in both languages
- Documentation extension title links now that don't match any known symbol now result in a warning with the same rich information as other unresolved symbol links.

## Dependencies

None

## Testing

In a Swift package with a documentation catalog;

- Add code where two symbols have the same case insensitive name:
```
public struct Outer {
    public enum Inner {}
    public var inner: Inner
}
```

- Add a documentation extension file and link to one of the symbols without prefixing with the module and without disambiguation:
```
# ``Outer/Inner``

Some documentation extension content here.
```
The content of this documentation extension file should be included on the documentation page for the `Inner` enumeration.

- Add another documentation extension file and link to a symbol that doesn't exist in the module:
```
# ``ThisDoesNotExist``

This should result in a warning
```
There should be a warning saying that the module doesn't contain a "ThisDoesNotExist" symbol.

- Add another documentation extension file and link to first symbol but make the symbol link more spelled out:
```
# ``MyModule/Outer/Inner-enum``

This symbol already has a documentation extension elsewhere
```
There should be a warning saying that multiple documentation extension files match the `Inner` enumeration.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [ ] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
