### PR TITLE
Label Sample-Code Call-to-Action buttons with "View Source"

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -795,7 +795,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
                     action: .reference(
                         identifier: downloadIdentifier,
                         isActive: true,
-                        overridingTitle: callToAction.buttonLabel,
+                        overridingTitle: callToAction.buttonLabel(for: article.metadata?.pageKind?.kind),
                         overridingTitleInlineContent: nil))
                 externalLocationReferences[url.description] = ExternalLocationReference(identifier: downloadIdentifier)
             } else if let fileReference = callToAction.file,
@@ -804,7 +804,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
                 node.sampleDownload = .init(action: .reference(
                     identifier: downloadIdentifier,
                     isActive: true,
-                    overridingTitle: callToAction.buttonLabel,
+                    overridingTitle: callToAction.buttonLabel(for: article.metadata?.pageKind?.kind),
                     overridingTitleInlineContent: nil
                 ))
             }

--- a/Sources/SwiftDocC/Semantics/Metadata/CallToAction.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/CallToAction.swift
@@ -83,15 +83,7 @@ public final class CallToAction: Semantic, AutomaticDirectiveConvertible {
     /// indirectly via ``purpose``.
     @available(*, deprecated, renamed: "buttonLabel(for:)")
     public var buttonLabel: String {
-        if let label = label {
-            return label
-        } else if let purpose = purpose {
-            return purpose.defaultLabel
-        } else {
-            // The `validate()` method ensures that this type should never be constructed without
-            // one of the above.
-            fatalError("A valid CallToAction should have either a purpose or label")
-        }
+        return buttonLabel(for: nil)
     }
     
     /// The label that should be used when rendering the user-interface for this call to action button.
@@ -199,12 +191,7 @@ extension CallToAction.Purpose {
     /// a separate label.
     @available(*, deprecated, message: "Replaced with 'CallToAction.buttonLabel(for:)'.")
     public var defaultLabel: String {
-        switch self {
-        case .download:
-            return "Download"
-        case .link:
-            return "Visit"
-        }
+        return defaultLabel(for: nil)
     }
     
     fileprivate func defaultLabel(for pageKind: Metadata.PageKind.Kind?) -> String {

--- a/Sources/docc/DocCDocumentation.docc/DocC.symbols.json
+++ b/Sources/docc/DocCDocumentation.docc/DocC.symbols.json
@@ -817,7 +817,13 @@
             "text" : "  - `download` indicates that the link is to a downloadable file. The button will be labeled \"Download\"."
           },
           {
-            "text" : "  - `link` indicates that the link is to an external webpage. The button will be labeled \"Visit\"."
+            "text" : "  - `link` indicates that the link is to an external webpage."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "     The button will be labeled \"Visit\" when used on article pages and \"View Source\" when used on sample code pages."
           },
           {
             "text" : "- The `label` parameter specifies the literal text to use as the button label."

--- a/Tests/SwiftDocCTests/Semantics/CallToActionTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/CallToActionTests.swift
@@ -137,33 +137,47 @@ class CallToActionTests: XCTestCase {
     }
 
     func testDefaultLabel() throws {
-        func assertExpectedLabel(source: String, expectedLabel: String) throws {
+        func assertExpectedLabel(source: String, expectedDefaultLabel: String, expectedSampleCodeLabel: String) throws {
             let document = Document(parsing: source, options: .parseBlockDirectives)
-            let directive = document.child(at: 0) as? BlockDirective
-            XCTAssertNotNil(directive)
+            let directive = try XCTUnwrap(document.child(at: 0) as? BlockDirective)
 
             let (bundle, context) = try testBundleAndContext(named: "SampleBundle")
 
-            directive.map { directive in
-                var problems = [Problem]()
-                XCTAssertEqual(CallToAction.directiveName, directive.name)
-                let callToAction = CallToAction(from: directive, source: nil, for: bundle, in: context, problems: &problems)
-                XCTAssertNotNil(callToAction)
-                XCTAssert(problems.isEmpty)
-                XCTAssertEqual(callToAction?.buttonLabel, expectedLabel)
-            }
+            var problems = [Problem]()
+            XCTAssertEqual(CallToAction.directiveName, directive.name)
+            let callToAction = try XCTUnwrap(CallToAction(from: directive, source: nil, for: bundle, in: context, problems: &problems))
+            XCTAssert(problems.isEmpty)
+            
+            XCTAssertEqual(callToAction.buttonLabel(for: nil), expectedDefaultLabel)
+            XCTAssertEqual(callToAction.buttonLabel(for: .article), expectedDefaultLabel)
+            XCTAssertEqual(callToAction.buttonLabel(for: .sampleCode), expectedSampleCodeLabel)
         }
 
-        var validLabels: [(arg: String, label: String)] = []
+        var validLabels: [(arg: String, defaultLabel: String, sampleCodeLabel: String)] = []
         for buttonKind in CallToAction.Purpose.allCases {
-            validLabels.append(("purpose: \(buttonKind)", buttonKind.defaultLabel))
+            let expectedDefaultLabel: String
+            let expectedSampleCodeLabel: String
+            switch buttonKind {
+            case .download:
+                expectedDefaultLabel = "Download"
+                expectedSampleCodeLabel = "Download"
+            case .link:
+                expectedDefaultLabel = "Visit"
+                expectedSampleCodeLabel = "View Source"
+            }
+            
+            validLabels.append(("purpose: \(buttonKind)", expectedDefaultLabel, expectedSampleCodeLabel))
             // Ensure that adding a label argument overrides the kind's default label
-            validLabels.append(("purpose: \(buttonKind), label: \"Button\"", "Button"))
+            validLabels.append(("purpose: \(buttonKind), label: \"Button\"", "Button", "Button"))
         }
 
-        for (arg, label) in validLabels {
+        for (arg, defaultLabel, sampleCodeLabel) in validLabels {
             let directive = "@CallToAction(file: \"Downloads/plus.svg\", \(arg))"
-            try assertExpectedLabel(source: directive, expectedLabel: label)
+            try assertExpectedLabel(
+                source: directive,
+                expectedDefaultLabel: defaultLabel,
+                expectedSampleCodeLabel: sampleCodeLabel
+            )
         }
     }
 }

--- a/Tests/SwiftDocCTests/Test Bundles/SampleBundle.docc/MyArticle.md
+++ b/Tests/SwiftDocCTests/Test Bundles/SampleBundle.docc/MyArticle.md
@@ -1,0 +1,9 @@
+# MyArticle
+
+@Metadata {
+    @CallToAction(url: "https://www.example.com", purpose: link)
+}
+
+Check out this cool website.
+
+<!-- Copyright (c) 2023 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Tests/SwiftDocCTests/Test Bundles/SampleBundle.docc/MyExternalSample.md
+++ b/Tests/SwiftDocCTests/Test Bundles/SampleBundle.docc/MyExternalSample.md
@@ -1,0 +1,10 @@
+# MyExternalSample
+
+@Metadata {
+    @CallToAction(url: "https://www.example.com/source-repository.git", purpose: link)
+    @PageKind(sampleCode)
+}
+
+Check out my cool sample code project.
+
+<!-- Copyright (c) 2023 Apple Inc and the Swift Project authors. All Rights Reserved. -->


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://108013602

## Summary

Updates the logic for `@CallToAction` buttons that are attached to `sampleCode` pages and use the `link` purpose to render with a more specific “View Source” title instead of the more generic “Visit” title.

This makes the intent of the button more clear. Regular article pages should continue to have the same behavior.

## Testing

Create an article with `@CallToAction` directive using that provides a `url` and `link` purpose and a `@PageKind(sampleCode)` directive. Confirm that the call to action button is labeled "View Source".

```swift
@Metadata {
    @PageKind(sampleCode)
    @CallToAction(url: "https://github.com/apple/swift-docc", purpose: link)
}
```

<img width="1018" alt="Screenshot 2023-04-25 at 4 06 25 PM" src="https://user-images.githubusercontent.com/6750147/234426283-e58e2bd9-fe45-4afc-97c1-12a0e9715635.png">

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
