### PR TITLE
Support resolving code file references in ConvertService

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/References/FileReference.swift
+++ b/Sources/SwiftDocC/Model/Rendering/References/FileReference.swift
@@ -47,12 +47,21 @@ public struct FileReference: RenderReference, Equatable {
     ///   - fileType: The type of file, typically represented by its file extension.
     ///   - syntax: The syntax of the file's content.
     ///   - content: The line-by-line contents of the file.
-    public init(identifier: RenderReferenceIdentifier, fileName: String, fileType: String, syntax: String, content: [String]) {
+    ///   - highlights: The line highlights for this file.
+    public init(
+        identifier: RenderReferenceIdentifier,
+        fileName: String,
+        fileType: String,
+        syntax: String,
+        content: [String],
+        highlights: [LineHighlighter.Highlight] = []
+    ) {
         self.identifier = identifier
         self.fileName = fileName
         self.fileType = fileType
         self.syntax = syntax
         self.content = content
+        self.highlights = highlights
     }
     
     public init(from decoder: Decoder) throws {

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -53,11 +53,15 @@ public struct RenderNodeTranslator: SemanticVisitor {
     
     public mutating func visitCode(_ code: Code) -> RenderTree? {
         let fileType = NSString(string: code.fileName).pathExtension
-        let fileReference = code.fileReference
+        guard let fileIdentifier = context.identifier(forAssetName: code.fileReference.path, in: identifier) else {
+            return nil
+        }
         
-        guard let fileData = try? context.resource(with: code.fileReference),
-            let fileContents = String(data: fileData, encoding: .utf8) else {
-            return RenderReferenceIdentifier("")
+        let fileReference = ResourceReference(bundleIdentifier: code.fileReference.bundleIdentifier, path: fileIdentifier)
+        guard let fileData = try? context.resource(with: fileReference),
+              let fileContents = String(data: fileData, encoding: .utf8)
+        else {
+            return nil
         }
         
         let assetReference = RenderReferenceIdentifier(fileReference.path)

--- a/Tests/SwiftDocCTests/Model/LineHighlighterTests.swift
+++ b/Tests/SwiftDocCTests/Model/LineHighlighterTests.swift
@@ -68,7 +68,7 @@ class LineHighlighterTests: XCTestCase {
         let tutorialReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/tutorials/Line-Highlighter-Tests/Tutorial", fragment: nil, sourceLanguage: .swift)
         let tutorial = try context.entity(with: tutorialReference).semantic as! Tutorial
         let section = tutorial.sections.first!
-        return LineHighlighter(context: context, tutorialSection: section).highlights
+        return LineHighlighter(context: context, tutorialSection: section, tutorialReference: tutorialReference).highlights
     }
     
     func testNoSteps() throws {


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://107965493

## Summary

This enables convert service requests to resolve file assets that are references in the tutorial steps. This is done by asking the context to resolve the file asset if its data doesn't already exist.

## Dependencies

None

## Testing

In a client that uses` ConvertService`:
- Verify that passing an tutorial file with steps using `@Code` references result in DocC returning a render node with file references for those code files with line highlights for the differences between the files' content. 

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
