### PR TITLE
Revert support for module-relative documentation extension links (#574)

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -1335,18 +1335,9 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
                 }
                 
                 if LinkResolutionMigrationConfiguration.shouldUseHierarchyBasedLinkResolver {
-                    // If there's a single module then resolve relative to the module symbol. Otherwise resolve relative to the bundle root.
-                    // This means that links can omit the module name if there's only one module but need to start with the module name if there are multiple modules.
-                    let rootReference: ResolvedTopicReference
-                    let moduleReferences = hierarchyBasedLinkResolver!.modules()
-                    if moduleReferences.count == 1 {
-                        rootReference = moduleReferences.first!
-                    } else {
-                        rootReference = bundle.rootReference
-                    }
-                    
+                    // FIXME: Resolve the link relative to the module https://github.com/apple/swift-docc/issues/516
                     let reference = TopicReference.unresolved(.init(topicURL: url))
-                    switch resolve(reference, in: rootReference, fromSymbolLink: true) {
+                    switch resolve(reference, in: bundle.rootReference, fromSymbolLink: true) {
                     case .success(let resolved):
                         if let existing = uncuratedDocumentationExtensions[resolved] {
                             if symbolsWithMultipleDocumentationExtensionMatches[resolved] == nil {

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -3040,51 +3040,6 @@ let expected = """
         }
     }
     
-    func testMatchesDocumentationExtensionsRelativeToModule() throws {
-        try XCTSkipUnless(LinkResolutionMigrationConfiguration.shouldUseHierarchyBasedLinkResolver)
-        
-        let (_, bundle, context) = try testBundleAndContext(copying: "MixedLanguageFrameworkWithLanguageRefinements") { url in
-            // Top level symbols, omitting the module name
-            try """
-            # ``MyStruct/myStructProperty``
-            
-            @Metadata {
-              @DocumentationExtension(mergeBehavior: override)
-            }
-            
-            my struct property
-            """.write(to: url.appendingPathComponent("struct-property.md"), atomically: true, encoding: .utf8)
-            
-            try """
-            # ``MyTypeAlias``
-            
-            @Metadata {
-              @DocumentationExtension(mergeBehavior: override)
-            }
-            
-            my type alias
-            """.write(to: url.appendingPathComponent("alias.md"), atomically: true, encoding: .utf8)
-        }
-        
-        do {
-            // The resolved reference needs more disambiguation than the documentation extension link did.
-            let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MixedFramework/MyStruct/myStructProperty", sourceLanguage: .swift)
-            
-            let node = try context.entity(with: reference)
-            let symbol = try XCTUnwrap(node.semantic as? Symbol)
-            XCTAssertEqual(symbol.abstract?.plainText, "my struct property", "The abstract should be from the overriding documentation extension.")
-        }
-        
-        do {
-            // The resolved reference needs more disambiguation than the documentation extension link did.
-            let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MixedFramework/MyTypeAlias", sourceLanguage: .swift)
-            
-            let node = try context.entity(with: reference)
-            let symbol = try XCTUnwrap(node.semantic as? Symbol)
-            XCTAssertEqual(symbol.abstract?.plainText, "my type alias", "The abstract should be from the overriding documentation extension.")
-        }
-    }
-    
     func testMultipleDocumentationExtensionMatchDiagnostic() throws {
         try XCTSkipUnless(LinkResolutionMigrationConfiguration.shouldUseHierarchyBasedLinkResolver)
         


### PR DESCRIPTION
- **Explanation**: Revert the support for resolving documentation extensions links relative to modules since it caused a regression when a module and a top-level symbol had the same name.features to work in documentation extension title links.
- **Scope**: Regression with matching documentation extension files with symbols.
- **Issue**: rdar://108666088
- **Risk**: Low.
- **Testing**:  Manually verified that reverting this change fixes the regression. Existing automated tests continue to pass. 
- **Original PR:** #575
- **Reviewers**: @QuietMisdreavus and @ethan-kusters 