### PR TITLE
Better support for relative links when multiple symbols in the hierarchy have the same name

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/Symbol/ConformanceSection.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Symbol/ConformanceSection.swift
@@ -87,10 +87,16 @@ public struct ConformanceSection: Codable, Equatable {
         }
         
         // Adds "," or ", and" to the requirements wherever necessary.
-        let merged = zip(rendered, separators).flatMap({ $0 + [$1] })
-            + rendered[separators.count...].flatMap({ $0 })
+        var merged: [RenderInlineContent] = []
+        merged.reserveCapacity(rendered.count * 4) // 3 for each constraint and 1 for each separator
+        for (constraint, separator) in zip(rendered, separators) {
+            merged.append(contentsOf: constraint)
+            merged.append(separator)
+        }
+        merged.append(contentsOf: rendered.last!)
+        merged.append(.text("."))
         
-        self.constraints = merged + [RenderInlineContent.text(".")]
+        self.constraints = merged
     }
     
     private static let selfPrefix = "Self."

--- a/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
@@ -1185,8 +1185,6 @@ class PathHierarchyTests: XCTestCase {
         XCTAssertEqual(try tree.findSymbol(path: "Something/Something", parent: topLevelSymbolID).identifier.precise, "s:9SomethingAAVAAO")
         XCTAssertEqual(try tree.findSymbol(path: "Something/second", parent: topLevelSymbolID).identifier.precise, "s:9SomethingAAV6secondSivp")
         
-        // Test more paths here when the link resolver can handle them (rdar://108672152) https://github.com/apple/swift-docc/issues/572
-        
         let wrapperID = try tree.find(path: "/Something/Wrapper", onlyFindSymbols: true)
         XCTAssertEqual(try tree.findSymbol(path: "Something/second", parent: wrapperID).identifier.precise, "s:9SomethingAAV6secondSivp")
         XCTAssertEqual(try tree.findSymbol(path: "Something/third", parent: wrapperID).identifier.precise, "s:9Something7WrapperVAAV5thirdSivp")

--- a/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
@@ -1149,6 +1149,56 @@ class PathHierarchyTests: XCTestCase {
                        "/ShapeKit/OverloadedEnum/firstTestMemberName(_:)-88rbf")
     }
     
+    func testSymbolsWithSameNameAsModule() throws {
+        try XCTSkipUnless(LinkResolutionMigrationConfiguration.shouldUseHierarchyBasedLinkResolver)
+        let (_, context) = try testBundleAndContext(named: "SymbolsWithSameNameAsModule")
+        let tree = try XCTUnwrap(context.hierarchyBasedLinkResolver?.pathHierarchy)
+        
+        // /* in a module named "Something "*/
+        // public struct Something {
+        //     public enum Something {
+        //         case first
+        //     }
+        //     public var second = 0
+        // }
+        // public struct Wrapper {
+        //     public struct Something {
+        //         public var third = 0
+        //     }
+        // }
+        try assertFindsPath("Something", in: tree, asSymbolID: "Something")
+        try assertFindsPath("/Something", in: tree, asSymbolID: "Something")
+        
+        let moduleID = try tree.find(path: "/Something", onlyFindSymbols: true)
+        XCTAssertEqual(try tree.findSymbol(path: "/Something", parent: moduleID).identifier.precise, "Something")
+        XCTAssertEqual(try tree.findSymbol(path: "Something-module", parent: moduleID).identifier.precise, "Something")
+        XCTAssertEqual(try tree.findSymbol(path: "Something", parent: moduleID).identifier.precise, "s:9SomethingAAV")
+        XCTAssertEqual(try tree.findSymbol(path: "/Something/Something", parent: moduleID).identifier.precise, "s:9SomethingAAV")
+        XCTAssertEqual(try tree.findSymbol(path: "Something/Something", parent: moduleID).identifier.precise, "s:9SomethingAAVAAO")
+        XCTAssertEqual(try tree.findSymbol(path: "Something/Something/Something", parent: moduleID).identifier.precise, "s:9SomethingAAVAAO")
+        XCTAssertEqual(try tree.findSymbol(path: "/Something/Something/Something", parent: moduleID).identifier.precise, "s:9SomethingAAVAAO")
+        XCTAssertEqual(try tree.findSymbol(path: "/Something/Something", parent: moduleID).identifier.precise, "s:9SomethingAAV")
+        XCTAssertEqual(try tree.findSymbol(path: "Something/second", parent: moduleID).identifier.precise, "s:9SomethingAAV6secondSivp")
+        
+        let topLevelSymbolID = try tree.find(path: "/Something/Something", onlyFindSymbols: true)
+        XCTAssertEqual(try tree.findSymbol(path: "Something", parent: topLevelSymbolID).identifier.precise, "s:9SomethingAAVAAO")
+        XCTAssertEqual(try tree.findSymbol(path: "Something/Something", parent: topLevelSymbolID).identifier.precise, "s:9SomethingAAVAAO")
+        XCTAssertEqual(try tree.findSymbol(path: "Something/second", parent: topLevelSymbolID).identifier.precise, "s:9SomethingAAV6secondSivp")
+        
+        // Test more paths here when the link resolver can handle them (rdar://108672152) https://github.com/apple/swift-docc/issues/572
+        
+        let wrapperID = try tree.find(path: "/Something/Wrapper", onlyFindSymbols: true)
+        XCTAssertEqual(try tree.findSymbol(path: "Something/second", parent: wrapperID).identifier.precise, "s:9SomethingAAV6secondSivp")
+        XCTAssertEqual(try tree.findSymbol(path: "Something/third", parent: wrapperID).identifier.precise, "s:9Something7WrapperVAAV5thirdSivp")
+        
+        let wrappedID = try tree.find(path: "/Something/Wrapper/Something", onlyFindSymbols: true)
+        XCTAssertEqual(try tree.findSymbol(path: "Something/second", parent: wrappedID).identifier.precise, "s:9SomethingAAV6secondSivp")
+        XCTAssertEqual(try tree.findSymbol(path: "Something/third", parent: wrappedID).identifier.precise, "s:9Something7WrapperVAAV5thirdSivp")
+        
+        XCTAssertEqual(try tree.findSymbol(path: "Something/first", parent: topLevelSymbolID).identifier.precise, "s:9SomethingAAVAAO5firstyA2CmF")
+        XCTAssertEqual(try tree.findSymbol(path: "Something/second", parent: topLevelSymbolID).identifier.precise, "s:9SomethingAAV6secondSivp")
+    }
+    
     func testSnippets() throws {
         try XCTSkipUnless(LinkResolutionMigrationConfiguration.shouldUseHierarchyBasedLinkResolver)
         let (_, context) = try testBundleAndContext(named: "Snippets")

--- a/Tests/SwiftDocCTests/Infrastructure/ReferenceResolverTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/ReferenceResolverTests.swift
@@ -476,16 +476,12 @@ class ReferenceResolverTests: XCTestCase {
         }
 
         // Make sure that linking to `Swift/Array` raises a diagnostic about the page having been removed
-        if LinkResolutionMigrationConfiguration.shouldUseHierarchyBasedLinkResolver {
-            let diagnostic = try XCTUnwrap(context.problems.first(where: { $0.diagnostic.identifier == "org.swift.docc.removedExtensionLinkDestination" }))
-            XCTAssertEqual(diagnostic.possibleSolutions.count, 1)
-            let solution = try XCTUnwrap(diagnostic.possibleSolutions.first)
-            XCTAssertEqual(solution.replacements.count, 1)
-            let replacement = try XCTUnwrap(solution.replacements.first)
-            XCTAssertEqual(replacement.replacement, "`Swift/Array`")
-        } else {
-            XCTAssert(context.problems.contains(where: { $0.diagnostic.identifier == "org.swift.docc.unresolvedTopicReference" }))
-        }
+        let diagnostic = try XCTUnwrap(context.problems.first(where: { $0.diagnostic.identifier == "org.swift.docc.removedExtensionLinkDestination" }))
+        XCTAssertEqual(diagnostic.possibleSolutions.count, 1)
+        let solution = try XCTUnwrap(diagnostic.possibleSolutions.first)
+        XCTAssertEqual(solution.replacements.count, 1)
+        let replacement = try XCTUnwrap(solution.replacements.first)
+        XCTAssertEqual(replacement.replacement, "`Swift/Array`")
 
         // Also make sure that the extension pages are still gone
         let extendedModule = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ModuleWithSingleExtension/Swift", sourceLanguage: .swift)

--- a/Tests/SwiftDocCTests/Infrastructure/ReferenceResolverTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/ReferenceResolverTests.swift
@@ -471,7 +471,7 @@ class ReferenceResolverTests: XCTestCase {
             try """
             # ``ModuleWithSingleExtension``
 
-            This is a test module with an extension to ``Swift/Array#Array``.
+            This is a test module with an extension to ``Swift/Array``.
             """.write(to: topLevelArticle, atomically: true, encoding: .utf8)
         }
 

--- a/Tests/SwiftDocCTests/Test Bundles/SymbolsWithSameNameAsModule.docc/Something.symbols.json
+++ b/Tests/SwiftDocCTests/Test Bundles/SymbolsWithSameNameAsModule.docc/Something.symbols.json
@@ -1,0 +1,729 @@
+{
+  "metadata": {
+    "formatVersion": {
+      "major": 0,
+      "minor": 6,
+      "patch": 0
+    },
+    "generator": "Apple Swift version 5.9 (swiftlang-5.9.0.100.22 clang-1500.0.7.24.100)"
+  },
+  "module": {
+    "name": "Something",
+    "platform": {
+      "architecture": "arm64",
+      "vendor": "apple",
+      "operatingSystem": {
+        "name": "macosx",
+        "minimumVersion": {
+          "major": 14,
+          "minor": 0
+        }
+      }
+    }
+  },
+  "symbols": [
+    {
+      "kind": {
+        "identifier": "swift.enum.case",
+        "displayName": "Case"
+      },
+      "identifier": {
+        "precise": "s:9SomethingAAVAAO5firstyA2CmF",
+        "interfaceLanguage": "swift"
+      },
+      "pathComponents": [
+        "Something",
+        "Something",
+        "first"
+      ],
+      "names": {
+        "title": "Something.Something.first",
+        "subHeading": [
+          {
+            "kind": "keyword",
+            "spelling": "case"
+          },
+          {
+            "kind": "text",
+            "spelling": " "
+          },
+          {
+            "kind": "identifier",
+            "spelling": "first"
+          }
+        ]
+      },
+      "declarationFragments": [
+        {
+          "kind": "keyword",
+          "spelling": "case"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "first"
+        }
+      ],
+      "accessLevel": "public",
+      "location": {
+        "uri": "file:///Users/username/path/to/Something/TypeNameCollisions.swift",
+        "position": {
+          "line": 15,
+          "character": 13
+        }
+      }
+    },
+    {
+      "kind": {
+        "identifier": "swift.struct",
+        "displayName": "Structure"
+      },
+      "identifier": {
+        "precise": "s:9Something7WrapperV",
+        "interfaceLanguage": "swift"
+      },
+      "pathComponents": [
+        "Wrapper"
+      ],
+      "names": {
+        "title": "Wrapper",
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "Wrapper"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "keyword",
+            "spelling": "struct"
+          },
+          {
+            "kind": "text",
+            "spelling": " "
+          },
+          {
+            "kind": "identifier",
+            "spelling": "Wrapper"
+          }
+        ]
+      },
+      "declarationFragments": [
+        {
+          "kind": "keyword",
+          "spelling": "struct"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "Wrapper"
+        }
+      ],
+      "accessLevel": "public",
+      "location": {
+        "uri": "file:///Users/username/path/to/Something/TypeNameCollisions.swift",
+        "position": {
+          "line": 21,
+          "character": 14
+        }
+      }
+    },
+    {
+      "kind": {
+        "identifier": "swift.property",
+        "displayName": "Instance Property"
+      },
+      "identifier": {
+        "precise": "s:9Something7WrapperVAAV5thirdSivp",
+        "interfaceLanguage": "swift"
+      },
+      "pathComponents": [
+        "Wrapper",
+        "Something",
+        "third"
+      ],
+      "names": {
+        "title": "third",
+        "subHeading": [
+          {
+            "kind": "keyword",
+            "spelling": "var"
+          },
+          {
+            "kind": "text",
+            "spelling": " "
+          },
+          {
+            "kind": "identifier",
+            "spelling": "third"
+          },
+          {
+            "kind": "text",
+            "spelling": ": "
+          },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "Int",
+            "preciseIdentifier": "s:Si"
+          }
+        ]
+      },
+      "declarationFragments": [
+        {
+          "kind": "keyword",
+          "spelling": "var"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "third"
+        },
+        {
+          "kind": "text",
+          "spelling": ": "
+        },
+        {
+          "kind": "typeIdentifier",
+          "spelling": "Int",
+          "preciseIdentifier": "s:Si"
+        }
+      ],
+      "accessLevel": "public",
+      "location": {
+        "uri": "file:///Users/username/path/to/Something/TypeNameCollisions.swift",
+        "position": {
+          "line": 24,
+          "character": 19
+        }
+      }
+    },
+    {
+      "kind": {
+        "identifier": "swift.func.op",
+        "displayName": "Operator"
+      },
+      "identifier": {
+        "precise": "s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:9SomethingAAVAAO",
+        "interfaceLanguage": "swift"
+      },
+      "pathComponents": [
+        "Something",
+        "Something",
+        "!=(_:_:)"
+      ],
+      "names": {
+        "title": "!=(_:_:)",
+        "subHeading": [
+          {
+            "kind": "keyword",
+            "spelling": "static"
+          },
+          {
+            "kind": "text",
+            "spelling": " "
+          },
+          {
+            "kind": "keyword",
+            "spelling": "func"
+          },
+          {
+            "kind": "text",
+            "spelling": " "
+          },
+          {
+            "kind": "identifier",
+            "spelling": "!="
+          },
+          {
+            "kind": "text",
+            "spelling": " "
+          },
+          {
+            "kind": "text",
+            "spelling": "("
+          },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "Self"
+          },
+          {
+            "kind": "text",
+            "spelling": ", "
+          },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "Self"
+          },
+          {
+            "kind": "text",
+            "spelling": ") -> "
+          },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "Bool",
+            "preciseIdentifier": "s:Sb"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "name": "lhs",
+            "declarationFragments": [
+              {
+                "kind": "identifier",
+                "spelling": "lhs"
+              },
+              {
+                "kind": "text",
+                "spelling": ": "
+              },
+              {
+                "kind": "typeIdentifier",
+                "spelling": "Self"
+              }
+            ]
+          },
+          {
+            "name": "rhs",
+            "declarationFragments": [
+              {
+                "kind": "identifier",
+                "spelling": "rhs"
+              },
+              {
+                "kind": "text",
+                "spelling": ": "
+              },
+              {
+                "kind": "typeIdentifier",
+                "spelling": "Self"
+              }
+            ]
+          }
+        ],
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "spelling": "Bool",
+            "preciseIdentifier": "s:Sb"
+          }
+        ]
+      },
+      "swiftExtension": {
+        "extendedModule": "Swift",
+        "typeKind": "swift.protocol"
+      },
+      "declarationFragments": [
+        {
+          "kind": "keyword",
+          "spelling": "static"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "keyword",
+          "spelling": "func"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "!="
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "lhs"
+        },
+        {
+          "kind": "text",
+          "spelling": ": "
+        },
+        {
+          "kind": "typeIdentifier",
+          "spelling": "Self"
+        },
+        {
+          "kind": "text",
+          "spelling": ", "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "rhs"
+        },
+        {
+          "kind": "text",
+          "spelling": ": "
+        },
+        {
+          "kind": "typeIdentifier",
+          "spelling": "Self"
+        },
+        {
+          "kind": "text",
+          "spelling": ") -> "
+        },
+        {
+          "kind": "typeIdentifier",
+          "spelling": "Bool",
+          "preciseIdentifier": "s:Sb"
+        }
+      ],
+      "accessLevel": "public"
+    },
+    {
+      "kind": {
+        "identifier": "swift.property",
+        "displayName": "Instance Property"
+      },
+      "identifier": {
+        "precise": "s:9SomethingAAV6secondSivp",
+        "interfaceLanguage": "swift"
+      },
+      "pathComponents": [
+        "Something",
+        "second"
+      ],
+      "names": {
+        "title": "second",
+        "subHeading": [
+          {
+            "kind": "keyword",
+            "spelling": "var"
+          },
+          {
+            "kind": "text",
+            "spelling": " "
+          },
+          {
+            "kind": "identifier",
+            "spelling": "second"
+          },
+          {
+            "kind": "text",
+            "spelling": ": "
+          },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "Int",
+            "preciseIdentifier": "s:Si"
+          }
+        ]
+      },
+      "declarationFragments": [
+        {
+          "kind": "keyword",
+          "spelling": "var"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "second"
+        },
+        {
+          "kind": "text",
+          "spelling": ": "
+        },
+        {
+          "kind": "typeIdentifier",
+          "spelling": "Int",
+          "preciseIdentifier": "s:Si"
+        }
+      ],
+      "accessLevel": "public",
+      "location": {
+        "uri": "file:///Users/username/path/to/Something/TypeNameCollisions.swift",
+        "position": {
+          "line": 17,
+          "character": 15
+        }
+      }
+    },
+    {
+      "kind": {
+        "identifier": "swift.struct",
+        "displayName": "Structure"
+      },
+      "identifier": {
+        "precise": "s:9SomethingAAV",
+        "interfaceLanguage": "swift"
+      },
+      "pathComponents": [
+        "Something"
+      ],
+      "names": {
+        "title": "Something",
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "Something"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "keyword",
+            "spelling": "struct"
+          },
+          {
+            "kind": "text",
+            "spelling": " "
+          },
+          {
+            "kind": "identifier",
+            "spelling": "Something"
+          }
+        ]
+      },
+      "docComment": {
+        "uri": "file:///Users/username/path/to/Something/TypeNameCollisions.swift",
+        "module": "Something",
+        "lines": [
+          {
+            "range": {
+              "start": {
+                "line": 11,
+                "character": 4
+              },
+              "end": {
+                "line": 11,
+                "character": 49
+              }
+            },
+            "text": "A top-level type names the same as the module"
+          }
+        ]
+      },
+      "declarationFragments": [
+        {
+          "kind": "keyword",
+          "spelling": "struct"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "Something"
+        }
+      ],
+      "accessLevel": "public",
+      "location": {
+        "uri": "file:///Users/username/path/to/Something/TypeNameCollisions.swift",
+        "position": {
+          "line": 12,
+          "character": 14
+        }
+      }
+    },
+    {
+      "kind": {
+        "identifier": "swift.struct",
+        "displayName": "Structure"
+      },
+      "identifier": {
+        "precise": "s:9Something7WrapperVAAV",
+        "interfaceLanguage": "swift"
+      },
+      "pathComponents": [
+        "Wrapper",
+        "Something"
+      ],
+      "names": {
+        "title": "Wrapper.Something",
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "Something"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "keyword",
+            "spelling": "struct"
+          },
+          {
+            "kind": "text",
+            "spelling": " "
+          },
+          {
+            "kind": "identifier",
+            "spelling": "Something"
+          }
+        ]
+      },
+      "docComment": {
+        "uri": "file:///Users/username/path/to/Something/TypeNameCollisions.swift",
+        "module": "Something",
+        "lines": [
+          {
+            "range": {
+              "start": {
+                "line": 22,
+                "character": 8
+              },
+              "end": {
+                "line": 22,
+                "character": 84
+              }
+            },
+            "text": "An inner type with the same name as the module and as other top-level types."
+          }
+        ]
+      },
+      "declarationFragments": [
+        {
+          "kind": "keyword",
+          "spelling": "struct"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "Something"
+        }
+      ],
+      "accessLevel": "public",
+      "location": {
+        "uri": "file:///Users/username/path/to/Something/TypeNameCollisions.swift",
+        "position": {
+          "line": 23,
+          "character": 18
+        }
+      }
+    },
+    {
+      "kind": {
+        "identifier": "swift.enum",
+        "displayName": "Enumeration"
+      },
+      "identifier": {
+        "precise": "s:9SomethingAAVAAO",
+        "interfaceLanguage": "swift"
+      },
+      "pathComponents": [
+        "Something",
+        "Something"
+      ],
+      "names": {
+        "title": "Something.Something",
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "Something"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "keyword",
+            "spelling": "enum"
+          },
+          {
+            "kind": "text",
+            "spelling": " "
+          },
+          {
+            "kind": "identifier",
+            "spelling": "Something"
+          }
+        ]
+      },
+      "declarationFragments": [
+        {
+          "kind": "keyword",
+          "spelling": "enum"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "Something"
+        }
+      ],
+      "accessLevel": "public",
+      "location": {
+        "uri": "file:///Users/username/path/to/Something/TypeNameCollisions.swift",
+        "position": {
+          "line": 14,
+          "character": 16
+        }
+      }
+    }
+  ],
+  "relationships": [
+    {
+      "kind": "memberOf",
+      "source": "s:9Something7WrapperVAAV",
+      "target": "s:9Something7WrapperV"
+    },
+    {
+      "kind": "conformsTo",
+      "source": "s:9SomethingAAVAAO",
+      "target": "s:SH",
+      "targetFallback": "Swift.Hashable"
+    },
+    {
+      "kind": "memberOf",
+      "source": "s:9SomethingAAVAAO5firstyA2CmF",
+      "target": "s:9SomethingAAVAAO"
+    },
+    {
+      "kind": "memberOf",
+      "source": "s:9SomethingAAVAAO",
+      "target": "s:9SomethingAAV"
+    },
+    {
+      "kind": "conformsTo",
+      "source": "s:9SomethingAAVAAO",
+      "target": "s:SQ",
+      "targetFallback": "Swift.Equatable"
+    },
+    {
+      "kind": "memberOf",
+      "source": "s:9SomethingAAV6secondSivp",
+      "target": "s:9SomethingAAV"
+    },
+    {
+      "kind": "memberOf",
+      "source": "s:9Something7WrapperVAAV5thirdSivp",
+      "target": "s:9Something7WrapperVAAV"
+    },
+    {
+      "kind": "memberOf",
+      "source": "s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:9SomethingAAVAAO",
+      "target": "s:9SomethingAAVAAO",
+      "sourceOrigin": {
+        "identifier": "s:SQsE2neoiySbx_xtFZ",
+        "displayName": "Equatable.!=(_:_:)"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Bug/issue #, if applicable:
- rdar://76252171 #516 
- rdar://108672152 #572

## Summary

This implements much better support for relative symbol links when multiple symbols in the hierarchy have the same name (or have the same name as the module). This also unblocks—and reenables—support for omitting the module name in documentation extensions.

This change is smaller than the diff makes it appear. 867 of the additions are tests and test data and much of the implementation changes are moved or updated code (153 added, 143 removed).

### Details

To describe these changes in detail it's easiest to look at an example. If we consider this Swift code:

```swift
/* in a module named "Something" */

public struct Something {
    /// Example 1: ``Something/second``
    /// Example 2: ``Something/fourth``
    public enum Something {
        case first
    }
    /// Example 3: ``Something/Something/Something``
    public var second = 0
}

/// Example 4: ``Something/second``
public struct Wrapper {
    public struct Something {
        /// Example 5: ``Something/Something/second``
        public var third = 0
    }
}
```

#### Considering example 1 in the code above
The link resolution starts at the scope of the enum (since the link is in the enum's documentation comment).

Before these changes, the link would match the "Something" with the enum and look for "second" among the enum's members. This would result in an error that "second" doesn't exist at "Something/Something" (the enum).

With these changes, the link resolution would start out the same way as before but when it fails to find "second" within the the enum it would remember that error and walk up the hierarchy to find a new starting point for the search. Since the struct also matches "Something", the implementation would proceed to look for "second" among the struct's members. This succeeds, so the implementation discards the previous error and returns the found "second" struct property.

 #### Considering example 2 in the code above
The link resolution starts at the scope of the enum (since the link is in the enum's documentation comment).

Before these changes, just like in example 1, the link would match the "Something" with the enum and look for "fourth" among the enum's members. This would result in an error that "fourth" doesn't exist at "Something/Something" (the enum).

With these changes, like in example 1, the link resolution would start out the same way as before but when it fails to find "fourth" within the the enum it would remember that error and walk up the hierarchy to find a new starting point for the search. Since the struct also matches "Something", the implementation would proceed to look for "fourth" among the struct's members. This also fails, so the implementation walks up to the module which also match "Something". When the implementation fails to find "fourth" all the way up the hierarchy it raises the first (inner most) error that it encountered. This is the same error that would be raised before these changes.

 #### Considering example 3 in the code above
 A bit more condensed. Link resolutions starts at the "second" property. It's not a good starting point for the search (neither it nor its members match the first path component) so the implementation checks the outer scope. The "Something" struct matches the first component and the "Something" enum matches the second component but the enum doesn't have a "Something" member. Before these changes, link resolution would stop here with this error.
 
With these changes, the implementation encounters the same error, remembers that error, and tries again at the module scope (the scope that contained the previous starting point). At this scope the first "Something" match the module, the second "Something" match the struct, and the final "Something" match the enum. Since all path components are found the implementation discards the previous error and returns the found "Something" enum.
 
 #### Considering example 4 in the code above
A bit more condensed. Link resolutions starts at the Wrapper. Wrapper has a "Something" member but that doesn't have a "second" member. Before these changes, link resolution would stop here with this error.
 
With these changes, the implementation encounters the same error, remembers that error, and tries the link at the module's scope. The module has a "Something" member (the struct) which has a "second" member (the property) so the property is returned.

 #### Considering example 5 in the code above
A bit more condensed. Link resolutions starts at the "third" property. Similar to example 3, the property isn't a good starting point so the implementation checks the outer scope (the "Something" struct within the "Wrapper"). This matches the first component so the implementation tries—and fails—the second "Something" as an member of that inner struct. Before these changes, link resolution would stop here with this error.
 
With these changes the implementation encounters the same error, remembers that error, and tries the link at the Wrapper scope (the scope that contained the previous starting point). The wrapper isn't a good starting point so the implementation tries its outer scope (the module). The module match the first "Something" component, the "Something" top-level struct match the second path component, and the "something". property match the last path component. Since all path components are found the implementation discards the previous error and returns the found "Something" enum.

#### Performance

In my testing across different OS versions and architectures I haven't found any measurable performance difference from these changes. The retry logic is lazy and only happens when a link previously couldn't be resolved. Traversing the path hierarchy is pretty fast and the implementation peeks one level down before descending to avoid unnecessary traversal and error handling. 

In practice symbol hierarchies aren't very deep (almost always single digit) and name collisions in one path branch are uncommon so multiple retries for a single link are expected to be very uncommon.

#### Previous regressions

The first PR that enabled module-relative documentation extension links needed to be reverted (https://github.com/apple/swift-docc/pull/574) because it introduced a regression. 

This root cause for that regression was that documentation links were resolved relative to the module scope with a special case for matching a single path component against the module. This meant that the two links in this documentation extension resolved to the same symbol (the module).

```
# ``Something``

## Topics

- ``Something``
```

I added a new test to verify that with these new changes the documentation extension match the module but the curation math the top-level symbol.

I also manually tested the project where this regression was first encountered.

## Dependencies

None

## Testing

See the Details section for examples of links that used to fail to resolve but work with these changes.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
