### PR TITLE
[5.9] Better support for relative links when multiple symbols in the hierarchy have the same name

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/Symbol/ConformanceSection.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Symbol/ConformanceSection.swift
@@ -87,10 +87,16 @@ public struct ConformanceSection: Codable, Equatable {
         }
         
         // Adds "," or ", and" to the requirements wherever necessary.
-        let merged = zip(rendered, separators).flatMap({ $0 + [$1] })
-            + rendered[separators.count...].flatMap({ $0 })
+        var merged: [RenderInlineContent] = []
+        merged.reserveCapacity(rendered.count * 4) // 3 for each constraint and 1 for each separator
+        for (constraint, separator) in zip(rendered, separators) {
+            merged.append(contentsOf: constraint)
+            merged.append(separator)
+        }
+        merged.append(contentsOf: rendered.last!)
+        merged.append(.text("."))
         
-        self.constraints = merged + [RenderInlineContent.text(".")]
+        self.constraints = merged
     }
     
     private static let selfPrefix = "Self."

--- a/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
@@ -1149,6 +1149,54 @@ class PathHierarchyTests: XCTestCase {
                        "/ShapeKit/OverloadedEnum/firstTestMemberName(_:)-88rbf")
     }
     
+    func testSymbolsWithSameNameAsModule() throws {
+        try XCTSkipUnless(LinkResolutionMigrationConfiguration.shouldUseHierarchyBasedLinkResolver)
+        let (_, context) = try testBundleAndContext(named: "SymbolsWithSameNameAsModule")
+        let tree = try XCTUnwrap(context.hierarchyBasedLinkResolver?.pathHierarchy)
+        
+        // /* in a module named "Something "*/
+        // public struct Something {
+        //     public enum Something {
+        //         case first
+        //     }
+        //     public var second = 0
+        // }
+        // public struct Wrapper {
+        //     public struct Something {
+        //         public var third = 0
+        //     }
+        // }
+        try assertFindsPath("Something", in: tree, asSymbolID: "Something")
+        try assertFindsPath("/Something", in: tree, asSymbolID: "Something")
+        
+        let moduleID = try tree.find(path: "/Something", onlyFindSymbols: true)
+        XCTAssertEqual(try tree.findSymbol(path: "/Something", parent: moduleID).identifier.precise, "Something")
+        XCTAssertEqual(try tree.findSymbol(path: "Something-module", parent: moduleID).identifier.precise, "Something")
+        XCTAssertEqual(try tree.findSymbol(path: "Something", parent: moduleID).identifier.precise, "s:9SomethingAAV")
+        XCTAssertEqual(try tree.findSymbol(path: "/Something/Something", parent: moduleID).identifier.precise, "s:9SomethingAAV")
+        XCTAssertEqual(try tree.findSymbol(path: "Something/Something", parent: moduleID).identifier.precise, "s:9SomethingAAVAAO")
+        XCTAssertEqual(try tree.findSymbol(path: "Something/Something/Something", parent: moduleID).identifier.precise, "s:9SomethingAAVAAO")
+        XCTAssertEqual(try tree.findSymbol(path: "/Something/Something/Something", parent: moduleID).identifier.precise, "s:9SomethingAAVAAO")
+        XCTAssertEqual(try tree.findSymbol(path: "/Something/Something", parent: moduleID).identifier.precise, "s:9SomethingAAV")
+        XCTAssertEqual(try tree.findSymbol(path: "Something/second", parent: moduleID).identifier.precise, "s:9SomethingAAV6secondSivp")
+        
+        let topLevelSymbolID = try tree.find(path: "/Something/Something", onlyFindSymbols: true)
+        XCTAssertEqual(try tree.findSymbol(path: "Something", parent: topLevelSymbolID).identifier.precise, "s:9SomethingAAVAAO")
+        XCTAssertEqual(try tree.findSymbol(path: "Something/Something", parent: topLevelSymbolID).identifier.precise, "s:9SomethingAAVAAO")
+        XCTAssertEqual(try tree.findSymbol(path: "Something/second", parent: topLevelSymbolID).identifier.precise, "s:9SomethingAAV6secondSivp")
+        
+        let wrapperID = try tree.find(path: "/Something/Wrapper", onlyFindSymbols: true)
+        XCTAssertEqual(try tree.findSymbol(path: "Something/second", parent: wrapperID).identifier.precise, "s:9SomethingAAV6secondSivp")
+        XCTAssertEqual(try tree.findSymbol(path: "Something/third", parent: wrapperID).identifier.precise, "s:9Something7WrapperVAAV5thirdSivp")
+        
+        let wrappedID = try tree.find(path: "/Something/Wrapper/Something", onlyFindSymbols: true)
+        XCTAssertEqual(try tree.findSymbol(path: "Something/second", parent: wrappedID).identifier.precise, "s:9SomethingAAV6secondSivp")
+        XCTAssertEqual(try tree.findSymbol(path: "Something/third", parent: wrappedID).identifier.precise, "s:9Something7WrapperVAAV5thirdSivp")
+        
+        XCTAssertEqual(try tree.findSymbol(path: "Something/first", parent: topLevelSymbolID).identifier.precise, "s:9SomethingAAVAAO5firstyA2CmF")
+        XCTAssertEqual(try tree.findSymbol(path: "Something/second", parent: topLevelSymbolID).identifier.precise, "s:9SomethingAAV6secondSivp")
+    }
+    
     func testSnippets() throws {
         try XCTSkipUnless(LinkResolutionMigrationConfiguration.shouldUseHierarchyBasedLinkResolver)
         let (_, context) = try testBundleAndContext(named: "Snippets")

--- a/Tests/SwiftDocCTests/Infrastructure/ReferenceResolverTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/ReferenceResolverTests.swift
@@ -471,21 +471,17 @@ class ReferenceResolverTests: XCTestCase {
             try """
             # ``ModuleWithSingleExtension``
 
-            This is a test module with an extension to ``Swift/Array#Array``.
+            This is a test module with an extension to ``Swift/Array``.
             """.write(to: topLevelArticle, atomically: true, encoding: .utf8)
         }
 
         // Make sure that linking to `Swift/Array` raises a diagnostic about the page having been removed
-        if LinkResolutionMigrationConfiguration.shouldUseHierarchyBasedLinkResolver {
-            let diagnostic = try XCTUnwrap(context.problems.first(where: { $0.diagnostic.identifier == "org.swift.docc.removedExtensionLinkDestination" }))
-            XCTAssertEqual(diagnostic.possibleSolutions.count, 1)
-            let solution = try XCTUnwrap(diagnostic.possibleSolutions.first)
-            XCTAssertEqual(solution.replacements.count, 1)
-            let replacement = try XCTUnwrap(solution.replacements.first)
-            XCTAssertEqual(replacement.replacement, "`Swift/Array`")
-        } else {
-            XCTAssert(context.problems.contains(where: { $0.diagnostic.identifier == "org.swift.docc.unresolvedTopicReference" }))
-        }
+        let diagnostic = try XCTUnwrap(context.problems.first(where: { $0.diagnostic.identifier == "org.swift.docc.removedExtensionLinkDestination" }))
+        XCTAssertEqual(diagnostic.possibleSolutions.count, 1)
+        let solution = try XCTUnwrap(diagnostic.possibleSolutions.first)
+        XCTAssertEqual(solution.replacements.count, 1)
+        let replacement = try XCTUnwrap(solution.replacements.first)
+        XCTAssertEqual(replacement.replacement, "`Swift/Array`")
 
         // Also make sure that the extension pages are still gone
         let extendedModule = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ModuleWithSingleExtension/Swift", sourceLanguage: .swift)

--- a/Tests/SwiftDocCTests/Test Bundles/SymbolsWithSameNameAsModule.docc/Something.symbols.json
+++ b/Tests/SwiftDocCTests/Test Bundles/SymbolsWithSameNameAsModule.docc/Something.symbols.json
@@ -1,0 +1,729 @@
+{
+  "metadata": {
+    "formatVersion": {
+      "major": 0,
+      "minor": 6,
+      "patch": 0
+    },
+    "generator": "Apple Swift version 5.9 (swiftlang-5.9.0.100.22 clang-1500.0.7.24.100)"
+  },
+  "module": {
+    "name": "Something",
+    "platform": {
+      "architecture": "arm64",
+      "vendor": "apple",
+      "operatingSystem": {
+        "name": "macosx",
+        "minimumVersion": {
+          "major": 14,
+          "minor": 0
+        }
+      }
+    }
+  },
+  "symbols": [
+    {
+      "kind": {
+        "identifier": "swift.enum.case",
+        "displayName": "Case"
+      },
+      "identifier": {
+        "precise": "s:9SomethingAAVAAO5firstyA2CmF",
+        "interfaceLanguage": "swift"
+      },
+      "pathComponents": [
+        "Something",
+        "Something",
+        "first"
+      ],
+      "names": {
+        "title": "Something.Something.first",
+        "subHeading": [
+          {
+            "kind": "keyword",
+            "spelling": "case"
+          },
+          {
+            "kind": "text",
+            "spelling": " "
+          },
+          {
+            "kind": "identifier",
+            "spelling": "first"
+          }
+        ]
+      },
+      "declarationFragments": [
+        {
+          "kind": "keyword",
+          "spelling": "case"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "first"
+        }
+      ],
+      "accessLevel": "public",
+      "location": {
+        "uri": "file:///Users/username/path/to/Something/TypeNameCollisions.swift",
+        "position": {
+          "line": 15,
+          "character": 13
+        }
+      }
+    },
+    {
+      "kind": {
+        "identifier": "swift.struct",
+        "displayName": "Structure"
+      },
+      "identifier": {
+        "precise": "s:9Something7WrapperV",
+        "interfaceLanguage": "swift"
+      },
+      "pathComponents": [
+        "Wrapper"
+      ],
+      "names": {
+        "title": "Wrapper",
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "Wrapper"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "keyword",
+            "spelling": "struct"
+          },
+          {
+            "kind": "text",
+            "spelling": " "
+          },
+          {
+            "kind": "identifier",
+            "spelling": "Wrapper"
+          }
+        ]
+      },
+      "declarationFragments": [
+        {
+          "kind": "keyword",
+          "spelling": "struct"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "Wrapper"
+        }
+      ],
+      "accessLevel": "public",
+      "location": {
+        "uri": "file:///Users/username/path/to/Something/TypeNameCollisions.swift",
+        "position": {
+          "line": 21,
+          "character": 14
+        }
+      }
+    },
+    {
+      "kind": {
+        "identifier": "swift.property",
+        "displayName": "Instance Property"
+      },
+      "identifier": {
+        "precise": "s:9Something7WrapperVAAV5thirdSivp",
+        "interfaceLanguage": "swift"
+      },
+      "pathComponents": [
+        "Wrapper",
+        "Something",
+        "third"
+      ],
+      "names": {
+        "title": "third",
+        "subHeading": [
+          {
+            "kind": "keyword",
+            "spelling": "var"
+          },
+          {
+            "kind": "text",
+            "spelling": " "
+          },
+          {
+            "kind": "identifier",
+            "spelling": "third"
+          },
+          {
+            "kind": "text",
+            "spelling": ": "
+          },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "Int",
+            "preciseIdentifier": "s:Si"
+          }
+        ]
+      },
+      "declarationFragments": [
+        {
+          "kind": "keyword",
+          "spelling": "var"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "third"
+        },
+        {
+          "kind": "text",
+          "spelling": ": "
+        },
+        {
+          "kind": "typeIdentifier",
+          "spelling": "Int",
+          "preciseIdentifier": "s:Si"
+        }
+      ],
+      "accessLevel": "public",
+      "location": {
+        "uri": "file:///Users/username/path/to/Something/TypeNameCollisions.swift",
+        "position": {
+          "line": 24,
+          "character": 19
+        }
+      }
+    },
+    {
+      "kind": {
+        "identifier": "swift.func.op",
+        "displayName": "Operator"
+      },
+      "identifier": {
+        "precise": "s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:9SomethingAAVAAO",
+        "interfaceLanguage": "swift"
+      },
+      "pathComponents": [
+        "Something",
+        "Something",
+        "!=(_:_:)"
+      ],
+      "names": {
+        "title": "!=(_:_:)",
+        "subHeading": [
+          {
+            "kind": "keyword",
+            "spelling": "static"
+          },
+          {
+            "kind": "text",
+            "spelling": " "
+          },
+          {
+            "kind": "keyword",
+            "spelling": "func"
+          },
+          {
+            "kind": "text",
+            "spelling": " "
+          },
+          {
+            "kind": "identifier",
+            "spelling": "!="
+          },
+          {
+            "kind": "text",
+            "spelling": " "
+          },
+          {
+            "kind": "text",
+            "spelling": "("
+          },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "Self"
+          },
+          {
+            "kind": "text",
+            "spelling": ", "
+          },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "Self"
+          },
+          {
+            "kind": "text",
+            "spelling": ") -> "
+          },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "Bool",
+            "preciseIdentifier": "s:Sb"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "name": "lhs",
+            "declarationFragments": [
+              {
+                "kind": "identifier",
+                "spelling": "lhs"
+              },
+              {
+                "kind": "text",
+                "spelling": ": "
+              },
+              {
+                "kind": "typeIdentifier",
+                "spelling": "Self"
+              }
+            ]
+          },
+          {
+            "name": "rhs",
+            "declarationFragments": [
+              {
+                "kind": "identifier",
+                "spelling": "rhs"
+              },
+              {
+                "kind": "text",
+                "spelling": ": "
+              },
+              {
+                "kind": "typeIdentifier",
+                "spelling": "Self"
+              }
+            ]
+          }
+        ],
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "spelling": "Bool",
+            "preciseIdentifier": "s:Sb"
+          }
+        ]
+      },
+      "swiftExtension": {
+        "extendedModule": "Swift",
+        "typeKind": "swift.protocol"
+      },
+      "declarationFragments": [
+        {
+          "kind": "keyword",
+          "spelling": "static"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "keyword",
+          "spelling": "func"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "!="
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "lhs"
+        },
+        {
+          "kind": "text",
+          "spelling": ": "
+        },
+        {
+          "kind": "typeIdentifier",
+          "spelling": "Self"
+        },
+        {
+          "kind": "text",
+          "spelling": ", "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "rhs"
+        },
+        {
+          "kind": "text",
+          "spelling": ": "
+        },
+        {
+          "kind": "typeIdentifier",
+          "spelling": "Self"
+        },
+        {
+          "kind": "text",
+          "spelling": ") -> "
+        },
+        {
+          "kind": "typeIdentifier",
+          "spelling": "Bool",
+          "preciseIdentifier": "s:Sb"
+        }
+      ],
+      "accessLevel": "public"
+    },
+    {
+      "kind": {
+        "identifier": "swift.property",
+        "displayName": "Instance Property"
+      },
+      "identifier": {
+        "precise": "s:9SomethingAAV6secondSivp",
+        "interfaceLanguage": "swift"
+      },
+      "pathComponents": [
+        "Something",
+        "second"
+      ],
+      "names": {
+        "title": "second",
+        "subHeading": [
+          {
+            "kind": "keyword",
+            "spelling": "var"
+          },
+          {
+            "kind": "text",
+            "spelling": " "
+          },
+          {
+            "kind": "identifier",
+            "spelling": "second"
+          },
+          {
+            "kind": "text",
+            "spelling": ": "
+          },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "Int",
+            "preciseIdentifier": "s:Si"
+          }
+        ]
+      },
+      "declarationFragments": [
+        {
+          "kind": "keyword",
+          "spelling": "var"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "second"
+        },
+        {
+          "kind": "text",
+          "spelling": ": "
+        },
+        {
+          "kind": "typeIdentifier",
+          "spelling": "Int",
+          "preciseIdentifier": "s:Si"
+        }
+      ],
+      "accessLevel": "public",
+      "location": {
+        "uri": "file:///Users/username/path/to/Something/TypeNameCollisions.swift",
+        "position": {
+          "line": 17,
+          "character": 15
+        }
+      }
+    },
+    {
+      "kind": {
+        "identifier": "swift.struct",
+        "displayName": "Structure"
+      },
+      "identifier": {
+        "precise": "s:9SomethingAAV",
+        "interfaceLanguage": "swift"
+      },
+      "pathComponents": [
+        "Something"
+      ],
+      "names": {
+        "title": "Something",
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "Something"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "keyword",
+            "spelling": "struct"
+          },
+          {
+            "kind": "text",
+            "spelling": " "
+          },
+          {
+            "kind": "identifier",
+            "spelling": "Something"
+          }
+        ]
+      },
+      "docComment": {
+        "uri": "file:///Users/username/path/to/Something/TypeNameCollisions.swift",
+        "module": "Something",
+        "lines": [
+          {
+            "range": {
+              "start": {
+                "line": 11,
+                "character": 4
+              },
+              "end": {
+                "line": 11,
+                "character": 49
+              }
+            },
+            "text": "A top-level type names the same as the module"
+          }
+        ]
+      },
+      "declarationFragments": [
+        {
+          "kind": "keyword",
+          "spelling": "struct"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "Something"
+        }
+      ],
+      "accessLevel": "public",
+      "location": {
+        "uri": "file:///Users/username/path/to/Something/TypeNameCollisions.swift",
+        "position": {
+          "line": 12,
+          "character": 14
+        }
+      }
+    },
+    {
+      "kind": {
+        "identifier": "swift.struct",
+        "displayName": "Structure"
+      },
+      "identifier": {
+        "precise": "s:9Something7WrapperVAAV",
+        "interfaceLanguage": "swift"
+      },
+      "pathComponents": [
+        "Wrapper",
+        "Something"
+      ],
+      "names": {
+        "title": "Wrapper.Something",
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "Something"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "keyword",
+            "spelling": "struct"
+          },
+          {
+            "kind": "text",
+            "spelling": " "
+          },
+          {
+            "kind": "identifier",
+            "spelling": "Something"
+          }
+        ]
+      },
+      "docComment": {
+        "uri": "file:///Users/username/path/to/Something/TypeNameCollisions.swift",
+        "module": "Something",
+        "lines": [
+          {
+            "range": {
+              "start": {
+                "line": 22,
+                "character": 8
+              },
+              "end": {
+                "line": 22,
+                "character": 84
+              }
+            },
+            "text": "An inner type with the same name as the module and as other top-level types."
+          }
+        ]
+      },
+      "declarationFragments": [
+        {
+          "kind": "keyword",
+          "spelling": "struct"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "Something"
+        }
+      ],
+      "accessLevel": "public",
+      "location": {
+        "uri": "file:///Users/username/path/to/Something/TypeNameCollisions.swift",
+        "position": {
+          "line": 23,
+          "character": 18
+        }
+      }
+    },
+    {
+      "kind": {
+        "identifier": "swift.enum",
+        "displayName": "Enumeration"
+      },
+      "identifier": {
+        "precise": "s:9SomethingAAVAAO",
+        "interfaceLanguage": "swift"
+      },
+      "pathComponents": [
+        "Something",
+        "Something"
+      ],
+      "names": {
+        "title": "Something.Something",
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "Something"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "keyword",
+            "spelling": "enum"
+          },
+          {
+            "kind": "text",
+            "spelling": " "
+          },
+          {
+            "kind": "identifier",
+            "spelling": "Something"
+          }
+        ]
+      },
+      "declarationFragments": [
+        {
+          "kind": "keyword",
+          "spelling": "enum"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "Something"
+        }
+      ],
+      "accessLevel": "public",
+      "location": {
+        "uri": "file:///Users/username/path/to/Something/TypeNameCollisions.swift",
+        "position": {
+          "line": 14,
+          "character": 16
+        }
+      }
+    }
+  ],
+  "relationships": [
+    {
+      "kind": "memberOf",
+      "source": "s:9Something7WrapperVAAV",
+      "target": "s:9Something7WrapperV"
+    },
+    {
+      "kind": "conformsTo",
+      "source": "s:9SomethingAAVAAO",
+      "target": "s:SH",
+      "targetFallback": "Swift.Hashable"
+    },
+    {
+      "kind": "memberOf",
+      "source": "s:9SomethingAAVAAO5firstyA2CmF",
+      "target": "s:9SomethingAAVAAO"
+    },
+    {
+      "kind": "memberOf",
+      "source": "s:9SomethingAAVAAO",
+      "target": "s:9SomethingAAV"
+    },
+    {
+      "kind": "conformsTo",
+      "source": "s:9SomethingAAVAAO",
+      "target": "s:SQ",
+      "targetFallback": "Swift.Equatable"
+    },
+    {
+      "kind": "memberOf",
+      "source": "s:9SomethingAAV6secondSivp",
+      "target": "s:9SomethingAAV"
+    },
+    {
+      "kind": "memberOf",
+      "source": "s:9Something7WrapperVAAV5thirdSivp",
+      "target": "s:9Something7WrapperVAAV"
+    },
+    {
+      "kind": "memberOf",
+      "source": "s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:9SomethingAAVAAO",
+      "target": "s:9SomethingAAVAAO",
+      "sourceOrigin": {
+        "identifier": "s:SQsE2neoiySbx_xtFZ",
+        "displayName": "Equatable.!=(_:_:)"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
- **Explanation**: Better support for resolving symbol links when multiple symbols in the hierarchy (incl. the module symbol) have the same name. The original PR has detailed examples.
- **Scope**: Link resolution for local symbol links and documentation links.
- **Issue**: rdar://76252171&108672152
- **Risk**: Low. Changes to link resolution has broad impact but are also very well tested.
- **Testing**: New tests verify that links that previously failed now succeed, that still failing links have the same error messages, and that the previous regression that led to a revert isn't reintroduced by this. I also manually tested the project where that regression previously occurred.
- **Original PR:** #578 
- **Reviewers**: @daniel-grumberg 