### PR TITLE
Add successfully resolved external references to reference index

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -2442,6 +2442,9 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
         for reference in knownIdentifiers {
             referenceIndex[reference.absoluteString] = reference
         }
+        for case .success(let reference) in externallyResolvedLinks.values {
+            referenceIndex[reference.absoluteString] = reference
+        }
         for reference in nodeAnchorSections.keys {
             referenceIndex[reference.absoluteString] = reference
         }

--- a/Sources/SwiftDocC/Model/Rendering/RenderContentCompiler.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderContentCompiler.swift
@@ -206,7 +206,7 @@ struct RenderContentCompiler: MarkupVisitor {
     }
     
     mutating func resolveTopicReference(_ destination: String) -> ResolvedTopicReference? {
-         if let cached = context.referenceIndex[destination] {
+        if let cached = context.referenceIndex[destination] {
             if let node = context.topicGraph.nodeWithReference(cached), !context.topicGraph.isLinkable(node.reference) {
                 return nil
             }

--- a/Sources/SwiftDocC/Model/Rendering/RenderContentCompiler.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderContentCompiler.swift
@@ -206,11 +206,17 @@ struct RenderContentCompiler: MarkupVisitor {
     }
     
     mutating func resolveTopicReference(_ destination: String) -> ResolvedTopicReference? {
-        if let cached = context.referenceIndex[destination] {
+         if let cached = context.referenceIndex[destination] {
+            if let node = context.topicGraph.nodeWithReference(cached), !context.topicGraph.isLinkable(node.reference) {
+                return nil
+            }
             collectedTopicReferences.append(cached)
             return cached
         }
         
+        // FIXME: Links from this build already exist in the reference index and don't need to be resolved again.
+        // https://github.com/apple/swift-docc/issues/581
+
         guard let validatedURL = ValidatedURL(parsingAuthoredLink: destination) else {
             return nil
         }


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://108974747

## Summary

This change tracks successfully resolved external references the same as successfully resolved local references, enabling them to be looked up in the reference index without going through the link resolution code path again.

## Dependencies

None.

## Testing



## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
