### PR TITLE
[5.9 05-01-2023] Support resolving code file references in ConvertService 

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/References/FileReference.swift
+++ b/Sources/SwiftDocC/Model/Rendering/References/FileReference.swift
@@ -47,12 +47,21 @@ public struct FileReference: RenderReference, Equatable {
     ///   - fileType: The type of file, typically represented by its file extension.
     ///   - syntax: The syntax of the file's content.
     ///   - content: The line-by-line contents of the file.
-    public init(identifier: RenderReferenceIdentifier, fileName: String, fileType: String, syntax: String, content: [String]) {
+    ///   - highlights: The line highlights for this file.
+    public init(
+        identifier: RenderReferenceIdentifier,
+        fileName: String,
+        fileType: String,
+        syntax: String,
+        content: [String],
+        highlights: [LineHighlighter.Highlight] = []
+    ) {
         self.identifier = identifier
         self.fileName = fileName
         self.fileType = fileType
         self.syntax = syntax
         self.content = content
+        self.highlights = highlights
     }
     
     public init(from decoder: Decoder) throws {

--- a/Tests/SwiftDocCTests/DocumentationService/ConvertService/ConvertServiceTests.swift
+++ b/Tests/SwiftDocCTests/DocumentationService/ConvertService/ConvertServiceTests.swift
@@ -12,6 +12,7 @@ import XCTest
 import Foundation
 @testable import SwiftDocC
 import SymbolKit
+import SwiftDocCTestUtilities
 
 class ConvertServiceTests: XCTestCase {
     private let testBundleInfo = DocumentationBundle.Info(
@@ -835,6 +836,177 @@ class ConvertServiceTests: XCTestCase {
         }
     }
 
+    func testConvertTutorialWithCode() throws {
+        let tutorialContent = """
+        @Tutorial(time: 99) {
+            @Intro(title: "Tutorial Title") {
+                Tutorial intro.
+            }
+            @Section(title: "Section title") {
+                This section has one step with a code file reference.
+                
+                @Steps {
+                    @Step {
+                        Start with this
+                        
+                        @Code(name: "Something.swift", file: before.swift)
+                    }
+        
+                    @Step {
+                        Add this
+                        
+                        @Code(name: "Something.swift", file: after.swift)
+                    }
+                }
+            }
+        }
+        """
+        
+        let tempURL = try createTempFolder(content: [
+            Folder(name: "TutorialWithCodeTest.docc", content: [
+                TextFile(name: "Something.tutorial", utf8Content: tutorialContent),
+                
+                TextFile(name: "before.swift", utf8Content: """
+                    // This is an example swift file
+                    """),
+                TextFile(name: "after.swift", utf8Content: """
+                    // This is an example swift file
+                    let something = 0
+                    """),
+            ])
+        ])
+        let catalog = tempURL.appendingPathComponent("TutorialWithCodeTest.docc")
+        
+        let request = ConvertRequest(
+            bundleInfo: testBundleInfo,
+            externalIDsToConvert: nil,
+            documentPathsToConvert: nil,
+            bundleLocation: nil,
+            symbolGraphs: [],
+            knownDisambiguatedSymbolPathComponents: nil,
+            markupFiles: [],
+            tutorialFiles: [tutorialContent.data(using: .utf8)!],
+            miscResourceURLs: []
+        )
+        
+        let server = DocumentationServer()
+        
+        let mockLinkResolvingService = LinkResolvingService { message in
+            XCTAssertEqual(message.type, "resolve-reference")
+            XCTAssert(message.identifier.hasPrefix("SwiftDocC"))
+            do {
+                let payload = try XCTUnwrap(message.payload)
+                let request = try JSONDecoder()
+                    .decode(
+                        ConvertRequestContextWrapper<OutOfProcessReferenceResolver.Request>.self,
+                        from: payload
+                    )
+                
+                XCTAssertEqual(request.convertRequestIdentifier, "test-identifier")
+                
+                switch request.payload {
+                case .topic(let url):
+                    XCTFail("Unexpected topic request: \(url.absoluteString.singleQuoted)")
+                    // Fail to resolve every topic
+                    return DocumentationServer.Message(
+                        type: "resolve-reference-response",
+                        payload: try JSONEncoder().encode(
+                            OutOfProcessReferenceResolver.Response.errorMessage("Unexpected topic request")
+                        )
+                    )
+                    
+                case .symbol(let preciseIdentifier):
+                    XCTFail("Unexpected symbol request: \(preciseIdentifier)")
+                    // Fail to resolve every symbol
+                    return DocumentationServer.Message(
+                        type: "resolve-reference-response",
+                        payload: try JSONEncoder().encode(
+                            OutOfProcessReferenceResolver.Response.errorMessage("Unexpected symbol request")
+                        )
+                    )
+                    
+                case .asset(let assetReference):
+                    print(assetReference)
+                    switch (assetReference.assetName, assetReference.bundleIdentifier) {
+                    case (let assetName, "identifier") where ["before.swift", "after.swift"].contains(assetName):
+                        var asset = DataAsset()
+                        asset.register(
+                            catalog.appendingPathComponent(assetName),
+                            with: DataTraitCollection()
+                        )
+                        
+                        return DocumentationServer.Message(
+                            type: "resolve-reference-response",
+                            payload: try JSONEncoder().encode(
+                                OutOfProcessReferenceResolver.Response
+                                    .asset(asset)
+                            )
+                        )
+
+                    default:
+                        XCTFail("Unexpected asset request: \(assetReference.assetName)")
+                        // Fail to resolve all other assets
+                        return DocumentationServer.Message(
+                            type: "resolve-reference-response",
+                            payload: try JSONEncoder().encode(
+                                OutOfProcessReferenceResolver.Response.errorMessage("Unexpected topic request")
+                            )
+                        )
+                    }
+                }
+            } catch {
+                XCTFail(error.localizedDescription)
+                return nil
+            }
+        }
+        
+        server.register(service: mockLinkResolvingService)
+        
+        try processAndAssert(request: request, linkResolvingServer: server) { message in
+            XCTAssertEqual(message.type, "convert-response")
+            XCTAssertEqual(message.identifier, "test-identifier-response")
+            
+            let response = try JSONDecoder().decode(
+                ConvertResponse.self, from: XCTUnwrap(message.payload)
+            )
+            
+            XCTAssertEqual(response.renderNodes.count, 1)
+            let data = try XCTUnwrap(response.renderNodes.first)
+            let renderNode = try JSONDecoder().decode(RenderNode.self, from: data)
+            
+            let beforeIdentifier = RenderReferenceIdentifier("before.swift")
+            let afterIdentifier = RenderReferenceIdentifier("after.swift")
+            
+            XCTAssertEqual(
+                renderNode.references["before.swift"] as? FileReference,
+                FileReference(identifier: beforeIdentifier, fileName: "Something.swift", fileType: "swift", syntax: "swift", content: [
+                    "// This is an example swift file",
+                ], highlights: [])
+            )
+            XCTAssertEqual(
+                renderNode.references["after.swift"] as? FileReference,
+                FileReference(identifier: afterIdentifier, fileName: "Something.swift", fileType: "swift", syntax: "swift", content: [
+                    "// This is an example swift file",
+                    "let something = 0",
+                ], highlights: [.init(line: 2)])
+            )
+            
+            let stepsSection = try XCTUnwrap(renderNode.sections.compactMap { $0 as? TutorialSectionsRenderSection }.first?.tasks.first?.stepsSection)
+            XCTAssertEqual(stepsSection.count, 2)
+            if case .step(let step) = stepsSection.first {
+                XCTAssertEqual(step.code, beforeIdentifier)
+            } else {
+                XCTFail("Unexpected kind of step")
+            }
+            
+            if case .step(let step) = stepsSection.last {
+                XCTAssertEqual(step.code, afterIdentifier)
+            } else {
+                XCTFail("Unexpected kind of step")
+            }
+        }
+    }
+    
     func testConvertArticleWithImageReferencesAndDetailedGridLinks() throws {
         let articleData = try XCTUnwrap("""
             # First article

--- a/Tests/SwiftDocCTests/Model/LineHighlighterTests.swift
+++ b/Tests/SwiftDocCTests/Model/LineHighlighterTests.swift
@@ -68,7 +68,7 @@ class LineHighlighterTests: XCTestCase {
         let tutorialReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/tutorials/Line-Highlighter-Tests/Tutorial", fragment: nil, sourceLanguage: .swift)
         let tutorial = try context.entity(with: tutorialReference).semantic as! Tutorial
         let section = tutorial.sections.first!
-        return LineHighlighter(context: context, tutorialSection: section).highlights
+        return LineHighlighter(context: context, tutorialSection: section, tutorialReference: tutorialReference).highlights
     }
     
     func testNoSteps() throws {


### PR DESCRIPTION
- **Explanation**: Support resolving tutorial code file references in ConvertService requests.
- **Scope**: Tutorial content in ConvertService requests.
- **Issue**: rdar://107965493
- **Risk**: Low risk. Isolated and limited scope
- **Testing**: New tests verify that file references are resolved and that the Tutorial Render JSON include the code file's content and their line differences.
- **Original PR:** #570
- **Reviewers**: @ethan-kusters 