### PR TITLE
[5.9] Add successfully resolved external references to reference index

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -2442,6 +2442,9 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
         for reference in knownIdentifiers {
             referenceIndex[reference.absoluteString] = reference
         }
+        for case .success(let reference) in externallyResolvedLinks.values {
+            referenceIndex[reference.absoluteString] = reference
+        }
         for reference in nodeAnchorSections.keys {
             referenceIndex[reference.absoluteString] = reference
         }

--- a/Sources/SwiftDocC/Model/Rendering/RenderContentCompiler.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderContentCompiler.swift
@@ -207,10 +207,16 @@ struct RenderContentCompiler: MarkupVisitor {
     
     mutating func resolveTopicReference(_ destination: String) -> ResolvedTopicReference? {
         if let cached = context.referenceIndex[destination] {
+            if let node = context.topicGraph.nodeWithReference(cached), !context.topicGraph.isLinkable(node.reference) {
+                return nil
+            }
             collectedTopicReferences.append(cached)
             return cached
         }
         
+        // FIXME: Links from this build already exist in the reference index and don't need to be resolved again.
+        // https://github.com/apple/swift-docc/issues/581
+
         guard let validatedURL = ValidatedURL(parsingAuthoredLink: destination) else {
             return nil
         }


### PR DESCRIPTION
- **Explanation**: Tracks successfully resolved external references the same as successfully resolved local references, allowing the same code path to be used during rendering.
- **Scope**: Externally resolved content.
- **Issue**: rdar://108974747
- **Risk**: Low. Isolated and limited scope.
- **Testing**: New test verify that the external topic reference and its resolved content exist in the Render JSON for the page that linked to it.
- **Original PR:** #582
- **Reviewers**: @ethan-kusters 