### PR TITLE
LMDB: introduce a typealias for `mode_t`

### DIFF
--- a/Sources/SwiftDocC/Utility/LMDB/LMDB+Environment.swift
+++ b/Sources/SwiftDocC/Utility/LMDB/LMDB+Environment.swift
@@ -54,11 +54,11 @@ extension LMDB {
             - maxDBs: The maximum number of databases that can be opened in the environment. Default: infinite.
             - maxReaders: The maximum number of readers to use. Default: 126
             - mapSize: The size of the map on disk in bytes. Default: 10 MB.
-            - fileMode: The `mode_t` to use when opening a file for the database. Default: 744.
+            - fileMode: The `LMDB.ModeType` to use when opening a file for the database. Default: 744.
          
          - Throws: An error if the environment can't be initialized correctly.
          */
-        public init(path: String, flags: Flags = [], maxDBs: UInt32 = LMDB.defaultMaxDBs, maxReaders: UInt32 = LMDB.defaultMaxReaders, mapSize: size_t = LMDB.defaultMapSize, fileMode: mode_t = LMDB.defaultFileMode) throws {
+        public init(path: String, flags: Flags = [], maxDBs: UInt32 = LMDB.defaultMaxDBs, maxReaders: UInt32 = LMDB.defaultMaxReaders, mapSize: size_t = LMDB.defaultMapSize, fileMode: LMDB.ModeType = LMDB.defaultFileMode) throws {
 
             let result = mdb_env_create(&opaquePointer)
             guard result == 0 else {
@@ -91,7 +91,7 @@ extension LMDB {
             }
         }
         
-        private func configureEnvironment(opaquePointer: OpaquePointer? = nil, maxDBs: UInt32 = LMDB.defaultMaxDBs, maxReaders: UInt32 = LMDB.defaultMaxReaders, mapSize: size_t = LMDB.defaultMapSize, fileMode: mode_t = LMDB.defaultFileMode) throws {
+        private func configureEnvironment(opaquePointer: OpaquePointer? = nil, maxDBs: UInt32 = LMDB.defaultMaxDBs, maxReaders: UInt32 = LMDB.defaultMaxReaders, mapSize: size_t = LMDB.defaultMapSize, fileMode: LMDB.ModeType = LMDB.defaultFileMode) throws {
             
             if maxDBs != LMDB.defaultMaxDBs {
                 let returnCode = mdb_env_set_maxdbs(opaquePointer, MDB_dbi(maxDBs))

--- a/Sources/SwiftDocC/Utility/LMDB/LMDB.swift
+++ b/Sources/SwiftDocC/Utility/LMDB/LMDB.swift
@@ -18,6 +18,11 @@ import CLMDB
             Reads are never blocked, but writes are serialized using a mutually exclusive lock at the database level.
  */
 final class LMDB {
+    #if os(Windows)
+    public typealias ModeType = CInt
+    #else
+    public typealias ModeType = mode_t
+    #endif
         
     /// Default instance.
     public static var `default` = LMDB()
@@ -37,7 +42,11 @@ final class LMDB {
     public static let defaultMapSize: size_t = 10485760
     
     /// The default file mode for opening an environment which is `744`.
-    public static let defaultFileMode: mode_t = S_IRWXU | S_IRGRP | S_IROTH
+    #if os(Windows)
+    public static let defaultFileMode: ModeType = _S_IREAD | _S_IWRITE
+    #else
+    public static let defaultFileMode: ModeType = S_IRWXU | S_IRGRP | S_IROTH
+    #endif
     
 }
 


### PR DESCRIPTION
`mode_t` is a non-portable extension to C (POSIX).  Introduce a new typealias `ModeType` that represents the underlying type that is used. Provide an alternate definition for the default mode on Windows as it does not have non-user permissions on a file but rather relies on proper ACLing.