### PR TITLE
Model: enable concurrent rendering on Windows

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/RenderContext.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderContext.swift
@@ -61,8 +61,8 @@ public struct RenderContext {
             )
         }
         
-        #if os(macOS) || os(iOS) || os(Android)
-        // Concurrently render content on macOS/iOS & Android
+        #if os(macOS) || os(iOS) || os(Android) || os(Windows)
+        // Concurrently render content on macOS/iOS, Windows & Android
         let results: [(reference: ResolvedTopicReference, content: RenderReferenceStore.TopicContent)] = references.concurrentPerform { reference, results in
             results.append((reference, renderContentFor(reference)))
         }


### PR DESCRIPTION
Assume that concurrent rendering on Windows is the proper thing to do. It is unclear why Linux (but not Android) uses serial rendering.  This enables us to make progress with the Windows port.