### PR TITLE
FoundationExtensions: enable autoreleasepool on Windows

### DIFF
--- a/Sources/SwiftDocC/Utility/FoundationExtensions/AutoreleasepoolShim.swift
+++ b/Sources/SwiftDocC/Utility/FoundationExtensions/AutoreleasepoolShim.swift
@@ -8,8 +8,8 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-#if os(Linux) || os(Android)
-/// A shim for Linux that runs the given block of code.
+#if os(Linux) || os(Android) || os(Windows)
+/// A shim for non-ObjC targets that runs the given block of code.
 ///
 /// The existence of this shim allows you the use of auto-release pools to optimize memory footprint on Darwin platforms while maintaining
 /// compatibility with Linux where this API is not implemented.


### PR DESCRIPTION
The `autoreleasepool` is technically required on all non-ObjC runtimes. It is likely better to use the unstable `_runtime(_ObjC)` check but for now simply extend the OS list with Windows.