### PR TITLE
build: remove the PreviewServer on Windows

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -63,29 +63,6 @@ let package = Package(
             swiftSettings: swiftSettings
         ),
         
-        // Command-line tool library
-        .target(
-            name: "SwiftDocCUtilities",
-            dependencies: [
-                .target(name: "SwiftDocC"),
-                .product(name: "NIOHTTP1", package: "swift-nio"),
-                .product(name: "ArgumentParser", package: "swift-argument-parser")
-            ],
-            swiftSettings: swiftSettings
-        ),
-        .testTarget(
-            name: "SwiftDocCUtilitiesTests",
-            dependencies: [
-                .target(name: "SwiftDocCUtilities"),
-                .target(name: "SwiftDocC"),
-                .target(name: "SwiftDocCTestUtilities"),
-            ],
-            resources: [
-                .copy("Test Resources"),
-                .copy("Test Bundles"),
-            ],
-            swiftSettings: swiftSettings
-        ),
         // Test utility library
         .target(
             name: "SwiftDocCTestUtilities",
@@ -126,13 +103,61 @@ let package = Package(
     ]
 )
 
+// Command-line tool library
+#if os(Windows)
+package.targets.append(
+    .target(
+        name: "SwiftDocCUtilities",
+        dependencies: [
+            .target(name: "SwiftDocC"),
+            .product(name: "ArgumentParser", package: "swift-argument-parser")
+        ],
+        exclude: [
+            // PreviewServer requires NIO which cannot support non-POSIX platforms.
+            "PreviewServer",
+            "Action/Actions/PreviewAction.swift",
+            "ArgumentParsing/ActionExtensions/PreviewAction+CommandInitialization.swift",
+            "ArgumentParsing/Subcommands/Preview.swift",
+        ],
+        swiftSettings: swiftSettings
+    )
+)
+#else
+package.targets.append(
+    .target(
+        name: "SwiftDocCUtilities",
+        dependencies: [
+            .target(name: "SwiftDocC"),
+            .product(name: "NIOHTTP1", package: "swift-nio"),
+            .product(name: "ArgumentParser", package: "swift-argument-parser")
+        ],
+        swiftSettings: swiftSettings
+    )
+)
+#endif
+
+package.targets.append(
+    .testTarget(
+        name: "SwiftDocCUtilitiesTests",
+        dependencies: [
+            .target(name: "SwiftDocCUtilities"),
+            .target(name: "SwiftDocC"),
+            .target(name: "SwiftDocCTestUtilities"),
+        ],
+        resources: [
+            .copy("Test Resources"),
+            .copy("Test Bundles"),
+        ],
+        swiftSettings: swiftSettings
+    )
+)
+
 // If the `SWIFTCI_USE_LOCAL_DEPS` environment variable is set,
 // we're building in the Swift.org CI system alongside other projects in the Swift toolchain and
 // we can depend on local versions of our dependencies instead of fetching them remotely.
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     // Building standalone, so fetch all dependencies remotely.
     package.dependencies += [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.53.0"),
         .package(url: "https://github.com/apple/swift-markdown.git", branch: "main"),
         .package(url: "https://github.com/apple/swift-lmdb.git", branch: "main"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.2"),
@@ -140,6 +165,12 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(url: "https://github.com/apple/swift-crypto.git", from: "2.5.0"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
     ]
+
+#if !os(Windows)
+    package.dependencies += [
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.53.0"),
+    ]
+#endif
 } else {
     // Building in the Swift.org CI system, so rely on local versions of dependencies.
     package.dependencies += [

--- a/Sources/SwiftDocCUtilities/Docc.swift
+++ b/Sources/SwiftDocCUtilities/Docc.swift
@@ -10,12 +10,17 @@
 
 import ArgumentParser
 
+#if canImport(NIOHTTP)
+private let subcommands: [ParsableCommand.Type] = [Docc.Convert.self, Docc.Index.self, Docc.Preview.self, Docc.ProcessArchive.self]
+#else
+private let subcommands: [ParsableCommand.Type] = [Docc.Convert.self, Docc.Index.self, Docc.ProcessArchive.self]
+#endif
+
 /// The default, command-line interface you use to compile and preview documentation.
 public struct Docc: ParsableCommand {
-
     public static var configuration = CommandConfiguration(
         abstract: "Documentation Compiler: compile, analyze, and preview documentation.",
-        subcommands: [Convert.self, Index.self, Preview.self, ProcessArchive.self])
+        subcommands: subcommands)
 
     public init() {}
 }


### PR DESCRIPTION
This is the critical change to enable Windows support in DocC.  The dependency on NIO is restricted to the PreviewServer and as NIO is incapable of supporting non-POSIX models (or emulation of POSIX models), we cannot use this dependency on Windows.  As a temporary solution, remove the NIO dependency on Windows by removing the PreviewServer.