### PR TITLE
Utility: disable `DirectoryMonitor` on Windows temporarily

### DIFF
--- a/Sources/SwiftDocCUtilities/Utility/DirectoryMonitor.swift
+++ b/Sources/SwiftDocCUtilities/Utility/DirectoryMonitor.swift
@@ -11,7 +11,7 @@
 import Foundation
 import SwiftDocC
 
-#if !os(Linux) && !os(Android)
+#if !os(Linux) && !os(Android) && !os(Windows)
 import Darwin
 
 /// A throttle object to filter events that come too fast.


### PR DESCRIPTION
This temporarily disables the functionality on Windows to match the Linux port.  We should be able to reimplement this functionality as already done in clang and swift-tools-support-core on Windows.