### PR TITLE
docc: indicate Windows as being supported

### DIFF
--- a/Sources/docc/main.swift
+++ b/Sources/docc/main.swift
@@ -8,10 +8,10 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-#if os(macOS) || os(Linux) || os(Android)
+#if os(macOS) || os(Linux) || os(Android) || os(Windows)
 import SwiftDocCUtilities
 
 Docc.main()
 #else
-fatalError("Command line interface supported only on macOS and Linux platforms.") 
+fatalError("Command line interface supported only on macOS, Windows, and Linux platforms.")
 #endif

--- a/Sources/docc/main.swift
+++ b/Sources/docc/main.swift
@@ -13,5 +13,5 @@ import SwiftDocCUtilities
 
 Docc.main()
 #else
-fatalError("Command line interface supported only on macOS, Windows, and Linux platforms.")
+fatalError("Command line interface supported only on macOS, Linux and Windows platforms.")
 #endif


### PR DESCRIPTION
Allow list Windows execution.  Without this change, we would fail to run the CLI tool.