### PR TITLE
Add authoring support for `@TitleHeading` directive

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/External Data/OutOfProcessReferenceResolver.swift
+++ b/Sources/SwiftDocC/Infrastructure/External Data/OutOfProcessReferenceResolver.swift
@@ -276,7 +276,7 @@ public class OutOfProcessReferenceResolver: ExternalReferenceResolver, FallbackR
         // with a render node.
         
         if let topicImages = resolvedInformation.topicImages, !topicImages.isEmpty {
-            let metadata = node.metadata ?? Metadata(originalMarkup: BlockDirective(name: "Metadata", children: []), documentationExtension: nil, technologyRoot: nil, displayName: nil)
+            let metadata = node.metadata ?? Metadata(originalMarkup: BlockDirective(name: "Metadata", children: []), documentationExtension: nil, technologyRoot: nil, displayName: nil, titleHeading: nil)
             
             metadata.pageImages = topicImages.map { topicImage in
                 let purpose: PageImage.Purpose

--- a/Sources/SwiftDocC/Model/Rendering/RenderNode/RenderMetadata.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNode/RenderMetadata.swift
@@ -93,7 +93,7 @@ public struct RenderMetadata: VariantContainer {
     
     /// The variants of the title.
     public var titleVariants: VariantCollection<String?> = .init(defaultValue: nil)
-
+    
     /// An identifier for a symbol generated externally.
     public var externalID: String? {
         get { getVariantDefaultValue(keyPath: \.externalIDVariants) }

--- a/Sources/SwiftDocC/Model/Rendering/RenderNode/RenderMetadata.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNode/RenderMetadata.swift
@@ -85,6 +85,10 @@ public struct RenderMetadata: VariantContainer {
     /// Author provided custom metadata describing the page.
     public var customMetadata: [String: String] = [:]
     
+
+    /// -----------------------------------------------------------------------------
+    /// TODO: MODIFY THIS SECTION????? WHATS THE DIFFERENCE BETWEEN A TITLE AND A TITLE HEADING???
+    
     /// The title of the page.
     public var title: String? {
         get { getVariantDefaultValue(keyPath: \.titleVariants) }
@@ -93,7 +97,10 @@ public struct RenderMetadata: VariantContainer {
     
     /// The variants of the title.
     public var titleVariants: VariantCollection<String?> = .init(defaultValue: nil)
+
+    /// END OF TODO SECTION -----------------------------------------------------------------------------
     
+
     /// An identifier for a symbol generated externally.
     public var externalID: String? {
         get { getVariantDefaultValue(keyPath: \.externalIDVariants) }

--- a/Sources/SwiftDocC/Model/Rendering/RenderNode/RenderMetadata.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNode/RenderMetadata.swift
@@ -85,10 +85,6 @@ public struct RenderMetadata: VariantContainer {
     /// Author provided custom metadata describing the page.
     public var customMetadata: [String: String] = [:]
     
-
-    /// -----------------------------------------------------------------------------
-    /// TODO: MODIFY THIS SECTION????? WHATS THE DIFFERENCE BETWEEN A TITLE AND A TITLE HEADING???
-    
     /// The title of the page.
     public var title: String? {
         get { getVariantDefaultValue(keyPath: \.titleVariants) }
@@ -97,9 +93,6 @@ public struct RenderMetadata: VariantContainer {
     
     /// The variants of the title.
     public var titleVariants: VariantCollection<String?> = .init(defaultValue: nil)
-
-    /// END OF TODO SECTION -----------------------------------------------------------------------------
-    
 
     /// An identifier for a symbol generated externally.
     public var externalID: String? {

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -841,16 +841,15 @@ public struct RenderNodeTranslator: SemanticVisitor {
                 node.metadata.platformsVariants = .init(defaultValue: renderAvailability)
             }
         }
-
+        
         if let pageKind = article.metadata?.pageKind {
             node.metadata.role = pageKind.kind.renderRole.rawValue
             node.metadata.roleHeading = pageKind.kind.titleHeading
         }
         
         if let titleHeading = article.metadata?.titleHeading {
-            node.metadata.role = titleHeading.headingText
             node.metadata.roleHeading = titleHeading.headingText
-        }
+        } 
         
         collectedTopicReferences.append(contentsOf: contentCompiler.collectedTopicReferences)
         node.references = createTopicRenderReferences()
@@ -1251,6 +1250,10 @@ public struct RenderNodeTranslator: SemanticVisitor {
         
         if shouldCreateAutomaticRoleHeading(for: documentationNode) {
             node.metadata.roleHeadingVariants = VariantCollection<String?>(from: symbol.roleHeadingVariants)
+        }
+
+        if let titleHeading = documentationNode.metadata?.titleHeading {
+            node.metadata.roleHeadingVariants = VariantCollection<String?>(defaultValue: titleHeading.headingText)
         }
         
         node.metadata.symbolKindVariants = VariantCollection<String?>(from: symbol.kindVariants) { _, kindVariants in

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -847,6 +847,11 @@ public struct RenderNodeTranslator: SemanticVisitor {
             node.metadata.roleHeading = pageKind.kind.titleHeading
         }
         
+        if let titleHeading = article.metadata?.titleHeading {
+            node.metadata.role = titleHeading.headingText
+            node.metadata.roleHeading = titleHeading.headingText
+        }
+        
         collectedTopicReferences.append(contentsOf: contentCompiler.collectedTopicReferences)
         node.references = createTopicRenderReferences()
 

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -848,7 +848,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
         }
         
         if let titleHeading = article.metadata?.titleHeading {
-            node.metadata.roleHeading = titleHeading.headingText
+            node.metadata.roleHeading = titleHeading.heading
         } 
         
         collectedTopicReferences.append(contentsOf: contentCompiler.collectedTopicReferences)
@@ -1253,7 +1253,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
         }
 
         if let titleHeading = documentationNode.metadata?.titleHeading {
-            node.metadata.roleHeadingVariants = VariantCollection<String?>(defaultValue: titleHeading.headingText)
+            node.metadata.roleHeadingVariants = VariantCollection<String?>(defaultValue: titleHeading.heading)
         }
         
         node.metadata.symbolKindVariants = VariantCollection<String?>(from: symbol.kindVariants) { _, kindVariants in

--- a/Sources/SwiftDocC/Semantics/Article/Article.swift
+++ b/Sources/SwiftDocC/Semantics/Article/Article.swift
@@ -218,7 +218,7 @@ public final class Article: Semantic, MarkupConvertible, Abstracted, Redirected,
             problems.append(Problem(diagnostic: diagnostic, possibleSolutions: solutions))
             
             // Remove the display name customization from the article's metadata.
-            optionalMetadata = Metadata(originalMarkup: metadata.originalMarkup, documentationExtension: metadata.documentationOptions, technologyRoot: metadata.technologyRoot, displayName: nil)
+            optionalMetadata = Metadata(originalMarkup: metadata.originalMarkup, documentationExtension: metadata.documentationOptions, technologyRoot: metadata.technologyRoot, displayName: nil, titleHeading: metadata.titleHeading)
         }
         
         self.init(

--- a/Sources/SwiftDocC/Semantics/Metadata/Metadata.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/Metadata.swift
@@ -27,6 +27,7 @@ import Markdown
 /// - ``Availability``
 /// - ``PageKind``
 /// - ``SupportedLanguage``
+/// - ``TitleHeading``
 public final class Metadata: Semantic, AutomaticDirectiveConvertible {
     public let originalMarkup: BlockDirective
     
@@ -68,6 +69,9 @@ public final class Metadata: Semantic, AutomaticDirectiveConvertible {
     var pageColor: PageColor.Color? {
         _pageColor?.color
     }
+
+    @ChildDirective
+    var titleHeading: TitleHeading? = nil
     
     static var keyPaths: [String : AnyKeyPath] = [
         "documentationOptions"  : \Metadata._documentationOptions,
@@ -79,7 +83,8 @@ public final class Metadata: Semantic, AutomaticDirectiveConvertible {
         "availability"          : \Metadata._availability,
         "pageKind"              : \Metadata._pageKind,
         "supportedLanguages"    : \Metadata._supportedLanguages,
-        "_pageColor"             : \Metadata.__pageColor,
+        "_pageColor"            : \Metadata.__pageColor,
+        "titleHeading"          : \Metadata._titleHeading,
     ]
     
     /// Creates a metadata object with a given markup, documentation extension, and technology root.
@@ -87,12 +92,14 @@ public final class Metadata: Semantic, AutomaticDirectiveConvertible {
     ///   - originalMarkup: The original markup for this metadata directive.
     ///   - documentationExtension: Optional configuration that describes how this documentation extension file merges or overrides the in-source documentation.
     ///   - technologyRoot: Optional configuration to make this page root-level documentation.
-    ///   - displayName:Optional configuration to customize this page's symbol's display name.
-    init(originalMarkup: BlockDirective, documentationExtension: DocumentationExtension?, technologyRoot: TechnologyRoot?, displayName: DisplayName?) {
+    ///   - displayName: Optional configuration to customize this page's symbol's display name.
+    ///   - titleHeading: Optional configuration to customize the text of this page's title heading.
+    init(originalMarkup: BlockDirective, documentationExtension: DocumentationExtension?, technologyRoot: TechnologyRoot?, displayName: DisplayName?, titleHeading: TitleHeading?) {
         self.originalMarkup = originalMarkup
         self.documentationOptions = documentationExtension
         self.technologyRoot = technologyRoot
         self.displayName = displayName
+        self.titleHeading = titleHeading
     }
     
     @available(*, deprecated, message: "Do not call directly. Required for 'AutomaticDirectiveConvertible'.")
@@ -102,7 +109,7 @@ public final class Metadata: Semantic, AutomaticDirectiveConvertible {
     
     func validate(source: URL?, for bundle: DocumentationBundle, in context: DocumentationContext, problems: inout [Problem]) -> Bool {
         // Check that something is configured in the metadata block
-        if documentationOptions == nil && technologyRoot == nil && displayName == nil && pageImages.isEmpty && customMetadata.isEmpty && callToAction == nil && availability.isEmpty && pageKind == nil && pageColor == nil {
+        if documentationOptions == nil && technologyRoot == nil && displayName == nil && pageImages.isEmpty && customMetadata.isEmpty && callToAction == nil && availability.isEmpty && pageKind == nil && pageColor == nil && titleHeading == nil {
             let diagnostic = Diagnostic(
                 source: source,
                 severity: .information,

--- a/Sources/SwiftDocC/Semantics/Metadata/TitleHeading.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/TitleHeading.swift
@@ -11,7 +11,7 @@
 import Foundation
 import Markdown
 
-/// A directive for customizing the text of a page-title heading (aka an eyebrow or kick).
+/// A directive for customizing the text of a page's title heading.
 /// 
 /// @TitleHeading accepts an unnamed parameter containing containing the page-title’s heading text.
 /// 

--- a/Sources/SwiftDocC/Semantics/Metadata/TitleHeading.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/TitleHeading.swift
@@ -13,7 +13,9 @@ import Markdown
 
 /// A directive for customizing the text of a page's title heading.
 /// 
-/// @TitleHeading accepts an unnamed parameter containing containing the page-title’s heading text.
+/// The ``headingText`` property will override the page's default title heading.
+///
+/// @TitleHeading accepts an unnamed parameter containing containing the page's title heading.
 /// 
 /// This directive is only valid within a top-level ``Metadata`` directive:
 /// ```markdown

--- a/Sources/SwiftDocC/Semantics/Metadata/TitleHeading.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/TitleHeading.swift
@@ -1,0 +1,39 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2023 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+import Markdown
+
+/// A directive for customizing the text of a page-title heading (aka an eyebrow or kick).
+/// 
+/// @TitleHeading accepts an unnamed parameter containing containing the page-title’s heading text.
+/// 
+/// This directive is only valid within a top-level ``Metadata`` directive:
+/// ```markdown
+/// @Metadata {
+///    @TitleHeading("Release Notes")
+/// }
+/// ```
+public final class TitleHeading: Semantic, AutomaticDirectiveConvertible {
+    public let originalMarkup: BlockDirective
+
+    /// An unnamed parameter containing containing the page-title’s heading text.
+    @DirectiveArgumentWrapped(name: .unnamed)
+    public var headingText: String
+
+    static var keyPaths: [String : AnyKeyPath] = [
+        "headingText" : \TitleHeading._headingText,
+    ]
+
+    @available(*, deprecated, message: "Do not call directly. Required for 'AutomaticDirectiveConvertible'.")
+    init(originalMarkup: BlockDirective) {
+        self.originalMarkup = originalMarkup
+    }
+}

--- a/Sources/SwiftDocC/Semantics/Metadata/TitleHeading.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/TitleHeading.swift
@@ -13,7 +13,7 @@ import Markdown
 
 /// A directive for customizing the text of a page's title heading.
 /// 
-/// The ``headingText`` property will override the page's default title heading.
+/// The ``heading`` property will override the page's default title heading.
 ///
 /// @TitleHeading accepts an unnamed parameter containing containing the page's title heading.
 /// 
@@ -31,7 +31,7 @@ public final class TitleHeading: Semantic, AutomaticDirectiveConvertible {
     public var heading: String
 
     static var keyPaths: [String : AnyKeyPath] = [
-        "headingText" : \TitleHeading._headingText,
+        "heading" : \TitleHeading._heading,
     ]
 
     @available(*, deprecated, message: "Do not call directly. Required for 'AutomaticDirectiveConvertible'.")

--- a/Sources/SwiftDocC/Semantics/Metadata/TitleHeading.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/TitleHeading.swift
@@ -28,7 +28,7 @@ public final class TitleHeading: Semantic, AutomaticDirectiveConvertible {
 
     /// An unnamed parameter containing containing the page-title’s heading text.
     @DirectiveArgumentWrapped(name: .unnamed)
-    public var headingText: String
+    public var heading: String
 
     static var keyPaths: [String : AnyKeyPath] = [
         "headingText" : \TitleHeading._headingText,

--- a/Sources/docc/DocCDocumentation.docc/DocC.symbols.json
+++ b/Sources/docc/DocCDocumentation.docc/DocC.symbols.json
@@ -5100,13 +5100,19 @@
       "docComment" : {
         "lines" : [
           {
-            "text" : "A directive for customizing the text of a page-title heading (aka an eyebrow or kick)."
+            "text" : "A directive for customizing the text of a page's title heading."
           },
           {
             "text" : ""
           },
           {
-            "text" : "@TitleHeading accepts an unnamed parameter containing containing the page-title’s heading text."
+            "text" : "The ``headingText`` property will override the page's default title heading."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "@TitleHeading accepts an unnamed parameter containing containing the page's title heading."
           },
           {
             "text" : ""

--- a/Sources/docc/DocCDocumentation.docc/DocC.symbols.json
+++ b/Sources/docc/DocCDocumentation.docc/DocC.symbols.json
@@ -2963,6 +2963,9 @@
           },
           {
             "text" : "- ``SupportedLanguage``"
+          },
+          {
+            "text" : "- ``TitleHeading``"
           }
         ]
       },
@@ -5056,6 +5059,145 @@
       },
       "pathComponents" : [
         "TechnologyRoot"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "TitleHeading"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "("
+        },
+        {
+          "kind" : "text",
+          "spelling" : "_ "
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "headingText"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "String"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ")"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "text" : "A directive for customizing the text of a page-title heading (aka an eyebrow or kick)."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "@TitleHeading accepts an unnamed parameter containing containing the page-title’s heading text."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "This directive is only valid within a top-level ``Metadata`` directive:"
+          },
+          {
+            "text" : "```markdown"
+          },
+          {
+            "text" : "@Metadata {"
+          },
+          {
+            "text" : "   @TitleHeading(\"Release Notes\")"
+          },
+          {
+            "text" : "}"
+          },
+          {
+            "text" : "```"
+          },
+          {
+            "text" : "- Parameters:"
+          },
+          {
+            "text" : "  - headingText: An unnamed parameter containing containing the page-title’s heading text."
+          },
+          {
+            "text" : "     **(required)**"
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$TitleHeading"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$TitleHeading",
+            "spelling" : "TitleHeading"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "TitleHeading"
+          },
+          {
+            "kind" : "text",
+            "spelling" : "("
+          },
+          {
+            "kind" : "text",
+            "spelling" : "_ "
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "headingText"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "spelling" : "String"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ")"
+          }
+        ],
+        "title" : "TitleHeading"
+      },
+      "pathComponents" : [
+        "TitleHeading"
       ]
     },
     {

--- a/Sources/docc/DocCDocumentation.docc/DocC.symbols.json
+++ b/Sources/docc/DocCDocumentation.docc/DocC.symbols.json
@@ -5082,7 +5082,7 @@
         },
         {
           "kind" : "identifier",
-          "spelling" : "headingText"
+          "spelling" : "heading"
         },
         {
           "kind" : "text",
@@ -5106,7 +5106,7 @@
             "text" : ""
           },
           {
-            "text" : "The ``headingText`` property will override the page's default title heading."
+            "text" : "The ``heading`` property will override the page's default title heading."
           },
           {
             "text" : ""
@@ -5139,7 +5139,7 @@
             "text" : "- Parameters:"
           },
           {
-            "text" : "  - headingText: An unnamed parameter containing containing the page-title’s heading text."
+            "text" : "  - heading: An unnamed parameter containing containing the page-title’s heading text."
           },
           {
             "text" : "     **(required)**"
@@ -5185,7 +5185,7 @@
           },
           {
             "kind" : "identifier",
-            "spelling" : "headingText"
+            "spelling" : "heading"
           },
           {
             "kind" : "text",

--- a/Sources/docc/DocCDocumentation.docc/Reference Syntax/API Reference Syntax/Metadata.md
+++ b/Sources/docc/DocCDocumentation.docc/Reference Syntax/API Reference Syntax/Metadata.md
@@ -30,6 +30,16 @@ Use the `Metadata` directive with the ``DisplayName`` directive to configure a s
 }
 ```
 
+Use the `Metadata` directive with the ``TitleHeading`` directive to configure the text of a page-title heading (also known as an eyebrow or kick).
+
+```
+# ``SlothCreator``
+
+@Metadata {
+    @TitleHeading("Release Notes")
+}
+```
+
 ## Topics
 
 ### Extending or Overriding Source Documentation
@@ -47,6 +57,7 @@ Use the `Metadata` directive with the ``DisplayName`` directive to configure a s
 - ``PageKind``
 - ``PageColor``
 - ``CallToAction``
+- ``TitleHeading``
 
 ### Customizing the Languages of an Article
 

--- a/Sources/docc/DocCDocumentation.docc/Reference Syntax/API Reference Syntax/Metadata.md
+++ b/Sources/docc/DocCDocumentation.docc/Reference Syntax/API Reference Syntax/Metadata.md
@@ -30,7 +30,7 @@ Use the `Metadata` directive with the ``DisplayName`` directive to configure a s
 }
 ```
 
-Use the `Metadata` directive with the ``TitleHeading`` directive to configure the text of a page-title heading (also known as an eyebrow or kick).
+Use the `Metadata` directive with the ``TitleHeading`` directive to configure the text of a page's title heading.
 
 ```
 # ``SlothCreator``

--- a/Sources/docc/DocCDocumentation.docc/Reference Syntax/API Reference Syntax/TitleHeading.md
+++ b/Sources/docc/DocCDocumentation.docc/Reference Syntax/API Reference Syntax/TitleHeading.md
@@ -1,6 +1,6 @@
 # ``docc/TitleHeading``
 
-Configures a symbol's documentation page and any references to that page to show a custom title heading instead of the default (page kind).
+A directive that specifies a title heading for a given documentation page.
 
 @Metadata {
     @DocumentationExtension(mergeBehavior: override)

--- a/Sources/docc/DocCDocumentation.docc/Reference Syntax/API Reference Syntax/TitleHeading.md
+++ b/Sources/docc/DocCDocumentation.docc/Reference Syntax/API Reference Syntax/TitleHeading.md
@@ -24,11 +24,6 @@ A title heading is also known as a page eyebrow or kicker.
 ```
 
 A custom title heading appears in place of the page kind at the top of the page.
-
-> Note: Customizing the title heading of a symbol page doesn't alter the page's URL.
-
-> Note: Adding a `TitleHeading` directive to a non-symbol page results in a warning. 
-
 ### Containing Elements
 
 The following items can include a title heading element:

--- a/Sources/docc/DocCDocumentation.docc/Reference Syntax/API Reference Syntax/TitleHeading.md
+++ b/Sources/docc/DocCDocumentation.docc/Reference Syntax/API Reference Syntax/TitleHeading.md
@@ -1,0 +1,38 @@
+# ``docc/TitleHeading``
+
+Configures a symbol's documentation page and any references to that page to show a custom title heading instead of the default (page kind).
+
+@Metadata {
+    @DocumentationExtension(mergeBehavior: override)
+}
+
+- Parameters:
+    - headingText: The text for the custom title heading.
+
+## Overview
+
+Place the `TitleHeading` directive within a `Metadata` directive to configure a symbol's documentation page to show a custom title heading. This allows for the creation of custom kinds of pages beyond just articles.
+
+A title heading is also known as a page eyebrow or kicker.
+
+```
+# ``SlothCreator``
+
+@Metadata {
+    @TitleHeading("Release Notes")
+}
+```
+
+A custom title heading appears in place of the page kind at the top of the page.
+
+> Note: Customizing the title heading of a symbol page doesn't alter the page's URL.
+
+> Note: Adding a `TitleHeading` directive to a non-symbol page results in a warning. 
+
+### Containing Elements
+
+The following items can include a title heading element:
+
+- ``Metadata``
+
+<!-- Copyright (c) 2023 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Sources/docc/DocCDocumentation.docc/Reference Syntax/API Reference Syntax/TitleHeading.md
+++ b/Sources/docc/DocCDocumentation.docc/Reference Syntax/API Reference Syntax/TitleHeading.md
@@ -7,7 +7,7 @@ A directive that specifies a title heading for a given documentation page.
 }
 
 - Parameters:
-    - headingText: The text for the custom title heading.
+    - heading: The text for the custom title heading.
 
 ## Overview
 

--- a/Sources/docc/DocCDocumentation.docc/Reference Syntax/API Reference Syntax/TitleHeading.md
+++ b/Sources/docc/DocCDocumentation.docc/Reference Syntax/API Reference Syntax/TitleHeading.md
@@ -28,6 +28,8 @@ A custom title heading appears in place of the page kind at the top of the page.
 
 The following items can include a title heading element:
 
-- ``Metadata``
+@Links(visualStyle: list) {
+   - ``Metadata``
+}
 
 <!-- Copyright (c) 2023 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Sources/docc/DocCDocumentation.docc/Reference Syntax/API Reference Syntax/TitleHeading.md
+++ b/Sources/docc/DocCDocumentation.docc/Reference Syntax/API Reference Syntax/TitleHeading.md
@@ -11,7 +11,7 @@ Configures a symbol's documentation page and any references to that page to show
 
 ## Overview
 
-Place the `TitleHeading` directive within a `Metadata` directive to configure a symbol's documentation page to show a custom title heading. This allows for the creation of custom kinds of pages beyond just articles.
+Place the `TitleHeading` directive within a `Metadata` directive to configure a documentation page to show a custom title heading. Custom title headings, along with custom [page icons](doc:PageImage) and [page colors](doc:PageColor), allow for the creation of custom kinds of pages beyond just articles.
 
 A title heading is also known as a page eyebrow or kicker.
 

--- a/Tests/SwiftDocCTests/Infrastructure/TestExternalReferenceResolvers.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/TestExternalReferenceResolvers.swift
@@ -159,7 +159,7 @@ class TestMultiResultExternalReferenceResolver: ExternalReferenceResolver, Fallb
         // This is a workaround for how external content is processed. See details in OutOfProcessReferenceResolver.addImagesAndCacheMediaReferences(to:from:)
         
         if let topicImages = entityInfo.topicImages {
-            let metadata = node.metadata ?? Metadata(originalMarkup: BlockDirective(name: "Metadata", children: []), documentationExtension: nil, technologyRoot: nil, displayName: nil)
+            let metadata = node.metadata ?? Metadata(originalMarkup: BlockDirective(name: "Metadata", children: []), documentationExtension: nil, technologyRoot: nil, displayName: nil, titleHeading: nil)
             
             metadata.pageImages = topicImages.map { topicImage, alt in
                 let purpose: PageImage.Purpose

--- a/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorTests.swift
@@ -1225,6 +1225,9 @@ class RenderNodeTranslatorTests: XCTestCase {
             roundTrippedArticle.metadata.color?.standardColorIdentifier,
             "yellow"
         )
+
+        XCTAssertEqual(roundTrippedArticle.metadata.roleHeading, "Book-Like Content")
+        XCTAssertEqual(roundTrippedArticle.metadata.role, "article")
      }
     
     func testPageColorMetadataInSymbolExtension() throws {

--- a/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorTests.swift
@@ -230,7 +230,7 @@ class RenderNodeTranslatorTests: XCTestCase {
             let source = """
             # My Article
             My introduction.
-            My exposè.
+            My exposé.
             My conclusion.
             """
             let document = Document(parsing: source, options: .parseBlockDirectives)
@@ -247,7 +247,7 @@ class RenderNodeTranslatorTests: XCTestCase {
             let source = """
             # My Article
             My introduction.
-            My exposè.
+            My exposé.
             My conclusion.
             ## Topics
             ### Basics

--- a/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorTests.swift
@@ -1250,4 +1250,26 @@ class RenderNodeTranslatorTests: XCTestCase {
         let roundTrippedSymbol = try JSONDecoder().decode(RenderNode.self, from: encodedSymbol)
         XCTAssertEqual(roundTrippedSymbol.metadata.color?.standardColorIdentifier, "purple")
     }
+
+    func testTitleHeadingMetadataInSymbolExtension() throws {
+        let (bundle, context) = try testBundleAndContext(named: "MixedManualAutomaticCuration")
+        let reference = ResolvedTopicReference(
+            bundleIdentifier: bundle.identifier,
+            path: "/documentation/TestBed",
+            sourceLanguage: .swift
+        )
+        let symbol = try XCTUnwrap(context.entity(with: reference).semantic as? Symbol)
+        var translator = RenderNodeTranslator(
+            context: context,
+            bundle: bundle,
+            identifier: reference,
+            source: nil
+        )
+        let renderNode = try XCTUnwrap(translator.visitSymbol(symbol) as? RenderNode)
+   
+        let encodedSymbol = try JSONEncoder().encode(renderNode)
+        let roundTrippedSymbol = try JSONDecoder().decode(RenderNode.self, from: encodedSymbol)
+        XCTAssertEqual(roundTrippedSymbol.metadata.roleHeading, "TestBed Notes")
+        XCTAssertEqual(roundTrippedSymbol.metadata.role, "collection")
+    }
 }

--- a/Tests/SwiftDocCTests/Semantics/DirectiveInfrastructure/DirectiveIndexTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/DirectiveInfrastructure/DirectiveIndexTests.swift
@@ -48,6 +48,7 @@ class DirectiveIndexTests: XCTestCase {
                 "Tab",
                 "TabNavigator",
                 "TechnologyRoot",
+                "TitleHeading",
                 "TopicsVisualStyle",
                 "Tutorial",
                 "TutorialReference",

--- a/Tests/SwiftDocCTests/Semantics/DirectiveInfrastructure/DirectiveMirrorTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/DirectiveInfrastructure/DirectiveMirrorTests.swift
@@ -31,6 +31,19 @@ class DirectiveMirrorTests: XCTestCase {
         XCTAssertEqual(reflectedDirective.arguments["style"]?.propertyLabel, "style")
         XCTAssertEqual(reflectedDirective.arguments["style"]?.allowedValues, ["conceptual", "symbol"])
     }
+
+    func testReflectTitleHeadingDirective() {
+        let reflectedDirective = DirectiveMirror(reflecting: TitleHeading.self).reflectedDirective
+        
+        XCTAssertEqual(reflectedDirective.name, "TitleHeading")
+        XCTAssertFalse(reflectedDirective.allowsMarkup)
+        XCTAssertEqual(reflectedDirective.arguments.count, 1)
+        
+        XCTAssertEqual(reflectedDirective.arguments["headingText"]?.unnamed, true)
+        XCTAssertEqual(reflectedDirective.arguments["headingText"]?.required, true)
+        XCTAssertEqual(reflectedDirective.arguments["headingText"]?.labelDisplayName, "_ headingText")
+        XCTAssertEqual(reflectedDirective.arguments["headingText"]?.propertyLabel, "headingText")
+    }
     
     func testReflectMetadataDirective() {
         let reflectedDirective = DirectiveMirror(reflecting: Metadata.self).reflectedDirective
@@ -39,7 +52,7 @@ class DirectiveMirrorTests: XCTestCase {
         XCTAssertFalse(reflectedDirective.allowsMarkup)
         XCTAssert(reflectedDirective.arguments.isEmpty)
         
-        XCTAssertEqual(reflectedDirective.childDirectives.count, 10)
+        XCTAssertEqual(reflectedDirective.childDirectives.count, 11)
         
         XCTAssertEqual(
             reflectedDirective.childDirectives["DocumentationExtension"]?.propertyLabel,

--- a/Tests/SwiftDocCTests/Semantics/DirectiveInfrastructure/DirectiveMirrorTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/DirectiveInfrastructure/DirectiveMirrorTests.swift
@@ -39,10 +39,10 @@ class DirectiveMirrorTests: XCTestCase {
         XCTAssertFalse(reflectedDirective.allowsMarkup)
         XCTAssertEqual(reflectedDirective.arguments.count, 1)
         
-        XCTAssertEqual(reflectedDirective.arguments["headingText"]?.unnamed, true)
-        XCTAssertEqual(reflectedDirective.arguments["headingText"]?.required, true)
-        XCTAssertEqual(reflectedDirective.arguments["headingText"]?.labelDisplayName, "_ headingText")
-        XCTAssertEqual(reflectedDirective.arguments["headingText"]?.propertyLabel, "headingText")
+        XCTAssertEqual(reflectedDirective.arguments["heading"]?.unnamed, true)
+        XCTAssertEqual(reflectedDirective.arguments["heading"]?.required, true)
+        XCTAssertEqual(reflectedDirective.arguments["heading"]?.labelDisplayName, "_ heading")
+        XCTAssertEqual(reflectedDirective.arguments["heading"]?.propertyLabel, "heading")
     }
     
     func testReflectMetadataDirective() {

--- a/Tests/SwiftDocCTests/Semantics/MetadataTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/MetadataTests.swift
@@ -265,6 +265,7 @@ class MetadataTests: XCTestCase {
         let article = Article(from: document, source: nil, for: bundle, in: context, problems: &problems)
         XCTAssertNotNil(article, "An Article value can be created with a Metadata child with a TitleHeading child.")
         XCTAssertNotNil(article?.metadata?.titleHeading, "The Article has the parsed TitleHeading metadata.")
+        XCTAssertNotNil(article?.metadata?.titleHeading?.headingText, "Custom Heading")
         
         XCTAssert(problems.isEmpty, "There shouldn't be any problems. Got:\n\(problems.map { $0.diagnostic.summary })")
         

--- a/Tests/SwiftDocCTests/Semantics/MetadataTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/MetadataTests.swift
@@ -145,7 +145,7 @@ class MetadataTests: XCTestCase {
         XCTAssertNotNil(metadata)
         XCTAssert(problems.isEmpty, "There shouldn't be any problems. Got:\n\(problems.map { $0.diagnostic.summary })")
         
-        XCTAssertEqual(metadata?.titleHeading?.headingText, "Custom Heading")
+        XCTAssertEqual(metadata?.titleHeading?.heading, "Custom Heading")
     }
     
     func testCustomMetadataSupport() throws {
@@ -265,7 +265,7 @@ class MetadataTests: XCTestCase {
         let article = Article(from: document, source: nil, for: bundle, in: context, problems: &problems)
         XCTAssertNotNil(article, "An Article value can be created with a Metadata child with a TitleHeading child.")
         XCTAssertNotNil(article?.metadata?.titleHeading, "The Article has the parsed TitleHeading metadata.")
-        XCTAssertEqual(article?.metadata?.titleHeading?.headingText, "Custom Heading")
+        XCTAssertEqual(article?.metadata?.titleHeading?.heading, "Custom Heading")
         
         XCTAssert(problems.isEmpty, "There shouldn't be any problems. Got:\n\(problems.map { $0.diagnostic.summary })")
         

--- a/Tests/SwiftDocCTests/Semantics/MetadataTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/MetadataTests.swift
@@ -249,31 +249,6 @@ class MetadataTests: XCTestCase {
         XCTAssertEqual(solution.replacements.last?.replacement, "# Custom Name")
     }
 
-    func testSymbolArticleSupportsMetadataTitleHeading() throws {
-        let source = """
-        # ``SomeSymbol``
-        
-        @Metadata {
-           @TitleHeading("Custom Heading")
-        }
-
-        The abstract of this documentation extension
-        """
-        let document = Document(parsing: source, options:  [.parseBlockDirectives, .parseSymbolLinks])
-        let (bundle, context) = try testBundleAndContext(named: "TestBundle")
-        var problems = [Problem]()
-        let article = Article(from: document, source: nil, for: bundle, in: context, problems: &problems)
-        XCTAssertNotNil(article, "An Article value can be created with a Metadata child with a TitleHeading child.")
-        XCTAssertNotNil(article?.metadata?.titleHeading, "The Article has the parsed TitleHeading metadata.")
-        XCTAssertNotNil(article?.metadata?.titleHeading?.headingText, "Custom Heading")
-        
-        XCTAssert(problems.isEmpty, "There shouldn't be any problems. Got:\n\(problems.map { $0.diagnostic.summary })")
-        
-        var analyzer = SemanticAnalyzer(source: nil, context: context, bundle: bundle)
-        _ = analyzer.visit(document)
-        XCTAssert(analyzer.problems.isEmpty, "Expected no problems. Got:\n \(DiagnosticConsoleWriter.formattedDescription(for: analyzer.problems))")
-    }
-
     func testArticleSupportsMetadataTitleHeading() throws {
         let source = """
         # Article title

--- a/Tests/SwiftDocCTests/Semantics/MetadataTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/MetadataTests.swift
@@ -130,6 +130,23 @@ class MetadataTests: XCTestCase {
         
         XCTAssertEqual(metadata?.displayName?.name, "Custom Name")
     }
+
+    func testTitleHeadingSupport() throws {
+        let source = """
+        @Metadata {
+           @TitleHeading("Custom Heading")
+        }
+        """
+        let document = Document(parsing: source, options: .parseBlockDirectives)
+        let directive = document.child(at: 0)! as! BlockDirective
+        let (bundle, context) = try testBundleAndContext(named: "TestBundle")
+        var problems = [Problem]()
+        let metadata = Metadata(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        XCTAssertNotNil(metadata)
+        XCTAssert(problems.isEmpty, "There shouldn't be any problems. Got:\n\(problems.map { $0.diagnostic.summary })")
+        
+        XCTAssertEqual(metadata?.titleHeading?.headingText, "Custom Heading")
+    }
     
     func testCustomMetadataSupport() throws {
         let source = """
@@ -230,6 +247,55 @@ class MetadataTests: XCTestCase {
         
         XCTAssertEqual(solution.replacements.last?.range, SourceLocation(line: 1, column: 1, source: nil) ..< SourceLocation(line: 1, column: 16, source: nil))
         XCTAssertEqual(solution.replacements.last?.replacement, "# Custom Name")
+    }
+
+    func testSymbolArticleSupportsMetadataTitleHeading() throws {
+        let source = """
+        # ``SomeSymbol``
+        
+        @Metadata {
+           @TitleHeading("Custom Heading")
+        }
+
+        The abstract of this documentation extension
+        """
+        let document = Document(parsing: source, options:  [.parseBlockDirectives, .parseSymbolLinks])
+        let (bundle, context) = try testBundleAndContext(named: "TestBundle")
+        var problems = [Problem]()
+        let article = Article(from: document, source: nil, for: bundle, in: context, problems: &problems)
+        XCTAssertNotNil(article, "An Article value can be created with a Metadata child with a TitleHeading child.")
+        XCTAssertNotNil(article?.metadata?.titleHeading, "The Article has the parsed TitleHeading metadata.")
+        
+        XCTAssert(problems.isEmpty, "There shouldn't be any problems. Got:\n\(problems.map { $0.diagnostic.summary })")
+        
+        var analyzer = SemanticAnalyzer(source: nil, context: context, bundle: bundle)
+        _ = analyzer.visit(document)
+        XCTAssert(analyzer.problems.isEmpty, "Expected no problems. Got:\n \(DiagnosticConsoleWriter.formattedDescription(for: analyzer.problems))")
+    }
+
+    func testArticleSupportsMetadataTitleHeading() throws {
+        let source = """
+        # Article title
+        
+        @Metadata {
+           @TitleHeading("Custom Heading")
+        }
+
+        The abstract of this documentation extension
+        """
+        let document = Document(parsing: source, options:  [.parseBlockDirectives, .parseSymbolLinks])
+        let (bundle, context) = try testBundleAndContext(named: "TestBundle")
+        var problems = [Problem]()
+        let article = Article(from: document, source: nil, for: bundle, in: context, problems: &problems)
+        XCTAssertNotNil(article, "An Article value can be created with a Metadata child with a TitleHeading child.")
+        XCTAssertNotNil(article?.metadata?.titleHeading, "The Article has the parsed TitleHeading metadata.")
+        XCTAssertEqual(article?.metadata?.titleHeading?.headingText, "Custom Heading")
+        
+        XCTAssert(problems.isEmpty, "There shouldn't be any problems. Got:\n\(problems.map { $0.diagnostic.summary })")
+        
+        var analyzer = SemanticAnalyzer(source: nil, context: context, bundle: bundle)
+        _ = analyzer.visit(document)
+        XCTAssert(analyzer.problems.isEmpty, "Expected no problems. Got:\n \(DiagnosticConsoleWriter.formattedDescription(for: analyzer.problems))")
     }
     
     func testDuplicateMetadata() throws {

--- a/Tests/SwiftDocCTests/Test Bundles/BookLikeContent.docc/MyArticle.md
+++ b/Tests/SwiftDocCTests/Test Bundles/BookLikeContent.docc/MyArticle.md
@@ -7,6 +7,7 @@ This is the abstract of my article. Nice!
     @PageImage(source: "figure1", alt: "An example figure.", purpose: card)
     @CustomMetadata(key: "country", value: "Belgium")
     @PageColor(yellow)
+    @TitleHeading("Book-Like Content")
 }
 
 @Row(numberOfColumns: 8) {

--- a/Tests/SwiftDocCTests/Test Bundles/MixedManualAutomaticCuration.docc/TestBed.md
+++ b/Tests/SwiftDocCTests/Test Bundles/MixedManualAutomaticCuration.docc/TestBed.md
@@ -2,6 +2,7 @@
 
 @Metadata {
     @PageColor(purple)
+    @TitleHeading("TestBed Notes")
 }
 
 TestBed framework.


### PR DESCRIPTION
Bug/issue #: #408

## Summary

Add support for an `@TitleHeading` directive that allows for customizing the text of a page-title heading (also known as an eyebrow or kick).


## Testing

### With a documentation catalog

In a documentation catalog with symbol graph files and documentation extension files:

1. Preview the documentation for that docc catalog with `docc preview /path/to/Example.docc` 
2. In the documentation extension file for the module symbol: add a title heading directive. For example:
    ```
    @Metadata {
        @TitleHeading("Release Notes")
    }
    ``` 
3. Navigate to that page in the preview. The custom title heading ("Release Notes") should appear as the title heading for that symbol.


## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
