### PR TITLE
Remove `#if os` check on Package.swift file

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -62,6 +62,29 @@ let package = Package(
             ],
             swiftSettings: swiftSettings
         ),
+        // Command-line tool library
+        .target(
+            name: "SwiftDocCUtilities",
+            dependencies: [
+                .target(name: "SwiftDocC"),
+                .product(name: "NIOHTTP1", package: "swift-nio", condition: .when(platforms: [.macOS, .iOS, .linux, .android])),
+                .product(name: "ArgumentParser", package: "swift-argument-parser")
+            ],
+            swiftSettings: swiftSettings
+        ),
+        .testTarget(
+            name: "SwiftDocCUtilitiesTests",
+            dependencies: [
+                .target(name: "SwiftDocCUtilities"),
+                .target(name: "SwiftDocC"),
+                .target(name: "SwiftDocCTestUtilities"),
+            ],
+            resources: [
+                .copy("Test Resources"),
+                .copy("Test Bundles"),
+            ],
+            swiftSettings: swiftSettings
+        ),
         
         // Test utility library
         .target(
@@ -103,77 +126,13 @@ let package = Package(
     ]
 )
 
-// Command-line tool library
-#if os(Windows)
-package.targets.append(contentsOf: [
-    .target(
-        name: "SwiftDocCUtilities",
-        dependencies: [
-            .target(name: "SwiftDocC"),
-            .product(name: "ArgumentParser", package: "swift-argument-parser")
-        ],
-        exclude: [
-            // PreviewServer requires NIO which cannot support non-POSIX platforms.
-            "PreviewServer",
-            "Action/Actions/PreviewAction.swift",
-            "ArgumentParsing/ActionExtensions/PreviewAction+CommandInitialization.swift",
-            "ArgumentParsing/Subcommands/Preview.swift",
-        ],
-        swiftSettings: swiftSettings
-    ),
-    .testTarget(
-        name: "SwiftDocCUtilitiesTests",
-        dependencies: [
-            .target(name: "SwiftDocCUtilities"),
-            .target(name: "SwiftDocC"),
-            .target(name: "SwiftDocCTestUtilities"),
-        ],
-        exclude: [
-            // PreviewServer requires NIO which cannot support non-POSIX platforms.
-            "ArgumentParsing/PreviewSubcommandTests.swift",
-            "PreviewActionIntegrationTests.swift",
-            "PreviewServer",
-        ],
-        resources: [
-            .copy("Test Resources"),
-            .copy("Test Bundles"),
-        ],
-        swiftSettings: swiftSettings
-    ),
-])
-#else
-package.targets.append(contentsOf: [
-    .target(
-        name: "SwiftDocCUtilities",
-        dependencies: [
-            .target(name: "SwiftDocC"),
-            .product(name: "NIOHTTP1", package: "swift-nio"),
-            .product(name: "ArgumentParser", package: "swift-argument-parser")
-        ],
-        swiftSettings: swiftSettings
-    ),
-    .testTarget(
-        name: "SwiftDocCUtilitiesTests",
-        dependencies: [
-            .target(name: "SwiftDocCUtilities"),
-            .target(name: "SwiftDocC"),
-            .target(name: "SwiftDocCTestUtilities"),
-        ],
-        resources: [
-            .copy("Test Resources"),
-            .copy("Test Bundles"),
-        ],
-        swiftSettings: swiftSettings
-    ),
-])
-#endif
-
 // If the `SWIFTCI_USE_LOCAL_DEPS` environment variable is set,
 // we're building in the Swift.org CI system alongside other projects in the Swift toolchain and
 // we can depend on local versions of our dependencies instead of fetching them remotely.
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     // Building standalone, so fetch all dependencies remotely.
     package.dependencies += [
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.53.0"),
         .package(url: "https://github.com/apple/swift-markdown.git", branch: "main"),
         .package(url: "https://github.com/apple/swift-lmdb.git", branch: "main"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.2"),
@@ -181,12 +140,6 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(url: "https://github.com/apple/swift-crypto.git", from: "2.5.0"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.2.0"),
     ]
-
-#if !os(Windows)
-    package.dependencies += [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.53.0"),
-    ]
-#endif
 } else {
     // Building in the Swift.org CI system, so rely on local versions of dependencies.
     package.dependencies += [

--- a/Sources/SwiftDocCUtilities/Action/Actions/PreviewAction.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/PreviewAction.swift
@@ -8,6 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+#if canImport(NIOHTTP1)
 import Foundation
 import SwiftDocC
 
@@ -272,3 +273,4 @@ extension DocumentationContext {
         }
     }
 }
+#endif

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/ActionExtensions/PreviewAction+CommandInitialization.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/ActionExtensions/PreviewAction+CommandInitialization.swift
@@ -8,6 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+#if canImport(NIOHTTP1)
 import Foundation
 
 extension PreviewAction {
@@ -33,3 +34,4 @@ extension PreviewAction {
             printTemplatePath: printTemplatePath)
     }
 }
+#endif

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Preview.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Preview.swift
@@ -8,6 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+#if canImport(NIOHTTP1)
 import ArgumentParser
 import Foundation
 
@@ -52,3 +53,4 @@ extension Docc {
         }
     }
 }
+#endif

--- a/Sources/SwiftDocCUtilities/PreviewServer/PreviewHTTPHandler.swift
+++ b/Sources/SwiftDocCUtilities/PreviewServer/PreviewHTTPHandler.swift
@@ -8,6 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+#if canImport(NIOHTTP1)
 import Foundation
 import NIO
 import NIOHTTP1
@@ -131,3 +132,4 @@ final class PreviewHTTPHandler: ChannelInboundHandler {
         completeResponse(context, trailers: nil, promise: nil)
     }
 }
+#endif

--- a/Sources/SwiftDocCUtilities/PreviewServer/PreviewServer.swift
+++ b/Sources/SwiftDocCUtilities/PreviewServer/PreviewServer.swift
@@ -8,6 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+#if canImport(NIOHTTP1)
 import Foundation
 import SwiftDocC
 
@@ -185,3 +186,4 @@ final class PreviewServer {
         print("Stopped preview server at \(bindTo)", to: &logHandle)
     }
 }
+#endif

--- a/Sources/SwiftDocCUtilities/PreviewServer/RequestHandler/DefaultRequestHandler.swift
+++ b/Sources/SwiftDocCUtilities/PreviewServer/RequestHandler/DefaultRequestHandler.swift
@@ -8,6 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+#if canImport(NIOHTTP1)
 import Foundation
 import NIO
 import NIOHTTP1
@@ -46,3 +47,4 @@ struct DefaultRequestHandler: RequestHandlerFactory {
         }
     }
 }
+#endif

--- a/Sources/SwiftDocCUtilities/PreviewServer/RequestHandler/ErrorRequestHandler.swift
+++ b/Sources/SwiftDocCUtilities/PreviewServer/RequestHandler/ErrorRequestHandler.swift
@@ -8,6 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+#if canImport(NIOHTTP1)
 import Foundation
 import NIO
 import NIOHTTP1
@@ -52,3 +53,4 @@ struct ErrorRequestHandler: RequestHandlerFactory {
         }
     }
 }
+#endif

--- a/Sources/SwiftDocCUtilities/PreviewServer/RequestHandler/FileRequestHandler.swift
+++ b/Sources/SwiftDocCUtilities/PreviewServer/RequestHandler/FileRequestHandler.swift
@@ -8,6 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+#if canImport(NIOHTTP1)
 import Foundation
 import NIO
 import NIOHTTP1
@@ -189,3 +190,4 @@ struct FileRequestHandler: RequestHandlerFactory {
             }
     }
 }
+#endif

--- a/Sources/SwiftDocCUtilities/PreviewServer/RequestHandler/HTTPResponseHead+FromRequest.swift
+++ b/Sources/SwiftDocCUtilities/PreviewServer/RequestHandler/HTTPResponseHead+FromRequest.swift
@@ -8,6 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+#if canImport(NIOHTTP1)
 import Foundation
 import NIOHTTP1
 
@@ -36,3 +37,4 @@ extension HTTPResponseHead {
         }
     }
 }
+#endif

--- a/Sources/SwiftDocCUtilities/PreviewServer/RequestHandler/RequestHandlerFactory.swift
+++ b/Sources/SwiftDocCUtilities/PreviewServer/RequestHandler/RequestHandlerFactory.swift
@@ -8,6 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+#if canImport(NIOHTTP1)
 import NIO
 import NIOHTTP1
 
@@ -20,3 +21,4 @@ protocol RequestHandlerFactory {
     func create<ChannelHandler: ChannelInboundHandler>(channelHandler: ChannelHandler) -> RequestHandler
         where ChannelHandler.OutboundOut == HTTPServerResponsePart
 }
+#endif

--- a/Tests/SwiftDocCUtilitiesTests/ArgumentParsing/PreviewSubcommandTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ArgumentParsing/PreviewSubcommandTests.swift
@@ -8,6 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+#if canImport(NIOHTTP1)
 import XCTest
 @testable import SwiftDocCUtilities
 
@@ -98,3 +99,4 @@ class PreviewSubcommandTests: XCTestCase {
         }
     }
 }
+#endif

--- a/Tests/SwiftDocCUtilitiesTests/PreviewActionIntegrationTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/PreviewActionIntegrationTests.swift
@@ -8,6 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+#if canImport(NIOHTTP1)
 import XCTest
 @testable import SwiftDocC
 @testable import SwiftDocCUtilities
@@ -544,3 +545,4 @@ class PreviewActionIntegrationTests: XCTestCase {
         super.tearDown()
     }
 }
+#endif

--- a/Tests/SwiftDocCUtilitiesTests/PreviewServer/HTTPClient.swift
+++ b/Tests/SwiftDocCUtilitiesTests/PreviewServer/HTTPClient.swift
@@ -8,6 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+#if canImport(NIOHTTP1)
 import Foundation
 import NIO
 import NIOHTTP1
@@ -98,3 +99,4 @@ final class HTTPClient {
         try? group.syncShutdownGracefully()
     }
 }
+#endif

--- a/Tests/SwiftDocCUtilitiesTests/PreviewServer/PreviewHTTPHandlerTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/PreviewServer/PreviewHTTPHandlerTests.swift
@@ -8,6 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+#if canImport(NIOHTTP1)
 import Foundation
 import XCTest
 @testable import SwiftDocC
@@ -82,3 +83,4 @@ class PreviewHTTPHandlerTests: XCTestCase {
         }
     }
 }
+#endif

--- a/Tests/SwiftDocCUtilitiesTests/PreviewServer/PreviewServerTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/PreviewServer/PreviewServerTests.swift
@@ -8,6 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+#if canImport(NIOHTTP1)
 import XCTest
 import Foundation
 
@@ -206,3 +207,4 @@ class PreviewServerTests {
         XCTAssertEqual("\(socketBind)", "/tmp/file.sock")
     }
 }
+#endif

--- a/Tests/SwiftDocCUtilitiesTests/PreviewServer/RequestHandler/DefaultRequestHandlerTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/PreviewServer/RequestHandler/DefaultRequestHandlerTests.swift
@@ -8,6 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+#if canImport(NIOHTTP1)
 import Foundation
 import XCTest
 @testable import SwiftDocC
@@ -57,3 +58,4 @@ class DefaultRequestHandlerTests: XCTestCase {
     }
 
 }
+#endif

--- a/Tests/SwiftDocCUtilitiesTests/PreviewServer/RequestHandler/ErrorRequestHandlerTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/PreviewServer/RequestHandler/ErrorRequestHandlerTests.swift
@@ -8,6 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+#if canImport(NIOHTTP1)
 import Foundation
 import XCTest
 @testable import SwiftDocC
@@ -54,3 +55,4 @@ class ErrorRequestHandlerTests: XCTestCase {
         XCTAssertEqual(response.body, "Message!")
     }
 }
+#endif

--- a/Tests/SwiftDocCUtilitiesTests/PreviewServer/RequestHandler/FileRequestHandlerTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/PreviewServer/RequestHandler/FileRequestHandlerTests.swift
@@ -8,6 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+#if canImport(NIOHTTP1)
 import Foundation
 import XCTest
 @testable import SwiftDocC
@@ -151,3 +152,4 @@ class FileRequestHandlerTests: XCTestCase {
         XCTAssertEqual(response.requestError?.status.code, RequestError.init(status: .badRequest).status.code)
     }
 }
+#endif

--- a/Tests/SwiftDocCUtilitiesTests/PreviewServer/ServerTestUtils.swift
+++ b/Tests/SwiftDocCUtilitiesTests/PreviewServer/ServerTestUtils.swift
@@ -8,6 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+#if canImport(NIOHTTP1)
 import Foundation
 import NIO
 import NIOHTTP1
@@ -104,3 +105,4 @@ func responseWithPipeline(request: HTTPRequestHead, handler factory: RequestHand
     response.requestError = channelHandler.requestError
     return response
 }
+#endif


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

A follow-up PR for #608 (Revert the change of Package.swift in that PR)

See https://github.com/apple/swift-docc/pull/608#issuecomment-1580891971

TLDR: Adding #if os check on Manifest file is not a good practice because it only indicates the host platform not the destination platform.

Imagine the following two scenarios: 
1. We have added the cross compile ability to SwiftPM (Build Linux product on Windows) then the check here will give us a wrong answer. 

2. We have added a new platform support which NIO also does not support and NIO support for Windows is ready.

For the original code, we need to remove the exclude for Windows and then add another exclude for the new platform. 

- In this simple case only one dependency NIO is considered, it would be simple to change `#if os(Windows)` to `#if os(newOS)`

- But if there are multi dependency and Windows is getting support for only one dependency then  we will have to maintain such code for the 2 platform

For the updated code, no major changed is needed. If NIO adds Windows support, we just add it to the `condition: .when(platforms: [.macOS, .linux, .android])` array. And that's it.

## Testing

- [ ] Windows Platform build is not checked.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
