### PR TITLE
Tests: replace `sleep` with `Thread.sleep(forTimeInterval:)`

### DIFF
--- a/Tests/SwiftDocCTests/Utility/SynchronizationTests.swift
+++ b/Tests/SwiftDocCTests/Utility/SynchronizationTests.swift
@@ -73,7 +73,7 @@ class SynchronizationTests: XCTestCase {
 
         // Schedule the synchronized block of work asynchronously
         testQueue.async {
-            synced.sync { _ in _ = sleep(5) }
+            synced.sync { _ in Thread.sleep(forTimeInterval: 5) }
         }
         
         // Asynchronously perform a check after 0.25 secs that the lock is locked
@@ -112,7 +112,7 @@ class SynchronizationTests: XCTestCase {
         // Block the access for a second, then update to `true`
         testQueue.async {
             synced.sync {
-                _ = sleep(1)
+                Thread.sleep(forTimeInterval: 1)
                 $0 = true
             }
         }
@@ -147,7 +147,7 @@ class SynchronizationTests: XCTestCase {
         // Block the access for a second, then update to `true`
         testQueue.async {
             synced.sync {
-                _ = sleep(5)
+                Thread.sleep(forTimeInterval: 5)
                 value = true
             }
         }


### PR DESCRIPTION
`sleep` is not portable as it is not a standard C function.  Use the Foundation function to provide a single codepath across all the targets.