### PR TITLE
Fix a crash when linking to a symbol that doesn't have a page

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchyBasedLinkResolver.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchyBasedLinkResolver.swift
@@ -219,7 +219,12 @@ final class PathHierarchyBasedLinkResolver {
         do {
             let parentID = resolvedReferenceMap[parent]
             let found = try pathHierarchy.find(path: Self.path(for: unresolvedReference), parent: parentID, onlyFindSymbols: isCurrentlyResolvingSymbolLink)
-            let foundReference = resolvedReferenceMap[found]!
+            guard let foundReference = resolvedReferenceMap[found] else {
+                // It's possible for the path hierarchy to find a symbol that the local build doesn't create a page for. Such symbols can't be linked to.
+                let simplifiedFoundPath = sequence(first: pathHierarchy.lookup[found]!, next: \.parent)
+                    .map(\.name).reversed().joined(separator: "/")
+                return .failure(unresolvedReference, .init("\(simplifiedFoundPath.singleQuoted) has no page and isn't available for linking."))
+            }
             
             return .success(foundReference)
         } catch let error as PathHierarchy.Error {


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://110177531

## Summary

This fixes a crash when writing a symbol link to a symbol that doesn't have a page.

The hierarchy based link resolver used to assume that every symbol from the symbol graph files could be linked to but that isn't true. Some default implementation symbols don't have pages in the documentation build and aren't available for linking.

With this change, the link resolver detects that there is no page for the found symbol and raises a specific error message.

## Dependencies

None

## Testing

In a project where extension symbols are disabled (`DOCC_EXTRACT_EXTENSION_SYMBOLS = NO` in Xcode, ` --exclude-extended-types` with the Swift-DocC plugin

- Extend an external protocol with a new public symbol. For example
  ```swift
  extension Identifiable {
      public func something() {}
  }
  ```

- Link to the symbol on the extended type. For example
  ```swift
  /// ``Identifiable/something()``
  public struct Something { }
  ```

Instead of crashing, DocC should warn that the symbol has no page and isn't available for linking.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
