### PR TITLE
[5.9] Fix a crash when linking to a symbol that doesn't have a page 

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchyBasedLinkResolver.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchyBasedLinkResolver.swift
@@ -219,7 +219,12 @@ final class PathHierarchyBasedLinkResolver {
         do {
             let parentID = resolvedReferenceMap[parent]
             let found = try pathHierarchy.find(path: Self.path(for: unresolvedReference), parent: parentID, onlyFindSymbols: isCurrentlyResolvingSymbolLink)
-            let foundReference = resolvedReferenceMap[found]!
+            guard let foundReference = resolvedReferenceMap[found] else {
+                // It's possible for the path hierarchy to find a symbol that the local build doesn't create a page for. Such symbols can't be linked to.
+                let simplifiedFoundPath = sequence(first: pathHierarchy.lookup[found]!, next: \.parent)
+                    .map(\.name).reversed().joined(separator: "/")
+                return .failure(unresolvedReference, .init("\(simplifiedFoundPath.singleQuoted) has no page and isn't available for linking."))
+            }
             
             return .success(foundReference)
         } catch let error as PathHierarchy.Error {


### PR DESCRIPTION
- **Explanation**: Warn instead of crashing when linking to a symbol that doesn't have a page in that documentation build.
- **Scope**: Crashes for certain authored symbol links.
- **Issue**: rdar://110177531
- **Risk**: Low.
- **Testing**: Added unit test to verify that a minimal example that used to crash now raise a warning instead.
- **Original PR:** #617 
- **Reviewers**: @QuietMisdreavus 
