### PR TITLE
Tests: use `XCTUnwrap` over forced unwrappng

### DIFF
--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -2548,7 +2548,7 @@ let expected = """
                         subdirectory: "Test Resources")!),
         ]).write(inside: tempURL)
         
-        let (_, _, context) = try! loadBundle(from: bundleURL)
+        let (_, _, context) = try XCTUnwrap(loadBundle(from: bundleURL))
         
         // MissingDocs contains a struct that has a link to a non-existent type.
         // If there are no problems, that indicates that symbol graph link


### PR DESCRIPTION
Failure to unwrap would trigger an assertion failure whereas the use of `XCTUnwrap` will fail the test case and permit the remainder of the test suite to be processed.  This allows us to better understand the state of the test suite coverage when porting.