### PR TITLE
keep the original URL when decoding Download/ExternalLocationReference

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/References/ExternalLocationReference.swift
+++ b/Sources/SwiftDocC/Model/Rendering/References/ExternalLocationReference.swift
@@ -24,16 +24,9 @@ public struct ExternalLocationReference: RenderReference, URLReference {
 
     public private(set) var type: RenderReferenceType = .externalLocation
 
-    public var identifier: RenderReferenceIdentifier {
-        didSet {
-            // Keep the url property in sync if it was just a copy of the reference identifier
-            if self.url == oldValue.identifier {
-                self.url = identifier.identifier
-            }
-        }
-    }
+    public let identifier: RenderReferenceIdentifier
 
-    private var url: String
+    private let url: String
 
     enum CodingKeys: String, CodingKey {
         case type

--- a/Sources/SwiftDocC/Model/Rendering/References/ExternalLocationReference.swift
+++ b/Sources/SwiftDocC/Model/Rendering/References/ExternalLocationReference.swift
@@ -43,12 +43,7 @@ public struct ExternalLocationReference: RenderReference, URLReference {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
         self.identifier = try container.decode(RenderReferenceIdentifier.self, forKey: .identifier)
-        let url = try container.decodeIfPresent(String.self, forKey: .url)
-        if let url = url {
-            self.url = url
-        } else {
-            self.url = self.identifier.identifier
-        }
+        self.url = try container.decode(String.self, forKey: .url)
         self.type = try container.decode(RenderReferenceType.self, forKey: .type)
     }
 

--- a/Sources/SwiftDocC/Model/Rendering/References/ExternalLocationReference.swift
+++ b/Sources/SwiftDocC/Model/Rendering/References/ExternalLocationReference.swift
@@ -26,7 +26,7 @@ public struct ExternalLocationReference: RenderReference, URLReference {
 
     public let identifier: RenderReferenceIdentifier
 
-    private let url: String
+    let url: String
 
     enum CodingKeys: String, CodingKey {
         case type

--- a/Sources/SwiftDocC/Model/Rendering/Tutorial/References/DownloadReference.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Tutorial/References/DownloadReference.swift
@@ -27,6 +27,12 @@ public struct DownloadReference: RenderReference, URLReference, Equatable {
     /// The location of the downloadable resource.
     public var url: URL
 
+    /// Indicates whether the ``url`` property was loaded from the regular initializer or from the
+    /// `Decodable` initializer.
+    ///
+    /// This is used during encoding to determine whether to filter ``url`` through the
+    /// `renderURL(for:)` method. In case the URL was loaded from JSON, we don't want to modify it
+    /// further after a round-trip.
     private var urlWasDecoded = false
 
     /// The SHA512 hash value for the resource.

--- a/Tests/SwiftDocCTests/Rendering/Rendering Fixtures/external-location-custom-url.json
+++ b/Tests/SwiftDocCTests/Rendering/Rendering Fixtures/external-location-custom-url.json
@@ -1,0 +1,110 @@
+{
+  "schemaVersion" : {
+    "major" : 1,
+    "minor" : 0,
+    "patch" : 0
+  },
+  "seeAlsoSections" : [ ],
+  "metadata" : {
+    "platforms" : [
+      {
+        "name" : "macOS",
+        "introducedAt" : "10.15"
+      }
+    ],
+    "modules" : [
+      { "name" : "MyKit" }
+    ],
+    "title" : "Wifi Access",
+    "roleHeading" : "Plist Key"
+  },
+  "abstract" : [
+    {
+      "type" : "text",
+      "text" : "A "
+    },
+    {
+      "type" : "codeVoice",
+      "code" : "WiFi access"
+    },
+    {
+      "type" : "text",
+      "text" : " abstract description."
+    }
+  ],
+  "sections" : [
+  ],
+  "identifier" : {
+      "url" : "doc:\/\/org.swift.docc.example\/plist\/wifiaccess",
+      "interfaceLanguage": "swift"
+  },
+  "hierarchy" : {
+    "paths" : [["doc:\/\/org.swift.docc.example\/plist\/wifiaccess"]]
+  },
+  "topicSections" : [
+  ],
+  "kind" : "symbol",
+  "references" : {
+    "doc:\/\/org.swift.docc.example\/downloads\/sample.zip": {
+      "identifier": "ExternalLocation.zip",
+      "url": "https://example.com/ExternalLocation.zip",
+      "type": "externalLocation"
+    },
+    "doc:\/\/org.swift.docc.example\/plist\/wifiaccess": {
+      "abstract" : [
+        {
+          "text" : "WiFi access",
+          "type" : "text"
+        }
+      ],
+      "identifier" : "doc:\/\/org.swift.docc.example\/plist\/wifiaccess",
+      "kind" : "symbol",
+      "title" : "WiFi Access",
+      "type" : "topic",
+      "url" : "\/documentation\/mykit"
+    }
+  },
+  "sampleCodeDownload": {
+      "action": {
+          "identifier": "doc:\/\/org.swift.docc.example\/downloads\/sample.zip",
+          "isActive": true,
+          "overridingTitle": "Download",
+          "type": "reference"
+      }
+  },
+  "primaryContentSections" : [
+    {
+      "kind" : "content",
+      "content" : [
+        {
+          "anchor" : "discussion",
+          "level" : 2,
+          "type" : "heading",
+          "text" : "Discussion"
+        },
+        {
+          "type" : "paragraph",
+          "inlineContent" : [
+            {
+              "type" : "text",
+              "text" : "Use "
+            },
+            {
+              "type" : "codeVoice",
+              "code" : "Wifi access"
+            },
+            {
+              "type" : "text",
+              "text" : " to secure wifi access for your app."
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "variants": [{
+      "paths" : ["\/plist\/wifiaccess"],
+      "traits" : []
+  }]
+}
+

--- a/Tests/SwiftDocCTests/Rendering/SampleDownloadTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/SampleDownloadTests.swift
@@ -240,4 +240,22 @@ class SampleDownloadTests: XCTestCase {
         let reference = try XCTUnwrap(renderNode.references[identifier.identifier])
         XCTAssert(reference is ExternalLocationReference)
     }
+
+    /// Ensure that a DownloadReference where the URL is different from the reference identifier
+    /// can still round-trip through an ExternalLocationReference with the URL and reference identifier intact.
+    func testRoundTripWithDifferentUrl() throws {
+        let baseReference = DownloadReference(identifier: .init("DownloadReference.zip"), renderURL: .init(string: "https://example.com/DownloadReference.zip")!, checksum: nil)
+
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+
+        let encodedReference = try encoder.encode(baseReference)
+
+        let interimReference = try decoder.decode(ExternalLocationReference.self, from: encodedReference)
+        let interimEncodedReference = try encoder.encode(interimReference)
+
+        let roundTripReference = try decoder.decode(DownloadReference.self, from: interimEncodedReference)
+
+        XCTAssertEqual(baseReference, roundTripReference)
+    }
 }


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://110536969

## Summary

When a DownloadReference or ExternalLocationReference are decoded from JSON, they both modify URL when re-encoded back to JSON. This can cause issues if the URL is different from what either of these types use as their default (`/downloads/file` and the identifier, respectively). This PR tweaks the Codable logic for both of these types to always use the decoded URL when re-encoding.

## Dependencies

None

## Testing

This bug manifests when the Render JSON is modified after rendering, and then re-encoded after the fact. As such, testing is restricted to the automated test added in this PR.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ n/a ] Updated documentation if necessary
