### PR TITLE
Add authoring support for `@TitleHeading` directive

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/External Data/OutOfProcessReferenceResolver.swift
+++ b/Sources/SwiftDocC/Infrastructure/External Data/OutOfProcessReferenceResolver.swift
@@ -276,7 +276,7 @@ public class OutOfProcessReferenceResolver: ExternalReferenceResolver, FallbackR
         // with a render node.
         
         if let topicImages = resolvedInformation.topicImages, !topicImages.isEmpty {
-            let metadata = node.metadata ?? Metadata(originalMarkup: BlockDirective(name: "Metadata", children: []), documentationExtension: nil, technologyRoot: nil, displayName: nil)
+            let metadata = node.metadata ?? Metadata(originalMarkup: BlockDirective(name: "Metadata", children: []), documentationExtension: nil, technologyRoot: nil, displayName: nil, titleHeading: nil)
             
             metadata.pageImages = topicImages.map { topicImage in
                 let purpose: PageImage.Purpose

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -841,11 +841,15 @@ public struct RenderNodeTranslator: SemanticVisitor {
                 node.metadata.platformsVariants = .init(defaultValue: renderAvailability)
             }
         }
-
+        
         if let pageKind = article.metadata?.pageKind {
             node.metadata.role = pageKind.kind.renderRole.rawValue
             node.metadata.roleHeading = pageKind.kind.titleHeading
         }
+        
+        if let titleHeading = article.metadata?.titleHeading {
+            node.metadata.roleHeading = titleHeading.heading
+        } 
         
         collectedTopicReferences.append(contentsOf: contentCompiler.collectedTopicReferences)
         node.references = createTopicRenderReferences()
@@ -1246,6 +1250,10 @@ public struct RenderNodeTranslator: SemanticVisitor {
         
         if shouldCreateAutomaticRoleHeading(for: documentationNode) {
             node.metadata.roleHeadingVariants = VariantCollection<String?>(from: symbol.roleHeadingVariants)
+        }
+
+        if let titleHeading = documentationNode.metadata?.titleHeading {
+            node.metadata.roleHeadingVariants = VariantCollection<String?>(defaultValue: titleHeading.heading)
         }
         
         node.metadata.symbolKindVariants = VariantCollection<String?>(from: symbol.kindVariants) { _, kindVariants in

--- a/Sources/SwiftDocC/Semantics/Article/Article.swift
+++ b/Sources/SwiftDocC/Semantics/Article/Article.swift
@@ -218,7 +218,7 @@ public final class Article: Semantic, MarkupConvertible, Abstracted, Redirected,
             problems.append(Problem(diagnostic: diagnostic, possibleSolutions: solutions))
             
             // Remove the display name customization from the article's metadata.
-            optionalMetadata = Metadata(originalMarkup: metadata.originalMarkup, documentationExtension: metadata.documentationOptions, technologyRoot: metadata.technologyRoot, displayName: nil)
+            optionalMetadata = Metadata(originalMarkup: metadata.originalMarkup, documentationExtension: metadata.documentationOptions, technologyRoot: metadata.technologyRoot, displayName: nil, titleHeading: metadata.titleHeading)
         }
         
         self.init(

--- a/Sources/SwiftDocC/Semantics/Metadata/Metadata.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/Metadata.swift
@@ -27,6 +27,7 @@ import Markdown
 /// - ``Availability``
 /// - ``PageKind``
 /// - ``SupportedLanguage``
+/// - ``TitleHeading``
 public final class Metadata: Semantic, AutomaticDirectiveConvertible {
     public let originalMarkup: BlockDirective
     
@@ -68,6 +69,9 @@ public final class Metadata: Semantic, AutomaticDirectiveConvertible {
     var pageColor: PageColor.Color? {
         _pageColor?.color
     }
+
+    @ChildDirective
+    var titleHeading: TitleHeading? = nil
     
     static var keyPaths: [String : AnyKeyPath] = [
         "documentationOptions"  : \Metadata._documentationOptions,
@@ -79,7 +83,8 @@ public final class Metadata: Semantic, AutomaticDirectiveConvertible {
         "availability"          : \Metadata._availability,
         "pageKind"              : \Metadata._pageKind,
         "supportedLanguages"    : \Metadata._supportedLanguages,
-        "_pageColor"             : \Metadata.__pageColor,
+        "_pageColor"            : \Metadata.__pageColor,
+        "titleHeading"          : \Metadata._titleHeading,
     ]
     
     /// Creates a metadata object with a given markup, documentation extension, and technology root.
@@ -87,12 +92,14 @@ public final class Metadata: Semantic, AutomaticDirectiveConvertible {
     ///   - originalMarkup: The original markup for this metadata directive.
     ///   - documentationExtension: Optional configuration that describes how this documentation extension file merges or overrides the in-source documentation.
     ///   - technologyRoot: Optional configuration to make this page root-level documentation.
-    ///   - displayName:Optional configuration to customize this page's symbol's display name.
-    init(originalMarkup: BlockDirective, documentationExtension: DocumentationExtension?, technologyRoot: TechnologyRoot?, displayName: DisplayName?) {
+    ///   - displayName: Optional configuration to customize this page's symbol's display name.
+    ///   - titleHeading: Optional configuration to customize the text of this page's title heading.
+    init(originalMarkup: BlockDirective, documentationExtension: DocumentationExtension?, technologyRoot: TechnologyRoot?, displayName: DisplayName?, titleHeading: TitleHeading?) {
         self.originalMarkup = originalMarkup
         self.documentationOptions = documentationExtension
         self.technologyRoot = technologyRoot
         self.displayName = displayName
+        self.titleHeading = titleHeading
     }
     
     @available(*, deprecated, message: "Do not call directly. Required for 'AutomaticDirectiveConvertible'.")
@@ -102,7 +109,7 @@ public final class Metadata: Semantic, AutomaticDirectiveConvertible {
     
     func validate(source: URL?, for bundle: DocumentationBundle, in context: DocumentationContext, problems: inout [Problem]) -> Bool {
         // Check that something is configured in the metadata block
-        if documentationOptions == nil && technologyRoot == nil && displayName == nil && pageImages.isEmpty && customMetadata.isEmpty && callToAction == nil && availability.isEmpty && pageKind == nil && pageColor == nil {
+        if documentationOptions == nil && technologyRoot == nil && displayName == nil && pageImages.isEmpty && customMetadata.isEmpty && callToAction == nil && availability.isEmpty && pageKind == nil && pageColor == nil && titleHeading == nil {
             let diagnostic = Diagnostic(
                 source: source,
                 severity: .information,

--- a/Sources/SwiftDocC/Semantics/Metadata/TitleHeading.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/TitleHeading.swift
@@ -1,0 +1,41 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2023 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+import Markdown
+
+/// A directive for customizing the text of a page's title heading.
+/// 
+/// The ``heading`` property will override the page's default title heading.
+///
+/// @TitleHeading accepts an unnamed parameter containing containing the page's title heading.
+/// 
+/// This directive is only valid within a top-level ``Metadata`` directive:
+/// ```markdown
+/// @Metadata {
+///    @TitleHeading("Release Notes")
+/// }
+/// ```
+public final class TitleHeading: Semantic, AutomaticDirectiveConvertible {
+    public let originalMarkup: BlockDirective
+
+    /// An unnamed parameter containing containing the page-title’s heading text.
+    @DirectiveArgumentWrapped(name: .unnamed)
+    public var heading: String
+
+    static var keyPaths: [String : AnyKeyPath] = [
+        "heading" : \TitleHeading._heading,
+    ]
+
+    @available(*, deprecated, message: "Do not call directly. Required for 'AutomaticDirectiveConvertible'.")
+    init(originalMarkup: BlockDirective) {
+        self.originalMarkup = originalMarkup
+    }
+}

--- a/Sources/docc/DocCDocumentation.docc/DocC.symbols.json
+++ b/Sources/docc/DocCDocumentation.docc/DocC.symbols.json
@@ -2963,6 +2963,9 @@
           },
           {
             "text" : "- ``SupportedLanguage``"
+          },
+          {
+            "text" : "- ``TitleHeading``"
           }
         ]
       },
@@ -5056,6 +5059,151 @@
       },
       "pathComponents" : [
         "TechnologyRoot"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "TitleHeading"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "("
+        },
+        {
+          "kind" : "text",
+          "spelling" : "_ "
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "heading"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "String"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ")"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "text" : "A directive for customizing the text of a page's title heading."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "The ``heading`` property will override the page's default title heading."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "@TitleHeading accepts an unnamed parameter containing containing the page's title heading."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "This directive is only valid within a top-level ``Metadata`` directive:"
+          },
+          {
+            "text" : "```markdown"
+          },
+          {
+            "text" : "@Metadata {"
+          },
+          {
+            "text" : "   @TitleHeading(\"Release Notes\")"
+          },
+          {
+            "text" : "}"
+          },
+          {
+            "text" : "```"
+          },
+          {
+            "text" : "- Parameters:"
+          },
+          {
+            "text" : "  - heading: An unnamed parameter containing containing the page-title’s heading text."
+          },
+          {
+            "text" : "     **(required)**"
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$TitleHeading"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$TitleHeading",
+            "spelling" : "TitleHeading"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "TitleHeading"
+          },
+          {
+            "kind" : "text",
+            "spelling" : "("
+          },
+          {
+            "kind" : "text",
+            "spelling" : "_ "
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "heading"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "spelling" : "String"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ")"
+          }
+        ],
+        "title" : "TitleHeading"
+      },
+      "pathComponents" : [
+        "TitleHeading"
       ]
     },
     {

--- a/Sources/docc/DocCDocumentation.docc/Reference Syntax/API Reference Syntax/Metadata.md
+++ b/Sources/docc/DocCDocumentation.docc/Reference Syntax/API Reference Syntax/Metadata.md
@@ -30,6 +30,16 @@ Use the `Metadata` directive with the ``DisplayName`` directive to configure a s
 }
 ```
 
+Use the `Metadata` directive with the ``TitleHeading`` directive to configure the text of a page's title heading.
+
+```
+# ``SlothCreator``
+
+@Metadata {
+    @TitleHeading("Release Notes")
+}
+```
+
 ## Topics
 
 ### Extending or Overriding Source Documentation
@@ -47,6 +57,7 @@ Use the `Metadata` directive with the ``DisplayName`` directive to configure a s
 - ``PageKind``
 - ``PageColor``
 - ``CallToAction``
+- ``TitleHeading``
 
 ### Customizing the Languages of an Article
 

--- a/Sources/docc/DocCDocumentation.docc/Reference Syntax/API Reference Syntax/TitleHeading.md
+++ b/Sources/docc/DocCDocumentation.docc/Reference Syntax/API Reference Syntax/TitleHeading.md
@@ -1,0 +1,35 @@
+# ``docc/TitleHeading``
+
+A directive that specifies a title heading for a given documentation page.
+
+@Metadata {
+    @DocumentationExtension(mergeBehavior: override)
+}
+
+- Parameters:
+    - heading: The text for the custom title heading.
+
+## Overview
+
+Place the `TitleHeading` directive within a `Metadata` directive to configure a documentation page to show a custom title heading. Custom title headings, along with custom [page icons](doc:PageImage) and [page colors](doc:PageColor), allow for the creation of custom kinds of pages beyond just articles.
+
+A title heading is also known as a page eyebrow or kicker.
+
+```
+# ``SlothCreator``
+
+@Metadata {
+    @TitleHeading("Release Notes")
+}
+```
+
+A custom title heading appears in place of the page kind at the top of the page.
+### Containing Elements
+
+The following items can include a title heading element:
+
+@Links(visualStyle: list) {
+   - ``Metadata``
+}
+
+<!-- Copyright (c) 2023 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Tests/SwiftDocCTests/Infrastructure/TestExternalReferenceResolvers.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/TestExternalReferenceResolvers.swift
@@ -159,7 +159,7 @@ class TestMultiResultExternalReferenceResolver: ExternalReferenceResolver, Fallb
         // This is a workaround for how external content is processed. See details in OutOfProcessReferenceResolver.addImagesAndCacheMediaReferences(to:from:)
         
         if let topicImages = entityInfo.topicImages {
-            let metadata = node.metadata ?? Metadata(originalMarkup: BlockDirective(name: "Metadata", children: []), documentationExtension: nil, technologyRoot: nil, displayName: nil)
+            let metadata = node.metadata ?? Metadata(originalMarkup: BlockDirective(name: "Metadata", children: []), documentationExtension: nil, technologyRoot: nil, displayName: nil, titleHeading: nil)
             
             metadata.pageImages = topicImages.map { topicImage, alt in
                 let purpose: PageImage.Purpose

--- a/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorTests.swift
@@ -230,7 +230,7 @@ class RenderNodeTranslatorTests: XCTestCase {
             let source = """
             # My Article
             My introduction.
-            My exposè.
+            My exposé.
             My conclusion.
             """
             let document = Document(parsing: source, options: .parseBlockDirectives)
@@ -247,7 +247,7 @@ class RenderNodeTranslatorTests: XCTestCase {
             let source = """
             # My Article
             My introduction.
-            My exposè.
+            My exposé.
             My conclusion.
             ## Topics
             ### Basics
@@ -1225,6 +1225,9 @@ class RenderNodeTranslatorTests: XCTestCase {
             roundTrippedArticle.metadata.color?.standardColorIdentifier,
             "yellow"
         )
+
+        XCTAssertEqual(roundTrippedArticle.metadata.roleHeading, "Book-Like Content")
+        XCTAssertEqual(roundTrippedArticle.metadata.role, "article")
      }
     
     func testPageColorMetadataInSymbolExtension() throws {
@@ -1246,5 +1249,27 @@ class RenderNodeTranslatorTests: XCTestCase {
         let encodedSymbol = try JSONEncoder().encode(renderNode)
         let roundTrippedSymbol = try JSONDecoder().decode(RenderNode.self, from: encodedSymbol)
         XCTAssertEqual(roundTrippedSymbol.metadata.color?.standardColorIdentifier, "purple")
+    }
+
+    func testTitleHeadingMetadataInSymbolExtension() throws {
+        let (bundle, context) = try testBundleAndContext(named: "MixedManualAutomaticCuration")
+        let reference = ResolvedTopicReference(
+            bundleIdentifier: bundle.identifier,
+            path: "/documentation/TestBed",
+            sourceLanguage: .swift
+        )
+        let symbol = try XCTUnwrap(context.entity(with: reference).semantic as? Symbol)
+        var translator = RenderNodeTranslator(
+            context: context,
+            bundle: bundle,
+            identifier: reference,
+            source: nil
+        )
+        let renderNode = try XCTUnwrap(translator.visitSymbol(symbol) as? RenderNode)
+   
+        let encodedSymbol = try JSONEncoder().encode(renderNode)
+        let roundTrippedSymbol = try JSONDecoder().decode(RenderNode.self, from: encodedSymbol)
+        XCTAssertEqual(roundTrippedSymbol.metadata.roleHeading, "TestBed Notes")
+        XCTAssertEqual(roundTrippedSymbol.metadata.role, "collection")
     }
 }

--- a/Tests/SwiftDocCTests/Semantics/DirectiveInfrastructure/DirectiveIndexTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/DirectiveInfrastructure/DirectiveIndexTests.swift
@@ -48,6 +48,7 @@ class DirectiveIndexTests: XCTestCase {
                 "Tab",
                 "TabNavigator",
                 "TechnologyRoot",
+                "TitleHeading",
                 "TopicsVisualStyle",
                 "Tutorial",
                 "TutorialReference",

--- a/Tests/SwiftDocCTests/Semantics/DirectiveInfrastructure/DirectiveMirrorTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/DirectiveInfrastructure/DirectiveMirrorTests.swift
@@ -31,6 +31,19 @@ class DirectiveMirrorTests: XCTestCase {
         XCTAssertEqual(reflectedDirective.arguments["style"]?.propertyLabel, "style")
         XCTAssertEqual(reflectedDirective.arguments["style"]?.allowedValues, ["conceptual", "symbol"])
     }
+
+    func testReflectTitleHeadingDirective() {
+        let reflectedDirective = DirectiveMirror(reflecting: TitleHeading.self).reflectedDirective
+        
+        XCTAssertEqual(reflectedDirective.name, "TitleHeading")
+        XCTAssertFalse(reflectedDirective.allowsMarkup)
+        XCTAssertEqual(reflectedDirective.arguments.count, 1)
+        
+        XCTAssertEqual(reflectedDirective.arguments["heading"]?.unnamed, true)
+        XCTAssertEqual(reflectedDirective.arguments["heading"]?.required, true)
+        XCTAssertEqual(reflectedDirective.arguments["heading"]?.labelDisplayName, "_ heading")
+        XCTAssertEqual(reflectedDirective.arguments["heading"]?.propertyLabel, "heading")
+    }
     
     func testReflectMetadataDirective() {
         let reflectedDirective = DirectiveMirror(reflecting: Metadata.self).reflectedDirective
@@ -39,7 +52,7 @@ class DirectiveMirrorTests: XCTestCase {
         XCTAssertFalse(reflectedDirective.allowsMarkup)
         XCTAssert(reflectedDirective.arguments.isEmpty)
         
-        XCTAssertEqual(reflectedDirective.childDirectives.count, 10)
+        XCTAssertEqual(reflectedDirective.childDirectives.count, 11)
         
         XCTAssertEqual(
             reflectedDirective.childDirectives["DocumentationExtension"]?.propertyLabel,

--- a/Tests/SwiftDocCTests/Semantics/MetadataTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/MetadataTests.swift
@@ -130,6 +130,23 @@ class MetadataTests: XCTestCase {
         
         XCTAssertEqual(metadata?.displayName?.name, "Custom Name")
     }
+
+    func testTitleHeadingSupport() throws {
+        let source = """
+        @Metadata {
+           @TitleHeading("Custom Heading")
+        }
+        """
+        let document = Document(parsing: source, options: .parseBlockDirectives)
+        let directive = document.child(at: 0)! as! BlockDirective
+        let (bundle, context) = try testBundleAndContext(named: "TestBundle")
+        var problems = [Problem]()
+        let metadata = Metadata(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        XCTAssertNotNil(metadata)
+        XCTAssert(problems.isEmpty, "There shouldn't be any problems. Got:\n\(problems.map { $0.diagnostic.summary })")
+        
+        XCTAssertEqual(metadata?.titleHeading?.heading, "Custom Heading")
+    }
     
     func testCustomMetadataSupport() throws {
         let source = """
@@ -230,6 +247,31 @@ class MetadataTests: XCTestCase {
         
         XCTAssertEqual(solution.replacements.last?.range, SourceLocation(line: 1, column: 1, source: nil) ..< SourceLocation(line: 1, column: 16, source: nil))
         XCTAssertEqual(solution.replacements.last?.replacement, "# Custom Name")
+    }
+
+    func testArticleSupportsMetadataTitleHeading() throws {
+        let source = """
+        # Article title
+        
+        @Metadata {
+           @TitleHeading("Custom Heading")
+        }
+
+        The abstract of this documentation extension
+        """
+        let document = Document(parsing: source, options:  [.parseBlockDirectives, .parseSymbolLinks])
+        let (bundle, context) = try testBundleAndContext(named: "TestBundle")
+        var problems = [Problem]()
+        let article = Article(from: document, source: nil, for: bundle, in: context, problems: &problems)
+        XCTAssertNotNil(article, "An Article value can be created with a Metadata child with a TitleHeading child.")
+        XCTAssertNotNil(article?.metadata?.titleHeading, "The Article has the parsed TitleHeading metadata.")
+        XCTAssertEqual(article?.metadata?.titleHeading?.heading, "Custom Heading")
+        
+        XCTAssert(problems.isEmpty, "There shouldn't be any problems. Got:\n\(problems.map { $0.diagnostic.summary })")
+        
+        var analyzer = SemanticAnalyzer(source: nil, context: context, bundle: bundle)
+        _ = analyzer.visit(document)
+        XCTAssert(analyzer.problems.isEmpty, "Expected no problems. Got:\n \(DiagnosticConsoleWriter.formattedDescription(for: analyzer.problems))")
     }
     
     func testDuplicateMetadata() throws {

--- a/Tests/SwiftDocCTests/Test Bundles/BookLikeContent.docc/MyArticle.md
+++ b/Tests/SwiftDocCTests/Test Bundles/BookLikeContent.docc/MyArticle.md
@@ -7,6 +7,7 @@ This is the abstract of my article. Nice!
     @PageImage(source: "figure1", alt: "An example figure.", purpose: card)
     @CustomMetadata(key: "country", value: "Belgium")
     @PageColor(yellow)
+    @TitleHeading("Book-Like Content")
 }
 
 @Row(numberOfColumns: 8) {

--- a/Tests/SwiftDocCTests/Test Bundles/MixedManualAutomaticCuration.docc/TestBed.md
+++ b/Tests/SwiftDocCTests/Test Bundles/MixedManualAutomaticCuration.docc/TestBed.md
@@ -2,6 +2,7 @@
 
 @Metadata {
     @PageColor(purple)
+    @TitleHeading("TestBed Notes")
 }
 
 TestBed framework.


### PR DESCRIPTION
- **Explanation**: Add authoring support for @TitleHeading directive
- **Scope**: Small in scope. Completes a feature that was pitched already.
- **Issue**: rdar://110662981 and #408 
- **Risk**: Low risk: isolated change and well-tested.
- **Testing**: End to end testing with Swift-DocC-Render. Additional unit tests have been added.
- **Original PR:** #611 
- **Reviewers**: @ethan-kusters 