### PR TITLE
`@PageKind` sets the kind for the documentation node

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -2048,13 +2048,14 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
         in bundle: DocumentationBundle
     ) -> DocumentationContext.Articles {
         articles.map { article in
+            let kind = article.value.metadata?.pageKind?.kind.documentationNodeKind ?? .article
             guard let (documentation, title) = DocumentationContext.documentationNodeAndTitle(
                 for: article,
                 // By default, articles are available in the languages the module that's being documented
                 // is available in. It's possible to override that behavior using the `@SupportedLanguage`
                 // directive though; see its documentation for more details.
                 availableSourceLanguages: soleRootModuleReference.map { sourceLanguages(for: $0) },
-                kind: .article,
+                kind: kind,
                 in: bundle
             ) else {
                 return article

--- a/Sources/SwiftDocC/Semantics/Metadata/PageKind.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/PageKind.swift
@@ -52,6 +52,15 @@ extension Metadata {
                     return "Sample Code"
                 }
             }
+
+            var documentationNodeKind: DocumentationNode.Kind {
+                switch self {
+                case .article:
+                    return .article
+                case .sampleCode:
+                    return .sampleCode
+                }
+            }
         }
 
         /// The page kind to apply to the page.

--- a/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
@@ -965,6 +965,19 @@ class ConvertActionTests: XCTestCase {
                 """
             ),
 
+            TextFile(name: "SampleArticle.md", utf8Content: """
+                # Sample Article
+
+                @Metadata {
+                    @PageKind(sampleCode)
+                }
+
+                Sample abstract.
+
+                Discussion content
+                """
+            ),
+
             // A module page
             TextFile(name: "TestBed.md", utf8Content: """
                 # ``TestBed``
@@ -1046,6 +1059,15 @@ class ConvertActionTests: XCTestCase {
                     headings: ["Overview", "Article Section"],
                     rawIndexableTextContent: "Article abstract. Overview Discussion content  Article Section This is another section of the article."
                 )
+            case "/documentation/TestBundle/SampleArticle":
+                return IndexingRecord(
+                    kind: .article,
+                    location: .topLevelPage(reference),
+                    title: "Sample Article",
+                    summary: "Sample abstract.",
+                    headings: ["Overview"],
+                    rawIndexableTextContent: "Sample abstract. Overview Discussion content"
+                )
             default:
                 XCTFail("Encountered unexpected page '\(reference)'")
                 return nil
@@ -1064,6 +1086,7 @@ class ConvertActionTests: XCTestCase {
                         abstract: "TestBed abstract.",
                         taskGroups: [
                             .init(title: "Basics", identifiers: ["doc://com.test.example/documentation/TestBundle/Article"]),
+                            .init(title: "Articles", identifiers: ["doc://com.test.example/documentation/TestBundle/SampleArticle"]),
                             .init(title: "Structures", identifiers: ["doc://com.test.example/documentation/TestBed/A"]),
                         ],
                         usr: "TestBed",
@@ -1108,6 +1131,23 @@ class ConvertActionTests: XCTestCase {
                         references: nil,
                         redirects: nil
                     ),
+                ]
+            case "/documentation/TestBundle/SampleArticle":
+                return [
+                    LinkDestinationSummary(
+                        kind: .sampleCode,
+                        relativePresentationURL: URL(string: "/documentation/testbundle/samplearticle")!,
+                        referenceURL: reference.url,
+                        title: "Sample Article",
+                        language: .swift,
+                        abstract: "Sample abstract.",
+                        taskGroups: [],
+                        availableLanguages: [.swift],
+                        platforms: nil,
+                        topicImages: nil,
+                        references: nil,
+                        redirects: nil
+                    )
                 ]
             default:
                 XCTFail("Encountered unexpected page '\(reference)'")


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://110182993

## Summary

When `@PageKind` is used to set an article's kind, it doesn't actually set the kind for the `DocumentationNode` created from that article, only the `RenderNode` role. This PR sets the node kind for the `DocumentationNode` when the article is loaded, so that it can be used e.g. in the `linkable-entities.json` file emitted from the node.

## Dependencies

None

## Testing

To test, use a documentation catalog that includes an article that uses `@PageKind(sampleCode)`. The bundle at `Tests/SwiftDocCTests/Test Bundles/SampleBundle.docc` has two such articles, `MyExternalSample` and `MyLocalSample`, and is used in the following instructions.

Steps:
1. `swift run docc convert --output-path .build/output.docarchive --emit-digest 'Tests/SwiftDocCTests/Test Bundles/SampleBundle.docc'`
2. Inspect `.build/output.docarchive/linkable-entities.json` and ensure that the pages for `MyExternalSample` and `MyLocalSample` have their `kind` set to `org.swift.docc.kind.sampleCode`.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ n/a ] Updated documentation if necessary
