### PR TITLE
Make `ExternalLocationReference` url property public and mutable

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/References/ExternalLocationReference.swift
+++ b/Sources/SwiftDocC/Model/Rendering/References/ExternalLocationReference.swift
@@ -26,7 +26,7 @@ public struct ExternalLocationReference: RenderReference, URLReference {
 
     public let identifier: RenderReferenceIdentifier
 
-    let url: String
+    public var url: String
 
     enum CodingKeys: String, CodingKey {
         case type

--- a/Tests/SwiftDocCTests/Rendering/SampleDownloadTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/SampleDownloadTests.swift
@@ -291,4 +291,14 @@ class SampleDownloadTests: XCTestCase {
         let externalReference = try XCTUnwrap(symbol.references[identifier.identifier] as? ExternalLocationReference)
         XCTAssertEqual(externalReference.url, "https://example.com/ExternalLocation.zip")
     }
+    
+    func testRoundTripExternalLocationReferenceWithModifiedURL() throws {
+        var reference = ExternalLocationReference(identifier: RenderReferenceIdentifier("/test/sample.zip"))
+        XCTAssertEqual(reference.url, "/test/sample.zip")
+        reference.url = "https://swift.org/documentation/test/sample.zip"
+        let encodedReference = try JSONEncoder().encode(reference)
+        let decodedReference = try JSONDecoder().decode(ExternalLocationReference.self, from: encodedReference)
+        XCTAssertEqual(decodedReference.identifier.identifier, "/test/sample.zip")
+        XCTAssertEqual(decodedReference.url, "https://swift.org/documentation/test/sample.zip")
+    }
 }


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://110803672

## Summary

Allows clients to access and modify the destination URL for an `ExternalLocationReference`.

## Dependencies

None.

## Testing

A unit test has been added to cover this functionality.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
