### PR TITLE
[5.9] `@PageKind` sets the kind for the documentation node

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -2048,13 +2048,14 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
         in bundle: DocumentationBundle
     ) -> DocumentationContext.Articles {
         articles.map { article in
+            let kind = article.value.metadata?.pageKind?.kind.documentationNodeKind ?? .article
             guard let (documentation, title) = DocumentationContext.documentationNodeAndTitle(
                 for: article,
                 // By default, articles are available in the languages the module that's being documented
                 // is available in. It's possible to override that behavior using the `@SupportedLanguage`
                 // directive though; see its documentation for more details.
                 availableSourceLanguages: soleRootModuleReference.map { sourceLanguages(for: $0) },
-                kind: .article,
+                kind: kind,
                 in: bundle
             ) else {
                 return article

--- a/Sources/SwiftDocC/Semantics/Metadata/PageKind.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/PageKind.swift
@@ -52,6 +52,15 @@ extension Metadata {
                     return "Sample Code"
                 }
             }
+
+            var documentationNodeKind: DocumentationNode.Kind {
+                switch self {
+                case .article:
+                    return .article
+                case .sampleCode:
+                    return .sampleCode
+                }
+            }
         }
 
         /// The page kind to apply to the page.

--- a/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
@@ -965,6 +965,19 @@ class ConvertActionTests: XCTestCase {
                 """
             ),
 
+            TextFile(name: "SampleArticle.md", utf8Content: """
+                # Sample Article
+
+                @Metadata {
+                    @PageKind(sampleCode)
+                }
+
+                Sample abstract.
+
+                Discussion content
+                """
+            ),
+
             // A module page
             TextFile(name: "TestBed.md", utf8Content: """
                 # ``TestBed``
@@ -1046,6 +1059,15 @@ class ConvertActionTests: XCTestCase {
                     headings: ["Overview", "Article Section"],
                     rawIndexableTextContent: "Article abstract. Overview Discussion content  Article Section This is another section of the article."
                 )
+            case "/documentation/TestBundle/SampleArticle":
+                return IndexingRecord(
+                    kind: .article,
+                    location: .topLevelPage(reference),
+                    title: "Sample Article",
+                    summary: "Sample abstract.",
+                    headings: ["Overview"],
+                    rawIndexableTextContent: "Sample abstract. Overview Discussion content"
+                )
             default:
                 XCTFail("Encountered unexpected page '\(reference)'")
                 return nil
@@ -1064,6 +1086,7 @@ class ConvertActionTests: XCTestCase {
                         abstract: "TestBed abstract.",
                         taskGroups: [
                             .init(title: "Basics", identifiers: ["doc://com.test.example/documentation/TestBundle/Article"]),
+                            .init(title: "Articles", identifiers: ["doc://com.test.example/documentation/TestBundle/SampleArticle"]),
                             .init(title: "Structures", identifiers: ["doc://com.test.example/documentation/TestBed/A"]),
                         ],
                         usr: "TestBed",
@@ -1108,6 +1131,23 @@ class ConvertActionTests: XCTestCase {
                         references: nil,
                         redirects: nil
                     ),
+                ]
+            case "/documentation/TestBundle/SampleArticle":
+                return [
+                    LinkDestinationSummary(
+                        kind: .sampleCode,
+                        relativePresentationURL: URL(string: "/documentation/testbundle/samplearticle")!,
+                        referenceURL: reference.url,
+                        title: "Sample Article",
+                        language: .swift,
+                        abstract: "Sample abstract.",
+                        taskGroups: [],
+                        availableLanguages: [.swift],
+                        platforms: nil,
+                        topicImages: nil,
+                        references: nil,
+                        redirects: nil
+                    )
                 ]
             default:
                 XCTFail("Encountered unexpected page '\(reference)'")


### PR DESCRIPTION
Cherry-pick of #626

- **Explanation**: The `@PageKind` directive doesn't set the DocumentationNode's kind, which means that the kind rendered into `linkable-entities.json` is incorrect for these pages.
- **Scope**: Affects users of `@PageKind` who also use the digest files emitted by Swift-DocC.
- **Issue**: rdar://110182993
- **Risk**: Low. Documentation output should not be affected.
- **Testing**: An automated test has been added to ensure the correct behavior.
- **Reviewer**: @d-ronnqvist 