### PR TITLE
Tests: adjust LMDB test harness for Windows

### DIFF
--- a/Tests/SwiftDocCTests/Utility/LMDBTests.swift
+++ b/Tests/SwiftDocCTests/Utility/LMDBTests.swift
@@ -20,6 +20,16 @@ final class SwiftLMDBTests: XCTestCase {
         let tempURL = try createTemporaryDirectory()
         
         environment = try! LMDB.Environment(path: tempURL.path, maxDBs: 4, mapSize: 1024 * 1024 * 1024) // 1GB of mapSize
+
+        // `addTeardownBlock` execute in LIFO order, which is important as we
+        // need this to execute before the implicit closure for the cleaning of
+        // the temporary directory.
+        addTeardownBlock {
+            // Explicitly close the environment to release the handles to the
+            // database files.  This is required on Windows where the files
+            // cannot be deleted while they are open.
+            self.environment.close()
+        }
     }
     
     override func tearDown() {


### PR DESCRIPTION
Ensure that we release the open handles before attempting to clean up the temporary directory.  This repairs the execution of 11 tests on Windows, bringing us to a 95% pass rate (excluding `LogHandleTests`).