### PR TITLE
Tests: disable the LogHandle tests on Windows

### DIFF
--- a/Tests/SwiftDocCUtilitiesTests/Utility/LogHandleTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/Utility/LogHandleTests.swift
@@ -16,7 +16,10 @@ class LogHandleTests: XCTestCase {
 
     /// Test that ``LogHandle`` doesn't append extra newlines to output
     /// - Bug: rdar://73462272
-    func testWriteToStandardOutput() {
+    func testWriteToStandardOutput() throws {
+#if os(Windows)
+        throw XCTSkip("cannot reassign file handles on Windows")
+#else
         let pipe = Pipe()
 
         // dup stdout to restore later
@@ -50,9 +53,13 @@ class LogHandleTests: XCTestCase {
             ========================================
             """
         )
+#endif
     }
 
-    func testFlushesStandardOutput() {
+    func testFlushesStandardOutput() throws {
+#if os(Windows)
+        throw XCTSkip("cannot reassign file handles on Windows")
+#else
         let pipe = Pipe()
 
         // dup stdout to restore later
@@ -67,9 +74,13 @@ class LogHandleTests: XCTestCase {
         let data = pipe.fileHandleForReading.availableData
         let text = String(data: data, encoding: .utf8)
         XCTAssertEqual(text, "No newlines here", "\(LogHandle.self) didn't flush stdout")
+#endif
     }
 
-    func testFlushesStandardError() {
+    func testFlushesStandardError() throws {
+#if os(Windows)
+        throw XCTSkip("cannot reassign file handles on Windows")
+#else
         let pipe = Pipe()
 
         // dup stdout to restore later
@@ -84,5 +95,6 @@ class LogHandleTests: XCTestCase {
         let data = pipe.fileHandleForReading.availableData
         let text = String(data: data, encoding: .utf8)
         XCTAssertEqual(text, "No newlines here", "\(LogHandle.self) didn't flush stderr")
+#endif
     }
 }


### PR DESCRIPTION
`FileHandle` transacts in `HANDLE`s on Windows rather than file descriptors.  This makes it impossible to replace the end point of the pipe after it has been created as the conversion from a HANDLE to a file descriptor transfers ownership and as such the FileHandle does not work with file descriptors at all.  Replicating that behaviour here would detach the `FileHandle` associated with the `Pipe` and thus cannot be done inline.