### PR TITLE
[5.9] don't crash on an extension with an empty declaration

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Symbol Graph/ExtendedTypeFormatTransformation.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Graph/ExtendedTypeFormatTransformation.swift
@@ -322,7 +322,7 @@ extension ExtendedTypeFormatTransformation {
                 newMixins[SymbolGraph.Symbol.Swift.Extension.mixinKey] = swiftExtension
             }
             
-            if let declarationFragments = extensionBlockSymbol[mixin: SymbolGraph.Symbol.DeclarationFragments.self]?.declarationFragments {
+            if let declarationFragments = extensionBlockSymbol[mixin: SymbolGraph.Symbol.DeclarationFragments.self]?.declarationFragments, declarationFragments.count >= 3 {
                 var prefixWithoutWhereClause: [SymbolGraph.Symbol.DeclarationFragments.Fragment] = Array(declarationFragments[..<3])
                 
             outer: for fragment in declarationFragments[3...] {

--- a/Tests/SwiftDocCTests/Infrastructure/ReferenceResolverTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/ReferenceResolverTests.swift
@@ -535,7 +535,19 @@ class ReferenceResolverTests: XCTestCase {
         let renderReference = try XCTUnwrap(renderNode.references[boolReference])
         XCTAssert(renderReference is UnresolvedRenderReference)
     }
-    
+
+    func testExtensionWithEmptyDeclarationFragments() throws {
+        let (bundle, context) = try testBundleAndContext(named: "ModuleWithEmptyDeclarationFragments")
+
+        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ModuleWithEmptyDeclarationFragments", sourceLanguage: .swift))
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode
+
+        // Despite having an extension to Float, there are no symbols added by that extension, so
+        // the resulting documentation should be empty
+        XCTAssertEqual(renderNode.topicSections.count, 0)
+    }
+
     struct TestExternalReferenceResolver: ExternalReferenceResolver {
         var bundleIdentifier = "com.external.testbundle"
         var expectedReferencePath = "/externally/resolved/path"

--- a/Tests/SwiftDocCTests/Test Bundles/ModuleWithEmptyDeclarationFragments.docc/Info.plist
+++ b/Tests/SwiftDocCTests/Test Bundles/ModuleWithEmptyDeclarationFragments.docc/Info.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleVersion</key>
+	<string>0.1.0</string>
+	<key>CFBundleIdentifier</key>
+	<string>org.swift.docc.example</string>
+	<key>CFBundleDisplayName</key>
+	<string>Module with empty declaration fragments</string>
+	<key>CFBundleName</key>
+	<string>ModuleWithEmptyDeclarationFragments</string>
+</dict>
+</plist>

--- a/Tests/SwiftDocCTests/Test Bundles/ModuleWithEmptyDeclarationFragments.docc/ModuleWithEmptyDeclarationFragments.md
+++ b/Tests/SwiftDocCTests/Test Bundles/ModuleWithEmptyDeclarationFragments.docc/ModuleWithEmptyDeclarationFragments.md
@@ -1,0 +1,10 @@
+# ``ModuleWithEmptyDeclarationFragments``
+
+This module contains a single extension to `Float`, which was generated with an empty declaration.
+
+## Overview
+
+The purpose of this test fixture is to ensure that Swift-DocC does not crash when encountering these
+erroneous symbol graphs on extension block symbols.
+
+<!-- Copyright (c) 2023 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Tests/SwiftDocCTests/Test Bundles/ModuleWithEmptyDeclarationFragments.docc/ModuleWithEmptyDeclarationFragments.symbols.json
+++ b/Tests/SwiftDocCTests/Test Bundles/ModuleWithEmptyDeclarationFragments.docc/ModuleWithEmptyDeclarationFragments.symbols.json
@@ -1,0 +1,26 @@
+{
+    "metadata": {
+        "formatVersion": {
+            "major": 0,
+            "minor": 6,
+            "patch": 0
+        },
+        "generator": "Swift 5.9"
+    },
+    "module": {
+        "name": "ModuleWithEmptyDeclarationFragments",
+        "platform": {
+            "architecture": "x86_64",
+            "vendor": "apple",
+            "operatingSystem": {
+                "name": "macosx",
+                "minimumVersion": {
+                    "major": 12,
+                    "minor": 4
+                }
+            }
+        }
+    },
+    "symbols": [],
+    "relationships": []
+}

--- a/Tests/SwiftDocCTests/Test Bundles/ModuleWithEmptyDeclarationFragments.docc/ModuleWithEmptyDeclarationFragments@Swift.symbols.json
+++ b/Tests/SwiftDocCTests/Test Bundles/ModuleWithEmptyDeclarationFragments.docc/ModuleWithEmptyDeclarationFragments@Swift.symbols.json
@@ -1,0 +1,95 @@
+{
+    "metadata": {
+        "formatVersion": {
+            "major": 0,
+            "minor": 6,
+            "patch": 0
+        },
+        "generator": "Swift 5.9"
+    },
+    "module": {
+        "name": "ModuleWithEmptyDeclarationFragments",
+        "platform": {
+            "architecture": "x86_64",
+            "vendor": "apple",
+            "operatingSystem": {
+                "name": "macosx",
+                "minimumVersion": {
+                    "major": 12,
+                    "minor": 4
+                }
+            }
+        }
+    },
+    "symbols": [
+        {
+            "kind": {
+                "identifier": "swift.extension",
+                "displayName": "Extension"
+            },
+            "identifier": {
+                "precise": "s:e:s:Sf10FoundationE4_argSfvp",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "Float"
+            ],
+            "names": {
+                "title": "Float",
+                "navigator": [
+                    {
+                        "kind": "identifier",
+                        "spelling": "Float"
+                    }
+                ],
+                "subHeading": []
+            },
+            "swiftExtension": {
+                "extendedModule": "Swift",
+                "typeKind": "swift.struct"
+            },
+            "declarationFragments": [],
+            "accessLevel": "public",
+            "availability": [
+                {
+                    "domain": "macOS",
+                    "introduced": {
+                        "major": 12
+                    }
+                },
+                {
+                    "domain": "watchOS",
+                    "introduced": {
+                        "major": 8
+                    }
+                },
+                {
+                    "domain": "iOS",
+                    "introduced": {
+                        "major": 15
+                    }
+                },
+                {
+                    "domain": "tvOS",
+                    "introduced": {
+                        "major": 15
+                    }
+                }
+            ]
+        }
+    ],
+    "relationships": [
+        {
+            "kind": "extensionTo",
+            "source": "s:e:s:Sf10FoundationE4_argSfvp",
+            "target": "s:Sf",
+            "targetFallback": "Swift.Float"
+        },
+        {
+            "kind": "conformsTo",
+            "source": "s:e:s:Sf10FoundationE4_argSfvp",
+            "target": "s:SQ",
+            "targetFallback": "Swift.Equatable"
+        }
+    ]
+}


### PR DESCRIPTION
- **Explanation**: Current development versions of the Swift compiler emit some extension-block symbols with an empty `declarationFragments` array, causing Swift-DocC to crash. This PR adds a guard to prevent the out-of-bounds access.
- **Scope**: Affects projects which export-import Foundation, or other packages/frameworks which include public underscored protocols.
- **Issue**: rdar://110683602
- **Risk**: Low. The fix does not change anything about the output, as the converted extension symbols get a synthesized declaration anyway.
- **Testing**: An automated test has been added to ensure the issue is fixed. I've also performed manual testing with the original reproduction case and ensured that it stopped crashing.
- **Reviewer**: @theMomax and @d-ronnqvist 