### PR TITLE
Finalize the diagnostic engine if an error is thrown

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Diagnostics/DiagnosticEngine.swift
+++ b/Sources/SwiftDocC/Infrastructure/Diagnostics/DiagnosticEngine.swift
@@ -97,9 +97,7 @@ public final class DiagnosticEngine {
     }
     
     public func finalize() {
-        workQueue.async { [weak self] in
-            // If the engine isn't around then return early
-            guard let self = self else { return }
+        workQueue.sync {
             for consumer in self.consumers.sync({ $0.values }) {
                 try? consumer.finalize()
             }

--- a/Sources/SwiftDocC/Infrastructure/DocumentationConverter.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationConverter.swift
@@ -177,6 +177,10 @@ public struct DocumentationConverter: DocumentationConverterProtocol {
     mutating public func convert<OutputConsumer: ConvertOutputConsumer>(
         outputConsumer: OutputConsumer
     ) throws -> (analysisProblems: [Problem], conversionProblems: [Problem]) {
+        defer {
+            diagnosticEngine.finalize()
+        }
+        
         // Unregister the current file data provider and all its bundles
         // when running repeated conversions.
         if let dataProvider = self.currentDataProvider {
@@ -396,8 +400,6 @@ public struct DocumentationConverter: DocumentationConverterProtocol {
         benchmark(add: Benchmark.PeakMemory())
 
         context.linkResolutionMismatches.reportGatheredMismatchesIfEnabled()
-        
-        diagnosticEngine.finalize()
         
         return (analysisProblems: context.problems, conversionProblems: conversionProblems)
     }


### PR DESCRIPTION

<!--
If you're opening a PR to cherry-pick a change for a release branch, use this template instead:
https://github.com/apple/swift-docc/blob/main/.github/PULL_REQUEST_TEMPLATE/CHERRY_PICK.md
-->

Bug/issue #, if applicable: rdar://110782381

## Summary

If an error is thrown before the documentation converter completes successfully, the diagnostic engine is never finalized. This means that diagnostic consumers that gather and write diagnostic as two separate steps won't write any diagnostics.

This PR changes that so that the diagnostic engine is finalized before the documentation converter returns from `convert(...)`. It also makes the finalization synchronous so that callers can rely on any diagnostics having been written after `convert(...) ends—either successfully or with a thrown error.

## Dependencies

None

## Testing

- Run `docc convert` with a `--diagnostics-file /path/to/some-file.json` and some content that result in an unexpected error (for example a symbol graph file with relationships but no symbols).

- After the failed documentation build, the diagnostic file should have been created.


## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [ ] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary
