### PR TITLE
deprecate ExternalLocationReference in favor of DownloadReference

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/References/ExternalLocationReference.swift
+++ b/Sources/SwiftDocC/Model/Rendering/References/ExternalLocationReference.swift
@@ -19,6 +19,7 @@ import Foundation
 /// An `ExternalLocationReference` is intended to encode to Render JSON compatible with a
 /// ``DownloadReference``, but with the `url` set to the text given in the `@CallToAction`'s `url`
 /// argument.
+@available(*, deprecated, message: "Use DownloadReference and its `init(identifier:verbatimURL:checksum)` initializer instead.")
 public struct ExternalLocationReference: RenderReference, URLReference {
     public static var baseURL: URL = DownloadReference.baseURL
 

--- a/Sources/SwiftDocC/Model/Rendering/RenderNode/CodableRenderReference.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNode/CodableRenderReference.swift
@@ -37,14 +37,12 @@ struct CodableRenderReference: Codable {
             reference = try TopicRenderReference(from: decoder)
         case .section:
             reference = try TopicRenderReference(from: decoder)
-        case .download:
+        case .download, .externalLocation:
             reference = try DownloadReference(from: decoder)
         case .unresolvable:
             reference = try UnresolvedRenderReference(from: decoder)
         case .link:
             reference = try LinkReference(from: decoder)
-        case .externalLocation:
-            reference = try ExternalLocationReference(from: decoder)
         }
     }
     

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -816,7 +816,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
                         isActive: true,
                         overridingTitle: callToAction.buttonLabel(for: article.metadata?.pageKind?.kind),
                         overridingTitleInlineContent: nil))
-                externalLocationReferences[url.description] = ExternalLocationReference(identifier: downloadIdentifier)
+                downloadReferences[url.description] = DownloadReference(identifier: downloadIdentifier, verbatimURL: url, checksum: nil)
             } else if let fileReference = callToAction.file,
                       let downloadIdentifier = createAndRegisterRenderReference(forMedia: fileReference, assetContext: .download)
             {
@@ -858,7 +858,6 @@ public struct RenderNodeTranslator: SemanticVisitor {
         addReferences(videoReferences, to: &node)
         addReferences(linkReferences, to: &node)
         addReferences(downloadReferences, to: &node)
-        addReferences(externalLocationReferences, to: &node)
         // See Also can contain external links, we need to separately transfer
         // link references from the content compiler
         addReferences(contentCompiler.linkReferences, to: &node)
@@ -1709,7 +1708,6 @@ public struct RenderNodeTranslator: SemanticVisitor {
     var linkReferences: [String: LinkReference] = [:]
     var requirementReferences: [String: XcodeRequirementReference] = [:]
     var downloadReferences: [String: DownloadReference] = [:]
-    var externalLocationReferences: [String: ExternalLocationReference] = [:]
     
     private var bundleAvailability: [BundleModuleIdentifier: [AvailabilityRenderItem]] = [:]
     

--- a/Sources/SwiftDocC/Model/Rendering/Tutorial/References/DownloadReference.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Tutorial/References/DownloadReference.swift
@@ -27,13 +27,12 @@ public struct DownloadReference: RenderReference, URLReference, Equatable {
     /// The location of the downloadable resource.
     public var url: URL
 
-    /// Indicates whether the ``url`` property was loaded from the regular initializer or from the
-    /// `Decodable` initializer.
+    /// Indicates whether the ``url`` property should be encoded verbatim into Render JSON.
     ///
     /// This is used during encoding to determine whether to filter ``url`` through the
     /// `renderURL(for:)` method. In case the URL was loaded from JSON, we don't want to modify it
     /// further after a round-trip.
-    private var urlWasDecoded = false
+    private var encodeUrlVerbatim = false
 
     /// The SHA512 hash value for the resource.
     public var checksum: String?
@@ -57,11 +56,24 @@ public struct DownloadReference: RenderReference, URLReference, Equatable {
     /// - Parameters:
     ///   - identifier: An identifier for the resource's reference.
     ///   - url: The path to the resource.
-    ///   - sha512Checksum: The SHA512 hash value for the resource.
+    ///   - checksum: The SHA512 hash value for the resource.
     public init(identifier: RenderReferenceIdentifier, renderURL url: URL, checksum: String?) {
         self.identifier = identifier
         self.url = url
         self.checksum = checksum
+    }
+
+    /// Creates a new reference to a downloadable resource, with a URL that should be encoded as-is.
+    ///
+    /// - Parameters:
+    ///   - identifier: An identifier for the resource's reference.
+    ///   - url: The path to the resource. This will be encoded as-is into the Render JSON.
+    ///   - checksum: The SHA512 hash value for the resource.
+    public init(identifier: RenderReferenceIdentifier, verbatimURL url: URL, checksum: String?) {
+        self.identifier = identifier
+        self.url = url
+        self.checksum = checksum
+        self.encodeUrlVerbatim = true
     }
 
     @available(*, deprecated, message: "Use 'init(identifier:renderURL:checksum:)' instead")
@@ -81,7 +93,7 @@ public struct DownloadReference: RenderReference, URLReference, Equatable {
         self.type = try container.decode(RenderReferenceType.self, forKey: .type)
         self.identifier = try container.decode(RenderReferenceIdentifier.self, forKey: .identifier)
         self.url = try container.decode(URL.self, forKey: .url)
-        self.urlWasDecoded = true
+        self.encodeUrlVerbatim = true
         self.checksum = try container.decodeIfPresent(String.self, forKey: .checksum)
     }
 
@@ -92,7 +104,7 @@ public struct DownloadReference: RenderReference, URLReference, Equatable {
         try container.encodeIfPresent(checksum, forKey: .checksum)
         
         // Render URL
-        if !urlWasDecoded {
+        if !encodeUrlVerbatim {
             try container.encode(renderURL(for: url), forKey: .url)
         } else {
             try container.encode(url, forKey: .url)

--- a/Sources/SwiftDocCUtilities/Action/Actions/Convert/ConvertFileWritingConsumer.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Convert/ConvertFileWritingConsumer.swift
@@ -161,14 +161,6 @@ struct ConvertFileWritingConsumer: ConvertOutputConsumer {
         let assetsURL = targetFolder.appendingPathComponent("assets.json", isDirectory: false)
         let data = try encode(digest)
         try fileManager.createFile(at: assetsURL, contents: data)
-
-        let externalAssetsDigest = Digest.ExternalAssets(
-            externalLocations: (uniqueAssets[.externalLocation] as? [ExternalLocationReference]) ?? []
-        )
-
-        let externalAssetsURL = targetFolder.appendingPathComponent("external-assets.json", isDirectory: false)
-        let externalAssetsData = try encode(externalAssetsDigest)
-        try fileManager.createFile(at: externalAssetsURL, contents: externalAssetsData)
     }
     
     func consume(benchmarks: Benchmark) throws {
@@ -224,10 +216,6 @@ enum Digest {
         let images: [ImageReference]
         let videos: [VideoReference]
         let downloads: [DownloadReference]
-    }
-
-    struct ExternalAssets: Codable {
-        let externalLocations: [ExternalLocationReference]
     }
     
     struct Diagnostic: Codable {

--- a/Tests/SwiftDocCTests/Rendering/SampleDownloadTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/SampleDownloadTests.swift
@@ -152,15 +152,9 @@ class SampleDownloadTests: XCTestCase {
         XCTAssertEqual(ident.identifier, "files/ExternalSample.zip")
 
         // Ensure that the encoded URL still references the entered URL
-        let downloadReference = try XCTUnwrap(renderNode.references[ident.identifier] as? ExternalLocationReference)
+        let downloadReference = try XCTUnwrap(renderNode.references[ident.identifier] as? DownloadReference)
 
-        let encoder = JSONEncoder()
-        let decoder = JSONDecoder()
-
-        let encodedReference = try encoder.encode(downloadReference)
-        let decodedReference = try decoder.decode(DownloadReference.self, from: encodedReference)
-
-        XCTAssertEqual(decodedReference.url.description, "files/ExternalSample.zip")
+        XCTAssertEqual(downloadReference.url.description, "files/ExternalSample.zip")
     }
 
     func testExternalLocationRoundtrip() throws {
@@ -172,47 +166,21 @@ class SampleDownloadTests: XCTestCase {
         }
         XCTAssertEqual(ident.identifier, "files/ExternalSample.zip")
 
-        // Make sure that the ExternalLocationReference we get can round-trip as itself as well as through a DownloadReference
-        let downloadReference = try XCTUnwrap(renderNode.references[ident.identifier] as? ExternalLocationReference)
+        // Make sure that the reference data survives a round-trip encoding/decoding.
+        let downloadReference = try XCTUnwrap(renderNode.references[ident.identifier] as? DownloadReference)
 
         let encoder = JSONEncoder()
         encoder.outputFormatting.insert(.sortedKeys)
         let decoder = JSONDecoder()
 
         let encodedReference = try encoder.encode(downloadReference)
+        let firstJson = String(data: encodedReference, encoding: .utf8)
 
-        // ExternalLocationReference -> ExternalLocationReference
-        // The encoded JSON should be the same before and after re-encoding.
-        do {
-            let decodedReference = try decoder.decode(ExternalLocationReference.self, from: encodedReference)
-            let reEncodedReference = try encoder.encode(decodedReference)
+        let decodedReference = try decoder.decode(DownloadReference.self, from: encodedReference)
+        let reEncodedReference = try encoder.encode(decodedReference)
+        let finalJson = String(data: reEncodedReference, encoding: .utf8)
 
-            let firstJson = String(data: encodedReference, encoding: .utf8)
-            let finalJson = String(data: reEncodedReference, encoding: .utf8)
-
-            XCTAssertEqual(firstJson, finalJson)
-        }
-
-        // ExternalLocationReference -> DownloadReference -> ExternalLocationReference
-        // The reference identifier should be the same all throughout, and the final ExternalLocationReference
-        // should encode to the same JSON as the initial reference.
-        do {
-            let decodedReference = try decoder.decode(DownloadReference.self, from: encodedReference)
-
-            XCTAssertEqual(decodedReference.identifier, downloadReference.identifier)
-
-            let encodedDownload = try encoder.encode(decodedReference)
-            let reDecodedReference = try decoder.decode(ExternalLocationReference.self, from: encodedDownload)
-
-            XCTAssertEqual(reDecodedReference.identifier, downloadReference.identifier)
-
-            let reEncodedReference = try encoder.encode(reDecodedReference)
-
-            let firstJson = String(data: encodedReference, encoding: .utf8)
-            let finalJson = String(data: reEncodedReference, encoding: .utf8)
-
-            XCTAssertEqual(firstJson, finalJson)
-        }
+        XCTAssertEqual(firstJson, finalJson)
     }
     
     func testExternalLinkOnSampleCodePage() throws {
@@ -224,8 +192,8 @@ class SampleDownloadTests: XCTestCase {
         }
         
         XCTAssertEqual(identifier.identifier, "https://www.example.com/source-repository.git")
-        let reference = try XCTUnwrap(renderNode.references[identifier.identifier])
-        XCTAssert(reference is ExternalLocationReference)
+        let reference = try XCTUnwrap(renderNode.references[identifier.identifier] as? DownloadReference)
+        XCTAssertEqual(reference.url.description, "https://www.example.com/source-repository.git")
     }
     
     func testExternalLinkOnRegularArticlePage() throws {
@@ -237,24 +205,21 @@ class SampleDownloadTests: XCTestCase {
         }
         
         XCTAssertEqual(identifier.identifier, "https://www.example.com")
-        let reference = try XCTUnwrap(renderNode.references[identifier.identifier])
-        XCTAssert(reference is ExternalLocationReference)
+        let reference = try XCTUnwrap(renderNode.references[identifier.identifier] as? DownloadReference)
+        XCTAssertEqual(reference.url.description, "https://www.example.com")
     }
 
     /// Ensure that a DownloadReference where the URL is different from the reference identifier
     /// can still round-trip through an ExternalLocationReference with the URL and reference identifier intact.
-    func testRoundTripWithDifferentUrl() throws {
-        let baseReference = DownloadReference(identifier: .init("DownloadReference.zip"), renderURL: .init(string: "https://example.com/DownloadReference.zip")!, checksum: nil)
+    func testRoundTripVerbatimUrl() throws {
+        let baseReference = DownloadReference(identifier: .init("DownloadReference.zip"), verbatimURL: .init(string: "https://example.com/DownloadReference.zip")!, checksum: nil)
 
         let encoder = JSONEncoder()
         let decoder = JSONDecoder()
 
         let encodedReference = try encoder.encode(baseReference)
 
-        let interimReference = try decoder.decode(ExternalLocationReference.self, from: encodedReference)
-        let interimEncodedReference = try encoder.encode(interimReference)
-
-        let roundTripReference = try decoder.decode(DownloadReference.self, from: interimEncodedReference)
+        let roundTripReference = try decoder.decode(DownloadReference.self, from: encodedReference)
 
         XCTAssertEqual(baseReference, roundTripReference)
     }
@@ -288,17 +253,20 @@ class SampleDownloadTests: XCTestCase {
 
         XCTAssertEqual(identifier.identifier, "doc://org.swift.docc.example/downloads/sample.zip")
 
-        let externalReference = try XCTUnwrap(symbol.references[identifier.identifier] as? ExternalLocationReference)
-        XCTAssertEqual(externalReference.url, "https://example.com/ExternalLocation.zip")
+        let externalReference = try XCTUnwrap(symbol.references[identifier.identifier] as? DownloadReference)
+        XCTAssertEqual(externalReference.url.description, "https://example.com/ExternalLocation.zip")
     }
     
-    func testRoundTripExternalLocationReferenceWithModifiedURL() throws {
-        var reference = ExternalLocationReference(identifier: RenderReferenceIdentifier("/test/sample.zip"))
-        XCTAssertEqual(reference.url, "/test/sample.zip")
-        reference.url = "https://swift.org/documentation/test/sample.zip"
+    func testRoundTripDownloadReferenceWithModifiedUrl() throws {
+        let identifier = RenderReferenceIdentifier("/test/sample.zip")
+        let originalURL = try XCTUnwrap(URL(string: "/test/sample.zip"))
+        var reference = DownloadReference(identifier: identifier, verbatimURL: originalURL, checksum: nil)
+        XCTAssertEqual(reference.url.description, "/test/sample.zip")
+        let newURL = try XCTUnwrap(URL(string: "https://swift.org/documentation/test/sample.zip"))
+        reference.url = newURL
         let encodedReference = try JSONEncoder().encode(reference)
-        let decodedReference = try JSONDecoder().decode(ExternalLocationReference.self, from: encodedReference)
+        let decodedReference = try JSONDecoder().decode(DownloadReference.self, from: encodedReference)
         XCTAssertEqual(decodedReference.identifier.identifier, "/test/sample.zip")
-        XCTAssertEqual(decodedReference.url, "https://swift.org/documentation/test/sample.zip")
+        XCTAssertEqual(decodedReference.url, newURL)
     }
 }

--- a/Tests/SwiftDocCTests/Rendering/SampleDownloadTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/SampleDownloadTests.swift
@@ -269,4 +269,12 @@ class SampleDownloadTests: XCTestCase {
         XCTAssertEqual(decodedReference.identifier.identifier, "/test/sample.zip")
         XCTAssertEqual(decodedReference.url, newURL)
     }
+
+    func testProjectFilesForCallToActionDirectives() throws {
+        // Make sure that the `projectFiles()` method correctly returns the DownloadReference
+        // created by the `@CallToAction` directive.
+        let renderNode = try renderNodeFromSampleBundle(at: "/documentation/SampleBundle/MySample")
+        let downloadReference = try XCTUnwrap(renderNode.projectFiles())
+        XCTAssertEqual(downloadReference.url.description, "https://example.com/sample.zip")
+    }
 }

--- a/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
@@ -1312,19 +1312,12 @@ class ConvertActionTests: XCTestCase {
             XCTFail("Can't find assets.json in output")
             return
         }
-        XCTAssertEqual(resultAssets.downloads.count, 1)
+        XCTAssertEqual(resultAssets.downloads.count, 2)
 
         XCTAssert(resultAssets.downloads.contains(where: {
             $0.identifier.identifier == "project.zip"
         }))
-
-        guard let externalAssets: Digest.ExternalAssets = contentsOfJSONFile(url: result.outputs[0].appendingPathComponent("external-assets.json")) else {
-            XCTFail("Can't find external-assets.json in output")
-            return
-        }
-        XCTAssertEqual(externalAssets.externalLocations.count, 1)
-
-        XCTAssert(externalAssets.externalLocations.contains(where: {
+        XCTAssert(resultAssets.downloads.contains(where: {
             $0.identifier.identifier == "https://example.com/sample.zip"
         }))
     }


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://111121386

## Summary

This PR refactors `DownloadReference` and `ExternalLocationReference` to deprecate the latter by incorporating it into the former. Now that there is a property on `DownloadReference` to prevent rewriting the URL upon encoding, this refactor takes advantage of that to incorporate the original uses of `ExternalLocationReference` back into `DownloadReference`.

## Dependencies

None

## Testing

This is primarily an internal refactor, but there are two major changes in the output: `external-assets.json` will no longer be generated (its previous contents will now be folded into the `downloads` property of `assets.json`, and references that would have used the `externalLocation` reference type (i.e. `@CallToAction(url:_:)`) now instead use the `download` reference type.

Steps:
1. `DOCC_JSON_PRETTYPRINT=YES swift run docc convert --emit-digest 'Tests/SwiftDocCTests/Test Bundles/SampleBundle.docc'`
2. Inspect the resulting built archive:
   a. The `external-assets.json` file should not exist.
   b. The `assets.json` file should contain a `download` reference with a `url` of `"https://www.example.com/source-repository.git"`.
   c. The rendered JSON for `MyExternalSample` should contain a reference to `"https://www.example.com/source-repository.git"` with a reference type of `download`.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ n/a ] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ n/a ] Updated documentation if necessary
