### PR TITLE
Navigator: close the `LMDB.Environment` on `finalize(_:_:_:)`

### DIFF
--- a/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
+++ b/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
@@ -1097,7 +1097,9 @@ extension NavigatorIndex {
                     return
                 }
             }
-            
+
+            defer { environment.close() }
+
             let database: LMDB.Database
             if let alreadyDefinedDatabase = navigatorIndex.database {
                 database = alreadyDefinedDatabase


### PR DESCRIPTION
Ensure that we close the LMDB environment on the exit from `finalize(_:_:_:)` method.  This is important for platforms which do not permit alteration of directories with open references.  Having the environment be closed after finalization enables the generated index to be moved into the final destination on Windows.