### PR TITLE
Indexing: add a workaround for clearing the index

### DIFF
--- a/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
+++ b/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
@@ -285,6 +285,11 @@ public class NavigatorIndex {
             throw Error.missingBundleIndentifier
         }
     }
+
+    internal func clearIndex() throws {
+        self.environment?.close()
+        try FileManager.default.removeItem(at: self.url)
+    }
     
     /// Indicates the page type of a given item inside the tree.
     /// - Note: This information is stored as UInt8 to decrease the required size to store it and make

--- a/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
+++ b/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
@@ -285,11 +285,6 @@ public class NavigatorIndex {
             throw Error.missingBundleIndentifier
         }
     }
-
-    internal func clearIndex() throws {
-        self.environment?.close()
-        try FileManager.default.removeItem(at: self.url)
-    }
     
     /// Indicates the page type of a given item inside the tree.
     /// - Note: This information is stored as UInt8 to decrease the required size to store it and make

--- a/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
@@ -1982,7 +1982,7 @@ class ConvertActionTests: XCTestCase {
         XCTAssertEqual(indexFromConvertAction.count, 37)
         
         indexFromConvertAction.environment?.close()
-        try FileManager.default.removeItem(at: self.url)
+        try FileManager.default.removeItem(at: indexURL)
         
         // Run just the index command over the built documentation
         

--- a/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
@@ -1981,7 +1981,8 @@ class ConvertActionTests: XCTestCase {
         let indexFromConvertAction = try NavigatorIndex.readNavigatorIndex(url: indexURL)
         XCTAssertEqual(indexFromConvertAction.count, 37)
         
-        try indexFromConvertAction.clearIndex()
+        indexFromConvertAction.environment?.close()
+        try FileManager.default.removeItem(at: self.url)
         
         // Run just the index command over the built documentation
         

--- a/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
@@ -1981,7 +1981,7 @@ class ConvertActionTests: XCTestCase {
         let indexFromConvertAction = try NavigatorIndex.readNavigatorIndex(url: indexURL)
         XCTAssertEqual(indexFromConvertAction.count, 37)
         
-        try FileManager.default.removeItem(at: indexURL)
+        try indexFromConvertAction.clearIndex()
         
         // Run just the index command over the built documentation
         


### PR DESCRIPTION
The unit tests will occasionally desire to clean up the generated index while retaining a reference to the NavigatorIndex instance.  This is prevented on Windows as the LMDB environment will preserve an open handle which results in the index not being removed.

Adding an internal API to support this use case as this is used for tests only AFAICT.