### PR TITLE
[5.9] Finalize the diagnostic engine if an error is thrown

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Diagnostics/DiagnosticEngine.swift
+++ b/Sources/SwiftDocC/Infrastructure/Diagnostics/DiagnosticEngine.swift
@@ -97,9 +97,7 @@ public final class DiagnosticEngine {
     }
     
     public func finalize() {
-        workQueue.async { [weak self] in
-            // If the engine isn't around then return early
-            guard let self = self else { return }
+        workQueue.sync {
             for consumer in self.consumers.sync({ $0.values }) {
                 try? consumer.finalize()
             }

--- a/Sources/SwiftDocC/Infrastructure/DocumentationConverter.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationConverter.swift
@@ -177,6 +177,10 @@ public struct DocumentationConverter: DocumentationConverterProtocol {
     mutating public func convert<OutputConsumer: ConvertOutputConsumer>(
         outputConsumer: OutputConsumer
     ) throws -> (analysisProblems: [Problem], conversionProblems: [Problem]) {
+        defer {
+            diagnosticEngine.finalize()
+        }
+        
         // Unregister the current file data provider and all its bundles
         // when running repeated conversions.
         if let dataProvider = self.currentDataProvider {
@@ -396,8 +400,6 @@ public struct DocumentationConverter: DocumentationConverterProtocol {
         benchmark(add: Benchmark.PeakMemory())
 
         context.linkResolutionMismatches.reportGatheredMismatchesIfEnabled()
-        
-        diagnosticEngine.finalize()
         
         return (analysisProblems: context.problems, conversionProblems: conversionProblems)
     }

--- a/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
@@ -2316,6 +2316,47 @@ class ConvertActionTests: XCTestCase {
             XCTAssert(error is ErrorsEncountered, "Unexpected error type thrown by \(ConvertAction.self)")
         }
     }
+    
+    func testWritesDiagnosticFileWhenThrowingError() throws {
+        let bundle = Folder(name: "unit-test.docc", content: [
+            InfoPlist(displayName: "TestBundle", identifier: "com.test.example"),
+            CopyOfFile(original: symbolGraphFile, newName: "MyKit.symbols.json"),
+            TextFile(name: "Article.md", utf8Content: """
+            Bad title
+
+            This article has a malformed title and can't be analyzed, so it
+            produces one warning.
+            """),
+            incompleteSymbolGraphFile,
+        ])
+
+        let testDataProvider = try TestFileSystem(folders: [bundle, Folder.emptyHTMLTemplateDirectory])
+        let targetDirectory = URL(fileURLWithPath: testDataProvider.currentDirectoryPath)
+            .appendingPathComponent("target", isDirectory: true)
+
+        let diagnosticFile = try createTemporaryDirectory().appendingPathComponent("test-diagnostics.json")
+        
+        var action = try ConvertAction(
+            documentationBundleURL: bundle.absoluteURL,
+            outOfProcessResolver: nil,
+            analyze: true,
+            targetDirectory: targetDirectory,
+            htmlTemplateDirectory: Folder.emptyHTMLTemplateDirectory.absoluteURL,
+            emitDigest: false,
+            currentPlatforms: nil,
+            dataProvider: testDataProvider,
+            fileManager: testDataProvider,
+            temporaryDirectory: createTemporaryDirectory(),
+            diagnosticLevel: "error",
+            diagnosticFilePath: diagnosticFile
+        )
+        
+        XCTAssertFalse(FileManager.default.fileExists(atPath: diagnosticFile.path), "Diagnostic file doesn't exist before")
+        XCTAssertThrowsError(try action.performAndHandleResult()) { error in
+            XCTAssert(error is ErrorsEncountered, "Unexpected error type thrown by \(ConvertAction.self)")
+        }
+        XCTAssertTrue(FileManager.default.fileExists(atPath: diagnosticFile.path), "Diagnostic file exist after")
+    }
 
     // Verifies setting convert inherit docs flag
     func testConvertInheritDocsOption() throws {


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift-docc/pull/637

- **Explanation**: Ensure that diagnostics are reported if an error is thrown before the documentation converter completes successfully.
- **Scope**: Unreported diagnostics.
- **Issue**: rdar://110782381
- **Risk**: Low. 
- **Testing**: Added new automated test to verify that DocC writes a diagnostic file when the converter throws an error.
- **Reviewer**: @daniel-grumberg 