### PR TITLE
[5.9] Allow certain directives in documentation comments

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/RenderContentCompiler.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderContentCompiler.swift
@@ -346,40 +346,12 @@ struct RenderContentCompiler: MarkupVisitor {
     }
 
     mutating func visitBlockDirective(_ blockDirective: BlockDirective) -> [RenderContent] {
-        switch blockDirective.name {
-        case Snippet.directiveName:
-            guard let snippet = Snippet(from: blockDirective, for: bundle, in: context) else {
-                return []
-            }
-            
-            guard let snippetReference = resolveSymbolReference(destination: snippet.path),
-                  let snippetEntity = try? context.entity(with: snippetReference),
-                  let snippetSymbol = snippetEntity.symbol,
-                  let snippetMixin = snippetSymbol.mixins[SymbolGraph.Symbol.Snippet.mixinKey] as? SymbolGraph.Symbol.Snippet else {
-                return []
-            }
-            
-            if let requestedSlice = snippet.slice,
-               let requestedLineRange = snippetMixin.slices[requestedSlice] {
-                // Render only the slice.
-                let lineRange = requestedLineRange.lowerBound..<min(requestedLineRange.upperBound, snippetMixin.lines.count)
-                let lines = snippetMixin.lines[lineRange]
-                let minimumIndentation = lines.map { $0.prefix { $0.isWhitespace }.count }.min() ?? 0
-                let trimmedLines = lines.map { String($0.dropFirst(minimumIndentation)) }
-                return [RenderBlockContent.codeListing(.init(syntax: snippetMixin.language, code: trimmedLines, metadata: nil))]
-            } else {
-                // Render the whole snippet with its explanation content.
-                let docCommentContent = snippetEntity.markup.children.flatMap { self.visit($0) }
-                let code = RenderBlockContent.codeListing(.init(syntax: snippetMixin.language, code: snippetMixin.lines, metadata: nil))
-                return docCommentContent + [code]
-            }
-        default:
-            guard let renderableDirective = DirectiveIndex.shared.renderableDirectives[blockDirective.name] else {
-                return []
-            }
-            
-            return renderableDirective.render(blockDirective, with: &self)
+
+        guard let renderableDirective = DirectiveIndex.shared.renderableDirectives[blockDirective.name] else {
+            return []
         }
+            
+        return renderableDirective.render(blockDirective, with: &self)
     }
 
     func defaultVisit(_ markup: Markup) -> [RenderContent] {

--- a/Sources/SwiftDocC/Semantics/Snippets/Snippet.swift
+++ b/Sources/SwiftDocC/Semantics/Snippets/Snippet.swift
@@ -10,6 +10,7 @@
 
 import Foundation
 import Markdown
+import SymbolKit
 
 public final class Snippet: Semantic, AutomaticDirectiveConvertible {
     public let originalMarkup: BlockDirective
@@ -43,5 +44,35 @@ public final class Snippet: Semantic, AutomaticDirectiveConvertible {
         }
         
         return true
+    }
+}
+
+extension Snippet: RenderableDirectiveConvertible {
+    func render(with contentCompiler: inout RenderContentCompiler) -> [RenderContent] {
+        guard let snippet = Snippet(from: originalMarkup, for: contentCompiler.bundle, in: contentCompiler.context) else {
+                return []
+            }
+            
+            guard let snippetReference = contentCompiler.resolveSymbolReference(destination: snippet.path),
+                  let snippetEntity = try? contentCompiler.context.entity(with: snippetReference),
+                  let snippetSymbol = snippetEntity.symbol,
+                  let snippetMixin = snippetSymbol.mixins[SymbolGraph.Symbol.Snippet.mixinKey] as? SymbolGraph.Symbol.Snippet else {
+                return []
+            }
+            
+            if let requestedSlice = snippet.slice,
+               let requestedLineRange = snippetMixin.slices[requestedSlice] {
+                // Render only the slice.
+                let lineRange = requestedLineRange.lowerBound..<min(requestedLineRange.upperBound, snippetMixin.lines.count)
+                let lines = snippetMixin.lines[lineRange]
+                let minimumIndentation = lines.map { $0.prefix { $0.isWhitespace }.count }.min() ?? 0
+                let trimmedLines = lines.map { String($0.dropFirst(minimumIndentation)) }
+                return [RenderBlockContent.codeListing(.init(syntax: snippetMixin.language, code: trimmedLines, metadata: nil))]
+            } else {
+                // Render the whole snippet with its explanation content.
+                let docCommentContent = snippetEntity.markup.children.flatMap { contentCompiler.visit($0) }
+                let code = RenderBlockContent.codeListing(.init(syntax: snippetMixin.language, code: snippetMixin.lines, metadata: nil))
+                return docCommentContent + [code]
+            }
     }
 }

--- a/Sources/SwiftDocC/Utility/MarkupExtensions/BlockDirectiveExtensions.swift
+++ b/Sources/SwiftDocC/Utility/MarkupExtensions/BlockDirectiveExtensions.swift
@@ -45,6 +45,7 @@ extension BlockDirective {
         TechnologyRoot.directiveName,
         TechnologyRoot.directiveName,
         Tile.directiveName,
+        TitleHeading.directiveName,
         Tutorial.directiveName,
         TutorialArticle.directiveName,
         TutorialReference.directiveName,

--- a/Tests/SwiftDocCTests/Diagnostics/DiagnosticTests.swift
+++ b/Tests/SwiftDocCTests/Diagnostics/DiagnosticTests.swift
@@ -185,15 +185,15 @@ class DiagnosticTests: XCTestCase {
         let commentWithKnownDirective = """
           Brief description of this method
           
-          @Image(source: "my-sloth-image.png", alt: "An illustration of a sleeping sloth.")
+          @TitleHeading("Fancy Type of Article")
           @returns Description of return value
           """
         let symbolWithKnownDirective = createTestSymbol(commentText: commentWithKnownDirective)
         let engine1 = DiagnosticEngine()
 
         let _ = DocumentationNode.contentFrom(documentedSymbol: symbolWithKnownDirective, documentationExtension: nil, engine: engine1)
-
-        // count should 1 for the known directive '@Image'
+        
+        // count should be 1 for the known directive '@TitleHeading'
         // TODO: Consider adding a diagnostic for Doxygen tags (rdar://92184094)
         XCTAssertEqual(engine1.problems.count, 1)
         XCTAssertEqual(engine1.problems.map { $0.diagnostic.identifier }, ["org.swift.docc.UnsupportedDocCommentDirective"])

--- a/Tests/SwiftDocCTests/Semantics/DirectiveInfrastructure/DirectiveIndexTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/DirectiveInfrastructure/DirectiveIndexTests.swift
@@ -66,6 +66,7 @@ class DirectiveIndexTests: XCTestCase {
                 "Links",
                 "Row",
                 "Small",
+                "Snippet",
                 "TabNavigator",
                 "Video",
             ]

--- a/Tests/SwiftDocCTests/Semantics/Reference/TabNavigatorTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/Reference/TabNavigatorTests.swift
@@ -151,13 +151,23 @@ class TabNavigatorTests: XCTestCase {
                     @Small {
                         Hey but small.
                     }
+
+                    @Snippet(path: "Snippets/Snippets/MySnippet")
                 }
             }
             """
         }
         
         XCTAssertNotNil(tabNavigator)
-        XCTAssertEqual(problems, [])
+
+        // UnresolvedTopicReference warning expected since the reference to the snippet "Snippets/Snippets/MySnippet" 
+        // should fail to resolve here and then nothing would be added to the content.
+        XCTAssertEqual(
+            problems,
+            ["23: warning – org.swift.docc.unresolvedTopicReference"]
+        )
+
+        
         
         XCTAssertEqual(renderBlockContent.count, 1)
         XCTAssertEqual(

--- a/Tests/SwiftDocCTests/Semantics/SymbolTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/SymbolTests.swift
@@ -480,7 +480,7 @@ class SymbolTests: XCTestCase {
         XCTAssertEqual(withRedirectInArticle.redirects?.map { $0.oldPath.absoluteString }, ["some/previous/path/to/this/symbol"])
     }
     
-    func testWarningWhenDocCommentContainsDirective() throws {
+    func testWarningWhenDocCommentContainsUnsupportedDirective() throws {
         let (withRedirectInArticle, problems) = try makeDocumentationNodeSymbol(
             docComment: """
                 A cool API to call.
@@ -493,10 +493,24 @@ class SymbolTests: XCTestCase {
         )
         XCTAssertFalse(problems.isEmpty)
         XCTAssertEqual(withRedirectInArticle.redirects, nil)
-        
+
         XCTAssertEqual(problems.first?.diagnostic.identifier, "org.swift.docc.UnsupportedDocCommentDirective")
         XCTAssertEqual(problems.first?.diagnostic.range?.lowerBound.line, 3)
         XCTAssertEqual(problems.first?.diagnostic.range?.lowerBound.column, 1)
+    }
+
+    func testNoWarningWhenDocCommentContainsDirective() throws {
+        let (_, problems) = try makeDocumentationNodeSymbol(
+            docComment: """
+                A cool API to call.
+
+                @Snippet(from: "Snippets/Snippets/MySnippet")
+                """,
+            articleContent: """
+                # This is my article
+                """
+        )
+        XCTAssertTrue(problems.isEmpty)
     }
     
     func testNoWarningWhenDocCommentContainsDoxygen() throws {
@@ -1116,9 +1130,7 @@ class SymbolTests: XCTestCase {
         
         let engine = DiagnosticEngine()
         let _ = DocumentationNode.contentFrom(documentedSymbol: symbol, documentationExtension: nil, engine: engine)
-        XCTAssertEqual(engine.problems.count, 1)
-        let problem = try XCTUnwrap(engine.problems.first)
-        XCTAssertEqual(problem.diagnostic.source?.path, "/path/to/my file.swift")
+        XCTAssertEqual(engine.problems.count, 0)
     }
     
     // MARK: - Helpers

--- a/Tests/SwiftDocCTests/Test Bundles/BookLikeContent.docc/MyArticle.md
+++ b/Tests/SwiftDocCTests/Test Bundles/BookLikeContent.docc/MyArticle.md
@@ -34,6 +34,8 @@ This is the abstract of my article. Nice!
     }
 }
 
+@Snippet(path: "Snippets/Snippets/MySnippet", slice: "foo")
+
 @Small {
     Copyright (c) 2022 Apple Inc and the Swift Project authors. All Rights Reserved.
 }

--- a/Tests/SwiftDocCTests/Test Bundles/Snippets.docc/Snippets.md
+++ b/Tests/SwiftDocCTests/Test Bundles/Snippets.docc/Snippets.md
@@ -10,4 +10,33 @@ This is a slice of the above snippet, called "foo".
 
 @Snippet(path: "Snippets/Snippets/MySnippet", slice: "foo")
 
-<!-- Copyright (c) 2022 Apple Inc and the Swift Project authors. All Rights Reserved. -->
+This is a snippet nested inside a tab navigator.
+
+@TabNavigator {
+    @Tab("hi") {
+        @Row {
+            @Column {
+                Hello!
+            }
+
+            @Column {
+                Hello there!
+            }
+        }
+
+        Hello there.
+    }
+
+    @Tab("hey") {
+        Hey there.
+
+        @Small {
+            Hey but small.
+        }
+
+        @Snippet(path: "Snippets/Snippets/MySnippet", slice: "middle") {}
+    }
+}
+
+
+<!-- Copyright (c) 2023 Apple Inc and the Swift Project authors. All Rights Reserved. -->


### PR DESCRIPTION
- Explanation: Allow some directives in doc comments.
- Scope: Small in scope. Completes a feature that was pitched already.
- GitHub Issue: rdar://111414385 and https://github.com/apple/swift-docc/issues/591
- Risk: Low risk: isolated change and well-tested.
- Testing: End to end testing with Swift-DocC-Render. Additional unit tests have been added.
- Original PR: https://github.com/apple/swift-docc/pull/641
- Reviewer: @ethan-kusters