### PR TITLE
Allow anchor <doc:#heading> within same article

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
@@ -764,10 +764,16 @@ extension PathHierarchy {
         let isAbsolute = path.first == "/"
             || String(components.first ?? "") == NodeURLGenerator.Path.documentationFolderName
             || String(components.first ?? "") == NodeURLGenerator.Path.tutorialsFolderName
-       
+
+        // If there is a # character in the last component, split that into two components
         if let hashIndex = components.last?.firstIndex(of: "#") {
             let last = components.removeLast()
-            components.append(last[..<hashIndex])
+            // Allow anrhor-only links where there's nothing before #.
+            // In case the pre-# part is empty, and we're omitting empty components, don't add it in.
+            let pathName = last[..<hashIndex]
+            if !pathName.isEmpty || !omittingEmptyComponents {
+                components.append(pathName)
+            }
             
             let fragment = String(last[hashIndex...].dropFirst())
             return (components.map(Self.parse(pathComponent:)) + [PathComponent(full: fragment, name: fragment, kind: nil, hash: nil)], isAbsolute)


### PR DESCRIPTION
<!--
If you're opening a PR to cherry-pick a change for a release branch, use this template instead:
https://github.com/apple/swift-docc/blob/main/.github/PULL_REQUEST_TEMPLATE/CHERRY_PICK.md
-->

Bug/issue #, if applicable: Closes #632

## Summary

This pull request makes it so that articles can contain links to specific headings on the same page, using both `<doc:Heading>`, and `<doc:#Heading>` syntax.

## Dependencies

None, once the PR is ready, itself — I think there are three failing test cases still.

## Testing

I've added a test in `testArticleSelfAnchorLinks.swift`, and verified this behavior manually, too. To test that a `#heading` link works, you can add a subheading link to an existing document bundle, and rebuild the docs.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [ ] **pending**: Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary — N/A for this PR I think?

