### PR TITLE
Document using DOCC_EXEC in SwiftPM

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,22 @@ The next time you invoke a documentation build with the "Build Documentation"
 button in Xcode's Product menu, your custom `docc` will be used for the build.
 You can confirm that your custom `docc` is being used by opening the latest build
 log in Xcode's report navigator and expanding the "Compile documentation" step.
-  
+
+### Invoking `docc` from Swift Package Manager
+
+You can also test a locally built version of Swift-DocC using Swift Package Manager
+CLI. SwiftPM will try to read `DOCC_EXEC` environment variable value, and use
+the path you provded if it's set.
+
+  1. In your test `Package.swift`, add a dependency on `swift-docc-plugin`.
+     [`swift-docc-plugin`](https://github.com/apple-swift-docc-plugin) is a 
+     Swift Package Manager plugin that invokes `docc` for you, see details in 
+     `swift-docc-plugin`.
+  2. Set `DOCC_EXEC` environment variable and run documentation generation
+     command like this:
+     
+        `DOCC_EXEC=/path/to/docc swift package generate-documentation`
+
 ## Using `docc` to build and preview documentation
 
 The preferred way of building documentation for your Swift package is by using

--- a/README.md
+++ b/README.md
@@ -148,14 +148,16 @@ log in Xcode's report navigator and expanding the "Compile documentation" step.
 ### Invoking `docc` from Swift Package Manager
 
 You can also test a locally built version of Swift-DocC using Swift Package Manager
-CLI. SwiftPM will try to read `DOCC_EXEC` environment variable value, and use
+CLI. The Swift-DocC SwiftPM plugin will try to read `DOCC_EXEC` environment variable value, and use
 the path you provded if it's set.
 
-  1. In your test `Package.swift`, add a dependency on [`Swift-DocC Plugin`](https://github.com/apple/swift-docc-plugin).
-  2. Set `DOCC_EXEC` environment variable and run documentation generation
-     command like this:
+  1. In your project's `Package.swift`, add a dependency on the [`Swift-DocC Plugin`](https://github.com/apple/swift-docc-plugin).
+  2. Set the `DOCC_EXEC` environment variable and run the documentation generation
+     command:
 
-        `DOCC_EXEC=/path/to/docc swift package generate-documentation`
+        ```bash
+        DOCC_EXEC=/path/to/docc swift package generate-documentation
+        ```
 
 ## Using `docc` to build and preview documentation
 

--- a/README.md
+++ b/README.md
@@ -151,13 +151,10 @@ You can also test a locally built version of Swift-DocC using Swift Package Mana
 CLI. SwiftPM will try to read `DOCC_EXEC` environment variable value, and use
 the path you provded if it's set.
 
-  1. In your test `Package.swift`, add a dependency on `swift-docc-plugin`.
-     [`swift-docc-plugin`](https://github.com/apple-swift-docc-plugin) is a 
-     Swift Package Manager plugin that invokes `docc` for you, see details in 
-     `swift-docc-plugin`.
+  1. In your test `Package.swift`, add a dependency on [`Swift-DocC Plugin`](https://github.com/apple/swift-docc-plugin).
   2. Set `DOCC_EXEC` environment variable and run documentation generation
      command like this:
-     
+
         `DOCC_EXEC=/path/to/docc swift package generate-documentation`
 
 ## Using `docc` to build and preview documentation

--- a/README.md
+++ b/README.md
@@ -147,9 +147,9 @@ log in Xcode's report navigator and expanding the "Compile documentation" step.
 
 ### Invoking `docc` from Swift Package Manager
 
-You can also test a locally built version of Swift-DocC using Swift Package Manager
-CLI. The Swift-DocC SwiftPM plugin will try to read `DOCC_EXEC` environment variable value, and use
-the path you provded if it's set.
+You can also test a locally built version of Swift-DocC using the Swift Package
+Manager from the command line. The Swift-DocC SwiftPM plugin will try to read
+`DOCC_EXEC` environment variable value, and use the path you provded if it's set.
 
   1. In your project's `Package.swift`, add a dependency on the [`Swift-DocC Plugin`](https://github.com/apple/swift-docc-plugin).
   2. Set the `DOCC_EXEC` environment variable and run the documentation generation


### PR DESCRIPTION
<!--
If you're opening a PR to cherry-pick a change for a release branch, use this template instead:
https://github.com/apple/swift-docc/blob/main/.github/PULL_REQUEST_TEMPLATE/CHERRY_PICK.md
-->

Bug/issue #, if applicable: N/A

## Summary

This pull request adds a paragraph in README describing how to invoke a locally built `docc` when using SwiftPM, setting `DOCC_EXEC` env variable. 

I was working on #652 and debugged my ideas that way, thought I'd add a doc entry for that.

## Dependencies

None. 

## Testing

To test whether it works:
1. Build `docc` as usual
2. run `DOCC_EXEC=./build/debug/docc swift generate-documentation --target=TARGET`


## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [-] Added tests
- [-] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary

