### PR TITLE
use SymbolKit's "alternate declarations" in declarations sections

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -57,10 +57,10 @@
     {
       "identity" : "swift-docc-symbolkit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/QuietMisdreavus/swift-docc-symbolkit",
+      "location" : "https://github.com/apple/swift-docc-symbolkit",
       "state" : {
-        "branch" : "alternate-declarations",
-        "revision" : "d21748c2d9ec2202dd2880cca71f6b18503afba2"
+        "branch" : "main",
+        "revision" : "fb0c2d5e2be00558e5666fbda50105da2de839d1"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -57,10 +57,10 @@
     {
       "identity" : "swift-docc-symbolkit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-docc-symbolkit",
+      "location" : "https://github.com/QuietMisdreavus/swift-docc-symbolkit",
       "state" : {
-        "branch" : "main",
-        "revision" : "31ee554ce4bed5fa05eea36bc30296f7d4149097"
+        "branch" : "alternate-declarations",
+        "revision" : "d21748c2d9ec2202dd2880cca71f6b18503afba2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -136,7 +136,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(url: "https://github.com/apple/swift-markdown.git", branch: "main"),
         .package(url: "https://github.com/apple/swift-lmdb.git", branch: "main"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.2"),
-        .package(url: "https://github.com/apple/swift-docc-symbolkit", branch: "main"),
+        .package(url: "https://github.com/QuietMisdreavus/swift-docc-symbolkit", branch: "alternate-declarations"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "2.5.0"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.2.0"),
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -136,7 +136,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(url: "https://github.com/apple/swift-markdown.git", branch: "main"),
         .package(url: "https://github.com/apple/swift-lmdb.git", branch: "main"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.2"),
-        .package(url: "https://github.com/QuietMisdreavus/swift-docc-symbolkit", branch: "alternate-declarations"),
+        .package(url: "https://github.com/apple/swift-docc-symbolkit", branch: "main"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "2.5.0"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.2.0"),
     ]

--- a/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/DeclarationsSectionTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/DeclarationsSectionTranslator.swift
@@ -68,12 +68,9 @@ struct DeclarationsSectionTranslator: RenderSectionTranslator {
                     for alternateDeclaration in decls {
                         let renderedTokens = alternateDeclaration.declarationFragments.map(translateFragment)
 
-                        let platformNames = platforms.sorted { (lhs, rhs) -> Bool in
-                            guard let lhsValue = lhs, let rhsValue = rhs else {
-                                return lhs == nil
-                            }
-                            return lhsValue.rawValue < rhsValue.rawValue
-                        }
+                        let platformNames = platforms
+                            .compactMap { $0 }
+                            .sorted(by: \.rawValue)
 
                         declarations.append(
                             DeclarationRenderSection(

--- a/Sources/SwiftDocC/Semantics/Symbol/Symbol.swift
+++ b/Sources/SwiftDocC/Semantics/Symbol/Symbol.swift
@@ -150,7 +150,10 @@ public final class Symbol: Semantic, Abstracted, Redirected, AutomaticTaskGroups
     public var declarationVariants = DocumentationDataVariants<[[PlatformName?]: SymbolGraph.Symbol.DeclarationFragments]>(
         defaultVariantValue: [:]
     )
-    
+
+    /// The symbols alternate declarations in each language variant the symbol is available in.
+    public var alternateDeclarationVariants = DocumentationDataVariants<[[PlatformName?]: [SymbolGraph.Symbol.DeclarationFragments]]>()
+
     public var locationVariants = DocumentationDataVariants<SymbolGraph.Symbol.Location>()
 
     /// The symbol's availability or conformance constraints, in each language variant the symbol is available in.
@@ -307,6 +310,8 @@ public final class Symbol: Semantic, Abstracted, Redirected, AutomaticTaskGroups
                     self.locationVariants[trait] = location
                 case let spi as SymbolGraph.Symbol.SPI:
                     self.isSPIVariants[trait] = spi.isSPI
+                case let alternateDeclarations as SymbolGraph.Symbol.AlternateDeclarations:
+                    self.alternateDeclarationVariants[trait] = [[platformNameVariants[trait]]: alternateDeclarations.declarations]
                 default: break;
                 }
             }

--- a/Tests/SwiftDocCTests/Rendering/DeclarationsRenderSectionTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/DeclarationsRenderSectionTests.swift
@@ -80,4 +80,25 @@ class DeclarationsRenderSectionTests: XCTestCase {
         let value = try JSONDecoder().decode(DeclarationsRenderSection.self, from: jsonData)
         try assertRoundTripCoding(value)
     }
+
+    func testAlternateDeclarations() throws {
+        let (bundle, context) = try testBundleAndContext(named: "AlternateDeclarations")
+        let reference = ResolvedTopicReference(
+            bundleIdentifier: bundle.identifier,
+            path: "/documentation/AlternateDeclarations/MyClass/present(completion:)",
+            sourceLanguage: .swift
+        )
+        let symbol = try XCTUnwrap(context.entity(with: reference).semantic as? Symbol)
+        var translator = RenderNodeTranslator(
+            context: context,
+            bundle: bundle,
+            identifier: reference,
+            source: nil
+        )
+        let renderNode = try XCTUnwrap(translator.visitSymbol(symbol) as? RenderNode)
+        let declarationsSection = try XCTUnwrap(renderNode.primaryContentSections.compactMap({ $0 as? DeclarationsRenderSection }).first)
+
+        XCTAssertEqual(declarationsSection.declarations.count, 2)
+        XCTAssert(declarationsSection.declarations.allSatisfy({ $0.platforms == [.macOS] }))
+    }
 }

--- a/Tests/SwiftDocCTests/Test Bundles/AlternateDeclarations.docc/AlternateDeclarations.md
+++ b/Tests/SwiftDocCTests/Test Bundles/AlternateDeclarations.docc/AlternateDeclarations.md
@@ -1,0 +1,9 @@
+# ``AlternateDeclarations``
+
+This bundle contains a class translated from Objective-C. That class contains one method, which was
+written to accept a completion handler. The Swift translation converted this into two methods: one
+with the original completion handler parameter, and one that uses `async`/`await`. This bundle
+exists to test SymbolKit's "alternate declarations" mechanism and ensure that Swift-DocC converts it
+into a Declarations section with both declarations.
+
+<!-- Copyright (c) 2023 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Tests/SwiftDocCTests/Test Bundles/AlternateDeclarations.docc/AlternateDeclarations.symbols.json
+++ b/Tests/SwiftDocCTests/Test Bundles/AlternateDeclarations.docc/AlternateDeclarations.symbols.json
@@ -1,0 +1,368 @@
+{
+    "metadata": {
+        "formatVersion": {
+            "major": 0,
+            "minor": 6,
+            "patch": 0
+        },
+        "generator": "Swift 5.9"
+    },
+    "module": {
+        "name": "AlternateDeclarations",
+        "platform": {
+            "architecture": "arm64",
+            "vendor": "apple",
+            "operatingSystem": {
+                "name": "macosx",
+                "minimumVersion": {
+                    "major": 12,
+                    "minor": 4
+                }
+            }
+        }
+    },
+    "symbols": [
+        {
+            "kind": {
+                "identifier": "swift.class",
+                "displayName": "Class"
+            },
+            "identifier": {
+                "precise": "c:objc(cs)MyClass",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "MyClass"
+            ],
+            "names": {
+                "title": "MyClass",
+                "navigator": [
+                    {
+                        "kind": "identifier",
+                        "spelling": "MyClass"
+                    }
+                ],
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "class"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "MyClass"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "class"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "MyClass"
+                }
+            ],
+            "accessLevel": "open"
+        },
+        {
+            "kind": {
+                "identifier": "swift.method",
+                "displayName": "Instance Method"
+            },
+            "identifier": {
+                "precise": "c:objc(cs)MyClass(im)presentWithCompletion:",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "MyClass",
+                "present(completion:)"
+            ],
+            "names": {
+                "title": "present(completion:)",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "present"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "("
+                    },
+                    {
+                        "kind": "externalParam",
+                        "spelling": "completion"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ": (("
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Bool",
+                        "preciseIdentifier": "s:Sb"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ") -> "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Void",
+                        "preciseIdentifier": "s:s4Voida"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": ")!)"
+                    }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "completion",
+                        "declarationFragments": [
+                            {
+                                "kind": "identifier",
+                                "spelling": "completion"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ": (("
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Bool",
+                                "preciseIdentifier": "s:Sb"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ") -> "
+                            },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "Void",
+                                "preciseIdentifier": "s:s4Voida"
+                            },
+                            {
+                                "kind": "text",
+                                "spelling": ")!"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Void",
+                        "preciseIdentifier": "s:s4Voida"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "present"
+                },
+                {
+                    "kind": "text",
+                    "spelling": "("
+                },
+                {
+                    "kind": "externalParam",
+                    "spelling": "completion"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ": (("
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Bool",
+                    "preciseIdentifier": "s:Sb"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ") -> "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Void",
+                    "preciseIdentifier": "s:s4Voida"
+                },
+                {
+                    "kind": "text",
+                    "spelling": ")!)"
+                }
+            ],
+            "accessLevel": "open"
+        },
+        {
+            "kind": {
+                "identifier": "swift.method",
+                "displayName": "Instance Method"
+            },
+            "identifier": {
+                "precise": "c:objc(cs)MyClass(im)presentWithCompletion:",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "MyClass",
+                "present()"
+            ],
+            "names": {
+                "title": "present()",
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "present"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "() "
+                    },
+                    {
+                        "kind": "keyword",
+                        "spelling": "async"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " -> "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Bool",
+                        "preciseIdentifier": "s:Sb"
+                    }
+                ]
+            },
+            "functionSignature": {
+                "returns": [
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "Bool",
+                        "preciseIdentifier": "s:Sb"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "present"
+                },
+                {
+                    "kind": "text",
+                    "spelling": "() "
+                },
+                {
+                    "kind": "keyword",
+                    "spelling": "async"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " -> "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "Bool",
+                    "preciseIdentifier": "s:Sb"
+                }
+            ],
+            "accessLevel": "open"
+        }
+    ],
+    "relationships": [
+        {
+            "kind": "conformsTo",
+            "source": "c:objc(cs)MyClass",
+            "target": "s:SQ",
+            "targetFallback": "Swift.Equatable"
+        },
+        {
+            "kind": "memberOf",
+            "source": "c:objc(cs)MyClass(im)presentWithCompletion:",
+            "target": "c:objc(cs)MyClass"
+        },
+        {
+            "kind": "inheritsFrom",
+            "source": "c:objc(cs)MyClass",
+            "target": "c:objc(cs)NSObject",
+            "targetFallback": "ObjectiveC.NSObject"
+        },
+        {
+            "kind": "conformsTo",
+            "source": "c:objc(cs)MyClass",
+            "target": "s:SH",
+            "targetFallback": "Swift.Hashable"
+        },
+        {
+            "kind": "conformsTo",
+            "source": "c:objc(cs)MyClass",
+            "target": "s:s23CustomStringConvertibleP",
+            "targetFallback": "Swift.CustomStringConvertible"
+        },
+        {
+            "kind": "conformsTo",
+            "source": "c:objc(cs)MyClass",
+            "target": "s:s7CVarArgP",
+            "targetFallback": "Swift.CVarArg"
+        },
+        {
+            "kind": "conformsTo",
+            "source": "c:objc(cs)MyClass",
+            "target": "c:objc(pl)NSObject",
+            "targetFallback": "ObjectiveC.NSObjectProtocol"
+        },
+        {
+            "kind": "memberOf",
+            "source": "c:objc(cs)MyClass(im)presentWithCompletion:",
+            "target": "c:objc(cs)MyClass"
+        },
+        {
+            "kind": "conformsTo",
+            "source": "c:objc(cs)MyClass",
+            "target": "s:s28CustomDebugStringConvertibleP",
+            "targetFallback": "Swift.CustomDebugStringConvertible"
+        }
+    ]
+}

--- a/Tests/SwiftDocCTests/Test Bundles/AlternateDeclarations.docc/Info.plist
+++ b/Tests/SwiftDocCTests/Test Bundles/AlternateDeclarations.docc/Info.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleName</key>
+	<string>AlternateDeclarations</string>
+	<key>CFBundleDisplayName</key>
+	<string>Alternate Declarations</string>
+	<key>CFBundleIdentifier</key>
+	<string>org.swift.docc.example</string>
+	<key>CFBundleVersion</key>
+	<string>0.1.0</string>
+</dict>
+</plist>


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://70594078

## Summary

When the same symbol has multiple available declarations on the same platform (e.g. when an Objective-C method is imported into Swift and converted into an `async`/`await` version), only one of those declarations is kept. This PR uses in-progress work on SymbolKit to show these declarations in the symbols Declarations section, instead of discarding them.

For example, consider the following Objective-C code:

```objc
@interface MyClass : NSObject

/// Some function with a completion handler.
///
/// This is an Objective-C function where you pass in a completion handler, However, in Swift,
/// you also have the option to run it with `async` and `await`!
- (void)presentWithCompletion:(void (^)(BOOL success))completion;

@end
```

When imported into Swift, two versions of this method are available. Ordinarily, Swift-DocC would discard the `async` version. With this PR, this is how the resulting page would appear:

<img width="708" alt="image" src="https://github.com/apple/swift-docc/assets/5217170/9c8b6a53-6d56-4dcc-bf98-fdb6adf67e7e">

## Dependencies

https://github.com/apple/swift-docc-symbolkit/pull/60

## Testing

Steps:
1. Generate documentation for the above Objective-C code as if it were Swift. (The test bundle added in this PR includes a symbol graph generated from this code.)
2. Ensure that the resulting symbol page for `MyClass.present(completion:)` shows both the completion-handler declaration as well as the `async` declaration.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ n/a ] Updated documentation if necessary
