### PR TITLE
SwiftDocCUtilitiesTests: adjust `TestFileSystem`'s handling of paths

### DIFF
--- a/Tests/SwiftDocCUtilitiesTests/Utility/TestFileSystem.swift
+++ b/Tests/SwiftDocCUtilitiesTests/Utility/TestFileSystem.swift
@@ -209,12 +209,7 @@ class TestFileSystem: FileManagerProtocol, DocumentationWorkspaceDataProvider {
         filesLock.lock()
         defer { filesLock.unlock() }
 
-        guard let target = URL(string: path) else {
-            throw Errors.invalidPath(path)
-        }
-        
-        let parent = target.deletingLastPathComponent()
-        
+        let parent = URL(fileURLWithPath: path).deletingLastPathComponent()
         if parent.pathComponents.count > 1 {
             // If it's not the root folder, check if parents exist
             if createIntermediates == false {
@@ -262,8 +257,7 @@ class TestFileSystem: FileManagerProtocol, DocumentationWorkspaceDataProvider {
         filesLock.lock()
         defer { filesLock.unlock() }
 
-        guard let fileURL = URL(string: at.path),
-              files.keys.contains(fileURL.deletingLastPathComponent().path) else {
+        guard files.keys.contains(at.deletingLastPathComponent().path) else {
             throw NSError(domain: NSCocoaErrorDomain, code: NSFileNoSuchFileError, userInfo: [NSFilePathErrorKey: at.path])
         }
         


### PR DESCRIPTION
When constructing a `URL` with a file path, we should always use `init(fileURLWithPath:)` as not all paths are represented as a URL and require additional encoding.  On Windows, this would result in us stripping the drive prefix (`C:`) which would corrupt the path and thus fail to lookup the item.  In the second instance, this allowed us to simply avoid an object copy entirely.

This helps improve the test pass rate significantly on Windows.