### PR TITLE
encoded an explicit null for DownloadReference's checksum

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/Tutorial/References/DownloadReference.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Tutorial/References/DownloadReference.swift
@@ -101,7 +101,7 @@ public struct DownloadReference: RenderReference, URLReference, Equatable {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(type.rawValue, forKey: .type)
         try container.encode(identifier, forKey: .identifier)
-        try container.encodeIfPresent(checksum, forKey: .checksum)
+        try container.encode(checksum, forKey: .checksum)
         
         // Render URL
         if !encodeUrlVerbatim {

--- a/Tests/SwiftDocCTests/Rendering/SampleDownloadTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/SampleDownloadTests.swift
@@ -277,4 +277,13 @@ class SampleDownloadTests: XCTestCase {
         let downloadReference = try XCTUnwrap(renderNode.projectFiles())
         XCTAssertEqual(downloadReference.url.description, "https://example.com/sample.zip")
     }
+
+    func testExplicitNullChecksum() throws {
+        let identifier = RenderReferenceIdentifier("/test/sample.zip")
+        let originalURL = try XCTUnwrap(URL(string: "/test/sample.zip"))
+        var reference = DownloadReference(identifier: identifier, verbatimURL: originalURL, checksum: nil)
+        let encodedReference = try JSONEncoder().encode(reference)
+        let encodedJson = try XCTUnwrap(String(data: encodedReference, encoding: .utf8))
+        XCTAssert(encodedJson.contains(#""checksum":null"#))
+    }
 }


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift-docc/pull/656

- **Explanation**: For ease of processing, this PR changes DownloadReference to encode an explicit `null` when `checksum` is not present.
- **Scope**: Affects tools which process Render JSON after generation.
- **Issue**: rdar://111865266
- **Risk**: Very low. There is no behavior change in DocC itself, and the resulting Render JSON is equivalent in semantics.
- **Testing**: A test has been added to ensure the output JSON is as expected. Existing automated tests still pass.
- **Reviewer**: @ethan-kusters 