### PR TITLE
[5.9] Make visitLineBreak return new line instead of space

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/RenderContentCompiler.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderContentCompiler.swift
@@ -275,7 +275,7 @@ struct RenderContentCompiler: MarkupVisitor {
     }
     
     mutating func visitLineBreak(_ lineBreak: LineBreak) -> [RenderContent] {
-        return [RenderInlineContent.text(" ")]
+        return [RenderInlineContent.text("\n")]
     }
     
     mutating func visitEmphasis(_ emphasis: Emphasis) -> [RenderContent] {


### PR DESCRIPTION
- **Explanation**: Make visitLineBreak return new line instead of space
- **Scope**: Impacts lineBreak markdown output
- **GitHub Issue**: #477
- **Risk**: Low, only `visitLineBreak` logic is impacted
- **Testing**: See the corresponding test update
- **Reviewer**: @d-ronnqvist 
- Original PR: #633