### PR TITLE
[5.9] Allow anchor <doc:#heading> within same article

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
@@ -764,10 +764,16 @@ extension PathHierarchy {
         let isAbsolute = path.first == "/"
             || String(components.first ?? "") == NodeURLGenerator.Path.documentationFolderName
             || String(components.first ?? "") == NodeURLGenerator.Path.tutorialsFolderName
-       
+
+        // If there is a # character in the last component, split that into two components
         if let hashIndex = components.last?.firstIndex(of: "#") {
             let last = components.removeLast()
-            components.append(last[..<hashIndex])
+            // Allow anrhor-only links where there's nothing before #.
+            // In case the pre-# part is empty, and we're omitting empty components, don't add it in.
+            let pathName = last[..<hashIndex]
+            if !pathName.isEmpty || !omittingEmptyComponents {
+                components.append(pathName)
+            }
             
             let fragment = String(last[hashIndex...].dropFirst())
             return (components.map(Self.parse(pathComponent:)) + [PathComponent(full: fragment, name: fragment, kind: nil, hash: nil)], isAbsolute)


### PR DESCRIPTION
- **Explanation**: Adds support for `<doc:#HeadingName>` when linking to a heading on the same page. Today, only `<doc:HeadingName>` or `<doc:ArticleName#HeadingName>` are supported.
- **Scope**: Parsing documentation links into components.
- **GitHub Issue**: #632 
- **Risk**: Low. Small and isolated changes to how the heading "fragment" is parsed in documentation links.
- **Testing**: New tests verify that links to headings within the same article can have a leading "#" character.
- **Reviewer**: @d-ronnqvist 
- Original PR: #652 (by [natikgadzhi](https://github.com/natikgadzhi))