### PR TITLE
Create file URLs for bundle files in TestFileSystem

### DIFF
--- a/Sources/SwiftDocCUtilities/Action/Actions/Convert/ConvertAction.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Convert/ConvertAction.swift
@@ -152,7 +152,7 @@ public struct ConvertAction: Action, RecreatingContext {
         engine.add(
             DiagnosticConsoleWriter(
                 formattingOptions: formattingOptions,
-                baseURL: documentationBundleURL ?? URL(string: fileManager.currentDirectoryPath)
+                baseURL: documentationBundleURL ?? URL(fileURLWithPath: fileManager.currentDirectoryPath)
             )
         )
         if let diagnosticFilePath = diagnosticFilePath {

--- a/Tests/SwiftDocCUtilitiesTests/Utility/TestFileSystem.swift
+++ b/Tests/SwiftDocCUtilitiesTests/Utility/TestFileSystem.swift
@@ -82,7 +82,7 @@ class TestFileSystem: FileManagerProtocol, DocumentationWorkspaceDataProvider {
         for folder in folders {
             let files = try addFolder(folder)
             if let info = folder.recursiveContent.mapFirst(where: { $0 as? InfoPlist }) {
-                let files = files.filter({ $0.hasPrefix(folder.absoluteURL.path) }).compactMap({ URL(string: $0) })
+                let files = files.filter({ $0.hasPrefix(folder.absoluteURL.path) }).compactMap({ URL(fileURLWithPath: $0) })
 
                 let markupFiles = files.filter({ DocumentationBundleFileTypes.isMarkupFile($0) })
                 let miscFiles = files.filter({ !DocumentationBundleFileTypes.isMarkupFile($0) })


### PR DESCRIPTION

Bug/issue #, if applicable: 

## Summary

Use `URL(fileURLWithPath:)` instead of `URL(string:)` when creating URLs for documentation bundle files in TestFileSystem. This makes them file URLs.

## Dependencies

None

## Testing

This isn't a user-facing change.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
