### PR TITLE
only use the last file component when deciding decoding strategy

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphLoader.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphLoader.swift
@@ -113,7 +113,7 @@ struct SymbolGraphLoader {
         // This strategy benchmarks better when we have multiple
         // "larger" symbol graphs.
         #if os(macOS) || os(iOS)
-        if bundle.symbolGraphURLs.filter({ !($0.pathComponents.last ?? "").contains("@") }).count > 1 {
+        if bundle.symbolGraphURLs.filter({ !$0.lastPathComponent.contains("@") }).count > 1 {
             // There are multiple main symbol graphs, better parallelize all files decoding.
             decodingStrategy = .concurrentlyAllFiles
         }

--- a/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphLoader.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphLoader.swift
@@ -113,7 +113,7 @@ struct SymbolGraphLoader {
         // This strategy benchmarks better when we have multiple
         // "larger" symbol graphs.
         #if os(macOS) || os(iOS)
-        if bundle.symbolGraphURLs.filter({ !$0.path.contains("@") }).count > 1 {
+        if bundle.symbolGraphURLs.filter({ !($0.pathComponents.last ?? "").contains("@") }).count > 1 {
             // There are multiple main symbol graphs, better parallelize all files decoding.
             decodingStrategy = .concurrentlyAllFiles
         }

--- a/Tests/SwiftDocCTests/Infrastructure/SymbolGraph/SymbolGraphLoaderTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/SymbolGraph/SymbolGraphLoaderTests.swift
@@ -313,10 +313,6 @@ class SymbolGraphLoaderTests: XCTestCase {
     /// Ensure that loading symbol graphs from a directory with an at-sign properly selects the
     /// `concurrentlyAllFiles` decoding strategy on macOS and iOS.
     func testLoadingSymbolsInAtSignDirectory() throws {
-        #if !os(macOS) && !os(iOS)
-        XCTSkip("This test is only valid on macOS and iOS.")
-        #endif
-
         let tempURL = try createTemporaryDirectory(pathComponents: "MyTempDir@2")
         let originalSymbolGraphs = [
             CopyOfFile(original: Bundle.module.url(forResource: "Asides.symbols", withExtension: "json", subdirectory: "Test Resources")!),
@@ -327,7 +323,11 @@ class SymbolGraphLoaderTests: XCTestCase {
         var loader = try makeSymbolGraphLoader(symbolGraphURLs: symbolGraphURLs)
         try loader.loadAll()
 
+        #if os(macOS) || os(iOS)
         XCTAssertEqual(loader.decodingStrategy, .concurrentlyAllFiles)
+        #else
+        XCTAssertEqual(loader.decodingStrategy, .concurrentlyEachFileInBatches)
+        #endif
     }
 
     func testInputWithMixedGraphFormats() throws {

--- a/Tests/SwiftDocCTests/Infrastructure/SymbolGraph/SymbolGraphLoaderTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/SymbolGraph/SymbolGraphLoaderTests.swift
@@ -309,7 +309,27 @@ class SymbolGraphLoaderTests: XCTestCase {
             XCTAssertTrue(foundMainAsyncMethodsGraph, "AsyncMethods graph wasn't found")
         }
     }
-    
+
+    /// Ensure that loading symbol graphs from a directory with an at-sign properly selects the
+    /// `concurrentlyAllFiles` decoding strategy on macOS and iOS.
+    func testLoadingSymbolsInAtSignDirectory() throws {
+        #if !os(macOS) && !os(iOS)
+        XCTSkip("This test is only valid on macOS and iOS.")
+        #endif
+
+        let tempURL = try createTemporaryDirectory(pathComponents: "MyTempDir@2")
+        let originalSymbolGraphs = [
+            CopyOfFile(original: Bundle.module.url(forResource: "Asides.symbols", withExtension: "json", subdirectory: "Test Resources")!),
+            CopyOfFile(original: Bundle.module.url(forResource: "WithCompletionHandler.symbols", withExtension: "json", subdirectory: "Test Resources")!)
+        ]
+        let symbolGraphURLs = try originalSymbolGraphs.map({ try $0.write(inside: tempURL) })
+
+        var loader = try makeSymbolGraphLoader(symbolGraphURLs: symbolGraphURLs)
+        try loader.loadAll()
+
+        XCTAssertEqual(loader.decodingStrategy, .concurrentlyAllFiles)
+    }
+
     func testInputWithMixedGraphFormats() throws {
         let tempURL = try createTemporaryDirectory()
         


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://112664398

## Summary

Swift CI has started failing on Swift-DocC's tests, because its workspace folder includes an `@` sign. This confuses the SymbolGraphLoader into thinking that there are no base-module symbol graphs, and thus refusing to use the `concurrentlyAllFiles` decoding strategy. This PR updates that logic to only inspect the last path component instead of the full file path, allowing these `@` sign directories to successfully detect base-module and extension symbol graphs.

## Dependencies

None

## Testing

Steps:
1. Generate symbol graphs for multiple modules (or copy out two symbol graphs from the "Test Resources" directory) into a directory whose name contains `@`.
2. Run `docc convert` in a debugger and ensure that `SymbolGraphLoader` correctly uses the `concurrentlyAllFiles `decoding strategy to load symbol graph files in parallel.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ n/a ] Updated documentation if necessary
