### PR TITLE
only use the last file component when deciding decoding strategy

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphLoader.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphLoader.swift
@@ -113,7 +113,7 @@ struct SymbolGraphLoader {
         // This strategy benchmarks better when we have multiple
         // "larger" symbol graphs.
         #if os(macOS) || os(iOS)
-        if bundle.symbolGraphURLs.filter({ !$0.path.contains("@") }).count > 1 {
+        if bundle.symbolGraphURLs.filter({ !$0.lastPathComponent.contains("@") }).count > 1 {
             // There are multiple main symbol graphs, better parallelize all files decoding.
             decodingStrategy = .concurrentlyAllFiles
         }


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift-docc/pull/665

- **Explanation**: Updates the symbol graph loader to only check the last path component for an `@` sign, instead of the full path.
- **Scope**: Unblocks Swift CI for runners using an `@2` versioned workspace.
- **Issue**: rdar://112664398
- **Risk**: Low. The change in infrastructural and could cause a difference in performance, but not in functionality.
- **Testing**: A test has been added to ensure the intended change. Existing automated tests pass.
- **Reviewer**: @ethan-kusters 
