### PR TITLE
Tests: standardize both sides of the URL

### DIFF
--- a/Tests/SwiftDocCUtilitiesTests/ArgumentParsing/ConvertSubcommandTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ArgumentParsing/ConvertSubcommandTests.swift
@@ -112,7 +112,7 @@ class ConvertSubcommandTests: XCTestCase {
             )
             let action = try ConvertAction(fromConvertCommand: convert)
             XCTAssertEqual(
-                action.htmlTemplateDirectory,
+                action.htmlTemplateDirectory?.standardizedFileURL,
                 defaultTemplateDir.standardizedFileURL
             )
         }


### PR DESCRIPTION
When testing with a rebound volume mount (i.e. using `subst` on Windows), the paths are compared without canonicalisation for the rebound path.  This causes a test failure as although the paths are logically equivalent, they are not physically equivalent.  The `standardizedPath` here ensures that we resolve the junction allowing the path comparison to succeed.