### PR TITLE
Tests: enable the non-Darwin behaviour on Windows

### DIFF
--- a/Tests/SwiftDocCTests/Rendering/RoundTripCoding.swift
+++ b/Tests/SwiftDocCTests/Rendering/RoundTripCoding.swift
@@ -50,7 +50,7 @@ func assertJSONRepresentation<Value: Decodable & Equatable>(
     var decoded: Value? = nil
     
     let encoding: String.Encoding
-    #if os(Linux) || os(Android)
+    #if os(Linux) || os(Android) || os(Windows)
     // Work around a JSON decoding issue on Linux (github.com/apple/swift/issues/57362).
     encoding = .utf8
     #else

--- a/Tests/SwiftDocCTests/Servers/FileServerTests.swift
+++ b/Tests/SwiftDocCTests/Servers/FileServerTests.swift
@@ -164,7 +164,7 @@ class FileServerTests: XCTestCase {
         (response, data) = fileServer.response(to: failingRequest)
         XCTAssertNil(data)
         // Initializing a URLResponse with `nil` as MIME type in Linux returns nil
-        #if os(Linux) || os(Android)
+        #if os(Linux) || os(Android) || os(Windows)
         XCTAssertNil(response.mimeType)
         #else
         // Doing the same in macOS or iOS returns the default MIME type


### PR DESCRIPTION
Windows, similar to Linux, requires that we use the explicit encoding of `.utf8` rather than `.fastest`.  This fixes a roundtrip test failure on Windows.