### PR TITLE
[5.9] Fix a few test failures on macOS 14 Beta versions.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -60,7 +60,7 @@
         "repositoryURL": "https://github.com/apple/swift-markdown.git",
         "state": {
           "branch": "release/5.9",
-          "revision": "bbeb362919d903eb722c913ad49a1b23d27bdc00",
+          "revision": "15bbd521f3efd161995ed55179e9984a7d734c61",
           "version": null
         }
       },

--- a/Sources/SwiftDocCUtilities/Action/Actions/PreviewAction.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/PreviewAction.swift
@@ -162,9 +162,11 @@ public final class PreviewAction: Action, RecreatingContext {
         // Preview the output and monitor the source bundle for changes.
         do {
             print(String(repeating: "=", count: 40), to: &logHandle)
-            print("Starting Local Preview Server", to: &logHandle)
-            printPreviewAddresses(base: URL(string: "http://localhost:\(port)")!)
-            print(String(repeating: "=", count: 40), to: &logHandle)
+            if let previewURL = URL(string: "http://localhost:\(port)") {
+                print("Starting Local Preview Server", to: &logHandle)
+                printPreviewAddresses(base: previewURL)
+                print(String(repeating: "=", count: 40), to: &logHandle)
+            }
 
             let to: PreviewServer.Bind = bindServerToSocketPath.map { .socket(path: $0) } ?? .localhost(port: port)
             servers[serverIdentifier] = try PreviewServer(contentURL: convertAction.targetDirectory, bindTo: to, logHandle: &logHandle)

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/Options/Source Repository/SourceRepositoryArguments.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/Options/Source Repository/SourceRepositoryArguments.swift
@@ -78,7 +78,7 @@ extension SourceRepository {
                 """
             )
         case let (sourceService?, sourceServiceBaseURL?, checkoutPath?):
-            guard let sourceServiceBaseURL = URL(string: sourceServiceBaseURL) else {
+            guard let sourceServiceBaseURL = URL(string: sourceServiceBaseURL), sourceServiceBaseURL.scheme != nil, sourceServiceBaseURL.host != nil else {
                 throw ValidationError("Invalid URL '\(sourceServiceBaseURL)' for '--source-service-base-url' argument.")
             }
             

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -1727,10 +1727,10 @@ let expected = """
             
             ## Topics
             
+            Only curate the pages. Headings don't support curation.
+            
             - ``MyClass/myFunc🙂()``
-            - <doc:article-with-emoji-in-heading#Hello-🌍>
             - <doc:article-with-😃-in-filename>
-            - <doc:article-with-😃-in-filename#Hello-world>
             """),
         ])
         let bundleURL = try testBundle.write(inside: createTemporaryDirectory())
@@ -1748,9 +1748,7 @@ let expected = """
         // Verify that all the links in the topic section resolved
         XCTAssertEqual(topicSection.links.map(\.destination), [
             "doc://special-characters/documentation/MyKit/MyClass/myFunc_()",
-            "doc://special-characters/documentation/special-characters/article-with-emoji-in-heading#Hello-%F0%9F%8C%8D",
             "doc://special-characters/documentation/special-characters/article-with---in-filename",
-            "doc://special-characters/documentation/special-characters/article-with---in-filename#Hello-world",
         ])
         
         // Verify that all resolved link exist in the context.
@@ -1765,12 +1763,10 @@ let expected = """
         let renderNode = translator.visit(moduleSymbol) as! RenderNode
         
         // Verify that the resolved links rendered as links
-        XCTAssertEqual(renderNode.topicSections.first?.identifiers.count, 4)
+        XCTAssertEqual(renderNode.topicSections.first?.identifiers.count, 2)
         XCTAssertEqual(renderNode.topicSections.first?.identifiers, [
             "doc://special-characters/documentation/MyKit/MyClass/myFunc_()",
-            "doc://special-characters/documentation/special-characters/article-with-emoji-in-heading#Hello-%F0%9F%8C%8D",
             "doc://special-characters/documentation/special-characters/article-with---in-filename",
-            "doc://special-characters/documentation/special-characters/article-with---in-filename#Hello-world",
         ])
         
         

--- a/Tests/SwiftDocCTests/Infrastructure/ResolvedTopicReferenceTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/ResolvedTopicReferenceTests.swift
@@ -54,7 +54,12 @@ class ResolvedTopicReferenceTests: XCTestCase {
         do {
             let resolvedOriginal = ResolvedTopicReference(bundleIdentifier: "bundleID", path: "/path/sub-path", fragment: "fragment", sourceLanguage: .swift)
             
-            let unresolved = UnresolvedTopicReference(topicURL: ValidatedURL(parsingExact: "doc://host.name/;;;")!)
+            var components = URLComponents()
+            components.scheme = "doc"
+            components.host = "host.name"
+            components.percentEncodedPath = "%20%20%20" // 3 spaces 
+            
+            let unresolved = UnresolvedTopicReference(topicURL: ValidatedURL(components: components))
             XCTAssertFalse(unresolved.path.isEmpty)
             
             let appended = resolvedOriginal.appendingPathOfReference(unresolved)

--- a/Tests/SwiftDocCTests/Semantics/RedirectedTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/RedirectedTests.swift
@@ -41,29 +41,6 @@ class RedirectedTests: XCTestCase {
         XCTAssertEqual(redirected?.oldPath.path, oldPath)
     }
     
-    func testInvalidURL() throws {
-          let someCharactersThatAreNotAllowedInPaths = "⊂⧺∀ℝ∀⊂⊤∃∫"
-          for character in someCharactersThatAreNotAllowedInPaths {
-              XCTAssertFalse(CharacterSet.urlPathAllowed.contains(character.unicodeScalars.first!), "Verify that \(character) is invalid")
-              
-              let pathWithInvalidCharacter = "/path/with/invalid\(character)for/paths"
-              let source = "@Redirected(from: \(pathWithInvalidCharacter))"
-              let document = Document(parsing: source, options: .parseBlockDirectives)
-              let directive = document.child(at: 0)! as! BlockDirective
-              let (bundle, context) = try testBundleAndContext(named: "TestBundle")
-              var problems = [Problem]()
-              let redirected = Redirect(from: directive, source: nil, for: bundle, in: context, problems: &problems)
-              XCTAssertNil(redirected?.oldPath.absoluteString, "\(character)")
-              XCTAssertFalse(problems.containsErrors)
-              XCTAssertEqual(1, problems.count)
-              XCTAssertEqual(problems.first?.diagnostic.identifier, "org.swift.docc.HasArgument.from.ConversionFailed")
-              XCTAssertEqual(
-                  problems.first?.diagnostic.summary,
-                  "Cannot convert '\(pathWithInvalidCharacter)' to type 'URL'"
-              )
-          }
-      }
-    
     func testExtraArguments() throws {
         let oldPath = "/old/path/to/this/page"
         let source = "@Redirected(from: \(oldPath), argument: value)"

--- a/Tests/SwiftDocCTests/Utility/ValidatedURLTests.swift
+++ b/Tests/SwiftDocCTests/Utility/ValidatedURLTests.swift
@@ -36,19 +36,9 @@ class ValidatedURLTests: XCTestCase {
     }
 
     func testInvalidURLs() {
-        let invalidURLs = [
-            URL(string: "http://:domain")!,
-        ]
-        
-        // Test ValidatedURL.init(String)
-        invalidURLs.forEach { url in
-            XCTAssertNil(ValidatedURL(parsingExact: url.absoluteString))
-        }
+        XCTAssertNil(ValidatedURL(parsingExact: "http://:domain"))
 
-        // Test ValidatedURL.init(URL)
-        invalidURLs.forEach { url in
-            XCTAssertNil(ValidatedURL(url))
-        }
+        XCTAssertNil(URL(string: "http://:domain").flatMap { ValidatedURL($0) })
     }
 
     func testRequiringScheme() {

--- a/Tests/SwiftDocCUtilitiesTests/ArgumentParsing/ConvertSubcommandSourceRepositoryTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ArgumentParsing/ConvertSubcommandSourceRepositoryTests.swift
@@ -32,10 +32,10 @@ class ConvertSubcommandSourceRepositoryTests: XCTestCase {
             try assertSourceRepositoryArguments(
                 checkoutPath: "checkout path",
                 sourceService: sourceService,
-                sourceServiceBaseURL: "example.com/path/to/base"
+                sourceServiceBaseURL: "https://example.com/path/to/base"
             ) { action in
                 XCTAssertEqual(action.sourceRepository?.checkoutPath, "checkout path")
-                XCTAssertEqual(action.sourceRepository?.sourceServiceBaseURL, URL(string: "example.com/path/to/base")!)
+                XCTAssertEqual(action.sourceRepository?.sourceServiceBaseURL.absoluteString, "https://example.com/path/to/base")
             }
         }
     }
@@ -55,7 +55,7 @@ class ConvertSubcommandSourceRepositoryTests: XCTestCase {
             try assertSourceRepositoryArguments(
                 checkoutPath: nil,
                 sourceService: nil,
-                sourceServiceBaseURL: "example.com/path/to/base"
+                sourceServiceBaseURL: "https://example.com/path/to/base"
             )
         ) { error in
             XCTAssertEqual(
@@ -124,7 +124,7 @@ class ConvertSubcommandSourceRepositoryTests: XCTestCase {
             try assertSourceRepositoryArguments(
                 checkoutPath: "checkout path",
                 sourceService: "not a supported source service",
-                sourceServiceBaseURL: "example.com/foo"
+                sourceServiceBaseURL: "https://example.com/foo"
             )
         ) { error in
             XCTAssertEqual(


### PR DESCRIPTION
Cherry-pick of #586 

- **Explanation**: Update tests and logic for what are considered valid URLs to fix test failures when running on macOS 14 Beta versions.
- **Scope**: Unit tests and handling of what's considered a valid URL.
- **Issue**: rdar://108237260
- **Risk**: Low. 
- **Testing**: This is mostly a test change. On the "main" branch, we verified these changes on macOS 13 and macOS 14 and on Linux (using the Swift CI).
- **Reviewer**: @franklinsch 