### PR TITLE
[5.9] Fix sample code curation regression

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -2051,14 +2051,13 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
         in bundle: DocumentationBundle
     ) -> DocumentationContext.Articles {
         articles.map { article in
-            let kind = article.value.metadata?.pageKind?.kind.documentationNodeKind ?? .article
             guard let (documentation, title) = DocumentationContext.documentationNodeAndTitle(
                 for: article,
                 // By default, articles are available in the languages the module that's being documented
                 // is available in. It's possible to override that behavior using the `@SupportedLanguage`
                 // directive though; see its documentation for more details.
                 availableSourceLanguages: soleRootModuleReference.map { sourceLanguages(for: $0) },
-                kind: kind,
+                kind: .article,
                 in: bundle
             ) else {
                 return article

--- a/Sources/SwiftDocC/LinkTargets/LinkDestinationSummary.swift
+++ b/Sources/SwiftDocC/LinkTargets/LinkDestinationSummary.swift
@@ -392,7 +392,7 @@ extension LinkDestinationSummary {
                 .sorted(by: \.identifier.identifier)
             
             self.init(
-                kind: documentationNode.kind,
+                kind: documentationNode.kindForLinkDestinationSummary,
                 language: documentationNode.sourceLanguage,
                 relativePresentationURL: relativePresentationURL,
                 referenceURL: referenceURL,
@@ -739,6 +739,27 @@ extension LinkDestinationSummary {
         }
         
         return true
+    }
+}
+
+private extension DocumentationNode {
+    /// The documentation node kind that should be used when creating a link destination
+    /// summary for this node.
+    var kindForLinkDestinationSummary: DocumentationNode.Kind {
+        // If this page has an explicit page kind set with the `@PageKind` metadata directive, that
+        // is the one that should be used for the link destination summary.
+        //
+        // This allows specialized articles, like SampleCode pages, that are otherwise treated as
+        // articles in the compilation process to still be rendered correctly when linked against.
+        // However, this solution is less than ideal...
+        //
+        // FIXME: Implement a more robust solution for handling specialized article-like pages.
+        //
+        // This implementation is less than ideal. There should be a more robust way of handling
+        // specialized articles, like sample code pages, that benefit from being treated as articles in
+        // some parts of the compilation process (like curation) but not others (like link destination
+        // summary creation and render node translation).
+        return metadata?.pageKind?.kind.documentationNodeKind ?? kind
     }
 }
 

--- a/Tests/SwiftDocCTests/Infrastructure/AutomaticCurationTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/AutomaticCurationTests.swift
@@ -539,4 +539,35 @@ class AutomaticCurationTests: XCTestCase {
             ]
         )
     }
+    
+    // Ensures that manually curated sample code articles are not also
+    // automatically curated.
+    func testSampleCodeArticlesRespectManualCuration() throws {
+        let renderNode = try renderNode(atPath: "/documentation/SomeSample", fromTestBundleNamed: "SampleBundle")
+        
+        guard renderNode.topicSections.count == 2 else {
+            XCTFail("Expected to find '2' topic sections. Found: \(renderNode.topicSections.count.description.singleQuoted).")
+            return
+        }
+        
+        XCTAssertEqual(renderNode.topicSections[0].title, "Examples")
+        XCTAssertEqual(
+            renderNode.topicSections[0].identifiers,
+            [
+                "doc://org.swift.docc.sample/documentation/SampleBundle/MySample",
+                "doc://org.swift.docc.sample/documentation/SampleBundle/MyLocalSample",
+                "doc://org.swift.docc.sample/documentation/SampleBundle/RelativeURLSample",
+                "doc://org.swift.docc.sample/documentation/SampleBundle/MyArticle",
+                "doc://org.swift.docc.sample/documentation/SampleBundle/MyExternalSample",
+            ]
+        )
+        
+        XCTAssertEqual(renderNode.topicSections[1].title, "Articles")
+        XCTAssertEqual(
+            renderNode.topicSections[1].identifiers,
+            [
+                "doc://org.swift.docc.sample/documentation/SampleBundle/MyUncuratedSample",
+            ]
+        )
+    }
 }

--- a/Tests/SwiftDocCTests/Test Bundles/SampleBundle.docc/MyUncuratedSample.md
+++ b/Tests/SwiftDocCTests/Test Bundles/SampleBundle.docc/MyUncuratedSample.md
@@ -1,0 +1,10 @@
+# MyUncuratedSample
+
+@Metadata {
+    @CallToAction(url: "https://example.com/sample.zip", purpose: download)
+    @PageKind(sampleCode)
+}
+
+Oh no! I forgot to curate this sample code article. 😔
+
+<!-- Copyright (c) 2023 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Tests/SwiftDocCTests/Test Bundles/SampleBundle.docc/RelativeURLSample.md
+++ b/Tests/SwiftDocCTests/Test Bundles/SampleBundle.docc/RelativeURLSample.md
@@ -2,6 +2,7 @@
 
 @Metadata {
     @CallToAction(url: "files/ExternalSample.zip", purpose: download)
+    @PageKind(sampleCode)
 }
 
 This sample references a file on the web server.

--- a/Tests/SwiftDocCTests/Test Bundles/SampleBundle.docc/SomeSample.md
+++ b/Tests/SwiftDocCTests/Test Bundles/SampleBundle.docc/SomeSample.md
@@ -13,5 +13,7 @@ This is a great framework, I tell you what.
 - <doc:MySample>
 - <doc:MyLocalSample>
 - <doc:RelativeURLSample>
+- <doc:MyArticle>
+- <doc:MyExternalSample>
 
 <!-- Copyright (c) 2022-2023 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Tests/SwiftDocCTests/XCTestCase+LoadingTestData.swift
+++ b/Tests/SwiftDocCTests/XCTestCase+LoadingTestData.swift
@@ -90,6 +90,13 @@ extension XCTestCase {
         return (bundle, context)
     }
     
+    func renderNode(atPath path: String, fromTestBundleNamed testBundleName: String) throws -> RenderNode {
+        let (bundle, context) = try testBundleAndContext(named: testBundleName)
+        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: path, sourceLanguage: .swift))
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        return try XCTUnwrap(translator.visit(node.semantic) as? RenderNode)
+    }
+    
     func testBundle(named name: String) throws -> DocumentationBundle {
         let (bundle, _) = try testBundleAndContext(named: name)
         return bundle


### PR DESCRIPTION
- **Explanation**: Fixes a regression where sample code pages stopped respecting manual curation. This made it impossible to curate a sample code page without ending up with duplicate entries for that page.
- **Scope**: Small
- **Issue**: rdar://112223641
- **Risk**: Low. Replaces the original fix for #630 with a more targeted fix directly in link destination summary creation. 
- **Reward**: High. The curation regression doesn't have a workaround besides just not curating sample code pages at all.
- **Testing**: Added a regression test for sample code autocuration. Existing tests for link destination summary creation continue to pass.
- **Original PR:** #674 
- **Reviewers**: @d-ronnqvist 
