### PR TITLE
Fix `ValidationError` text in `DirectoryPathOption.swift`

### DIFF
--- a/Sources/SwiftDocCUtilities/ArgumentParsing/Options/DirectoryPathOption.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/Options/DirectoryPathOption.swift
@@ -32,7 +32,7 @@ extension DirectoryPathOption {
 
         // Validate that the URL represents a directory
         guard url.hasDirectoryPath == true else {
-            throw ValidationError("No documentation directory exist at '\(url.path)'.")
+            throw ValidationError("No documentation directory exists at '\(url.path)'.")
         }
     }
 }


### PR DESCRIPTION
It should either read as `No documentation directories exist` for plural or `No documentation directory exists` for singular. I've updated the text to use the latter.