### PR TITLE
Fix 2 links in documentation comments

### DIFF
--- a/Sources/SwiftDocC/DocumentationService/Models/Services/Convert/ConvertRequest.swift
+++ b/Sources/SwiftDocC/DocumentationService/Models/Services/Convert/ConvertRequest.swift
@@ -132,9 +132,9 @@ public struct ConvertRequest: Codable {
     
     /// The symbol identifiers that have an expanded documentation page available if they meet the associated access level requirement.
     ///
-    /// DocC sets the ``RenderMetadata/hasExpandedDocumentationForSymbols`` property to `true`
-    /// for these symbols if they meet the provided  requirements, so that renderers can display a "View More" link
-    /// that navigates the user to the full version of the documentation page.
+    /// For each of these symbols DocC sets the ``RenderMetadata/hasNoExpandedDocumentation`` property to `true`
+    /// if the symbol fails to meet its provided requirements. This information in the page's ``RenderMetadata`` can be used to display
+    /// a "View More" link that navigates the user to the full version of the documentation page.
     public var symbolIdentifiersWithExpandedDocumentation: [String: ExpandedDocumentationRequirements]?
     
     /// The default code listing language for the documentation bundle to convert.

--- a/Sources/SwiftDocC/Model/Rendering/References/TopicColor.swift
+++ b/Sources/SwiftDocC/Model/Rendering/References/TopicColor.swift
@@ -27,14 +27,12 @@ public struct TopicColor: Codable, Hashable {
     ///
     ///  - term `yellow`: A context-dependent yellow color.
     ///
-    ///  @Comment {
-    ///     This value is optional to allow for a future where topic colors
-    ///     can be defined by something besides the standard color identifiers.
-    ///
-    ///     For example, we may allow fully custom colors in the future and allow
-    ///     for providing some kind of `ColorReference` here.
-    ///  }
     public let standardColorIdentifier: String?
+    // The color identifier is optional to allow for a future where topic colors
+    // can be defined by something besides the standard color identifiers.
+    //
+    // For example, we may allow fully custom colors in the future and allow
+    // for providing some kind of `ColorReference` here.
     
     /// Create a topic color with the given standard color identifier.
     public init(standardColorIdentifier: String) {

--- a/Sources/SwiftDocC/Semantics/Metadata/PageImage.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/PageImage.swift
@@ -15,7 +15,7 @@ import Markdown
 ///
 /// You can use this directive to set the image used when rendering a user-interface element representing the page.
 /// For example, use the page image directive to customize the icon used to represent this page in the navigation sidebar,
-/// or the card image used to represent this page when using the ``Links`` directive and the ``Links/detailedGrid``
+/// or the card image used to represent this page when using the ``Links`` directive and the ``Links/VisualStyle/detailedGrid``
 /// visual style.
 public final class PageImage: Semantic, AutomaticDirectiveConvertible {
     public let originalMarkup: BlockDirective

--- a/Sources/SwiftDocC/Semantics/Metadata/TitleHeading.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/TitleHeading.swift
@@ -15,8 +15,8 @@ import Markdown
 /// 
 /// The ``heading`` property will override the page's default title heading.
 ///
-/// @TitleHeading accepts an unnamed parameter containing containing the page's title heading.
-/// 
+/// The `@TitleHeading` directive accepts an unnamed parameter containing containing the page's title heading.
+///
 /// This directive is only valid within a top-level ``Metadata`` directive:
 /// ```markdown
 /// @Metadata {

--- a/Tests/SwiftDocCTests/Rendering/SampleDownloadTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/SampleDownloadTests.swift
@@ -281,7 +281,7 @@ class SampleDownloadTests: XCTestCase {
     func testExplicitNullChecksum() throws {
         let identifier = RenderReferenceIdentifier("/test/sample.zip")
         let originalURL = try XCTUnwrap(URL(string: "/test/sample.zip"))
-        var reference = DownloadReference(identifier: identifier, verbatimURL: originalURL, checksum: nil)
+        let reference = DownloadReference(identifier: identifier, verbatimURL: originalURL, checksum: nil)
         let encodedReference = try JSONEncoder().encode(reference)
         let encodedJson = try XCTUnwrap(String(data: encodedReference, encoding: .utf8))
         XCTAssert(encodedJson.contains(#""checksum":null"#))


### PR DESCRIPTION
<!--
If you're opening a PR to cherry-pick a change for a release branch, use this template instead:
https://github.com/apple/swift-docc/blob/main/.github/PULL_REQUEST_TEMPLATE/CHERRY_PICK.md
-->

Bug/issue #, if applicable: 

## Summary

This fixes 2 broken links in documentation comments and fixes a few documentation and code warnings.

## Dependencies

None

## Testing

None

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- ~[ ] Added tests~
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
