### PR TITLE
Allow `-o` option as a shortcut for `--output-path`

### DIFF
--- a/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Convert.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Convert.swift
@@ -225,7 +225,7 @@ extension Docc {
         
         /// A user-provided location where the convert action writes the built documentation.
         @Option(
-            name: [.customLong("output-path"), .customLong("output-dir")], // Remove "output-dir" when other tools no longer pass that option. (rdar://72449411)
+            name: [.customLong("output-path"), .customLong("output-dir"), .short], // Remove "output-dir" when other tools no longer pass that option. (rdar://72449411)
             help: "The location where the documentation compiler writes the built documentation.",
             transform: URL.init(fileURLWithPath:)
         )


### PR DESCRIPTION
## Summary

`--output-path` is quite verbose for one of the most common options of the `convert` command. It's common for other utilities to provide a short `-o` option for specifying output. E.g. both `swiftc` and `clang` provide `-o` for specifying its output files. This is also the case for other conversion utilities that don't output to stdout by default.


## Dependencies

N/A

## Testing

Pass `-o` to `convert` in place of `--output-path` or run the test suite, which now tests both options.

## Checklist

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary - documentation automatically updated by ArgumentParser.
