### PR TITLE
SwiftDocCUtilities: repair the Windows build

### DIFF
--- a/Sources/SwiftDocCUtilities/Action/Actions/PreviewAction.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/PreviewAction.swift
@@ -8,10 +8,10 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-#if canImport(NIOHTTP1)
 import Foundation
 import SwiftDocC
 
+#if canImport(NIOHTTP1)
 /// A preview server instance.
 var servers: [String: PreviewServer] = [:]
 
@@ -262,6 +262,7 @@ extension PreviewAction {
     }
 }
 #endif
+#endif
 
 extension DocumentationContext {
     
@@ -283,4 +284,3 @@ extension DocumentationContext {
         }
     }
 }
-#endif


### PR DESCRIPTION
NIO does not support Windows which prevents the availability of the PreviewServer.  However, the new extension to the `DocumentationContext` in the PreviewAction is used in the ConvertAction and does not rely on NIO.  Make it available without NIO.  This repairs the Windows build.