### PR TITLE
Support diffing for RenderNode

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Communication/Foundation/JSON.swift
+++ b/Sources/SwiftDocC/Infrastructure/Communication/Foundation/JSON.swift
@@ -138,3 +138,34 @@ extension JSON {
     }
     
 }
+
+extension JSON {
+    /// An integer coding key.
+    struct IntegerKey: CodingKey {
+        var intValue: Int?
+        var stringValue: String
+        
+        init(_ value: Int) {
+            self.intValue = value
+            self.stringValue = value.description
+        }
+        
+        init(_ value: String) {
+            self.intValue = nil
+            self.stringValue = value
+        }
+        
+        init?(intValue: Int) {
+            self.init(intValue)
+        }
+        
+        init?(stringValue: String) {
+            guard let intValue = Int(stringValue) else {
+                return nil
+            }
+            
+            self.intValue = intValue
+            self.stringValue = stringValue
+        }
+    }
+}

--- a/Sources/SwiftDocC/Model/Identifier.swift
+++ b/Sources/SwiftDocC/Model/Identifier.swift
@@ -514,6 +514,21 @@ extension ResolvedTopicReference {
     }
 }
 
+extension ResolvedTopicReference: RenderJSONDiffable {
+    /// Returns the differences between this ResolvedTopicReference and the given one.
+    func difference(from other: ResolvedTopicReference, at path: CodablePath) -> JSONPatchDifferences {
+        var diffBuilder = DifferenceBuilder(current: self, other: other, basePath: path)
+
+        // The only part of the URL that is encoded to RenderJSON is the absolute string.
+        diffBuilder.addDifferences(atKeyPath: \.url.absoluteString, forKey: CodingKeys.url)
+        
+        // The only part of the source language that is encoded to RenderJSON is the id.
+        diffBuilder.addDifferences(atKeyPath: \.sourceLanguage.id, forKey: CodingKeys.interfaceLanguage)
+        
+        return diffBuilder.differences
+    }
+}
+
 /// An unresolved reference to a documentation node.
 ///
 /// You can create unresolved references from partial information if that information can be derived from the enclosing context when the

--- a/Sources/SwiftDocC/Model/Rendering/Content/RenderInlineContent.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Content/RenderInlineContent.swift
@@ -217,3 +217,16 @@ extension Sequence where Element == RenderInlineContent {
         return map { $0.plainText }.joined()
     }
 }
+
+// Diffable conformance
+extension RenderInlineContent: RenderJSONDiffable {
+    /// Returns the differences between this RenderInlineContent and the given one.
+    func difference(from other: RenderInlineContent, at path: CodablePath) -> JSONPatchDifferences {
+        var diffBuilder = DifferenceBuilder(current: self, other: other, basePath: path)
+
+        diffBuilder.addDifferences(atKeyPath: \.type, forKey: CodingKeys.type)
+        diffBuilder.addDifferences(atKeyPath: \.plainText, forKey: CodingKeys.text)
+
+        return diffBuilder.differences
+    }
+}

--- a/Sources/SwiftDocC/Model/Rendering/Diffing/AnyRenderReference.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Diffing/AnyRenderReference.swift
@@ -1,0 +1,95 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+/// A RenderReference value that can be diffed.
+///
+/// An `AnyRenderReference` value forwards difference operations to the underlying base type, which implement the difference differently.
+struct AnyRenderReference: Encodable, Equatable, RenderJSONDiffable {
+    var value: RenderReference & Codable
+    
+    init(_ value: RenderReference & Codable) {
+        self.value = value
+    }
+    
+    func encode(to encoder: Encoder) throws {
+        try value.encode(to: encoder)
+    }
+    
+    /// Forwards the difference methods on to the correct concrete type.
+    func difference(from other: AnyRenderReference, at path: CodablePath) -> JSONPatchDifferences {
+        switch (self.value.type, other.value.type) {
+            
+        // MARK: References
+            
+        case (.file, .file):
+            return (value as! FileReference).difference(from: (other.value as! FileReference), at: path)
+        case (.fileType, .fileType):
+            return (value as! FileTypeReference).difference(from: (other.value as! FileTypeReference), at: path)
+        case (.image, .image):
+            return (value as! ImageReference).difference(from: (other.value as! ImageReference), at: path)
+        case (.link, .link):
+            return (value as! LinkReference).difference(from: (other.value as! LinkReference), at: path)
+        case (.section, .section), (.topic, .topic):
+            return (value as! TopicRenderReference).difference(from: (other.value as! TopicRenderReference), at: path)
+        case (.unresolvable, .unresolvable):
+            return (value as! UnresolvedRenderReference).difference(from: (other.value as! UnresolvedRenderReference), at: path)
+        case (.video, .video):
+            return (value as! VideoReference).difference(from: (other.value as! VideoReference), at: path)
+            
+        // MARK: Tutorial References
+            
+        case (.download, .download):
+            return (value as! DownloadReference).difference(from: (other.value as! DownloadReference), at: path)
+        case (.xcodeRequirement, .xcodeRequirement):
+            return (value as! XcodeRequirementReference).difference(from: (other.value as! XcodeRequirementReference), at: path)
+            
+        default:
+            assertionFailure("Case diffing \(value) with \(other.value) is not implemented.")
+            return []
+        }
+    }
+
+    static func == (lhs: AnyRenderReference, rhs: AnyRenderReference) -> Bool {
+        switch (lhs.value.type, rhs.value.type) {
+            
+        // MARK: References
+          
+        case (.file, .file):
+            return (lhs.value as! FileReference) == (rhs.value as! FileReference)
+        case (.fileType, .fileType):
+            return (lhs.value as! FileTypeReference) == (rhs.value as! FileTypeReference)
+        case (.image, .image):
+            return (lhs.value as! ImageReference) == (rhs.value as! ImageReference)
+        case (.link, .link):
+            return (lhs.value as! LinkReference) == (rhs.value as! LinkReference)
+        case (.section, .section), (.topic, .topic):
+            return (lhs.value as! TopicRenderReference) == (rhs.value as! TopicRenderReference)
+        case (.unresolvable, .unresolvable):
+            return (lhs.value as! UnresolvedRenderReference) == (rhs.value as! UnresolvedRenderReference)
+        case (.video, .video):
+            return (lhs.value as! VideoReference) == (rhs.value as! VideoReference)
+        
+        // MARK: Tutorial References
+            
+        case (.download, .download):
+            return (lhs.value as! DownloadReference) == (rhs.value as! DownloadReference)
+        case (.xcodeRequirement, .xcodeRequirement):
+            return (lhs.value as! XcodeRequirementReference) == (rhs.value as! XcodeRequirementReference)
+        
+        default:
+            assertionFailure("Case diffing \(lhs.value) with \(rhs.value) is not implemented.")
+            return false
+        }
+    }
+    
+    func isSimilar(to other: AnyRenderReference) -> Bool {
+        return self.value.identifier == other.value.identifier
+    }
+}

--- a/Sources/SwiftDocC/Model/Rendering/Diffing/AnyRenderSection.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Diffing/AnyRenderSection.swift
@@ -1,0 +1,159 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+/// A RenderSection value that can be diffed.
+///
+/// An `AnyRenderSection` value forwards difference operations to the underlying base type, each of which determine the difference differently.
+struct AnyRenderSection: Equatable, Encodable, RenderJSONDiffable {
+    var value: RenderSection
+    
+    init(_ value: RenderSection) {
+        self.value = value
+    }
+    
+    func encode(to encoder: Encoder) throws {
+        try value.encode(to: encoder)
+    }
+    
+    /// Forwards the difference methods on to the correct concrete type.
+    func difference(from other: AnyRenderSection, at path: CodablePath) -> JSONPatchDifferences {
+        switch (self.value.kind, other.value.kind) {
+            
+        // MARK: Symbol Sections
+            
+        case (.attributes, .attributes):
+            return (value as! AttributesRenderSection).difference(from: (other.value as! AttributesRenderSection), at: path)
+        case (.discussion, .discussion), (.content, .content):
+            return (value as! ContentRenderSection).difference(from: (other.value as! ContentRenderSection), at: path)
+        case (.declarations, .declarations):
+            return (value as! DeclarationsRenderSection).difference(from: (other.value as! DeclarationsRenderSection), at: path)
+        case (.parameters, .parameters):
+            return (value as! ParametersRenderSection).difference(from: (other.value as! ParametersRenderSection), at: path)
+        case (.plistDetails, .plistDetails):
+            return (value as! PlistDetailsRenderSection).difference(from: (other.value as! PlistDetailsRenderSection), at: path)
+        case (.possibleValues, .possibleValues):
+            return (value as! PossibleValuesRenderSection).difference(from: (other.value as! PossibleValuesRenderSection), at: path)
+        case (.relationships, .relationships):
+            return (value as! RelationshipsRenderSection).difference(from: (other.value as! RelationshipsRenderSection), at: path)
+        case (.restBody, .restBody):
+            return (value as! RESTBodyRenderSection).difference(from: (other.value as! RESTBodyRenderSection), at: path)
+        case (.restEndpoint, .restEndpoint):
+            return (value as! RESTEndpointRenderSection).difference(from: (other.value as! RESTEndpointRenderSection), at: path)
+        case (.restParameters, .restParameters):
+            return (value as! RESTParametersRenderSection).difference(from: (other.value as! RESTParametersRenderSection), at: path)
+        case (.restResponses, .restResponses):
+            return (value as! RESTResponseRenderSection).difference(from: (other.value as! RESTResponseRenderSection), at: path)
+        case (.sampleDownload, .sampleDownload):
+            return (value as! SampleDownloadSection).difference(from: (other.value as! SampleDownloadSection), at: path)
+        case (.taskGroup, .taskGroup):
+            return (value as! TaskGroupRenderSection).difference(from: (other.value as! TaskGroupRenderSection), at: path)
+            
+        // MARK: Tutorial Sections
+            
+        case (.intro, .intro), (.hero, .hero):
+            return (value as! IntroRenderSection).difference(from: (other.value as! IntroRenderSection), at: path)
+        case (.assessments, .assessments):
+            return (value as! TutorialAssessmentsRenderSection).difference(from: (other.value as! TutorialAssessmentsRenderSection), at: path)
+        case (.tasks, .tasks):
+            return (value as! TutorialSectionsRenderSection).difference(from: (other.value as! TutorialSectionsRenderSection), at: path)
+        
+        // MARK: Tutorial Article Sections
+            
+        case (.articleBody, .articleBody):
+            return (value as! TutorialArticleSection).difference(from: (other.value as! TutorialArticleSection), at: path)
+            
+        // MARK: Tutorials Overview Sections
+            
+        case (.callToAction, .callToAction):
+            return (value as! CallToActionSection).difference(from: (other.value as! CallToActionSection), at: path)
+        case (.contentAndMediaGroup, .contentAndMediaGroup):
+            return (value as! ContentAndMediaGroupSection).difference(from: (other.value as! ContentAndMediaGroupSection), at: path)
+        case (.contentAndMedia, .contentAndMedia):
+            return (value as! ContentAndMediaSection).difference(from: (other.value as! ContentAndMediaSection), at: path)
+        case (.resources, .resources):
+            return (value as! ResourcesRenderSection).difference(from: (other.value as! ResourcesRenderSection), at: path)
+        case (.volume, .volume):
+            return (value as! VolumeRenderSection).difference(from: (other.value as! VolumeRenderSection), at: path)
+            
+        default:
+            assertionFailure("Case diffing \(value) with \(other.value) is not implemented.")
+            return []
+        }
+    }
+
+    static func == (lhs: AnyRenderSection, rhs: AnyRenderSection) -> Bool {
+        switch (lhs.value.kind, rhs.value.kind) {
+            
+        // MARK: Symbol Sections
+            
+        case (.attributes, .attributes):
+            return (lhs.value as! AttributesRenderSection) == (rhs.value as! AttributesRenderSection)
+        case (.discussion, .discussion), (.content, .content):
+            return (lhs.value as! ContentRenderSection) == (rhs.value as! ContentRenderSection)
+        case (.declarations, .declarations):
+            return (lhs.value as! DeclarationsRenderSection) == (rhs.value as! DeclarationsRenderSection)
+        case (.parameters, .parameters):
+            return (lhs.value as! ParametersRenderSection) == (rhs.value as! ParametersRenderSection)
+        case (.plistDetails, .plistDetails):
+            return (lhs.value as! PlistDetailsRenderSection) == (rhs.value as! PlistDetailsRenderSection)
+        case (.possibleValues, .possibleValues):
+            return (lhs.value as! PossibleValuesRenderSection) == (rhs.value as! PossibleValuesRenderSection)
+        case (.relationships, .relationships):
+            return (lhs.value as! RelationshipsRenderSection) == (rhs.value as! RelationshipsRenderSection)
+        case (.restBody, .restBody):
+            return (lhs.value as! RESTBodyRenderSection) == (rhs.value as! RESTBodyRenderSection)
+        case (.restEndpoint, .restEndpoint):
+            return (lhs.value as! RESTEndpointRenderSection) == (rhs.value as! RESTEndpointRenderSection)
+        case (.restParameters, .restParameters):
+            return (lhs.value as! RESTParametersRenderSection) == (rhs.value as! RESTParametersRenderSection)
+        case (.restResponses, .restResponses):
+            return (lhs.value as! RESTResponseRenderSection) == (rhs.value as! RESTResponseRenderSection)
+        case (.sampleDownload, .sampleDownload):
+            return (lhs.value as! SampleDownloadSection) == (rhs.value as! SampleDownloadSection)
+        case (.taskGroup, .taskGroup):
+            return (lhs.value as! TaskGroupRenderSection) == (rhs.value as! TaskGroupRenderSection)
+            
+        // MARK: Tutorial Sections
+            
+        case (.intro, .intro), (.hero, .hero):
+            return (lhs.value as! IntroRenderSection) == (rhs.value as! IntroRenderSection)
+        case (.assessments, .assessments):
+            return (lhs.value as! TutorialAssessmentsRenderSection) == (rhs.value as! TutorialAssessmentsRenderSection)
+        case (.tasks, .tasks):
+            return (lhs.value as! TutorialSectionsRenderSection) == (rhs.value as! TutorialSectionsRenderSection)
+            
+        // MARK: Tutorial Article Sections
+            
+        case (.articleBody, .articleBody):
+            return (lhs.value as! TutorialArticleSection) == (rhs.value as! TutorialArticleSection)
+            
+        // MARK: Tutorials Overview Sections
+            
+        case (.callToAction, .callToAction):
+            return (lhs.value as! CallToActionSection) == (rhs.value as! CallToActionSection)
+        case (.contentAndMediaGroup, .contentAndMediaGroup):
+            return (lhs.value as! ContentAndMediaGroupSection) == (rhs.value as! ContentAndMediaGroupSection)
+        case (.contentAndMedia, .contentAndMedia):
+            return (lhs.value as! ContentAndMediaSection) == (rhs.value as! ContentAndMediaSection)
+        case (.resources, .resources):
+            return (lhs.value as! ResourcesRenderSection) == (rhs.value as! ResourcesRenderSection)
+        case (.volume, .volume):
+            return (lhs.value as! VolumeRenderSection) == (rhs.value as! VolumeRenderSection)
+        
+        default:
+            assertionFailure("Case diffing \(lhs.value) with \(rhs.value) is not implemented.")
+            return false
+        }
+    }
+    
+    func isSimilar(to other: AnyRenderSection) -> Bool {
+        return self.value.kind == other.value.kind
+    }
+}

--- a/Sources/SwiftDocC/Model/Rendering/Diffing/DifferenceBuilder.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Diffing/DifferenceBuilder.swift
@@ -1,0 +1,186 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+
+/// A builder that collects ``Differences`` between two objects of the same type.
+///
+/// The DifferenceBuilder is used when diffing two ``RenderNode`` objects against each other.
+/// Initalize the DifferenceBuilder with the two.
+struct DifferenceBuilder<T> {
+    
+    var differences: JSONPatchDifferences
+    let current: T
+    let other: T
+    let path: CodablePath
+    
+    init(current: T, other: T, basePath: CodablePath) {
+        self.differences = []
+        self.current = current
+        self.other = other
+        self.path = basePath
+    }
+    
+    /// Adds the difference between two properties to the DifferenceBuilder.
+    mutating func addDifferences<E>(atKeyPath keyPath: KeyPath<T, E>, forKey codingKey: CodingKey)
+    where E: Equatable & Encodable {
+        let currentProperty = current[keyPath: keyPath]
+        let otherProperty = other[keyPath: keyPath]
+        
+        if currentProperty != otherProperty {
+            differences.append(.replace(pointer: JSONPointer(from: path + [codingKey]), encodableValue: currentProperty))
+        }
+    }
+    
+    /// Determines the difference between the two diffable objects at the KeyPaths given.
+    mutating func addDifferences<D>(atKeyPath keyPath: KeyPath<T, D>, forKey codingKey: CodingKey)
+    where D: RenderJSONDiffable & Equatable & Encodable {
+        let currentProperty = current[keyPath: keyPath]
+        let otherProperty = other[keyPath: keyPath]
+        
+        if currentProperty == otherProperty {
+            return
+        }
+        
+        if currentProperty.isSimilar(to: otherProperty) {
+            differences.append(contentsOf: currentProperty.difference(from: otherProperty, at: path + [codingKey]))
+        } else {
+            differences.append(.replace(pointer: JSONPointer(from: path + [codingKey]), encodableValue: currentProperty))
+        }
+    }
+    
+    /// Determines the difference between the two arrays of diffable objects at the KeyPaths given.
+    mutating func addDifferences<Value>(atKeyPath keyPath: KeyPath<T, Dictionary<String, Value>>, forKey codingKey: CodingKey)
+    where Value: RenderJSONDiffable & Equatable & Encodable {
+        let currentProperty = current[keyPath: keyPath]
+        let otherProperty = other[keyPath: keyPath]
+        
+        if currentProperty == otherProperty {
+            return
+        }
+        
+        if currentProperty.isSimilar(to: otherProperty) {
+            differences.append(contentsOf: currentProperty.difference(from: otherProperty, at: path + [codingKey]))
+        } else {
+            differences.append(.replace(pointer: JSONPointer(from: path + [codingKey]), encodableValue: currentProperty))
+        }
+    }
+    
+    /// Determines the difference between the two dictionaries mapping strings to diffable objects at the KeyPaths given.
+    mutating func addDifferences<Element>(atKeyPath keyPath: KeyPath<T, Array<Element>>, forKey codingKey: CodingKey)
+    where Element: RenderJSONDiffable & Equatable & Codable {
+        let currentProperty = current[keyPath: keyPath]
+        let otherProperty = other[keyPath: keyPath]
+        
+        if currentProperty == otherProperty {
+            return
+        }
+        
+        if currentProperty.isSimilar(to: otherProperty) {
+            differences.append(contentsOf: currentProperty.difference(from: otherProperty, at: path + [codingKey]))
+        } else {
+            differences.append(.replace(pointer: JSONPointer(from: path + [codingKey]), encodableValue: currentProperty))
+        }
+    }
+    
+    /// Determines the difference between the two dictionaries mapping strings to diffable objects at the KeyPaths given.
+    mutating func addDifferences<Element>(atKeyPath keyPath: KeyPath<T, Array<Element>?>, forKey codingKey: CodingKey)
+    where Element: RenderJSONDiffable & Equatable & Codable {
+        let currentProperty = current[keyPath: keyPath]
+        let otherProperty = other[keyPath: keyPath]
+        
+        if currentProperty == otherProperty {
+            return
+        }
+        
+        if currentProperty.isSimilar(to: otherProperty) {
+            differences.append(contentsOf: currentProperty.difference(from: otherProperty, at: path + [codingKey]))
+        } else {
+            differences.append(.replace(pointer: JSONPointer(from: path + [codingKey]), encodableValue: currentProperty))
+        }
+    }
+    
+    /// Determines the difference between the two dictionaries mapping strings to arrays of diffable objects at the KeyPaths given.
+    mutating func addDifferences<Value>(atKeyPath keyPath: KeyPath<T, Dictionary<String, [Value]>>, forKey codingKey: CodingKey)
+    where Value: RenderJSONDiffable & Equatable & Encodable {
+        let currentProperty = current[keyPath: keyPath]
+        let otherProperty = other[keyPath: keyPath]
+        
+        if currentProperty == otherProperty {
+            return
+        }
+        
+        if currentProperty.isSimilar(to: otherProperty) {
+            differences.append(contentsOf: currentProperty.arrayValueDifference(from: otherProperty, at: path + [codingKey]))
+        } else {
+            differences.append(.replace(pointer: JSONPointer(from: path + [codingKey]), encodableValue: currentProperty))
+        }
+    }
+    
+    /// Unwraps and adds the difference between two optional RenderSections.
+    mutating func addDifferences(atKeyPath keyPath: KeyPath<T, Optional<RenderSection>>, forKey key: CodingKey) {
+        
+        let currentProperty = current[keyPath: keyPath]
+        let otherProperty = other[keyPath: keyPath]
+        
+        if let currentProperty = currentProperty, let otherProperty = otherProperty {
+            let anyCurrent = AnyRenderSection(currentProperty)
+            let anyOther = AnyRenderSection(otherProperty)
+            if anyCurrent.isSimilar(to: anyOther) {
+                differences.append(contentsOf: anyCurrent.difference(from: anyOther, at: path + [key]))
+            } else {
+                differences.append(.replace(pointer: JSONPointer(from: path + [key]), encodableValue: currentProperty))
+            }
+        } else if otherProperty != nil {
+            differences.append(.remove(pointer: JSONPointer(from: path + [key])))
+        } else if let currentProp = currentProperty {
+            differences.append(.add(pointer: JSONPointer(from: path + [key]), encodableValue: currentProp))
+        }
+    }
+    
+    /// Determines the difference between the two diffable Arrays of RenderSections at the KeyPaths given.
+    mutating func addDifferences(atKeyPath keyPath: KeyPath<T, Array<RenderSection>>, forKey codingKey: CodingKey) {
+        let currentArray = current[keyPath: keyPath]
+        let otherArray = other[keyPath: keyPath]
+        
+        let typeErasedCurrentArray = currentArray.map { section in
+            return AnyRenderSection(section)
+        }
+        let typeErasedOtherArray = otherArray.map { section in
+            return AnyRenderSection(section)
+        }
+        
+        if typeErasedCurrentArray == typeErasedOtherArray {
+            return
+        }
+
+        if typeErasedCurrentArray.isSimilar(to: typeErasedOtherArray) {
+            differences.append(contentsOf: typeErasedCurrentArray.difference(from: typeErasedOtherArray, at: path + [codingKey]))
+        } else {
+            differences.append(.replace(pointer: JSONPointer(from: path + [codingKey]), encodableValue: typeErasedCurrentArray))
+        }
+    }
+    
+    /// Determines the difference between the two dictionaries of RenderReferences at the KeyPaths given.
+    mutating func addDifferences(atKeyPath keyPath: KeyPath<T, Dictionary<String, RenderReference>>, forKey codingKey: CodingKey) {
+        let currentDict = current[keyPath: keyPath].mapValues { section in
+            return AnyRenderReference(section)
+        }
+        let otherDict = other[keyPath: keyPath].mapValues { section in
+            return AnyRenderReference(section)
+        }
+        
+        if currentDict == otherDict {
+            return
+        }
+
+        differences.append(contentsOf: currentDict.difference(from: otherDict, at: path + [codingKey]))
+    }
+}

--- a/Sources/SwiftDocC/Model/Rendering/Diffing/Differences.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Diffing/Differences.swift
@@ -1,0 +1,196 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+
+/// A list of JSON patches generated as differences between two documents.
+public typealias JSONPatchDifferences = [JSONPatchOperation]
+
+typealias CodablePath = [CodingKey]
+
+/// A protocol that defines Diffable conformance for properties and structs in RenderNode JSON.
+protocol RenderJSONDiffable {
+    
+    /// Returns the list of JSON patches (differences) to transform _other_ to _self_.
+    func difference(from other: Self, at path: CodablePath) -> JSONPatchDifferences
+    
+    /// Returns if differences between _self_ and _other_ should be reported property-by-property or as a complete replacement.
+    func isSimilar(to other: Self) -> Bool
+}
+
+// If not otherwise defined, difference(from:at:) methods will assume Diffable objects are not similar,
+// and should therefore be replaced.
+extension RenderJSONDiffable where Self: Equatable {
+    func isSimilar(to other: Self) -> Bool {
+        return self == other
+    }
+}
+
+extension Array: RenderJSONDiffable where Element: Equatable & Encodable {
+    /// Returns the differences between this array and the given one.
+    func difference(from other: Array<Element>, at path: CodablePath) -> JSONPatchDifferences {
+        let arrayDiffs = self.difference(from: other)
+        var differences = arrayDiffs.removals
+        
+        differences.append(contentsOf: arrayDiffs.insertions)
+        let patchOperations = differences.map { diff -> JSONPatchOperation in
+            switch diff {
+            case .remove(let offset, _, _):
+                let pointer = JSONPointer(from: path + [JSON.IntegerKey(offset)])
+                return .remove(pointer: pointer)
+            case .insert(let offset, let element, _):
+                let pointer = JSONPointer(from: path + [JSON.IntegerKey(offset)])
+                return .add(pointer: pointer, encodableValue: element)
+            }
+        }
+        
+        return patchOperations
+    }
+    
+    /// Returns the differences between two arrays with diffable values.
+    func difference(
+        from other: Array<Element>,
+        at path: CodablePath
+    ) -> JSONPatchDifferences where Element: RenderJSONDiffable {
+        // This implementation computes both the insertions and deletions of significantly different elements
+        // and the per-property differences between elements that are similar to one another.
+        
+        // First, compute the insertions and deletions based on elements that are _similar_.
+        let differences = self.difference(from: other) { element1, element2 in
+            return element1.isSimilar(to: element2)
+        }
+        var patchOperations = differences.map { diff -> JSONPatchOperation in
+            switch diff {
+            case .remove(let offset, _, _):
+                let pointer = JSONPointer(from: path + [JSON.IntegerKey(offset)])
+                return .remove(pointer: pointer)
+            case .insert(let offset, let element, _):
+                let pointer = JSONPointer(from: path + [JSON.IntegerKey(offset)])
+                return .add(pointer: pointer, encodableValue: element)
+            }
+        }
+        
+        // Second, apply the insertions and deletions of significantly different elements so that the
+        // elements that are _similar_ are aligned (have the same index in both arrays).
+        let similarOther = other.applying(differences)!
+        // Finally, iterate over the similar — but not equal — elements to compute their per-property differences.
+        for (index, value) in enumerated() where similarOther[index] != value {
+            patchOperations.append(contentsOf: value.difference(from: similarOther[index],
+                                                                at: path + [JSON.IntegerKey(index)]))
+        }
+        
+        return patchOperations
+    }
+    
+    // For now, whole arrays should not be replaced.
+    func isSimilar(to other: Array<Element>) -> Bool {
+        return true
+    }
+}
+
+extension Dictionary: RenderJSONDiffable where Key == String, Value: Encodable & Equatable {
+    /// Returns the differences between this dictionary and the given one.
+    func difference(from other: Dictionary<Key, Value>, at path: CodablePath) -> JSONPatchDifferences {
+        var differences = JSONPatchDifferences()
+        let uniqueKeysSet = Set(self.keys).union(Set(other.keys))
+        
+        for key in uniqueKeysSet {
+            if self[key] == nil {
+                differences.append(.remove(
+                    pointer: JSONPointer(from: path + [JSON.IntegerKey(key)])))
+            }
+            else if self[key] != other[key] {
+                differences.append(.replace(
+                    pointer: JSONPointer(from: path + [JSON.IntegerKey(key)]),
+                    encodableValue: self[key]))
+            }
+        }
+        
+        return differences
+    }
+    
+    /// Returns the differences between two dictionaries with diffable values.
+    func difference(
+        from other: Dictionary<Key, Value>,
+        at path: CodablePath
+    ) -> JSONPatchDifferences where Value: RenderJSONDiffable {
+        var differences = JSONPatchDifferences()
+        let uniqueKeysSet = Set(self.keys).union(Set(other.keys))
+        
+        for key in uniqueKeysSet {
+            differences.append(contentsOf: self[key].difference(from: other[key], at: path + [JSON.IntegerKey(key)]))
+        }
+        
+        return differences
+    }
+    
+    /// Returns the differences between two dictionaries of arrays with diffable values.
+    func arrayValueDifference<Element>(
+        from other: Dictionary<Key, [Element]>,
+        at path: CodablePath
+    ) -> JSONPatchDifferences where Element: RenderJSONDiffable & Equatable & Encodable {
+        var differences = JSONPatchDifferences()
+        let uniqueKeysSet = Set(self.keys).union(Set(other.keys))
+        
+        for key in uniqueKeysSet {
+            differences.append(contentsOf: (self[key] as! Array<Element>?).difference(from: other[key],
+                                                                                      at: path + [JSON.IntegerKey(key)]))
+        }
+        
+        return differences
+    }
+    
+    // For now, we are not replacing whole dictionaries.
+    func isSimilar(to other: Dictionary<String, Value>) -> Bool {
+        return true
+    }
+}
+
+extension Optional: RenderJSONDiffable where Wrapped: RenderJSONDiffable & Equatable & Encodable {
+    /// Returns the differences between this optional and the given one.
+    @_disfavoredOverload func difference(from other: Optional<Wrapped>, at path: CodablePath) -> JSONPatchDifferences {
+        var difference = JSONPatchDifferences()
+        
+        if let current = self, let other = other {
+            difference.append(contentsOf: current.difference(from: other, at: path))
+        } else if other != nil {
+            difference.append(JSONPatchOperation.remove(
+                pointer: JSONPointer(from: path)))
+        } else if let current = self {
+            difference.append(JSONPatchOperation.add(
+                pointer: JSONPointer(from: path), encodableValue: current))
+        }
+        return difference
+    }
+    
+    /// Returns the differences between this array of optional elements and the given one.
+    func difference<Element>(
+        from other: Optional<Array<Element>>,
+        at path: CodablePath
+    ) -> JSONPatchDifferences where Element : RenderJSONDiffable & Equatable & Encodable {
+        var difference = JSONPatchDifferences()
+        
+        if let current = self, let other = other {
+            difference.append(contentsOf: (current as! Array<Element>).difference(from: other, at: path))
+        } else if other != nil {
+            difference.append(JSONPatchOperation.remove(
+                pointer: JSONPointer(from: path)))
+        } else if let current = self {
+            difference.append(JSONPatchOperation.add(
+                pointer: JSONPointer(from: path), encodableValue: current))
+        }
+        return difference
+    }
+    
+    // Optionals should deal with replacements on their own.
+    func isSimilar(to other: Optional<Wrapped>) -> Bool {
+        return true
+    }
+}

--- a/Sources/SwiftDocC/Model/Rendering/Diffing/RenderNode+Diffable.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Diffing/RenderNode+Diffable.swift
@@ -11,7 +11,7 @@
 extension RenderNode: RenderJSONDiffable {
     
     /// Returns the differences between this RenderNode and the given one.
-    public func difference(from other: RenderNode) -> JSONPatchDifferences {
+    public func _difference(from other: RenderNode) -> JSONPatchDifferences {
         self.difference(from: other, at: [])
     }
     

--- a/Sources/SwiftDocC/Model/Rendering/Diffing/RenderNode+Diffable.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Diffing/RenderNode+Diffable.swift
@@ -1,0 +1,55 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+extension RenderNode: RenderJSONDiffable {
+    
+    /// Returns the differences between this RenderNode and the given one.
+    public func difference(from other: RenderNode) -> JSONPatchDifferences {
+        self.difference(from: other, at: [])
+    }
+    
+    func difference(from other: RenderNode, at path: CodablePath) -> JSONPatchDifferences {
+        var diffBuilder = DifferenceBuilder(current: self, other: other, basePath: path)
+        
+        // MARK: General
+                
+        diffBuilder.addDifferences(atKeyPath: \.identifier, forKey: CodingKeys.identifier)
+        diffBuilder.addDifferences(atKeyPath: \.schemaVersion, forKey: CodingKeys.schemaVersion)
+        diffBuilder.addDifferences(atKeyPath: \.kind, forKey: CodingKeys.kind)
+        diffBuilder.addDifferences(atKeyPath: \.sections, forKey: CodingKeys.sections)
+        diffBuilder.addDifferences(atKeyPath: \.references, forKey: CodingKeys.references)
+        diffBuilder.addDifferences(atKeyPath: \.hierarchy, forKey: CodingKeys.hierarchy)
+        diffBuilder.differences.append(contentsOf: metadata.difference(from: other.metadata, at: path + [CodingKeys.metadata])) // RenderMetadata isn't Equatable
+        
+        // MARK: Reference Documentation Data
+        
+        diffBuilder.addDifferences(atKeyPath: \.abstract, forKey: CodingKeys.abstract)
+        diffBuilder.addDifferences(atKeyPath: \.primaryContentSections, forKey: CodingKeys.primaryContentSections)
+        diffBuilder.addDifferences(atKeyPath: \.topicSectionsStyle, forKey: CodingKeys.topicSectionsStyle)
+        diffBuilder.addDifferences(atKeyPath: \.topicSections, forKey: CodingKeys.topicSections)
+        diffBuilder.addDifferences(atKeyPath: \.relationshipSections, forKey: CodingKeys.relationshipsSections)
+        diffBuilder.addDifferences(atKeyPath: \.defaultImplementationsSections, forKey: CodingKeys.defaultImplementationsSections)
+        diffBuilder.addDifferences(atKeyPath: \.seeAlsoSections, forKey: CodingKeys.seeAlsoSections)
+        diffBuilder.addDifferences(atKeyPath: \.deprecationSummary, forKey: CodingKeys.deprecationSummary)
+        diffBuilder.addDifferences(atKeyPath: \.variants, forKey: CodingKeys.variants)
+        diffBuilder.addDifferences(atKeyPath: \.diffAvailability, forKey: CodingKeys.diffAvailability)
+
+        // MARK: Sample Code Data
+        
+        diffBuilder.addDifferences(atKeyPath: \.sampleDownload, forKey: CodingKeys.sampleCodeDownload)
+        diffBuilder.addDifferences(atKeyPath: \.downloadNotAvailableSummary, forKey: CodingKeys.downloadNotAvailableSummary)
+        
+        return diffBuilder.differences
+    }
+    
+    func isSimilar(to other: RenderNode) -> Bool {
+        return identifier == other.identifier
+    }
+}

--- a/Sources/SwiftDocC/Model/Rendering/Navigation Tree/RenderHierarchy.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Navigation Tree/RenderHierarchy.swift
@@ -19,7 +19,7 @@ import Foundation
 /// ### Hierarchy Types
 /// - ``RenderReferenceHierarchy``
 /// - ``RenderTutorialsHierarchy``
-public enum RenderHierarchy: Codable {
+public enum RenderHierarchy: Codable, Equatable {
     /// The hierarchy for an API reference render node.
     case reference(RenderReferenceHierarchy)
     /// The hierarchy for tutorials-related render node.
@@ -44,6 +44,31 @@ public enum RenderHierarchy: Codable {
             try container.encode(hierarchy)
         case .tutorials(let hierarchy):
             try container.encode(hierarchy)
+        }
+    }
+}
+
+// Diffable conformance
+extension RenderHierarchy: RenderJSONDiffable {
+    /// Returns the difference between this RenderHierarchy and the given one.
+    func difference(from other: RenderHierarchy, at path: CodablePath) -> JSONPatchDifferences {
+        var differences = JSONPatchDifferences()
+
+        switch (self, other) {
+        case (let .reference(selfReferenceHierarchy), let .reference(otherReferenceHierarchy)):
+            differences.append(contentsOf: selfReferenceHierarchy.difference(from: otherReferenceHierarchy, at: path))
+        case (.tutorials(_), _), (_, .tutorials(_)):
+            return differences // Diffing tutorials is not currently supported
+        }
+        return differences
+    }
+
+    func isSimilar(to other: RenderHierarchy) -> Bool {
+        switch (self, other) {
+        case (let .reference(selfReferenceHierarchy), let .reference(otherReferenceHierarchy)):
+            return selfReferenceHierarchy.isSimilar(to: otherReferenceHierarchy)
+        case (.tutorials(_), _), (_, .tutorials(_)):
+            return false // Diffing tutorials is not currently supported
         }
     }
 }

--- a/Sources/SwiftDocC/Model/Rendering/Navigation Tree/RenderHierarchyChapter.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Navigation Tree/RenderHierarchyChapter.swift
@@ -9,7 +9,7 @@
 */
 
 /// A hierarchy tree node that represents a chapter in a tutorial series.
-public struct RenderHierarchyChapter: Codable {    
+public struct RenderHierarchyChapter: Codable, Equatable {
     /// The topic reference for the chapter.
     public var reference: RenderReferenceIdentifier
     

--- a/Sources/SwiftDocC/Model/Rendering/Navigation Tree/RenderHierarchyLandmark.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Navigation Tree/RenderHierarchyLandmark.swift
@@ -9,7 +9,7 @@
 */
 
 /// A hierarchy tree node that represents a landmark on a page.
-public struct RenderHierarchyLandmark: Codable {
+public struct RenderHierarchyLandmark: Codable, Equatable {
     /// The kind of a landmark.
     public enum Kind: String, Codable {
         /// A landmark at the start of a task.

--- a/Sources/SwiftDocC/Model/Rendering/Navigation Tree/RenderHierarchyTutorial.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Navigation Tree/RenderHierarchyTutorial.swift
@@ -9,7 +9,7 @@
 */
 
 /// A hierarchy tree node that represents a tutorial or a tutorial article.
-public struct RenderHierarchyTutorial: Codable {
+public struct RenderHierarchyTutorial: Codable, Equatable {
     /// The topic reference.
     public var reference: RenderReferenceIdentifier
         

--- a/Sources/SwiftDocC/Model/Rendering/Navigation Tree/RenderReferenceHierarchy.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Navigation Tree/RenderReferenceHierarchy.swift
@@ -11,7 +11,7 @@
 import Foundation
 
 /// A node that represents API symbol hierarchy.
-public struct RenderReferenceHierarchy: Codable {
+public struct RenderReferenceHierarchy: Codable, Equatable {
     /// The paths (breadcrumbs) that lead from the landing page to the given symbol.
     ///
     /// A single path is a list of topic-graph references, that trace the curation
@@ -26,4 +26,12 @@ public struct RenderReferenceHierarchy: Codable {
     ///
     /// Landing pages' hierarchy contains a single, empty path.
     public let paths: [[String]]
+}
+
+// Diffable conformance
+extension RenderReferenceHierarchy: RenderJSONDiffable {
+    /// Returns the difference between this RenderReferenceHierarchy and the given one.
+    func difference(from other: RenderReferenceHierarchy, at path: CodablePath) -> JSONPatchDifferences {
+        return paths.difference(from: other.paths, at: path + [CodingKeys.paths])
+    }
 }

--- a/Sources/SwiftDocC/Model/Rendering/Navigation Tree/RenderTutorialsHierarchy.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Navigation Tree/RenderTutorialsHierarchy.swift
@@ -9,7 +9,7 @@
 */
 
 /// A root node of a tutorials series hierarchy.
-public struct RenderTutorialsHierarchy {
+public struct RenderTutorialsHierarchy: Equatable {
     /// The topic reference for the landing page.
     public var reference: RenderReferenceIdentifier
     

--- a/Sources/SwiftDocC/Model/Rendering/References/FileReference.swift
+++ b/Sources/SwiftDocC/Model/Rendering/References/FileReference.swift
@@ -76,6 +76,24 @@ public struct FileReference: RenderReference, Equatable {
     }
 }
 
+// Diffable conformance
+extension FileReference: RenderJSONDiffable {
+    /// Returns the difference between this FileReference and the given one.
+    func difference(from other: FileReference, at path: CodablePath) -> JSONPatchDifferences {
+        var diffBuilder = DifferenceBuilder(current: self, other: other, basePath: path)
+
+        diffBuilder.addDifferences(atKeyPath: \.type, forKey: CodingKeys.type)
+        diffBuilder.addDifferences(atKeyPath: \.identifier, forKey: CodingKeys.identifier)
+        diffBuilder.addDifferences(atKeyPath: \.fileType, forKey: CodingKeys.fileType)
+        diffBuilder.addDifferences(atKeyPath: \.fileName, forKey: CodingKeys.fileName)
+        diffBuilder.addDifferences(atKeyPath: \.syntax, forKey: CodingKeys.syntax)
+        diffBuilder.addDifferences(atKeyPath: \.content, forKey: CodingKeys.content)
+        diffBuilder.addDifferences(atKeyPath: \.highlights, forKey: CodingKeys.highlights)
+        
+        return diffBuilder.differences
+    }
+}
+
 /// A reference to a type of file.
 ///
 /// This is not a reference to a specific file, but rather to a type of file. Use a file type reference together with a file reference to display an icon for that file type
@@ -101,5 +119,18 @@ public struct FileTypeReference: RenderReference, Equatable {
         self.identifier = identifier
         self.displayName = displayName
         self.iconBase64 = iconBase64
+    }
+}
+
+// Diffable conformance
+extension FileTypeReference: RenderJSONDiffable {
+    /// Returns the difference between this FileTypeReference and the given one.
+    func difference(from other: FileTypeReference, at path: CodablePath) -> JSONPatchDifferences {
+        var diffBuilder = DifferenceBuilder(current: self, other: other, basePath: path)
+
+        diffBuilder.addDifferences(atKeyPath: \.displayName, forKey: CodingKeys.displayName)
+        diffBuilder.addDifferences(atKeyPath: \.iconBase64, forKey: CodingKeys.iconBase64)
+
+        return diffBuilder.differences
     }
 }

--- a/Sources/SwiftDocC/Model/Rendering/References/ImageReference.swift
+++ b/Sources/SwiftDocC/Model/Rendering/References/ImageReference.swift
@@ -82,7 +82,7 @@ public struct ImageReference: MediaReference, URLReference, Equatable {
     
     
     /// A codable proxy value that the image reference uses to serialize information about its asset variants.
-    public struct VariantProxy: Codable {
+    public struct VariantProxy: Codable, Equatable {
         /// The URL to the file for this image variant.
         public var url: URL
         /// The traits of this image reference.
@@ -124,5 +124,32 @@ public struct ImageReference: MediaReference, URLReference, Equatable {
             try container.encode(traits, forKey: .traits)
             try container.encodeIfPresent(svgID, forKey: .svgID)
         }
+    }
+}
+
+// Diffable conformance
+extension ImageReference: RenderJSONDiffable {
+    /// Returns the difference between this ImageReference and the given one.
+    func difference(from other: ImageReference, at path: CodablePath) -> JSONPatchDifferences {
+        var diffBuilder = DifferenceBuilder(current: self, other: other, basePath: path)
+
+        diffBuilder.addDifferences(atKeyPath: \.asset, forKey: CodingKeys.variants)
+        diffBuilder.addDifferences(atKeyPath: \.altText, forKey: CodingKeys.alt)
+
+        return diffBuilder.differences
+    }
+}
+
+// Diffable conformance
+extension ImageReference.VariantProxy: RenderJSONDiffable {
+    /// Returns the difference between this VariantProxy and the given one.
+    func difference(from other: ImageReference.VariantProxy, at path: CodablePath) -> JSONPatchDifferences {
+        var diffBuilder = DifferenceBuilder(current: self, other: other, basePath: path)
+
+        diffBuilder.addDifferences(atKeyPath: \.url, forKey: CodingKeys.url)
+        diffBuilder.addDifferences(atKeyPath: \.traits, forKey: CodingKeys.traits)
+        diffBuilder.addDifferences(atKeyPath: \.svgID, forKey: CodingKeys.svgID)
+
+        return diffBuilder.differences
     }
 }

--- a/Sources/SwiftDocC/Model/Rendering/References/LinkReference.swift
+++ b/Sources/SwiftDocC/Model/Rendering/References/LinkReference.swift
@@ -77,3 +77,18 @@ public struct LinkReference: RenderReference, Equatable {
         try container.encode(url, forKey: .url)
     }
 }
+
+// Diffable conformance
+extension LinkReference: RenderJSONDiffable {
+    /// Returns the difference between this LinkReference and the given one.
+    func difference(from other: LinkReference, at path: CodablePath) -> JSONPatchDifferences {
+        var diffBuilder = DifferenceBuilder(current: self, other: other, basePath: path)
+
+        diffBuilder.addDifferences(atKeyPath: \.type, forKey: CodingKeys.type)
+        diffBuilder.addDifferences(atKeyPath: \.title, forKey: CodingKeys.title)
+        diffBuilder.addDifferences(atKeyPath: \.titleInlineContent, forKey: CodingKeys.titleInlineContent)
+        diffBuilder.addDifferences(atKeyPath: \.url, forKey: CodingKeys.url)
+
+        return diffBuilder.differences
+    }
+}

--- a/Sources/SwiftDocC/Model/Rendering/References/RenderReference.swift
+++ b/Sources/SwiftDocC/Model/Rendering/References/RenderReference.swift
@@ -33,7 +33,7 @@ public enum RenderReferenceType: String, Codable, Equatable {
 /// The identifier of a render reference.
 ///
 /// This structure wraps a string value to make handling of render identifiers more type safe and explicit.
-public struct RenderReferenceIdentifier: Codable, Hashable {
+public struct RenderReferenceIdentifier: Codable, Hashable, Equatable {
     /// The wrapped string identifier.
     public var identifier: String
     
@@ -51,6 +51,10 @@ public struct RenderReferenceIdentifier: Codable, Hashable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(identifier)
+    }
+    
+    private enum CodingKeys: CodingKey {
+        case identifier
     }
 }
 
@@ -80,5 +84,17 @@ extension RenderReferenceIdentifier {
     /// - Parameter linkDestination: The full path of the external link represented as a `String`.
     public init(forExternalLink linkDestination: String) {
         self.identifier = "\(linkDestination)"
+    }
+}
+
+// Diffable conformance
+extension RenderReferenceIdentifier: RenderJSONDiffable {
+    /// Returns the difference between this RenderReferenceIdentifier and the given one.
+    func difference(from other: RenderReferenceIdentifier, at path: CodablePath) -> JSONPatchDifferences {
+        var diffBuilder = DifferenceBuilder(current: self, other: other, basePath: path)
+
+        diffBuilder.addDifferences(atKeyPath: \.identifier, forKey: CodingKeys.identifier)
+
+        return diffBuilder.differences
     }
 }

--- a/Sources/SwiftDocC/Model/Rendering/References/TopicRenderReference.swift
+++ b/Sources/SwiftDocC/Model/Rendering/References/TopicRenderReference.swift
@@ -317,3 +317,34 @@ public struct TopicRenderReference: RenderReference, VariantContainer, Equatable
         try container.encodeIfNotEmpty(images, forKey: .images)
     }
 }
+
+// Diffable conformance
+extension TopicRenderReference: RenderJSONDiffable {
+    /// Returns the difference between two TopicRenderReferences.
+    func difference(from other: TopicRenderReference, at path: CodablePath) -> JSONPatchDifferences {
+        var diffBuilder = DifferenceBuilder(current: self, other: other, basePath: path)
+
+        diffBuilder.addDifferences(atKeyPath: \.type, forKey: CodingKeys.type)
+        diffBuilder.addDifferences(atKeyPath: \.identifier, forKey: CodingKeys.identifier)
+        diffBuilder.addDifferences(atKeyPath: \.title, forKey: CodingKeys.title)
+        diffBuilder.addDifferences(atKeyPath: \.url, forKey: CodingKeys.url)
+        diffBuilder.addDifferences(atKeyPath: \.abstract, forKey: CodingKeys.abstract)
+        diffBuilder.addDifferences(atKeyPath: \.kind, forKey: CodingKeys.kind)
+        diffBuilder.addDifferences(atKeyPath: \.required, forKey: CodingKeys.required)
+        diffBuilder.addDifferences(atKeyPath: \.role, forKey: CodingKeys.role)
+        diffBuilder.addDifferences(atKeyPath: \.fragments, forKey: CodingKeys.fragments)
+        diffBuilder.addDifferences(atKeyPath: \.navigatorTitle, forKey: CodingKeys.navigatorTitle)
+        diffBuilder.addDifferences(atKeyPath: \.conformance, forKey: CodingKeys.conformance)
+        diffBuilder.addDifferences(atKeyPath: \.estimatedTime, forKey: CodingKeys.estimatedTime)
+        diffBuilder.addDifferences(atKeyPath: \.defaultImplementationCount, forKey: CodingKeys.defaultImplementations)
+        diffBuilder.addDifferences(atKeyPath: \.isBeta, forKey: CodingKeys.beta)
+        diffBuilder.addDifferences(atKeyPath: \.isDeprecated, forKey: CodingKeys.deprecated)
+        diffBuilder.addDifferences(atKeyPath: \.titleStyle, forKey: CodingKeys.titleStyle)
+        diffBuilder.addDifferences(atKeyPath: \.name, forKey: CodingKeys.name)
+        diffBuilder.addDifferences(atKeyPath: \.ideTitle, forKey: CodingKeys.ideTitle)
+        diffBuilder.addDifferences(atKeyPath: \.tags, forKey: CodingKeys.tags)
+        diffBuilder.addDifferences(atKeyPath: \.images, forKey: CodingKeys.images)
+
+        return diffBuilder.differences
+    }
+}

--- a/Sources/SwiftDocC/Model/Rendering/References/UnresolvedReference.swift
+++ b/Sources/SwiftDocC/Model/Rendering/References/UnresolvedReference.swift
@@ -38,3 +38,17 @@ public struct UnresolvedRenderReference: RenderReference, Equatable {
         title = try values.decode(String.self, forKey: .title)
     }
 }
+
+// Diffable conformance
+extension UnresolvedRenderReference: RenderJSONDiffable {
+    /// Returns the difference between this UnresolvedRenderReference and the given one.
+    func difference(from other: UnresolvedRenderReference, at path: CodablePath) -> JSONPatchDifferences {
+        var diffBuilder = DifferenceBuilder(current: self, other: other, basePath: path)
+
+        diffBuilder.addDifferences(atKeyPath: \.type, forKey: CodingKeys.type)
+        diffBuilder.addDifferences(atKeyPath: \.identifier, forKey: CodingKeys.identifier)
+        diffBuilder.addDifferences(atKeyPath: \.title, forKey: CodingKeys.title)
+
+        return diffBuilder.differences
+    }
+}

--- a/Sources/SwiftDocC/Model/Rendering/References/VideoReference.swift
+++ b/Sources/SwiftDocC/Model/Rendering/References/VideoReference.swift
@@ -90,7 +90,7 @@ public struct VideoReference: MediaReference, URLReference, Equatable {
     }
     
     /// A codable proxy value that the video reference uses to serialize information about its asset variants.
-    public struct VariantProxy: Codable {
+    public struct VariantProxy: Codable, Equatable {
         /// The URL to the file for this video variant.
         public var url: URL
         /// The traits of this video reference.
@@ -123,5 +123,34 @@ public struct VideoReference: MediaReference, URLReference, Equatable {
             try container.encode(url, forKey: .url)
             try container.encode(traits, forKey: .traits)
         }
+    }
+}
+
+// Diffable conformance
+extension VideoReference: RenderJSONDiffable {
+    /// Returns the difference between this VideoReference and the given one.
+    func difference(from other: VideoReference, at path: CodablePath) -> JSONPatchDifferences {
+        var diffBuilder = DifferenceBuilder(current: self, other: other, basePath: path)
+
+        diffBuilder.addDifferences(atKeyPath: \.type, forKey: CodingKeys.type)
+        diffBuilder.addDifferences(atKeyPath: \.identifier, forKey: CodingKeys.identifier)
+        diffBuilder.addDifferences(atKeyPath: \.altText, forKey: CodingKeys.alt)
+        diffBuilder.addDifferences(atKeyPath: \.asset, forKey: CodingKeys.variants)
+        diffBuilder.addDifferences(atKeyPath: \.poster, forKey: CodingKeys.poster)
+
+        return diffBuilder.differences
+    }
+}
+
+// Diffable conformance
+extension VideoReference.VariantProxy: RenderJSONDiffable {
+    /// Returns the difference between this VariantProxy and the given one.
+    func difference(from other: VideoReference.VariantProxy, at path: CodablePath) -> JSONPatchDifferences {
+        var diffBuilder = DifferenceBuilder(current: self, other: other, basePath: path)
+
+        diffBuilder.addDifferences(atKeyPath: \.url, forKey: CodingKeys.url)
+        diffBuilder.addDifferences(atKeyPath: \.traits, forKey: CodingKeys.traits)
+
+        return diffBuilder.differences
     }
 }

--- a/Sources/SwiftDocC/Model/Rendering/RenderNode/CodableContentSection.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNode/CodableContentSection.swift
@@ -14,11 +14,20 @@ import Foundation
 ///
 /// This allows decoding a ``RenderSection`` into its appropriate concrete type, based on the section's
 /// ``RenderSection/kind``.
-public struct CodableContentSection: Codable {
-    var section: RenderSection
+public struct CodableContentSection: Codable, Equatable {
+    var section: RenderSection {
+        get {
+            typeErasedSection.value
+        }
+        set {
+            typeErasedSection = AnyRenderSection(newValue)
+        }
+    }
+    private var typeErasedSection: AnyRenderSection
     
     /// Creates a codable content section from the given section.
     public init(_ section: RenderSection) {
+        self.typeErasedSection = AnyRenderSection(section)
         self.section = section
     }
     
@@ -26,6 +35,7 @@ public struct CodableContentSection: Codable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let kind = try container.decode(RenderSectionKind.self, forKey: .kind)
         
+        self.typeErasedSection = AnyRenderSection(ContentRenderSection(kind: .content, content: []))
         switch kind {
             case .discussion:
                 section = try ContentRenderSection(from: decoder)

--- a/Sources/SwiftDocC/Model/Rendering/RenderNode/RenderMetadata.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNode/RenderMetadata.swift
@@ -181,14 +181,14 @@ public struct RenderMetadata: VariantContainer {
 
 extension RenderMetadata: Codable {
     /// A list of pre-defined roles to assign to nodes.
-    public enum Role: String {
+    public enum Role: String, Equatable {
         case symbol, containerSymbol, restRequestSymbol, dictionarySymbol, pseudoSymbol, pseudoCollection, collection, collectionGroup, article, sampleCode, unknown
         case table, codeListing, link, subsection, task, overview
         case tutorial = "project"
     }
     
     /// Metadata about a module dependency.
-    public struct Module: Codable {
+    public struct Module: Codable, Equatable {
         public let name: String
         /// Possible dependencies to the module, we allow for those in the render JSON model
         /// but have no authoring support at the moment.
@@ -210,7 +210,7 @@ extension RenderMetadata: Codable {
         }
     }
 
-    public struct CodingKeys: CodingKey, Hashable {
+    public struct CodingKeys: CodingKey, Hashable, Equatable {
         public var stringValue: String
         
         public init(stringValue: String) {
@@ -343,5 +343,58 @@ extension RenderMetadata: Codable {
         try container.encodeIfPresent(color, forKey: .color)
         try container.encodeIfNotEmpty(customMetadata, forKey: .customMetadata)
         try container.encodeIfTrue(hasNoExpandedDocumentation, forKey: .hasNoExpandedDocumentation)
+    }
+}
+
+// Diffable conformance
+extension RenderMetadata: RenderJSONDiffable {
+    /// Returns the differences between this RenderMetadata and the given one.
+    func difference(from other: RenderMetadata, at path: CodablePath) -> JSONPatchDifferences {
+        var diffBuilder = DifferenceBuilder(current: self, other: other, basePath: path)
+
+        diffBuilder.addDifferences(atKeyPath: \.category, forKey: CodingKeys.category)
+        diffBuilder.addDifferences(atKeyPath: \.categoryPathComponent, forKey: CodingKeys.categoryPathComponent)
+        diffBuilder.addDifferences(atKeyPath: \.estimatedTime, forKey: CodingKeys.estimatedTime)
+        diffBuilder.addDifferences(atKeyPath: \.modules, forKey: CodingKeys.modules)
+        diffBuilder.addDifferences(atKeyPath: \.extendedModule, forKey: CodingKeys.extendedModule)
+        diffBuilder.addDifferences(atKeyPath: \.modules, forKey: CodingKeys.modules)
+        diffBuilder.addDifferences(atKeyPath: \.platforms, forKey: CodingKeys.platforms)
+        diffBuilder.addDifferences(atKeyPath: \.required, forKey: CodingKeys.required)
+        diffBuilder.addDifferences(atKeyPath: \.roleHeading, forKey: CodingKeys.roleHeading)
+        diffBuilder.addDifferences(atKeyPath: \.role, forKey: CodingKeys.role)
+        diffBuilder.addDifferences(atKeyPath: \.images, forKey: CodingKeys.images)
+        diffBuilder.addDifferences(atKeyPath: \.color, forKey: CodingKeys.color)
+        diffBuilder.addDifferences(atKeyPath: \.customMetadata, forKey: CodingKeys.customMetadata)
+        diffBuilder.addDifferences(atKeyPath: \.title, forKey: CodingKeys.title)
+        diffBuilder.addDifferences(atKeyPath: \.externalID, forKey: CodingKeys.externalID)
+        diffBuilder.addDifferences(atKeyPath: \.symbolKind, forKey: CodingKeys.symbolKind)
+        diffBuilder.addDifferences(atKeyPath: \.symbolAccessLevel, forKey: CodingKeys.symbolAccessLevel)
+        diffBuilder.addDifferences(atKeyPath: \.fragments, forKey: CodingKeys.fragments)
+        diffBuilder.addDifferences(atKeyPath: \.navigatorTitle, forKey: CodingKeys.navigatorTitle)
+        diffBuilder.addDifferences(atKeyPath: \.conformance, forKey: CodingKeys.conformance)
+        diffBuilder.addDifferences(atKeyPath: \.sourceFileURI, forKey: CodingKeys.sourceFileURI)
+        diffBuilder.addDifferences(atKeyPath: \.remoteSource, forKey: CodingKeys.remoteSource)
+        diffBuilder.addDifferences(atKeyPath: \.tags, forKey: CodingKeys.tags)
+        diffBuilder.addDifferences(atKeyPath: \.hasNoExpandedDocumentation, forKey: CodingKeys.hasNoExpandedDocumentation)
+
+        return diffBuilder.differences
+    }
+    
+    /// Returns if this RenderMetadata is similar enough to the given one.
+    func isSimilar(to other: RenderMetadata) -> Bool {
+        return self.title == other.title
+    }
+}
+
+// Diffable conformance
+extension RenderMetadata.Module: RenderJSONDiffable {
+    /// Returns the difference between two RenderMetadata.Modules.
+    func difference(from other: RenderMetadata.Module, at path: CodablePath) -> JSONPatchDifferences {
+        var diffBuilder = DifferenceBuilder(current: self, other: other, basePath: path)
+        
+        diffBuilder.addDifferences(atKeyPath: \.name, forKey: CodingKeys.name)
+        diffBuilder.addDifferences(atKeyPath: \.relatedModules, forKey: CodingKeys.relatedModules)
+        
+        return diffBuilder.differences
     }
 }

--- a/Sources/SwiftDocC/Model/Rendering/RenderNode/RenderNode+Codable.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNode/RenderNode+Codable.swift
@@ -9,9 +9,9 @@
 */
 
 import Foundation
-
+    
 extension RenderNode: Codable {
-    private enum CodingKeys: CodingKey {
+    enum CodingKeys: CodingKey {
         case schemaVersion, identifier, sections, references, metadata, kind, hierarchy
         case abstract, topicSections, topicSectionsStyle, defaultImplementationsSections, primaryContentSections, relationshipsSections, declarationSections, seeAlsoSections, returnsSection, parametersSection, sampleCodeDownload, downloadNotAvailableSummary, deprecationSummary, diffAvailability, interfaceLanguage, variants, variantOverrides
     }

--- a/Sources/SwiftDocC/Model/Rendering/SemanticVersion.swift
+++ b/Sources/SwiftDocC/Model/Rendering/SemanticVersion.swift
@@ -62,3 +62,17 @@ public struct SemanticVersion: Codable, Equatable, CustomStringConvertible {
         return result
     }
 }
+
+// Diffable conformance
+extension SemanticVersion: RenderJSONDiffable {
+    /// Returns the differences between this SemanticVersion and the given one.
+    func difference(from other: SemanticVersion, at path: CodablePath) -> JSONPatchDifferences {
+        var diffBuilder = DifferenceBuilder(current: self, other: other, basePath: path)
+
+        diffBuilder.addDifferences(atKeyPath: \.major, forKey: CodingKeys.major)
+        diffBuilder.addDifferences(atKeyPath: \.minor, forKey: CodingKeys.minor)
+        diffBuilder.addDifferences(atKeyPath: \.patch, forKey: CodingKeys.patch)
+
+        return diffBuilder.differences
+    }
+}

--- a/Sources/SwiftDocC/Model/Rendering/Symbol/AttributesRenderSection.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Symbol/AttributesRenderSection.swift
@@ -152,3 +152,22 @@ public enum RenderAttribute: Codable, Equatable {
         }
     }
 }
+
+// Diffable conformance
+extension AttributesRenderSection: RenderJSONDiffable {
+    /// Returns the differences between this AttributesRenderSection and the given one.
+    func difference(from other: AttributesRenderSection, at path: CodablePath) -> JSONPatchDifferences {
+        var diffBuilder = DifferenceBuilder(current: self, other: other, basePath: path)
+
+        diffBuilder.addDifferences(atKeyPath: \.kind, forKey: CodingKeys.kind)
+        diffBuilder.addDifferences(atKeyPath: \.title, forKey: CodingKeys.title)
+        diffBuilder.addDifferences(atKeyPath: \.attributes, forKey: CodingKeys.attributes)
+
+        return diffBuilder.differences
+    }
+    
+    /// Returns if this AttributesRenderSection is similar enough to the given one.
+    func isSimilar(to other: AttributesRenderSection) -> Bool {
+        return self.attributes == other.attributes
+    }
+}

--- a/Sources/SwiftDocC/Model/Rendering/Symbol/ConformanceSection.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Symbol/ConformanceSection.swift
@@ -171,3 +171,17 @@ private extension String {
     /// Returns the string surrounded by spaces.
     var spaceDelimited: String { return " \(self) "}
 }
+
+// Diffable conformance
+extension ConformanceSection: RenderJSONDiffable {
+    /// Returns the differences between this ConformanceSection and the given one.
+    func difference(from other: ConformanceSection, at path: CodablePath) -> JSONPatchDifferences {
+        var diffBuilder = DifferenceBuilder(current: self, other: other, basePath: path)
+
+        diffBuilder.addDifferences(atKeyPath: \.availabilityPrefix, forKey: CodingKeys.availabilityPrefix)
+        diffBuilder.addDifferences(atKeyPath: \.conformancePrefix, forKey: CodingKeys.conformancePrefix)
+        diffBuilder.addDifferences(atKeyPath: \.constraints, forKey: CodingKeys.constraints)
+
+        return diffBuilder.differences
+    }
+}

--- a/Sources/SwiftDocC/Model/Rendering/Symbol/ContentRenderSection.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Symbol/ContentRenderSection.swift
@@ -9,7 +9,7 @@
 */
 
 /// A section of documentation content.
-public struct ContentRenderSection: RenderSection {
+public struct ContentRenderSection: RenderSection, Equatable {
     public let kind: RenderSectionKind
     
     /// Arbitrary content for this section.
@@ -32,5 +32,23 @@ public struct ContentRenderSection: RenderSection {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         kind = try container.decode(RenderSectionKind.self, forKey: .kind)
         content = try container.decode([RenderBlockContent].self, forKey: .content)
+    }
+}
+
+// Diffable conformance
+extension ContentRenderSection: RenderJSONDiffable {
+    /// Returns the differences between this ContentRenderSection and the given one.
+    func difference(from other: ContentRenderSection, at path: CodablePath) -> JSONPatchDifferences {
+        var diffBuilder = DifferenceBuilder(current: self, other: other, basePath: path)
+
+        diffBuilder.addDifferences(atKeyPath: \.kind, forKey: CodingKeys.kind)
+        diffBuilder.addDifferences(atKeyPath: \.content, forKey: CodingKeys.content)
+
+        return diffBuilder.differences
+    }
+    
+    /// Returns if this ContentRenderSection is similar enough to the given one.
+    func isSimilar(to other: ContentRenderSection) -> Bool {
+        return self.content == other.content
     }
 }

--- a/Sources/SwiftDocC/Model/Rendering/Symbol/DeclarationsRenderSection.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Symbol/DeclarationsRenderSection.swift
@@ -36,6 +36,25 @@ extension DeclarationsRenderSection: TextIndexing {
     }
 }
 
+// Diffable conformance
+extension DeclarationsRenderSection: RenderJSONDiffable {
+    /// Returns the differences between this DeclarationsRenderSection and the given one.
+    func difference(from other: DeclarationsRenderSection, at path: CodablePath) -> JSONPatchDifferences {
+        var diffBuilder = DifferenceBuilder(current: self, other: other, basePath: path)
+
+        diffBuilder.addDifferences(atKeyPath: \.kind, forKey: CodingKeys.kind)
+        diffBuilder.addDifferences(atKeyPath: \.declarations, forKey: CodingKeys.declarations)
+
+        return diffBuilder.differences
+    }
+    
+    /// Returns if this DeclarationsRenderSection is similar enough to the given one.
+    func isSimilar(to other: DeclarationsRenderSection) -> Bool {
+        return self.declarations == other.declarations
+    }
+
+}
+
 /// A section that contains a symbol declaration.
 public struct DeclarationRenderSection: Codable, Equatable {
     /// The platforms this declaration applies to.
@@ -56,7 +75,7 @@ public struct DeclarationRenderSection: Codable, Equatable {
     ///
     /// A lexical token is a string with an associated meaning in source code.
     /// For example, `123` is represented as a single token of kind "number".
-    public struct Token: Codable, Hashable {
+    public struct Token: Codable, Hashable, Equatable {
         /// The token text content.
         public let text: String
         /// The token programming kind.
@@ -170,5 +189,42 @@ extension DeclarationRenderSection: TextIndexing {
 
     public func rawIndexableTextContent(references: [String : RenderReference]) -> String {
         return ""
+    }
+}
+
+// Diffable conformance
+extension DeclarationRenderSection: RenderJSONDiffable {
+    /// Returns the differences between this DeclarationRenderSection and the given one.
+    func difference(from other: DeclarationRenderSection, at path: CodablePath) -> JSONPatchDifferences {
+        var diffBuilder = DifferenceBuilder(current: self, other: other, basePath: path)
+
+        diffBuilder.addDifferences(atKeyPath: \.platforms, forKey: CodingKeys.platforms)
+        diffBuilder.addDifferences(atKeyPath: \.tokens, forKey: CodingKeys.tokens)
+        diffBuilder.addDifferences(atKeyPath: \.languages, forKey: CodingKeys.languages)
+
+        return diffBuilder.differences
+    }
+
+    /// Returns if this DeclarationRenderSection is similar enough to the given one.
+    func isSimilar(to other: DeclarationRenderSection) -> Bool {
+        return self.tokens == other.tokens
+    }
+}
+
+// Diffable conformance
+extension DeclarationRenderSection.Token: RenderJSONDiffable {
+    /// Returns the differences between this Token and the given one.
+    func difference(from other: DeclarationRenderSection.Token, at path: CodablePath) -> JSONPatchDifferences {
+        var diffBuilder = DifferenceBuilder(current: self, other: other, basePath: path)
+
+        diffBuilder.addDifferences(atKeyPath: \.text, forKey: CodingKeys.text)
+        diffBuilder.addDifferences(atKeyPath: \.kind, forKey: CodingKeys.kind)
+
+        return diffBuilder.differences
+    }
+
+    /// Returns if this Token is similar enough to the given one.
+    func isSimilar(to other: DeclarationRenderSection.Token) -> Bool {
+        return self.text == other.text
     }
 }

--- a/Sources/SwiftDocC/Model/Rendering/Symbol/DiffAvailability.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Symbol/DiffAvailability.swift
@@ -11,7 +11,7 @@
 import Foundation
 
 /// An availability-change diff for a symbol, if that data is available.
-public struct DiffAvailability: Codable {
+public struct DiffAvailability: Codable, Equatable {
     /// The change information for a symbol that was updated in a beta version of the current platform.
     public var beta: Info?
 

--- a/Sources/SwiftDocC/Model/Rendering/Symbol/ParameterRenderSection.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Symbol/ParameterRenderSection.swift
@@ -9,7 +9,7 @@
 */
 
 /// A section that contains a list of parameters.
-public struct ParametersRenderSection: RenderSection {
+public struct ParametersRenderSection: RenderSection, Equatable {
     public var kind: RenderSectionKind = .parameters
     /// The list of parameter sub-sections.
     public let parameters: [ParameterRenderSection]
@@ -20,10 +20,46 @@ public struct ParametersRenderSection: RenderSection {
     }
 }
 
+// Diffable conformance
+extension ParametersRenderSection: RenderJSONDiffable {
+    /// Returns the differences between this ParametersRenderSection and the given one.
+    func difference(from other: ParametersRenderSection, at path: CodablePath) -> JSONPatchDifferences {
+        var diffBuilder = DifferenceBuilder(current: self, other: other, basePath: path)
+
+        diffBuilder.addDifferences(atKeyPath: \.kind, forKey: CodingKeys.kind)
+        diffBuilder.addDifferences(atKeyPath: \.parameters, forKey: CodingKeys.parameters)
+
+        return diffBuilder.differences
+    }
+
+    /// Returns if this ParametersRenderSection is similar enough to the given one.
+    func isSimilar(to other: ParametersRenderSection) -> Bool {
+        return self.parameters == other.parameters
+    }
+}
+
 /// A section that contains a single, named parameter.
-public struct ParameterRenderSection: Codable {
+public struct ParameterRenderSection: Codable, Equatable {
     /// The parameter name.
     public let name: String
     /// Free-form content to provide information about the parameter.
     public var content: [RenderBlockContent]
+}
+
+// Diffable conformance
+extension ParameterRenderSection: RenderJSONDiffable {
+    /// Returns the differences between this ParameterRenderSection and the given one.
+    func difference(from other: ParameterRenderSection, at path: CodablePath) -> JSONPatchDifferences {
+        var diffBuilder = DifferenceBuilder(current: self, other: other, basePath: path)
+
+        diffBuilder.addDifferences(atKeyPath: \.name, forKey: CodingKeys.name)
+        diffBuilder.addDifferences(atKeyPath: \.content, forKey: CodingKeys.content)
+
+        return diffBuilder.differences
+    }
+
+    /// Returns if this ParameterRenderSection is similar enough to the given one.
+    func isSimilar(to other: ParameterRenderSection) -> Bool {
+        return self.name == other.name || self.content == other.content
+    }
 }

--- a/Sources/SwiftDocC/Model/Rendering/Symbol/PlistDetailsRenderSection.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Symbol/PlistDetailsRenderSection.swift
@@ -19,13 +19,13 @@ public enum TitleStyle: String, Codable, Equatable {
 }
 
 /// A section that contains details about a property list key.
-struct PlistDetailsRenderSection: RenderSection {
+struct PlistDetailsRenderSection: RenderSection, Equatable {
     public var kind: RenderSectionKind = .plistDetails
     /// A title for the section.
     public var title = "Details"
     
     /// Details for a property list key.
-    struct Details: Codable {
+    struct Details: Codable, Equatable {
         /// The name of the key.
         let name: String
         /// A list of types acceptable for this key's value.
@@ -58,5 +58,23 @@ struct PlistDetailsRenderSection: RenderSection {
         try container.encode(kind, forKey: .kind)
         try container.encode(title, forKey: .title)
         try container.encode(details, forKey: .details)
+    }
+}
+
+// Diffable conformance
+extension PlistDetailsRenderSection: RenderJSONDiffable {
+    /// Returns the differences between this PlistDetailsRenderSection and the given one.
+    func difference(from other: PlistDetailsRenderSection, at path: CodablePath) -> JSONPatchDifferences {
+        var diffBuilder = DifferenceBuilder(current: self, other: other, basePath: path)
+
+        diffBuilder.addDifferences(atKeyPath: \.kind, forKey: CodingKeys.kind)
+        diffBuilder.addDifferences(atKeyPath: \.title, forKey: CodingKeys.title)
+
+        return diffBuilder.differences
+    }
+    
+    /// Returns if this PlistDetailsRenderSection is similar enough to the given one.
+    func isSimilar(to other: PlistDetailsRenderSection) -> Bool {
+        return self.title == other.title
     }
 }

--- a/Sources/SwiftDocC/Model/Rendering/Symbol/PossibleValuesRenderSection.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Symbol/PossibleValuesRenderSection.swift
@@ -13,14 +13,14 @@ import Foundation
 /// A section that lists a pre-defined list of possible values for a given symbol.
 ///
 /// For example, a property list key setting a target platform has allowed values of: "ppc", "i386", and "arm".
-public struct PossibleValuesRenderSection: RenderSection {
+public struct PossibleValuesRenderSection: RenderSection, Equatable {
     /// A named value and optional details content.
     ///
     /// Some values are self-explanatory in their context like "2" or "Info.plist". For values
     /// that are not, provide additional details like so:
     /// - name: "Default"
     /// - content: Use "Default" to load the first-available instance.
-    public struct NamedValue: Codable {
+    public struct NamedValue: Codable, Equatable {
         /// The value name.
         let name: String
         /// Details content, if any.
@@ -59,5 +59,42 @@ public struct PossibleValuesRenderSection: RenderSection {
         try container.encode(kind, forKey: .kind)
         try container.encode(title, forKey: .title)
         try container.encode(values, forKey: .values)
+    }
+}
+
+// Diffable conformance
+extension PossibleValuesRenderSection: RenderJSONDiffable {
+    /// Returns the differences between this PossibleValuesRenderSection and the given one.
+    func difference(from other: PossibleValuesRenderSection, at path: CodablePath) -> JSONPatchDifferences {
+        var diffBuilder = DifferenceBuilder(current: self, other: other, basePath: path)
+
+        diffBuilder.addDifferences(atKeyPath: \.kind, forKey: CodingKeys.kind)
+        diffBuilder.addDifferences(atKeyPath: \.title, forKey: CodingKeys.title)
+        diffBuilder.addDifferences(atKeyPath: \.values, forKey: CodingKeys.values)
+
+        return diffBuilder.differences
+    }
+    
+    /// Returns if this PossibleValuesRenderSection is similar enough to the given one.
+    func isSimilar(to other: PossibleValuesRenderSection) -> Bool {
+        return self.title == other.title || self.values == other.values
+    }
+}
+
+// Diffable conformance
+extension PossibleValuesRenderSection.NamedValue: RenderJSONDiffable {
+    /// Returns the differences between this NamedValue and the given one.
+    func difference(from other: PossibleValuesRenderSection.NamedValue, at path: CodablePath) -> JSONPatchDifferences {
+        var diffBuilder = DifferenceBuilder(current: self, other: other, basePath: path)
+
+        diffBuilder.addDifferences(atKeyPath: \.name, forKey: CodingKeys.name)
+        diffBuilder.addDifferences(atKeyPath: \.content, forKey: CodingKeys.content)
+
+        return diffBuilder.differences
+    }
+    
+    /// Returns if this NamedValue is similar enough to the given one.
+    func isSimilar(to other: PossibleValuesRenderSection.NamedValue) -> Bool {
+        return self.name == other.name || self.content == other.content
     }
 }

--- a/Sources/SwiftDocC/Model/Rendering/Symbol/RESTBodyRenderSection.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Symbol/RESTBodyRenderSection.swift
@@ -47,3 +47,24 @@ struct RESTBodyRenderSection: RenderSection, Equatable {
         self.parameters = parameters
     }
 }
+
+// Diffable conformance
+extension RESTBodyRenderSection: RenderJSONDiffable {
+    /// Returns the differences between this RESTBodyRenderSection and the given one.
+    func difference(from other: RESTBodyRenderSection, at path: CodablePath) -> JSONPatchDifferences {
+        var diffBuilder = DifferenceBuilder(current: self, other: other, basePath: path)
+
+        diffBuilder.addDifferences(atKeyPath: \.kind, forKey: CodingKeys.kind)
+        diffBuilder.addDifferences(atKeyPath: \.title, forKey: CodingKeys.title)
+        diffBuilder.addDifferences(atKeyPath: \.mimeType, forKey: CodingKeys.mimeType)
+        diffBuilder.addDifferences(atKeyPath: \.bodyContentType, forKey: CodingKeys.bodyContentType)
+        diffBuilder.addDifferences(atKeyPath: \.content, forKey: CodingKeys.content)
+
+        return diffBuilder.differences
+    }
+    
+    /// Returns if this RESTBodyRenderSection is similar enough to the given one.
+    func isSimilar(to other: RESTBodyRenderSection) -> Bool {
+        return self.title == other.title || self.content == other.content
+    }
+}

--- a/Sources/SwiftDocC/Model/Rendering/Symbol/RESTEndpointRenderSection.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Symbol/RESTEndpointRenderSection.swift
@@ -34,10 +34,10 @@ enum RESTEndpointType: String, Codable {
 ///  - (baseURL) `https://www.example.com`
 ///  - (path) `/api/artists/`
 ///  - (parameter) `{id}`
-public struct RESTEndpointRenderSection: RenderSection {
+public struct RESTEndpointRenderSection: RenderSection, Equatable {
     public var kind: RenderSectionKind = .restEndpoint
     /// A single token in a REST endpoint.
-    public struct Token: Codable {
+    public struct Token: Codable, Equatable {
         /// The kind of REST endpoint token.
         public enum Kind: String, Codable {
             case method, baseURL, path, parameter, text
@@ -62,5 +62,42 @@ public struct RESTEndpointRenderSection: RenderSection {
     public init(title: String, tokens: [Token]) {
         self.title = title
         self.tokens = tokens
+    }
+}
+
+// Diffable conformance
+extension RESTEndpointRenderSection: RenderJSONDiffable {
+    /// Returns the differences between this RESTEndpointRenderSection and the given one.
+    func difference(from other: RESTEndpointRenderSection, at path: CodablePath) -> JSONPatchDifferences {
+        var diffBuilder = DifferenceBuilder(current: self, other: other, basePath: path)
+
+        diffBuilder.addDifferences(atKeyPath: \.kind, forKey: CodingKeys.kind)
+        diffBuilder.addDifferences(atKeyPath: \.title, forKey: CodingKeys.title)
+        diffBuilder.addDifferences(atKeyPath: \.tokens, forKey: CodingKeys.tokens)
+
+        return diffBuilder.differences
+    }
+    
+    /// Returns if this RESTEndpointRenderSection is similar enough to the given one.
+    func isSimilar(to other: RESTEndpointRenderSection) -> Bool {
+        return self.title == other.title
+    }
+}
+
+// Diffable conformance
+extension RESTEndpointRenderSection.Token: RenderJSONDiffable {
+    /// Returns the differences between this Token and the given one.
+    func difference(from other: RESTEndpointRenderSection.Token, at path: CodablePath) -> JSONPatchDifferences {
+        var diffBuilder = DifferenceBuilder(current: self, other: other, basePath: path)
+
+        diffBuilder.addDifferences(atKeyPath: \.kind, forKey: CodingKeys.kind)
+        diffBuilder.addDifferences(atKeyPath: \.text, forKey: CodingKeys.text)
+
+        return diffBuilder.differences
+    }
+    
+    /// Returns if this Token is similar enough to the given one.
+    func isSimilar(to other: RESTEndpointRenderSection.Token) -> Bool {
+        return self.text == other.text
     }
 }

--- a/Sources/SwiftDocC/Model/Rendering/Symbol/RESTParametersRenderSection.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Symbol/RESTParametersRenderSection.swift
@@ -26,7 +26,7 @@ enum RESTParameterSource: String, Codable {
 }
 
 /// A section that contains a list of REST parameters.
-struct RESTParametersRenderSection: RenderSection {
+struct RESTParametersRenderSection: RenderSection, Equatable {
     public var kind: RenderSectionKind = .restParameters
     /// The title for the section.
     public let title: String
@@ -44,5 +44,25 @@ struct RESTParametersRenderSection: RenderSection {
         self.title = title
         self.items = items
         self.source = source
+    }
+}
+
+// Diffable conformance
+extension RESTParametersRenderSection: RenderJSONDiffable {
+    /// Returns the differences between this RESTParametersRenderSection and the given one.
+    func difference(from other: RESTParametersRenderSection, at path: CodablePath) -> JSONPatchDifferences {
+        var diffBuilder = DifferenceBuilder(current: self, other: other, basePath: path)
+
+        diffBuilder.addDifferences(atKeyPath: \.kind, forKey: CodingKeys.kind)
+        diffBuilder.addDifferences(atKeyPath: \.title, forKey: CodingKeys.title)
+        diffBuilder.addDifferences(atKeyPath: \.items, forKey: CodingKeys.items)
+        diffBuilder.addDifferences(atKeyPath: \.source, forKey: CodingKeys.source)
+
+        return diffBuilder.differences
+    }
+    
+    /// Returns if this RESTParametersRenderSection is similar enough to the given one.
+    func isSimilar(to other: RESTParametersRenderSection) -> Bool {
+        return self.title == other.title
     }
 }

--- a/Sources/SwiftDocC/Model/Rendering/Symbol/RESTResponseRenderSection.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Symbol/RESTResponseRenderSection.swift
@@ -28,6 +28,26 @@ struct RESTResponseRenderSection: RenderSection, Equatable {
     }
 }
 
+// Diffable conformance
+extension RESTResponseRenderSection: RenderJSONDiffable {
+    
+    /// Returns the differences between this RESTResponseRenderSection and the given one.
+    func difference(from other: RESTResponseRenderSection, at path: CodablePath) -> JSONPatchDifferences {
+        var diffBuilder = DifferenceBuilder(current: self, other: other, basePath: path)
+
+        diffBuilder.addDifferences(atKeyPath: \.kind, forKey: CodingKeys.kind)
+        diffBuilder.addDifferences(atKeyPath: \.title, forKey: CodingKeys.title)
+        diffBuilder.addDifferences(atKeyPath: \.items, forKey: CodingKeys.items)
+
+        return diffBuilder.differences
+    }
+    
+    /// Returns if this RESTResponseRenderSection is similar enough to the given one.
+    func isSimilar(to other: RESTResponseRenderSection) -> Bool {
+        return self.title == other.title || self.items == other.items
+    }
+}
+
 /// A REST response that includes the HTTP status, reason,
 /// and the MIME type encoding of the response body.
 ///
@@ -74,5 +94,26 @@ struct RESTResponse: Codable, TextIndexing, Equatable {
         mimeType = try container.decodeIfPresent(String.self, forKey: .mimeType)
         type = try container.decode([DeclarationRenderSection.Token].self, forKey: .type)
         content = try container.decodeIfPresent([RenderBlockContent].self, forKey: .content)
+    }
+}
+
+// Diffable conformance
+extension RESTResponse: RenderJSONDiffable {
+    /// Returns the differences between this RESTResponse and the given one.
+    func difference(from other: RESTResponse, at path: CodablePath) -> JSONPatchDifferences {
+        var diffBuilder = DifferenceBuilder(current: self, other: other, basePath: path)
+
+        diffBuilder.addDifferences(atKeyPath: \.status, forKey: CodingKeys.status)
+        diffBuilder.addDifferences(atKeyPath: \.reason, forKey: CodingKeys.reason)
+        diffBuilder.addDifferences(atKeyPath: \.mimeType, forKey: CodingKeys.mimeType)
+        diffBuilder.addDifferences(atKeyPath: \.type, forKey: CodingKeys.type)
+        diffBuilder.addDifferences(atKeyPath: \.content, forKey: CodingKeys.content)
+
+        return diffBuilder.differences
+    }
+    
+    /// Returns if this RESTResponse is similar enough to the given one.
+    func isSimilar(to other: RESTResponse) -> Bool {
+        return self.content == other.content
     }
 }

--- a/Sources/SwiftDocC/Model/Rendering/Symbol/RelationshipsRenderSection.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Symbol/RelationshipsRenderSection.swift
@@ -11,7 +11,7 @@
 import Foundation
 
 /// A section that contains a list of symbol relationships of the same kind.
-public struct RelationshipsRenderSection: RenderSection {
+public struct RelationshipsRenderSection: RenderSection, Equatable {
     public let kind: RenderSectionKind = .relationships
     
     /// A title for the section.
@@ -41,5 +41,25 @@ public struct RelationshipsRenderSection: RenderSection {
         identifiers = try container.decode([String].self, forKey: .identifiers)
         
         decoder.registerReferences(identifiers)
+    }
+}
+
+// Diffable conformance
+extension RelationshipsRenderSection: RenderJSONDiffable {
+    /// Returns the differences between this RelationshipsRenderSection and the given one.
+    func difference(from other: RelationshipsRenderSection, at path: CodablePath) -> JSONPatchDifferences {
+        var diffBuilder = DifferenceBuilder(current: self, other: other, basePath: path)
+
+        diffBuilder.addDifferences(atKeyPath: \.kind, forKey: CodingKeys.kind)
+        diffBuilder.addDifferences(atKeyPath: \.title, forKey: CodingKeys.title)
+        diffBuilder.addDifferences(atKeyPath: \.identifiers, forKey: CodingKeys.identifiers)
+        diffBuilder.addDifferences(atKeyPath: \.type, forKey: CodingKeys.type)
+
+        return diffBuilder.differences
+    }
+
+    /// Returns if this RelationshipsRenderSection is similar enough to the given one.
+    func isSimilar(to other: RelationshipsRenderSection) -> Bool {
+        return self.title == other.title
     }
 }

--- a/Sources/SwiftDocC/Model/Rendering/Symbol/SampleDownloadSection.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Symbol/SampleDownloadSection.swift
@@ -13,7 +13,7 @@ import Foundation
 /// A section that contains download data for a sample project.
 ///
 /// The `action` property is the reference to the file for download, e.g., `sample.zip`.
-public struct SampleDownloadSection: RenderSection {
+public struct SampleDownloadSection: RenderSection, Equatable {
     public var kind: RenderSectionKind = .sampleDownload
     /// The call to action in the section.
     public var action: RenderInlineContent
@@ -40,5 +40,23 @@ public struct SampleDownloadSection: RenderSection {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(kind, forKey: .kind)
         try container.encode(action, forKey: .action)
+    }
+}
+
+// Diffable conformance
+extension SampleDownloadSection: RenderJSONDiffable {
+    /// Returns the differences between this SampleDownloadSection and the given one.
+    func difference(from other: SampleDownloadSection, at path: CodablePath) -> JSONPatchDifferences {
+        var diffBuilder = DifferenceBuilder(current: self, other: other, basePath: path)
+
+        diffBuilder.addDifferences(atKeyPath: \.kind, forKey: CodingKeys.kind)
+        diffBuilder.addDifferences(atKeyPath: \.action, forKey: CodingKeys.action)
+
+        return diffBuilder.differences
+    }
+
+    /// Returns if this SampleDownloadSection is similar enough to the given one.
+    func isSimilar(to other: SampleDownloadSection) -> Bool {
+        return self.action == other.action
     }
 }

--- a/Sources/SwiftDocC/Model/Rendering/Tutorial Article/TutorialArticleSection.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Tutorial Article/TutorialArticleSection.swift
@@ -9,7 +9,7 @@
 */
 
 /// A Tutorial Article section.
-public struct TutorialArticleSection: RenderSection {
+public struct TutorialArticleSection: RenderSection, Equatable {
     
     public let kind: RenderSectionKind = .articleBody
     
@@ -31,7 +31,7 @@ public struct TutorialArticleSection: RenderSection {
 }
 
 /// The layout in which the content should be presented.
-public enum ContentLayout {
+public enum ContentLayout: Equatable {
     /// A full-width layout.
     case fullWidth(content: [RenderBlockContent])
     
@@ -86,5 +86,23 @@ extension ContentLayout: Codable {
         case .columns(let content):
             try container.encode(content, forKey: .content)
         }
+    }
+}
+
+// Diffable conformance
+extension TutorialArticleSection: RenderJSONDiffable {
+    /// Returns the differences between this TutorialArticleSection and the given one.
+    func difference(from other: TutorialArticleSection, at path: CodablePath) -> JSONPatchDifferences {
+        var diffBuilder = DifferenceBuilder(current: self, other: other, basePath: path)
+
+        diffBuilder.addDifferences(atKeyPath: \.kind, forKey: CodingKeys.kind)
+        diffBuilder.addDifferences(atKeyPath: \.content, forKey: CodingKeys.content)
+
+        return diffBuilder.differences
+    }
+
+    /// Returns if this TutorialArticleSection is similar enough to the given one.
+    func isSimilar(to other: TutorialArticleSection) -> Bool {
+        return self.content == other.content
     }
 }

--- a/Sources/SwiftDocC/Model/Rendering/Tutorial/References/DownloadReference.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Tutorial/References/DownloadReference.swift
@@ -123,3 +123,18 @@ extension DownloadReference {
         url.isAbsoluteWebURL ? url : destinationURL(for: url.lastPathComponent)
     }
 }
+
+// Diffable conformance
+extension DownloadReference: RenderJSONDiffable {
+    /// Returns the difference between this DownloadReference and the given one.
+    func difference(from other: DownloadReference, at path: CodablePath) -> JSONPatchDifferences {
+        var diffBuilder = DifferenceBuilder(current: self, other: other, basePath: path)
+
+        diffBuilder.addDifferences(atKeyPath: \.type, forKey: CodingKeys.type)
+        diffBuilder.addDifferences(atKeyPath: \.identifier, forKey: CodingKeys.identifier)
+        diffBuilder.addDifferences(atKeyPath: \.url, forKey: CodingKeys.url)
+        diffBuilder.addDifferences(atKeyPath: \.checksum, forKey: CodingKeys.checksum)
+
+        return diffBuilder.differences
+    }
+}

--- a/Sources/SwiftDocC/Model/Rendering/Tutorial/References/XcodeRequirementReference.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Tutorial/References/XcodeRequirementReference.swift
@@ -34,3 +34,18 @@ public struct XcodeRequirementReference: RenderReference, Equatable {
         self.url = url
     }
 }
+
+// Diffable conformance
+extension XcodeRequirementReference: RenderJSONDiffable {
+    /// Returns the difference between this XcodeRequirementReference and the given one.
+    func difference(from other: XcodeRequirementReference, at path: CodablePath) -> JSONPatchDifferences {
+        var diffBuilder = DifferenceBuilder(current: self, other: other, basePath: path)
+
+        diffBuilder.addDifferences(atKeyPath: \.type, forKey: CodingKeys.type)
+        diffBuilder.addDifferences(atKeyPath: \.identifier, forKey: CodingKeys.identifier)
+        diffBuilder.addDifferences(atKeyPath: \.title, forKey: CodingKeys.title)
+        diffBuilder.addDifferences(atKeyPath: \.url, forKey: CodingKeys.url)
+
+        return diffBuilder.differences
+    }
+}

--- a/Sources/SwiftDocC/Model/Rendering/Tutorial/Sections/IntroRenderSection.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Tutorial/Sections/IntroRenderSection.swift
@@ -65,3 +65,29 @@ public struct IntroRenderSection: RenderSection, Equatable {
         content = try container.decodeIfPresent([RenderBlockContent].self, forKey: .content) ?? []
     }
 }
+
+// Diffable conformance
+extension IntroRenderSection: RenderJSONDiffable {
+    /// Returns the differences between this IntroRenderSection and the given one.
+    func difference(from other: IntroRenderSection, at path: CodablePath) -> JSONPatchDifferences {
+        var diffBuilder = DifferenceBuilder(current: self, other: other, basePath: path)
+
+        diffBuilder.addDifferences(atKeyPath: \.title, forKey: CodingKeys.title)
+        diffBuilder.addDifferences(atKeyPath: \.chapter, forKey: CodingKeys.chapter)
+        diffBuilder.addDifferences(atKeyPath: \.estimatedTimeInMinutes, forKey: CodingKeys.estimatedTimeInMinutes)
+        diffBuilder.addDifferences(atKeyPath: \.xcodeRequirement, forKey: CodingKeys.xcodeRequirement)
+        diffBuilder.addDifferences(atKeyPath: \.backgroundImage, forKey: CodingKeys.backgroundImage)
+        diffBuilder.addDifferences(atKeyPath: \.action, forKey: CodingKeys.action)
+        diffBuilder.addDifferences(atKeyPath: \.image, forKey: CodingKeys.image)
+        diffBuilder.addDifferences(atKeyPath: \.video, forKey: CodingKeys.video)
+        diffBuilder.addDifferences(atKeyPath: \.projectFiles, forKey: CodingKeys.projectFiles)
+        diffBuilder.addDifferences(atKeyPath: \.content, forKey: CodingKeys.content)
+
+        return diffBuilder.differences
+    }
+
+    /// Returns if this IntroRenderSection is similar enough to the given one.
+    func isSimilar(to other: IntroRenderSection) -> Bool {
+        return self.title == other.title || self.content == other.content
+    }
+}

--- a/Sources/SwiftDocC/Model/Rendering/Tutorial/Sections/TutorialAssessmentsRenderSection.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Tutorial/Sections/TutorialAssessmentsRenderSection.swift
@@ -9,7 +9,7 @@
 */
 
 /// A section that checks the user's understanding of the concepts presented in a tutorial.
-public struct TutorialAssessmentsRenderSection: RenderSection {
+public struct TutorialAssessmentsRenderSection: RenderSection, Equatable {
     public var kind: RenderSectionKind = .assessments
     
     /// The questions for this assessment section. 
@@ -24,7 +24,7 @@ public struct TutorialAssessmentsRenderSection: RenderSection {
     public static let title = "Check Your Understanding"
     
     /// A render-friendly representation of an assessment question.
-    public struct Assessment: Codable, TextIndexing {
+    public struct Assessment: Codable, TextIndexing, Equatable {
         /// The type of assessment question.
         ///
         /// The default value is `multiple-choice`.
@@ -43,7 +43,7 @@ public struct TutorialAssessmentsRenderSection: RenderSection {
         
         /// A render-friendly representation of an answer to a
         /// multiple-choice assessment question.
-        public struct Choice: Codable {
+        public struct Choice: Codable, Equatable {
             /// The content of the choice.
             public var content: [RenderBlockContent]
             
@@ -94,4 +94,60 @@ public struct TutorialAssessmentsRenderSection: RenderSection {
     }
 }
 
+// Diffable conformance
+extension TutorialAssessmentsRenderSection: RenderJSONDiffable {
+    /// Returns the differences between this TutorialAssessmentsRenderSection and the given one.
+    func difference(from other: TutorialAssessmentsRenderSection, at path: CodablePath) -> JSONPatchDifferences {
+        var diffBuilder = DifferenceBuilder(current: self, other: other, basePath: path)
 
+        diffBuilder.addDifferences(atKeyPath: \.kind, forKey: CodingKeys.kind)
+        diffBuilder.addDifferences(atKeyPath: \.assessments, forKey: CodingKeys.assessments)
+        diffBuilder.addDifferences(atKeyPath: \.anchor, forKey: CodingKeys.anchor)
+
+        return diffBuilder.differences
+    }
+
+    /// Returns if this TutorialAssessmentsRenderSection is similar enough to the given one.
+    func isSimilar(to other: TutorialAssessmentsRenderSection) -> Bool {
+        return self.assessments == other.assessments
+    }
+}
+
+// Diffable conformance
+extension TutorialAssessmentsRenderSection.Assessment: RenderJSONDiffable {
+    /// Returns the differences between this Assessment and the given one.
+    func difference(from other: TutorialAssessmentsRenderSection.Assessment, at path: CodablePath) -> JSONPatchDifferences {
+        var diffBuilder = DifferenceBuilder(current: self, other: other, basePath: path)
+
+        diffBuilder.addDifferences(atKeyPath: \.title, forKey: CodingKeys.title)
+        diffBuilder.addDifferences(atKeyPath: \.content, forKey: CodingKeys.content)
+        diffBuilder.addDifferences(atKeyPath: \.choices, forKey: CodingKeys.choices)
+
+        return diffBuilder.differences
+    }
+
+    /// Returns if this Assessment is similar enough to the given one.
+    func isSimilar(to other: TutorialAssessmentsRenderSection.Assessment) -> Bool {
+        return self.title == other.title || self.content == other.content
+    }
+}
+
+// Diffable conformance
+extension TutorialAssessmentsRenderSection.Assessment.Choice: RenderJSONDiffable {
+    /// Returns the differences between this Choice and the given one.
+    func difference(from other: TutorialAssessmentsRenderSection.Assessment.Choice, at path: CodablePath) -> JSONPatchDifferences {
+        var diffBuilder = DifferenceBuilder(current: self, other: other, basePath: path)
+
+        diffBuilder.addDifferences(atKeyPath: \.content, forKey: CodingKeys.content)
+        diffBuilder.addDifferences(atKeyPath: \.isCorrect, forKey: CodingKeys.isCorrect)
+        diffBuilder.addDifferences(atKeyPath: \.justification, forKey: CodingKeys.justification)
+        diffBuilder.addDifferences(atKeyPath: \.reaction, forKey: CodingKeys.reaction)
+
+        return diffBuilder.differences
+    }
+
+    /// Returns if this Choice is similar enough to the given one.
+    func isSimilar(to other: TutorialAssessmentsRenderSection.Assessment.Choice) -> Bool {
+        return self.content == other.content
+    }
+}

--- a/Sources/SwiftDocC/Model/Rendering/Tutorial/Sections/TutorialSectionsRenderSection.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Tutorial/Sections/TutorialSectionsRenderSection.swift
@@ -11,14 +11,14 @@
 import Foundation
 
 /// A section of a Tutorial page.
-public struct TutorialSectionsRenderSection: RenderSection {
+public struct TutorialSectionsRenderSection: RenderSection, Equatable {
     public var kind: RenderSectionKind = .tasks
     
     /// The tasks in the section.
     public var tasks: [Section]
     
     /// A render-friendly representation of a tutorial section.
-    public struct Section: TextIndexing {
+    public struct Section: TextIndexing, Equatable {
         /// The title of the section.
         public var title: String
 
@@ -79,5 +79,43 @@ extension TutorialSectionsRenderSection.Section: Codable {
         try container.encode(contentSection, forKey: .contentSection)
         try container.encode(stepsSection, forKey: .stepsSection)
         try container.encode(anchor, forKey: .anchor)
+    }
+}
+
+// Diffable conformance
+extension TutorialSectionsRenderSection: RenderJSONDiffable {
+    /// Returns the differences between this TutorialSectionsRenderSection and the given one.
+    func difference(from other: TutorialSectionsRenderSection, at path: CodablePath) -> JSONPatchDifferences {
+        var diffBuilder = DifferenceBuilder(current: self, other: other, basePath: path)
+
+        diffBuilder.addDifferences(atKeyPath: \.kind, forKey: CodingKeys.kind)
+        diffBuilder.addDifferences(atKeyPath: \.tasks, forKey: CodingKeys.tasks)
+
+        return diffBuilder.differences
+    }
+
+    /// Returns if this TutorialSectionsRenderSection is similar enough to the given one.
+    func isSimilar(to other: TutorialSectionsRenderSection) -> Bool {
+        return self.tasks == other.tasks
+    }
+}
+
+// Diffable conformance
+extension TutorialSectionsRenderSection.Section: RenderJSONDiffable {
+    /// Returns the differences between this Section and the given one.
+    func difference(from other: TutorialSectionsRenderSection.Section, at path: CodablePath) -> JSONPatchDifferences {
+        var diffBuilder = DifferenceBuilder(current: self, other: other, basePath: path)
+
+        diffBuilder.addDifferences(atKeyPath: \.title, forKey: CodingKeys.title)
+        diffBuilder.addDifferences(atKeyPath: \.contentSection, forKey: CodingKeys.contentSection)
+        diffBuilder.addDifferences(atKeyPath: \.stepsSection, forKey: CodingKeys.stepsSection)
+        diffBuilder.addDifferences(atKeyPath: \.anchor, forKey: CodingKeys.contentSection)
+
+        return diffBuilder.differences
+    }
+
+    /// Returns if this Section is similar enough to the given one.
+    func isSimilar(to other: TutorialSectionsRenderSection.Section) -> Bool {
+        return self.title == other.title || self.contentSection == other.contentSection
     }
 }

--- a/Sources/SwiftDocC/Model/Rendering/Tutorials Overview/Resources/RenderTile.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Tutorials Overview/Resources/RenderTile.swift
@@ -14,7 +14,7 @@
 /// Depending on its type, a render tile contains links to a 
 /// specific kind of resource such as sample code, videos,
 /// or forum topics.
-public struct RenderTile: Codable, TextIndexing {
+public struct RenderTile: Codable, TextIndexing, Equatable {
     /// Predefined semantic tile identifiers.
     public enum Identifier: String, Codable {
         /// Identifies a tile that links to featured content.

--- a/Sources/SwiftDocC/Model/Rendering/Tutorials Overview/Sections/CallToActionSection.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Tutorials Overview/Sections/CallToActionSection.swift
@@ -11,7 +11,7 @@
 import Foundation
 
 /// A section that prompts the user to perform an action.
-public struct CallToActionSection: RenderSection {
+public struct CallToActionSection: RenderSection, Equatable {
     public var kind: RenderSectionKind = .callToAction
     
     /// The title of the section.
@@ -52,5 +52,27 @@ public struct CallToActionSection: RenderSection {
         abstract = try container.decodeIfPresent([RenderInlineContent].self, forKey: .abstract) ?? []
         // The featured eyebrow might not be present in older JSON
         featuredEyebrow = try container.decodeIfPresent(String.self, forKey: .featuredEyebrow)
+    }
+}
+
+// Diffable conformance
+extension CallToActionSection: RenderJSONDiffable {
+    /// Returns the differences between this CallToActionSection and the given one.
+    func difference(from other: CallToActionSection, at path: CodablePath) -> JSONPatchDifferences {
+        var diffBuilder = DifferenceBuilder(current: self, other: other, basePath: path)
+
+        diffBuilder.addDifferences(atKeyPath: \.kind, forKey: CodingKeys.kind)
+        diffBuilder.addDifferences(atKeyPath: \.title, forKey: CodingKeys.title)
+        diffBuilder.addDifferences(atKeyPath: \.abstract, forKey: CodingKeys.abstract)
+        diffBuilder.addDifferences(atKeyPath: \.media, forKey: CodingKeys.media)
+        diffBuilder.addDifferences(atKeyPath: \.action, forKey: CodingKeys.action)
+        diffBuilder.addDifferences(atKeyPath: \.featuredEyebrow, forKey: CodingKeys.featuredEyebrow)
+
+        return diffBuilder.differences
+    }
+
+    /// Returns if this CallToActionSection is similar enough to the given one.
+    func isSimilar(to other: CallToActionSection) -> Bool {
+        return self.title == other.title || self.action == other.action
     }
 }

--- a/Sources/SwiftDocC/Model/Rendering/Tutorials Overview/Sections/ContentAndMediaGroupSection.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Tutorials Overview/Sections/ContentAndMediaGroupSection.swift
@@ -9,7 +9,7 @@
 */
 
 /// A section that groups content and media sections.
-public struct ContentAndMediaGroupSection: RenderSection {
+public struct ContentAndMediaGroupSection: RenderSection, Equatable {
     public var kind: RenderSectionKind = .contentAndMediaGroup
     
     /// The layout direction of all content and media sections in this group.
@@ -28,5 +28,24 @@ public struct ContentAndMediaGroupSection: RenderSection {
         
         self.layout = sections.first!.layout
         self.sections = sections
+    }
+}
+
+// Diffable conformance
+extension ContentAndMediaGroupSection: RenderJSONDiffable {
+    /// Returns the differences between this ContentAndMediaGroupSection and the given one.
+    func difference(from other: ContentAndMediaGroupSection, at path: CodablePath) -> JSONPatchDifferences {
+        var diffBuilder = DifferenceBuilder(current: self, other: other, basePath: path)
+
+        diffBuilder.addDifferences(atKeyPath: \.kind, forKey: CodingKeys.kind)
+        diffBuilder.addDifferences(atKeyPath: \.layout, forKey: CodingKeys.layout)
+        diffBuilder.addDifferences(atKeyPath: \.sections, forKey: CodingKeys.sections)
+
+        return diffBuilder.differences
+    }
+    
+    /// Returns if this ContentAndMediaGroupSection is similar enough to the given one.
+    func isSimilar(to other: ContentAndMediaGroupSection) -> Bool {
+        return self.sections == other.sections
     }
 }

--- a/Sources/SwiftDocC/Model/Rendering/Tutorials Overview/Sections/ContentAndMediaSection.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Tutorials Overview/Sections/ContentAndMediaSection.swift
@@ -9,7 +9,7 @@
 */
 
 /// A section containing textual content and media laid out horizontally or vertically.
-public struct ContentAndMediaSection: RenderSection {
+public struct ContentAndMediaSection: RenderSection, Equatable {
     public var kind: RenderSectionKind = .contentAndMedia
     
     /// The layout direction.
@@ -63,7 +63,30 @@ public struct ContentAndMediaSection: RenderSection {
         content = try container.decodeIfPresent([RenderBlockContent].self, forKey: .content) ?? []
         media = try container.decodeIfPresent(RenderReferenceIdentifier.self, forKey: .media)
         mediaPosition = try container.decodeIfPresent(ContentAndMedia.MediaPosition.self, forKey: .mediaPosition)
-            // Provide backwards-compatibility for ContentAndMediaSections that don't have a `mediaPosition` key.
-            ?? .leading
+        // Provide backwards-compatibility for ContentAndMediaSections that don't have a `mediaPosition` key.
+        ?? .leading
+    }
+}
+    
+// Diffable conformance
+extension ContentAndMediaSection: RenderJSONDiffable {
+    /// Returns the differences between this ContentAndMediaSection and the given one.
+    func difference(from other: ContentAndMediaSection, at path: CodablePath) -> JSONPatchDifferences {
+        var diffBuilder = DifferenceBuilder(current: self, other: other, basePath: path)
+
+        diffBuilder.addDifferences(atKeyPath: \.kind, forKey: CodingKeys.kind)
+        diffBuilder.addDifferences(atKeyPath: \.layout, forKey: CodingKeys.layout)
+        diffBuilder.addDifferences(atKeyPath: \.title, forKey: CodingKeys.title)
+        diffBuilder.addDifferences(atKeyPath: \.eyebrow, forKey: CodingKeys.eyebrow)
+        diffBuilder.addDifferences(atKeyPath: \.content, forKey: CodingKeys.content)
+        diffBuilder.addDifferences(atKeyPath: \.media, forKey: CodingKeys.media)
+        diffBuilder.addDifferences(atKeyPath: \.mediaPosition, forKey: CodingKeys.mediaPosition)
+
+        return diffBuilder.differences
+    }
+
+    /// Returns if this ContentAndMediaSection is similar enough to the given one.
+    func isSimilar(to other: ContentAndMediaSection) -> Bool {
+        return self.title == other.title || self.content == other.content
     }
 }

--- a/Sources/SwiftDocC/Model/Rendering/Tutorials Overview/Sections/ResourcesRenderSection.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Tutorials Overview/Sections/ResourcesRenderSection.swift
@@ -9,7 +9,7 @@
 */
 
 /// A section that contains additional resources for learning about a technology.
-public struct ResourcesRenderSection: RenderSection {
+public struct ResourcesRenderSection: RenderSection, Equatable {
     public var kind: RenderSectionKind = .resources
     
     /// The resource tiles.
@@ -26,5 +26,24 @@ public struct ResourcesRenderSection: RenderSection {
     public init(tiles: [RenderTile], content: [RenderBlockContent]) {
         self.tiles = tiles
         self.content = content
+    }
+}
+
+// Diffable conformance
+extension ResourcesRenderSection: RenderJSONDiffable {
+    /// Returns the differences between this ResourcesRenderSection and the given one.
+    func difference(from other: ResourcesRenderSection, at path: CodablePath) -> JSONPatchDifferences {
+        var diffBuilder = DifferenceBuilder(current: self, other: other, basePath: path)
+
+        diffBuilder.addDifferences(atKeyPath: \.kind, forKey: CodingKeys.kind)
+        diffBuilder.addDifferences(atKeyPath: \.tiles, forKey: CodingKeys.tiles)
+        diffBuilder.addDifferences(atKeyPath: \.content, forKey: CodingKeys.content)
+
+        return diffBuilder.differences
+    }
+
+    /// Returns if this ResourcesRenderSection is similar enough to the given one.
+    func isSimilar(to other: ResourcesRenderSection) -> Bool {
+        return self.content == other.content
     }
 }

--- a/Sources/SwiftDocC/Model/Rendering/Tutorials Overview/Sections/VolumeRenderSection.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Tutorials Overview/Sections/VolumeRenderSection.swift
@@ -9,11 +9,11 @@
 */
 
 /// Represents a volume containing a grouped list of tutorials.
-public struct VolumeRenderSection: RenderSection {
+public struct VolumeRenderSection: RenderSection, Equatable {
     public var kind: RenderSectionKind = .volume
     
     /// A group in a volume.
-    public struct Chapter: Codable, TextIndexing {
+    public struct Chapter: Codable, TextIndexing, Equatable {
         /// The name of the chapter.
         public var name: String?
         /// An abstract describing the chapter.
@@ -75,5 +75,46 @@ public struct VolumeRenderSection: RenderSection {
         try container.encode(image, forKey: .image)
         try container.encode(content, forKey: .content)
         try container.encode(chapters, forKey: .chapters)
+    }
+}
+
+// Diffable conformance
+extension VolumeRenderSection: RenderJSONDiffable {
+    /// Returns the differences between this VolumeRenderSection and the given one.
+    func difference(from other: VolumeRenderSection, at path: CodablePath) -> JSONPatchDifferences {
+        var diffBuilder = DifferenceBuilder(current: self, other: other, basePath: path)
+
+        diffBuilder.addDifferences(atKeyPath: \.kind, forKey: CodingKeys.kind)
+        diffBuilder.addDifferences(atKeyPath: \.name, forKey: CodingKeys.name)
+        diffBuilder.addDifferences(atKeyPath: \.image, forKey: CodingKeys.image)
+        diffBuilder.addDifferences(atKeyPath: \.content, forKey: CodingKeys.content)
+        diffBuilder.addDifferences(atKeyPath: \.chapters, forKey: CodingKeys.chapters)
+
+        return diffBuilder.differences
+    }
+
+    /// Returns if this VolumeRenderSection is similar enough to the given one.
+    func isSimilar(to other: VolumeRenderSection) -> Bool {
+        return self.name == other.name || self.content == other.content
+    }
+}
+
+// Diffable conformance
+extension VolumeRenderSection.Chapter: RenderJSONDiffable {
+    /// Returns the differences between this Chapter and the given one.
+    func difference(from other: VolumeRenderSection.Chapter, at path: CodablePath) -> JSONPatchDifferences {
+        var diffBuilder = DifferenceBuilder(current: self, other: other, basePath: path)
+
+        diffBuilder.addDifferences(atKeyPath: \.name, forKey: CodingKeys.name)
+        diffBuilder.addDifferences(atKeyPath: \.content, forKey: CodingKeys.content)
+        diffBuilder.addDifferences(atKeyPath: \.tutorials, forKey: CodingKeys.tutorials)
+        diffBuilder.addDifferences(atKeyPath: \.image, forKey: CodingKeys.image)
+
+        return diffBuilder.differences
+    }
+
+    /// Returns if this Chapter is similar enough to the given one.
+    func isSimilar(to other: VolumeRenderSection.Chapter) -> Bool {
+        return self.name == other.name || self.content == other.content
     }
 }

--- a/Sources/SwiftDocC/Model/Rendering/Variants/JSONPointer.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Variants/JSONPointer.swift
@@ -13,7 +13,7 @@ import Foundation
 /// A pointer to a specific value in a JSON document.
 ///
 /// For more information, see [RFC6901](https://datatracker.ietf.org/doc/html/rfc6901).
-public struct JSONPointer: Codable, CustomStringConvertible {
+public struct JSONPointer: Codable, CustomStringConvertible, Equatable {
     /// The path components of the pointer.
     ///
     /// The path components of the pointer are not escaped.

--- a/Sources/SwiftDocC/Model/Rendering/Variants/VariantCollection+Coding.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Variants/VariantCollection+Coding.swift
@@ -112,33 +112,9 @@ extension KeyedEncodingContainer {
                 encoder,
                 
                 // Add the index to the encoder's coding path, since the coding path refers to the array.
-                pointer: JSONPointer(from: encoder.codingPath + [key, IntegerKey(index)])
+                pointer: JSONPointer(from: encoder.codingPath + [key, JSON.IntegerKey(index)])
             )
         }
-    }
-}
-
-/// An integer coding key.
-private struct IntegerKey: CodingKey {
-    var stringValue: String
-    var intValue: Int?
-    
-    init(_ value: Int) {
-        self.intValue = value
-        self.stringValue = value.description
-    }
-    
-    init?(stringValue: String) {
-        guard let intValue = Int(stringValue) else {
-            return nil
-        }
-        
-        self.intValue = intValue
-        self.stringValue = stringValue
-    }
-    
-    init?(intValue: Int) {
-        self.init(intValue)
     }
 }
 

--- a/Tests/SwiftDocCTests/Model/RenderNodeDiffingBundleTests.swift
+++ b/Tests/SwiftDocCTests/Model/RenderNodeDiffingBundleTests.swift
@@ -28,7 +28,10 @@ class RenderNodeDiffingBundleTests: XCTestCase {
             try text.write(to: symbolURL, atomically: true, encoding: .utf8)
         }
         
-        let differences = try getDiffsFromModifiedDocument(topicReferencePath: pathToSymbol, modification: modification)
+        let differences = try getDiffsFromModifiedDocument(bundleName: testBundleName,
+                                                           bundleIdentifier: testBundleIdentifier,
+                                                           topicReferencePath: pathToSymbol,
+                                                           modification: modification)
 
         XCTAssertFalse(differences.isEmpty, "Both render nodes should be different.")
         
@@ -53,7 +56,10 @@ class RenderNodeDiffingBundleTests: XCTestCase {
             try text.write(to: articleURL, atomically: true, encoding: .utf8)
         }
         
-        let differences = try getDiffsFromModifiedDocument(topicReferencePath: pathToArticle, modification: modification)
+        let differences = try getDiffsFromModifiedDocument(bundleName: testBundleName,
+                                                           bundleIdentifier: testBundleIdentifier,
+                                                           topicReferencePath: pathToArticle,
+                                                           modification: modification)
 
         XCTAssertFalse(differences.isEmpty, "Both render nodes should be different.")
         
@@ -64,7 +70,7 @@ class RenderNodeDiffingBundleTests: XCTestCase {
                                                                                            identifiers: ["doc://org.swift.docc.example/tutorials/Test-Bundle/TestTutorial",
                                                                                                 "doc://org.swift.docc.example/tutorials/Test-Bundle/TestTutorial2"],
                                                                                            generated: false)))
-        assertDifferences(_: differences, 
+        assertDifferences(_: differences,
                           contains: expectedDiff,
                           valueType: TaskGroupRenderSection.self)
     }
@@ -82,18 +88,21 @@ class RenderNodeDiffingBundleTests: XCTestCase {
             try text.write(to: articleURL, atomically: true, encoding: .utf8)
         }
         
-        let differences = try getDiffsFromModifiedDocument(topicReferencePath: pathToArticle, modification: modification)
+        let differences = try getDiffsFromModifiedDocument(bundleName: testBundleName,
+                                                           bundleIdentifier: testBundleIdentifier,
+                                                           topicReferencePath: pathToArticle,
+                                                           modification: modification)
         
         XCTAssertFalse(differences.isEmpty, "Both render nodes should be different.")
         
         let expectedSectionDiff = JSONPatchOperation.remove(pointer: JSONPointer(pathComponents: ["seeAlsoSections", "0"]))
-        assertDifferences(_: differences, 
+        assertDifferences(_: differences,
                           contains: expectedSectionDiff,
                           valueType: RenderInlineContent.self)
         
         let expectedReferenceDiff = JSONPatchOperation.remove(pointer: JSONPointer(pathComponents: ["references",
                                                                                                     "https://www.website.com"]))
-        assertDifferences(_: differences, 
+        assertDifferences(_: differences,
                           contains: expectedReferenceDiff,
                           valueType: RenderInlineContent.self)
     }
@@ -111,18 +120,21 @@ class RenderNodeDiffingBundleTests: XCTestCase {
             try text.write(to: symbolURL, atomically: true, encoding: .utf8)
         }
         
-        let differences = try getDiffsFromModifiedDocument(topicReferencePath: pathToSymbol, modification: modification)
+        let differences = try getDiffsFromModifiedDocument(bundleName: testBundleName,
+                                                           bundleIdentifier: testBundleIdentifier,
+                                                           topicReferencePath: pathToSymbol,
+                                                           modification: modification)
         
         XCTAssertFalse(differences.isEmpty, "Both render nodes should be different.")
         
         let expectedSectionDiff = JSONPatchOperation.remove(pointer: JSONPointer(pathComponents: ["topicSections", "3"]))
-        assertDifferences(_: differences, 
+        assertDifferences(_: differences,
                           contains: expectedSectionDiff,
                           valueType: RenderInlineContent.self)
         
         let expectedReferenceDiff = JSONPatchOperation.remove(pointer: JSONPointer(pathComponents: ["references",
                                                                                                     "doc://org.swift.docc.example/documentation/SideKit/UncuratedClass/angle"]))
-        assertDifferences(_: differences, 
+        assertDifferences(_: differences,
                           contains: expectedReferenceDiff,
                           valueType: RenderInlineContent.self)
     }
@@ -137,13 +149,16 @@ class RenderNodeDiffingBundleTests: XCTestCase {
             try text.write(to: symbolURL, atomically: true, encoding: .utf8)
         }
         
-        let differences = try getDiffsFromModifiedDocument(topicReferencePath: pathToSymbol, modification: modification)
+        let differences = try getDiffsFromModifiedDocument(bundleName: testBundleName,
+                                                           bundleIdentifier: testBundleIdentifier,
+                                                           topicReferencePath: pathToSymbol,
+                                                           modification: modification)
 
         XCTAssertFalse(differences.isEmpty, "Both render nodes should be different.")
         
         let expectedAbstractDiff = JSONPatchOperation.add(pointer: JSONPointer(pathComponents: ["abstract", "0"]),
                                                           value: AnyCodable(RenderInlineContent.text(newAbstractValue)))
-        assertDifferences(_: differences, 
+        assertDifferences(_: differences,
                           contains: expectedAbstractDiff,
                           valueType: RenderInlineContent.self)
         
@@ -151,7 +166,7 @@ class RenderNodeDiffingBundleTests: XCTestCase {
                                                                                                     "doc://org.swift.docc.example/documentation/MyKit/MyClass",
                                                                                                     "abstract",
                                                                                                     "0"]))
-        assertDifferences(_: differences, 
+        assertDifferences(_: differences,
                           contains: expectedReferenceDiff,
                           valueType: AnyRenderReference.self)
     }
@@ -172,7 +187,10 @@ class RenderNodeDiffingBundleTests: XCTestCase {
             try text.write(to: symbolURL, atomically: true, encoding: .utf8)
         }
         
-        let differences = try getDiffsFromModifiedDocument(topicReferencePath: pathToSymbol, modification: modification)
+        let differences = try getDiffsFromModifiedDocument(bundleName: testBundleName,
+                                                           bundleIdentifier: testBundleIdentifier,
+                                                           topicReferencePath: pathToSymbol,
+                                                           modification: modification)
         
         XCTAssertFalse(differences.isEmpty, "Both render nodes should be different.")
         
@@ -208,7 +226,10 @@ class RenderNodeDiffingBundleTests: XCTestCase {
             try text.write(to: symbolURL, atomically: true, encoding: .utf8)
         }
         
-        let differences = try getDiffsFromModifiedDocument(topicReferencePath: pathToSymbol, modification: modification)
+        let differences = try getDiffsFromModifiedDocument(bundleName: testBundleName,
+                                                           bundleIdentifier: testBundleIdentifier,
+                                                           topicReferencePath: pathToSymbol,
+                                                           modification: modification)
         
         XCTAssertFalse(differences.isEmpty, "Both render nodes should be different.")
         
@@ -241,7 +262,10 @@ class RenderNodeDiffingBundleTests: XCTestCase {
             try text.write(to: articleURL, atomically: true, encoding: .utf8)
         }
         
-        let differences = try getDiffsFromModifiedDocument(topicReferencePath: pathToArticle, modification: modification)
+        let differences = try getDiffsFromModifiedDocument(bundleName: testBundleName,
+                                                           bundleIdentifier: testBundleIdentifier,
+                                                           topicReferencePath: pathToArticle,
+                                                           modification: modification)
         
         XCTAssertFalse(differences.isEmpty, "Both render nodes should be different.")
         
@@ -274,11 +298,13 @@ class RenderNodeDiffingBundleTests: XCTestCase {
         }
     }
     
-    func getDiffsFromModifiedDocument(topicReferencePath: String,
+    func getDiffsFromModifiedDocument(bundleName: String,
+                                      bundleIdentifier: String,
+                                      topicReferencePath: String,
                                       modification: @escaping (URL) throws -> ()
     ) throws -> JSONPatchDifferences {
-        let (bundleOriginal, contextOriginal) = try testBundleAndContext(named: testBundleName)
-        let nodeOriginal = try contextOriginal.entity(with: ResolvedTopicReference(bundleIdentifier: testBundleIdentifier,
+        let (bundleOriginal, contextOriginal) = try testBundleAndContext(named: bundleName)
+        let nodeOriginal = try contextOriginal.entity(with: ResolvedTopicReference(bundleIdentifier: bundleIdentifier,
                                                                                    path: topicReferencePath,
                                                                                    sourceLanguage: .swift))
         var renderContext = RenderContext(documentationContext: contextOriginal, bundle: bundleOriginal)
@@ -288,10 +314,10 @@ class RenderNodeDiffingBundleTests: XCTestCase {
         let renderNodeOriginal = try XCTUnwrap(converter.renderNode(for: nodeOriginal, at: fileURL))
         
         // Make copy of the bundle on disk, modify the document, and write it
-        let (_, bundleModified, contextModified) = try testBundleAndContext(copying: testBundleName) { url in
+        let (_, bundleModified, contextModified) = try testBundleAndContext(copying: bundleName) { url in
             try modification(url)
         }
-        let nodeModified = try contextModified.entity(with: ResolvedTopicReference(bundleIdentifier: testBundleIdentifier,
+        let nodeModified = try contextModified.entity(with: ResolvedTopicReference(bundleIdentifier: bundleIdentifier,
                                                                                    path: topicReferencePath,
                                                                                    sourceLanguage: .swift))
         renderContext = RenderContext(documentationContext: contextModified, bundle: bundleModified)

--- a/Tests/SwiftDocCTests/Model/RenderNodeDiffingBundleTests.swift
+++ b/Tests/SwiftDocCTests/Model/RenderNodeDiffingBundleTests.swift
@@ -1,0 +1,350 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2023 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+@testable import SwiftDocC
+
+class RenderNodeDiffingBundleTests: XCTestCase {
+    let testBundleName = "TestBundle"
+    let testBundleIdentifier = "org.swift.docc.example"
+    
+    func testDiffSymbolFromBundleWithDiscussionSectionRemoved() throws {
+        let pathToSymbol = "/documentation/MyKit"
+        
+        let modification = { (url: URL) in
+            let symbolURL = url.appendingPathComponent("documentation/mykit.md")
+            let text = try String(contentsOf: symbolURL).replacingOccurrences(of: """
+            ## Discussion
+
+            MyKit is the best module
+            """, with: "")
+            try text.write(to: symbolURL, atomically: true, encoding: .utf8)
+        }
+        
+        let differences = try getDiffsFromModifiedDocument(topicReferencePath: pathToSymbol, modification: modification)
+
+        XCTAssertFalse(differences.isEmpty, "Both render nodes should be different.")
+        
+        let expectedSectionDiff = JSONPatchOperation.remove(pointer: JSONPointer(pathComponents: ["primaryContentSections", "0"]))
+        assertDifferences(_: differences,
+                          contains: expectedSectionDiff,
+                          valueType: RenderInlineContent.self)
+    }
+    
+    func testDiffArticleFromBundleWithTopicSectionAdded() throws {
+        let pathToArticle = "/documentation/Test-Bundle/article"
+        
+        let modification = { (url: URL) in
+            let articleURL = url.appendingPathComponent("article.md")
+            let text = try String(contentsOf: articleURL).replacingOccurrences(of: "## Topics", with: """
+            ## Topics
+
+            ### Tutorials
+             - <doc:/tutorials/Test-Bundle/TestTutorial>
+             - <doc:/tutorials/Test-Bundle/TestTutorial2>
+            """)
+            try text.write(to: articleURL, atomically: true, encoding: .utf8)
+        }
+        
+        let differences = try getDiffsFromModifiedDocument(topicReferencePath: pathToArticle, modification: modification)
+
+        XCTAssertFalse(differences.isEmpty, "Both render nodes should be different.")
+        
+        let expectedDiff = JSONPatchOperation.add(pointer: JSONPointer(pathComponents: ["topicSections", "0"]),
+                                                  value: AnyCodable(TaskGroupRenderSection(title: "Tutorials",
+                                                                                           abstract: nil,
+                                                                                           discussion: nil,
+                                                                                           identifiers: ["doc://org.swift.docc.example/tutorials/Test-Bundle/TestTutorial",
+                                                                                                "doc://org.swift.docc.example/tutorials/Test-Bundle/TestTutorial2"],
+                                                                                           generated: false)))
+        assertDifferences(_: differences, 
+                          contains: expectedDiff,
+                          valueType: TaskGroupRenderSection.self)
+    }
+    
+    func testDiffArticleFromBundleWithSeeAlsoSectionRemoved() throws {
+        let pathToArticle = "/documentation/Test-Bundle/article"
+        
+        let modification = { (url: URL) in
+            let articleURL = url.appendingPathComponent("article.md")
+            let text = try String(contentsOf: articleURL).replacingOccurrences(of: """
+            ## See Also
+            
+            - [Website](https://www.website.com)
+            """, with: "")
+            try text.write(to: articleURL, atomically: true, encoding: .utf8)
+        }
+        
+        let differences = try getDiffsFromModifiedDocument(topicReferencePath: pathToArticle, modification: modification)
+        
+        XCTAssertFalse(differences.isEmpty, "Both render nodes should be different.")
+        
+        let expectedSectionDiff = JSONPatchOperation.remove(pointer: JSONPointer(pathComponents: ["seeAlsoSections", "0"]))
+        assertDifferences(_: differences, 
+                          contains: expectedSectionDiff,
+                          valueType: RenderInlineContent.self)
+        
+        let expectedReferenceDiff = JSONPatchOperation.remove(pointer: JSONPointer(pathComponents: ["references",
+                                                                                                    "https://www.website.com"]))
+        assertDifferences(_: differences, 
+                          contains: expectedReferenceDiff,
+                          valueType: RenderInlineContent.self)
+    }
+    
+    func testDiffSymbolFromBundleWithTopicSectionRemoved() throws {
+        let pathToSymbol = "/documentation/MyKit"
+        
+        let modification = { (url: URL) in
+            let symbolURL = url.appendingPathComponent("documentation/mykit.md")
+            let text = try String(contentsOf: symbolURL).replacingOccurrences(of: """
+            ### Extensions to other frameworks
+
+             - ``SideKit/UncuratedClass/angle``
+            """, with: "")
+            try text.write(to: symbolURL, atomically: true, encoding: .utf8)
+        }
+        
+        let differences = try getDiffsFromModifiedDocument(topicReferencePath: pathToSymbol, modification: modification)
+        
+        XCTAssertFalse(differences.isEmpty, "Both render nodes should be different.")
+        
+        let expectedSectionDiff = JSONPatchOperation.remove(pointer: JSONPointer(pathComponents: ["topicSections", "3"]))
+        assertDifferences(_: differences, 
+                          contains: expectedSectionDiff,
+                          valueType: RenderInlineContent.self)
+        
+        let expectedReferenceDiff = JSONPatchOperation.remove(pointer: JSONPointer(pathComponents: ["references",
+                                                                                                    "doc://org.swift.docc.example/documentation/SideKit/UncuratedClass/angle"]))
+        assertDifferences(_: differences, 
+                          contains: expectedReferenceDiff,
+                          valueType: RenderInlineContent.self)
+    }
+    
+    func testDiffSymbolFromBundleWithAbstractUpdated() throws {
+        let pathToSymbol = "/documentation/MyKit/MyClass"
+        let newAbstractValue = "MyClass new abstract."
+        
+        let modification = { (url: URL) in
+            let symbolURL = url.appendingPathComponent("documentation/myclass.md")
+            let text = try String(contentsOf: symbolURL).replacingOccurrences(of: "MyClass abstract.", with: newAbstractValue)
+            try text.write(to: symbolURL, atomically: true, encoding: .utf8)
+        }
+        
+        let differences = try getDiffsFromModifiedDocument(topicReferencePath: pathToSymbol, modification: modification)
+
+        XCTAssertFalse(differences.isEmpty, "Both render nodes should be different.")
+        
+        let expectedAbstractDiff = JSONPatchOperation.add(pointer: JSONPointer(pathComponents: ["abstract", "0"]),
+                                                          value: AnyCodable(RenderInlineContent.text(newAbstractValue)))
+        assertDifferences(_: differences, 
+                          contains: expectedAbstractDiff,
+                          valueType: RenderInlineContent.self)
+        
+        let expectedReferenceDiff = JSONPatchOperation.remove(pointer: JSONPointer(pathComponents: ["references",
+                                                                                                    "doc://org.swift.docc.example/documentation/MyKit/MyClass",
+                                                                                                    "abstract",
+                                                                                                    "0"]))
+        assertDifferences(_: differences, 
+                          contains: expectedReferenceDiff,
+                          valueType: AnyRenderReference.self)
+    }
+    
+    func testDiffSymbolFromBundleWithDeprecationAdded() throws {
+        let pathToSymbol = "/documentation/MyKit/MyProtocol"
+        let newDeprecationValue = "This protocol has been deprecated."
+        
+        let modification = { (url: URL) in
+            let symbolURL = url.appendingPathComponent("documentation/myprotocol.md")
+            let text = try String(contentsOf: symbolURL).replacingOccurrences(of: "# <doc:MyKit/MyProtocol>", with: """
+            # <doc:MyKit/MyProtocol>
+            
+            @DeprecationSummary {
+            \(newDeprecationValue)
+            }
+            """)
+            try text.write(to: symbolURL, atomically: true, encoding: .utf8)
+        }
+        
+        let differences = try getDiffsFromModifiedDocument(topicReferencePath: pathToSymbol, modification: modification)
+        
+        XCTAssertFalse(differences.isEmpty, "Both render nodes should be different.")
+        
+        let expectedDeprecationDiff = JSONPatchOperation.add(pointer: JSONPointer(pathComponents: ["deprecationSummary"]),
+                                                             value: AnyCodable([RenderBlockContent.paragraph(RenderBlockContent.Paragraph(
+                                                                inlineContent: [RenderInlineContent.text(newDeprecationValue)]))]))
+        assertDifferences(_: differences,
+                          contains: expectedDeprecationDiff,
+                          valueType: [RenderBlockContent].self)
+        
+        let expectedReferenceDiff = JSONPatchOperation.replace(pointer: JSONPointer(pathComponents: ["references",
+                                                                                                     "doc://org.swift.docc.example/documentation/MyKit/MyProtocol",
+                                                                                                     "deprecated"]),
+                                                               value: AnyCodable(true))
+        assertDifferences(_: differences,
+                          contains: expectedReferenceDiff,
+                          valueType: Bool.self)
+    }
+    
+    func testDiffSymbolFromBundleWithDisplayNameDirectiveAdded() throws {
+        let pathToSymbol = "/documentation/MyKit"
+        let newTitleValue = "My Kit"
+        
+        let modification = { (url: URL) in
+            let symbolURL = url.appendingPathComponent("documentation/mykit.md")
+            let text = try String(contentsOf: symbolURL).replacingOccurrences(of: "# ``MyKit``", with: """
+            # ``MyKit``
+
+            @Metadata {
+                @DisplayName("\(newTitleValue)")
+            }
+            """)
+            try text.write(to: symbolURL, atomically: true, encoding: .utf8)
+        }
+        
+        let differences = try getDiffsFromModifiedDocument(topicReferencePath: pathToSymbol, modification: modification)
+        
+        XCTAssertFalse(differences.isEmpty, "Both render nodes should be different.")
+        
+        let expectedTitleDiff = JSONPatchOperation.replace(pointer: JSONPointer(pathComponents: ["metadata", "title"]),
+                                                           value: AnyCodable(newTitleValue))
+        assertDifferences(_: differences,
+                          contains: expectedTitleDiff,
+                          valueType: String.self)
+        
+        let expectedModuleDiff = JSONPatchOperation.add(pointer: JSONPointer(pathComponents: ["metadata", "modules", "0"]),
+                                                        value: AnyCodable(RenderMetadata.Module(name: newTitleValue, relatedModules: nil)))
+        assertDifferences(_: differences,
+                          contains: expectedModuleDiff,
+                          valueType: RenderMetadata.Module.self)
+    }
+    
+    func testDiffArticleFromBundleWithDownloadDirectiveAdded() throws {
+        let pathToArticle = "/documentation/Test-Bundle/article"
+        
+        let modification = { (url: URL) in
+            let articleURL = url.appendingPathComponent("article.md")
+            let text = try String(contentsOf: articleURL).replacingOccurrences(of: "# My Cool Article", with: """
+            # My Cool Article
+
+            @Metadata {
+                @CallToAction(file: "Downloads/mykit.svg", purpose: download)
+                @PageKind(sampleCode)
+            }
+            """)
+            try text.write(to: articleURL, atomically: true, encoding: .utf8)
+        }
+        
+        let differences = try getDiffsFromModifiedDocument(topicReferencePath: pathToArticle, modification: modification)
+        
+        XCTAssertFalse(differences.isEmpty, "Both render nodes should be different.")
+        
+        let expectedRoleHeadingDiff = JSONPatchOperation.replace(pointer: JSONPointer(pathComponents: ["metadata", "roleHeading"]),
+                                                                 value: AnyCodable("Sample Code"))
+        assertDifferences(_: differences,
+                          contains: expectedRoleHeadingDiff,
+                          valueType: String.self)
+        
+        let expectedRoleDiff = JSONPatchOperation.replace(pointer: JSONPointer(pathComponents: ["metadata", "role"]),
+                                                          value: AnyCodable("sampleCode"))
+        assertDifferences(_: differences,
+                          contains: expectedRoleDiff,
+                          valueType: String.self)
+    }
+    
+    func testNoDiffsWhenReconvertingSameBundle() throws {
+        let (bundle, context) = try testBundleAndContext(named: testBundleName)
+        let renderContext = RenderContext(documentationContext: context, bundle: bundle)
+        let converter = DocumentationContextConverter(bundle: bundle, context: context, renderContext: renderContext)
+        
+        for identifier in context.knownPages {
+            let source = context.documentURL(for: identifier)
+            let entity = try context.entity(with: identifier)
+            let renderNodeFirst = try XCTUnwrap(converter.renderNode(for: entity, at: source))
+            let renderNodeSecond = try XCTUnwrap(converter.renderNode(for: entity, at: source))
+            
+            let differences = renderNodeSecond.difference(from: renderNodeFirst)
+            XCTAssertTrue(differences.isEmpty, "Both render nodes should be identical.")
+        }
+    }
+    
+    func getDiffsFromModifiedDocument(topicReferencePath: String,
+                                      modification: @escaping (URL) throws -> ()
+    ) throws -> JSONPatchDifferences {
+        let (bundleOriginal, contextOriginal) = try testBundleAndContext(named: testBundleName)
+        let nodeOriginal = try contextOriginal.entity(with: ResolvedTopicReference(bundleIdentifier: testBundleIdentifier,
+                                                                                   path: topicReferencePath,
+                                                                                   sourceLanguage: .swift))
+        var renderContext = RenderContext(documentationContext: contextOriginal, bundle: bundleOriginal)
+        var converter = DocumentationContextConverter(bundle: bundleOriginal, context: contextOriginal, renderContext: renderContext)
+        var fileURL = try XCTUnwrap(contextOriginal.documentURL(for: nodeOriginal.reference))
+        
+        let renderNodeOriginal = try XCTUnwrap(converter.renderNode(for: nodeOriginal, at: fileURL))
+        
+        // Make copy of the bundle on disk, modify the document, and write it
+        let (_, bundleModified, contextModified) = try testBundleAndContext(copying: testBundleName) { url in
+            try modification(url)
+        }
+        let nodeModified = try contextModified.entity(with: ResolvedTopicReference(bundleIdentifier: testBundleIdentifier,
+                                                                                   path: topicReferencePath,
+                                                                                   sourceLanguage: .swift))
+        renderContext = RenderContext(documentationContext: contextModified, bundle: bundleModified)
+        converter = DocumentationContextConverter(bundle: bundleModified, context: contextModified, renderContext: renderContext)
+        fileURL = try XCTUnwrap(contextModified.documentURL(for: nodeModified.reference))
+        
+        let renderNodeModified = try XCTUnwrap(converter.renderNode(for: nodeModified, at: fileURL))
+        
+        let differences = renderNodeModified.difference(from: renderNodeOriginal)
+        
+        return differences
+    }
+    
+    func assertDifferences<Value: Equatable>(
+        _ differences: JSONPatchDifferences,
+        contains expectedDiff: JSONPatchOperation,
+        valueType: Value.Type,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        guard let foundDiff = differences.first(where: { $0.pointer == expectedDiff.pointer &&
+                                                         $0.operation == expectedDiff.operation }) else {
+            XCTFail("No diff with pointer \(expectedDiff.pointer) and operation \(expectedDiff.operation)", file: file, line: line)
+            return
+        }
+        
+        switch (expectedDiff, foundDiff) {
+        case let (.replace(_, expected), .replace(_, found)):
+            guard let expectedValue = expected.value as? Value else {
+                XCTFail("Wrong type of value for expected diff \(expected.value)", file: file, line: line)
+                return
+            }
+            guard let foundValue = found.value as? Value else {
+                XCTFail("Wrong type of value for found diff \(found.value)", file: file, line: line)
+                return
+            }
+            XCTAssertEqual(expectedValue, foundValue, file: file, line: line)
+
+        case let (.add(_, expected), .add(_, found)):
+            guard let expectedValue = expected.value as? Value else {
+                XCTFail("Wrong type of value for expected diff \(expected.value)", file: file, line: line)
+                return
+            }
+            guard let foundValue = found.value as? Value else {
+                XCTFail("Wrong type of value for found diff \(found.value)", file: file, line: line)
+                return
+            }
+            XCTAssertEqual(expectedValue, foundValue, file: file, line: line)
+            
+        case (.remove(_), .remove(_)):
+            return // The JSON pointers have already been compared above.
+        default:
+            XCTFail("Found diff \(foundDiff.operation) doesn't match the expected diff \(expectedDiff.operation).", file: file, line: line)
+        }
+    }
+}

--- a/Tests/SwiftDocCTests/Model/RenderNodeDiffingBundleTests.swift
+++ b/Tests/SwiftDocCTests/Model/RenderNodeDiffingBundleTests.swift
@@ -36,7 +36,7 @@ class RenderNodeDiffingBundleTests: XCTestCase {
         XCTAssertFalse(differences.isEmpty, "Both render nodes should be different.")
         
         let expectedSectionDiff = JSONPatchOperation.remove(pointer: JSONPointer(pathComponents: ["primaryContentSections", "0"]))
-        assertDifferences(_: differences,
+        assertDifferences(differences,
                           contains: expectedSectionDiff,
                           valueType: RenderInlineContent.self)
     }
@@ -70,7 +70,7 @@ class RenderNodeDiffingBundleTests: XCTestCase {
                                                                                            identifiers: ["doc://org.swift.docc.example/tutorials/Test-Bundle/TestTutorial",
                                                                                                 "doc://org.swift.docc.example/tutorials/Test-Bundle/TestTutorial2"],
                                                                                            generated: false)))
-        assertDifferences(_: differences,
+        assertDifferences(differences,
                           contains: expectedDiff,
                           valueType: TaskGroupRenderSection.self)
     }
@@ -96,13 +96,13 @@ class RenderNodeDiffingBundleTests: XCTestCase {
         XCTAssertFalse(differences.isEmpty, "Both render nodes should be different.")
         
         let expectedSectionDiff = JSONPatchOperation.remove(pointer: JSONPointer(pathComponents: ["seeAlsoSections", "0"]))
-        assertDifferences(_: differences,
+        assertDifferences(differences,
                           contains: expectedSectionDiff,
                           valueType: RenderInlineContent.self)
         
         let expectedReferenceDiff = JSONPatchOperation.remove(pointer: JSONPointer(pathComponents: ["references",
                                                                                                     "https://www.website.com"]))
-        assertDifferences(_: differences,
+        assertDifferences(differences,
                           contains: expectedReferenceDiff,
                           valueType: RenderInlineContent.self)
     }
@@ -128,13 +128,13 @@ class RenderNodeDiffingBundleTests: XCTestCase {
         XCTAssertFalse(differences.isEmpty, "Both render nodes should be different.")
         
         let expectedSectionDiff = JSONPatchOperation.remove(pointer: JSONPointer(pathComponents: ["topicSections", "3"]))
-        assertDifferences(_: differences,
+        assertDifferences(differences,
                           contains: expectedSectionDiff,
                           valueType: RenderInlineContent.self)
         
         let expectedReferenceDiff = JSONPatchOperation.remove(pointer: JSONPointer(pathComponents: ["references",
                                                                                                     "doc://org.swift.docc.example/documentation/SideKit/UncuratedClass/angle"]))
-        assertDifferences(_: differences,
+        assertDifferences(differences,
                           contains: expectedReferenceDiff,
                           valueType: RenderInlineContent.self)
     }
@@ -158,7 +158,7 @@ class RenderNodeDiffingBundleTests: XCTestCase {
         
         let expectedAbstractDiff = JSONPatchOperation.add(pointer: JSONPointer(pathComponents: ["abstract", "0"]),
                                                           value: AnyCodable(RenderInlineContent.text(newAbstractValue)))
-        assertDifferences(_: differences,
+        assertDifferences(differences,
                           contains: expectedAbstractDiff,
                           valueType: RenderInlineContent.self)
         
@@ -166,7 +166,7 @@ class RenderNodeDiffingBundleTests: XCTestCase {
                                                                                                     "doc://org.swift.docc.example/documentation/MyKit/MyClass",
                                                                                                     "abstract",
                                                                                                     "0"]))
-        assertDifferences(_: differences,
+        assertDifferences(differences,
                           contains: expectedReferenceDiff,
                           valueType: AnyRenderReference.self)
     }
@@ -197,7 +197,7 @@ class RenderNodeDiffingBundleTests: XCTestCase {
         let expectedDeprecationDiff = JSONPatchOperation.add(pointer: JSONPointer(pathComponents: ["deprecationSummary"]),
                                                              value: AnyCodable([RenderBlockContent.paragraph(RenderBlockContent.Paragraph(
                                                                 inlineContent: [RenderInlineContent.text(newDeprecationValue)]))]))
-        assertDifferences(_: differences,
+        assertDifferences(differences,
                           contains: expectedDeprecationDiff,
                           valueType: [RenderBlockContent].self)
         
@@ -205,7 +205,7 @@ class RenderNodeDiffingBundleTests: XCTestCase {
                                                                                                      "doc://org.swift.docc.example/documentation/MyKit/MyProtocol",
                                                                                                      "deprecated"]),
                                                                value: AnyCodable(true))
-        assertDifferences(_: differences,
+        assertDifferences(differences,
                           contains: expectedReferenceDiff,
                           valueType: Bool.self)
     }
@@ -235,13 +235,13 @@ class RenderNodeDiffingBundleTests: XCTestCase {
         
         let expectedTitleDiff = JSONPatchOperation.replace(pointer: JSONPointer(pathComponents: ["metadata", "title"]),
                                                            value: AnyCodable(newTitleValue))
-        assertDifferences(_: differences,
+        assertDifferences(differences,
                           contains: expectedTitleDiff,
                           valueType: String.self)
         
         let expectedModuleDiff = JSONPatchOperation.add(pointer: JSONPointer(pathComponents: ["metadata", "modules", "0"]),
                                                         value: AnyCodable(RenderMetadata.Module(name: newTitleValue, relatedModules: nil)))
-        assertDifferences(_: differences,
+        assertDifferences(differences,
                           contains: expectedModuleDiff,
                           valueType: RenderMetadata.Module.self)
     }
@@ -271,13 +271,13 @@ class RenderNodeDiffingBundleTests: XCTestCase {
         
         let expectedRoleHeadingDiff = JSONPatchOperation.replace(pointer: JSONPointer(pathComponents: ["metadata", "roleHeading"]),
                                                                  value: AnyCodable("Sample Code"))
-        assertDifferences(_: differences,
+        assertDifferences(differences,
                           contains: expectedRoleHeadingDiff,
                           valueType: String.self)
         
         let expectedRoleDiff = JSONPatchOperation.replace(pointer: JSONPointer(pathComponents: ["metadata", "role"]),
                                                           value: AnyCodable("sampleCode"))
-        assertDifferences(_: differences,
+        assertDifferences(differences,
                           contains: expectedRoleDiff,
                           valueType: String.self)
     }

--- a/Tests/SwiftDocCTests/Model/RenderNodeDiffingBundleTests.swift
+++ b/Tests/SwiftDocCTests/Model/RenderNodeDiffingBundleTests.swift
@@ -269,7 +269,7 @@ class RenderNodeDiffingBundleTests: XCTestCase {
             let renderNodeFirst = try XCTUnwrap(converter.renderNode(for: entity, at: source))
             let renderNodeSecond = try XCTUnwrap(converter.renderNode(for: entity, at: source))
             
-            let differences = renderNodeSecond.difference(from: renderNodeFirst)
+            let differences = renderNodeSecond._difference(from: renderNodeFirst)
             XCTAssertTrue(differences.isEmpty, "Both render nodes should be identical.")
         }
     }
@@ -300,7 +300,7 @@ class RenderNodeDiffingBundleTests: XCTestCase {
         
         let renderNodeModified = try XCTUnwrap(converter.renderNode(for: nodeModified, at: fileURL))
         
-        let differences = renderNodeModified.difference(from: renderNodeOriginal)
+        let differences = renderNodeModified._difference(from: renderNodeOriginal)
         
         return differences
     }


### PR DESCRIPTION
Bug/issue #, if applicable: N/A

## Summary

These changes implement support to diff any two RenderNode objects, across all their properties, and generate a list of [JSON Patches](https://www.rfc-editor.org/rfc/rfc6902.html) to go from the first RenderNode to the second one. To achieve this:

* A new `RenderJSONDiffable` protocol is defined to ensure similar object types can be diffed. `RenderJSONDiffable` conformance requires the object to implement `difference(from:at:)` and optionally `isSimilar(to:)` methods. This is done for all RenderNode object types and for common built-in types used with JSON.
* `DifferenceBuilder` is defined to help abstracting away the different difference methods. It collects differences between two objects and handles the JSON paths for those differences using `addDifferences(atKeyPath:forKey:)` method.
* The following content is not supported for diffing yet:
  * Language-specific overrides
  * Tutorials

## Dependencies

None.

## Testing

Given two RenderNode objects `renderNodeOriginal` and `renderNodeModified`, we can get the list of differences between them with:
```
renderNodeModified._difference(from: renderNodeOriginal)
```

Added unit tests loading test .docc bundles, making changes to markdown files within, converting them to RenderNode, and comparing against the version without changes to verify expected diffs. The tests currently cover diffing for:
```
- abstract
- references
- metadata
- primary content sections
- topic sections
- see also sections
- deprecation summary
- sample download
```

Ran performance tests comparing against commit previous to these changes.

* Results from performance test using a test bundle of size factor `10`:
```
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ Metric                                   │ Change          │ f70b3ea281773121a468d9c0966ab8a34bba58d2 │ current              │
├──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Duration for 'bundle-registration'       │ no change¹,²    │ 2.372 sec                                │ 2.35 sec             │
│ Duration for 'convert-total-time'        │ no change³,⁴    │ 3.503 sec                                │ 3.491 sec            │
│ Duration for 'documentation-processing'  │ no change⁵,⁶    │ 1.037 sec                                │ 1.046 sec            │
│ Duration for 'finalize-navigation-index' │ no change⁷,⁸    │ 0.052 sec                                │ 0.052 sec            │
│ Peak memory footprint                    │ no change⁹,¹⁰   │ 433.2 MB                                 │ 435.6 MB             │
│ Data subdirectory size                   │ no change       │ 111.7 MB                                 │ 111.7 MB             │
│ Index subdirectory size                  │ no change       │ 993 KB                                   │ 993 KB               │
│ Total DocC archive size                  │ no change       │ 117.7 MB                                 │ 117.7 MB             │
│ Topic Anchor Checksum                    │ no change       │ c8f03d4e81da8e3b6d7fb7f63c771147         │ c8f03d4e81da8e3b6d7f │
│ Topic Graph Checksum                     │ no change       │ 36cec4e1bc36e10c1c9323a139ffe2da         │ 36cec4e1bc36e10c1c93 │
└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```

* Results from performance test using a test bundle of size factor `50`:
```
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ Metric                                   │ Change          │ f70b3ea281773121a468d9c0966ab8a34bba58d2 │ current              │
├──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Duration for 'bundle-registration'       │ no change¹,²    │ 11.918 sec                               │ 11.975 sec           │
│ Duration for 'convert-total-time'        │ no change³,⁴    │ 18.245 sec                               │ 18.235 sec           │
│ Duration for 'documentation-processing'  │ no change⁵,⁶    │ 5.811 sec                                │ 5.756 sec            │
│ Duration for 'finalize-navigation-index' │ no change⁷      │ 0.27 sec                                 │ 0.264 sec            │
│ Peak memory footprint                    │ no change⁸,⁹    │ 2.02 GB                                  │ 2 GB                 │
│ Data subdirectory size                   │ no change       │ 564.3 MB                                 │ 564.3 MB             │
│ Index subdirectory size                  │ no change       │ 5.1 MB                                   │ 5.1 MB               │
│ Total DocC archive size                  │ no change       │ 594.7 MB                                 │ 594.7 MB             │
│ Topic Anchor Checksum                    │ no change       │ 08d0a84bec913460905fcae417423215         │ 08d0a84bec913460905f │
│ Topic Graph Checksum                     │ no change       │ b8bcd297c1546e3eaa8fbfc8c63eba69         │ b8bcd297c1546e3eaa8f │
└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary
