### PR TITLE
Add DocC availability information to all directive pages

### DIFF
--- a/Sources/SwiftDocC/Semantics/Comment.swift
+++ b/Sources/SwiftDocC/Semantics/Comment.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -18,6 +18,7 @@ import Markdown
  */
 public final class Comment: Semantic, DirectiveConvertible {
     public static let directiveName = "Comment"
+    public static let introducedVersion = "5.5"
     public let originalMarkup: BlockDirective
     
     /// The comment content.

--- a/Sources/SwiftDocC/Semantics/ContentAndMedia.swift
+++ b/Sources/SwiftDocC/Semantics/ContentAndMedia.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -14,7 +14,7 @@ import Markdown
 /// A piece of media, such as an image or video, with an attached description.
 public final class ContentAndMedia: Semantic, DirectiveConvertible {
     public static let directiveName = "ContentAndMedia"
-    
+    public static let introducedVersion = "5.5"
     public let originalMarkup: BlockDirective
     
     /// The title of this slide.

--- a/Sources/SwiftDocC/Semantics/DirectiveConvertable.swift
+++ b/Sources/SwiftDocC/Semantics/DirectiveConvertable.swift
@@ -21,6 +21,11 @@ public protocol DirectiveConvertible {
     static var directiveName: String { get }
     
     /**
+     The earliest release of Swift-DocC that supports this directive.
+     */
+    static var introducedVersion: String { get }
+    
+    /**
      The `BlockDirective` that was analyzed and converted to this ``Semantic`` object.
      */
     var originalMarkup: BlockDirective { get }

--- a/Sources/SwiftDocC/Semantics/DirectiveInfrastructure/DirectiveMirror.swift
+++ b/Sources/SwiftDocC/Semantics/DirectiveInfrastructure/DirectiveMirror.swift
@@ -227,6 +227,9 @@ extension DirectiveMirror {
         var name: String {
             return type.directiveName
         }
+        var introducedVersion: String {
+            return type.introducedVersion
+        }
         
         let arguments: [ReflectedArgument]
         

--- a/Sources/SwiftDocC/Semantics/Intro.swift
+++ b/Sources/SwiftDocC/Semantics/Intro.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -15,6 +15,7 @@ import Markdown
  An introductory section for instructional pages.
  */
 public final class Intro: Semantic, AutomaticDirectiveConvertible {
+    public static let introducedVersion = "5.5"
     public let originalMarkup: BlockDirective
     
     /// The title of the containing ``Tutorial``.

--- a/Sources/SwiftDocC/Semantics/Media/ImageMedia.swift
+++ b/Sources/SwiftDocC/Semantics/Media/ImageMedia.swift
@@ -14,7 +14,7 @@ import Markdown
 /// A block filled with an image.
 public final class ImageMedia: Semantic, Media, AutomaticDirectiveConvertible {
     public static let directiveName = "Image"
-    
+    public static let introducedVersion = "5.5"
     public let originalMarkup: BlockDirective
     
     @DirectiveArgumentWrapped(

--- a/Sources/SwiftDocC/Semantics/Media/VideoMedia.swift
+++ b/Sources/SwiftDocC/Semantics/Media/VideoMedia.swift
@@ -15,6 +15,8 @@ import Markdown
 public final class VideoMedia: Semantic, Media, AutomaticDirectiveConvertible {
     public static let directiveName = "Video"
     
+    public static let introducedVersion = "5.5"
+    
     public let originalMarkup: BlockDirective
     
     @DirectiveArgumentWrapped(

--- a/Sources/SwiftDocC/Semantics/Metadata/Availability.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/Availability.swift
@@ -44,7 +44,8 @@ extension Metadata {
     /// }
     /// ```
     public final class Availability: Semantic, AutomaticDirectiveConvertible {
-        static public let directiveName: String = "Available"
+        public static let directiveName: String = "Available"
+        public static let introducedVersion = "5.8"
 
         public enum Platform: RawRepresentable, Hashable, DirectiveArgumentValueConvertible {
             // FIXME: re-add `case any = "*"` when `isBeta` and `isDeprecated` are implemented

--- a/Sources/SwiftDocC/Semantics/Metadata/CallToAction.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/CallToAction.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2022-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -42,6 +42,8 @@ import Markdown
 /// }
 /// ```
 public final class CallToAction: Semantic, AutomaticDirectiveConvertible {
+    public static let introducedVersion = "5.8"
+    
     /// The kind of action the link is referencing.
     public enum Purpose: String, CaseIterable, DirectiveArgumentValueConvertible {
         /// References a link to download an associated asset, like a sample project.

--- a/Sources/SwiftDocC/Semantics/Metadata/CustomMetadata.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/CustomMetadata.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2022-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -11,7 +11,7 @@
 import Foundation
 import Markdown
 
-/// A directive that accepts an arbitary key/valye pair and emits it into the metadata of the page
+/// A directive that accepts an arbitrary key/value pair and emits it into the metadata of the page
 ///
 /// It accepts following parameters:
 ///
@@ -25,6 +25,7 @@ import Markdown
 /// }
 /// ```
 public final class CustomMetadata: Semantic, AutomaticDirectiveConvertible {
+    public static let introducedVersion = "5.8"
     public let originalMarkup: BlockDirective
     
     /// A key to identify a piece of metadata

--- a/Sources/SwiftDocC/Semantics/Metadata/DisplayName.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/DisplayName.swift
@@ -26,7 +26,7 @@ import Markdown
 /// }
 /// ```
 public final class DisplayName: Semantic, AutomaticDirectiveConvertible {
-    public static let introducedVersion = "5.6"
+    public static let introducedVersion = "5.7"
     public let originalMarkup: BlockDirective
     
     /// The custom display name for this symbol.

--- a/Sources/SwiftDocC/Semantics/Metadata/DisplayName.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/DisplayName.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2022-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -26,6 +26,7 @@ import Markdown
 /// }
 /// ```
 public final class DisplayName: Semantic, AutomaticDirectiveConvertible {
+    public static let introducedVersion = "5.6"
     public let originalMarkup: BlockDirective
     
     /// The custom display name for this symbol.

--- a/Sources/SwiftDocC/Semantics/Metadata/DocumentationExtension.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/DocumentationExtension.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -27,7 +27,9 @@ import Markdown
 /// }
 /// ```
 public final class DocumentationExtension: Semantic, AutomaticDirectiveConvertible {
+    public static let introducedVersion = "5.5"
     public let originalMarkup: BlockDirective
+    
     /// The merge behavior for this documentation extension.
     @DirectiveArgumentWrapped(name: .custom("mergeBehavior"))
     public var behavior: Behavior

--- a/Sources/SwiftDocC/Semantics/Metadata/Metadata.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/Metadata.swift
@@ -29,6 +29,7 @@ import Markdown
 /// - ``SupportedLanguage``
 /// - ``TitleHeading``
 public final class Metadata: Semantic, AutomaticDirectiveConvertible {
+    public static let introducedVersion = "5.5"
     public let originalMarkup: BlockDirective
     
     /// Configuration that describes how this documentation extension file merges or overrides the in-source documentation.

--- a/Sources/SwiftDocC/Semantics/Metadata/PageColor.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/PageColor.swift
@@ -28,7 +28,7 @@ import Markdown
 /// }
 /// ```
 public final class PageColor: Semantic, AutomaticDirectiveConvertible {
-    public static let introducedVersion = "5.8"
+    public static let introducedVersion = "5.9"
     public let originalMarkup: BlockDirective
     
     /// A context-dependent, standard color.

--- a/Sources/SwiftDocC/Semantics/Metadata/PageColor.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/PageColor.swift
@@ -28,6 +28,7 @@ import Markdown
 /// }
 /// ```
 public final class PageColor: Semantic, AutomaticDirectiveConvertible {
+    public static let introducedVersion = "5.8"
     public let originalMarkup: BlockDirective
     
     /// A context-dependent, standard color.

--- a/Sources/SwiftDocC/Semantics/Metadata/PageImage.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/PageImage.swift
@@ -18,6 +18,7 @@ import Markdown
 /// or the card image used to represent this page when using the ``Links`` directive and the ``Links/VisualStyle/detailedGrid``
 /// visual style.
 public final class PageImage: Semantic, AutomaticDirectiveConvertible {
+    public static let introducedVersion = "5.8"
     public let originalMarkup: BlockDirective
     
     /// The image's purpose.

--- a/Sources/SwiftDocC/Semantics/Metadata/PageKind.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/PageKind.swift
@@ -28,6 +28,7 @@ extension Metadata {
     /// }
     /// ```
     public final class PageKind: Semantic, AutomaticDirectiveConvertible {
+        public static let introducedVersion = "5.8"
         /// The available kinds for use with the `@PageKind` directive.
         public enum Kind: String, CaseIterable, DirectiveArgumentValueConvertible {
             /// An article of free-form text; the default for standalone markdown files.

--- a/Sources/SwiftDocC/Semantics/Metadata/SupportedLanguage.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/SupportedLanguage.swift
@@ -31,6 +31,7 @@ import Markdown
 /// | `swift`                                | Swift                       |
 /// | `objc`, `objective-c`   | Objective-C            |
 public final class SupportedLanguage: Semantic, AutomaticDirectiveConvertible {
+    public static let introducedVersion = "5.8"
     public let originalMarkup: BlockDirective
     
     /// A source language that this symbol is available in.

--- a/Sources/SwiftDocC/Semantics/Metadata/TechnologyRoot.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/TechnologyRoot.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -20,6 +20,7 @@ import Markdown
 /// }
 /// ```
 public final class TechnologyRoot: Semantic, AutomaticDirectiveConvertible {
+    public static let introducedVersion = "5.5"
     public let originalMarkup: BlockDirective
     
     static var keyPaths: [String : AnyKeyPath] = [:]

--- a/Sources/SwiftDocC/Semantics/Metadata/TitleHeading.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/TitleHeading.swift
@@ -24,6 +24,7 @@ import Markdown
 /// }
 /// ```
 public final class TitleHeading: Semantic, AutomaticDirectiveConvertible {
+    public static let introducedVersion = "5.9"
     public let originalMarkup: BlockDirective
 
     /// An unnamed parameter containing containing the page-title’s heading text.

--- a/Sources/SwiftDocC/Semantics/Options/AutomaticArticleSubheading.swift
+++ b/Sources/SwiftDocC/Semantics/Options/AutomaticArticleSubheading.swift
@@ -17,6 +17,7 @@ import Markdown
 /// By default, articles receive a second-level "Overview" heading unless the author explicitly writes
 /// some other H2 heading below the abstract. This allows for opting out of that behavior.
 public class AutomaticArticleSubheading: Semantic, AutomaticDirectiveConvertible {
+    public static let introducedVersion = "5.8"
     public let originalMarkup: BlockDirective
     
     // This property exist so that the generated directive documentation makes it

--- a/Sources/SwiftDocC/Semantics/Options/AutomaticSeeAlso.swift
+++ b/Sources/SwiftDocC/Semantics/Options/AutomaticSeeAlso.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2022-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -14,6 +14,7 @@ import Markdown
 /// A directive for specifying Swift-DocC's automatic behavior when generating a page's
 /// See Also section.
 public class AutomaticSeeAlso: Semantic, AutomaticDirectiveConvertible {
+    public static let introducedVersion = "5.8"
     public let originalMarkup: BlockDirective
     
     // This property exist so that the generated directive documentation makes it

--- a/Sources/SwiftDocC/Semantics/Options/AutomaticTitleHeading.swift
+++ b/Sources/SwiftDocC/Semantics/Options/AutomaticTitleHeading.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2022-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -16,6 +16,7 @@ import Markdown
 ///
 /// A title heading is also known as a page eyebrow or kicker.
 public class AutomaticTitleHeading: Semantic, AutomaticDirectiveConvertible {
+    public static let introducedVersion = "5.8"
     public let originalMarkup: BlockDirective
     
     // This property exist so that the generated directive documentation makes it

--- a/Sources/SwiftDocC/Semantics/Options/Options.swift
+++ b/Sources/SwiftDocC/Semantics/Options/Options.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2022-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -25,6 +25,7 @@ import Markdown
 ///
 /// - ``TopicsVisualStyle``
 public class Options: Semantic, AutomaticDirectiveConvertible {
+    public static let introducedVersion = "5.8"
     public let originalMarkup: BlockDirective
     
     /// Whether the options in this Options directive should apply locally to the page

--- a/Sources/SwiftDocC/Semantics/Options/TopicsVisualStyle.swift
+++ b/Sources/SwiftDocC/Semantics/Options/TopicsVisualStyle.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2022-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -14,6 +14,7 @@ import Markdown
 /// A directive for specifying the style that should be used when rendering a page's
 /// Topics section.
 public class TopicsVisualStyle: Semantic, AutomaticDirectiveConvertible {
+    public static let introducedVersion = "5.8"
     public let originalMarkup: BlockDirective
     
     /// The specified style that should be used when rendering a page's Topics section.

--- a/Sources/SwiftDocC/Semantics/Redirect.swift
+++ b/Sources/SwiftDocC/Semantics/Redirect.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -19,6 +19,7 @@ import Markdown
 /// that server can read this data and set an HTTP "301 Moved Permanently" redirect from
 /// the declared URL to the page's current URL and avoid breaking any existing links to the content.
 public final class Redirect: Semantic, AutomaticDirectiveConvertible {
+    public static let introducedVersion = "5.5"
     public static let directiveName = "Redirected"
     public let originalMarkup: BlockDirective
     

--- a/Sources/SwiftDocC/Semantics/Reference/Links.swift
+++ b/Sources/SwiftDocC/Semantics/Reference/Links.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2022-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -35,6 +35,7 @@ import Markdown
 /// ...
 /// ```
 public final class Links: Semantic, AutomaticDirectiveConvertible, MarkupContaining {
+    public static let introducedVersion = "5.8"
     public let originalMarkup: BlockDirective
     
     /// The inline markup contained in this 'Links' directive.

--- a/Sources/SwiftDocC/Semantics/Reference/Row.swift
+++ b/Sources/SwiftDocC/Semantics/Reference/Row.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2022-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -48,6 +48,7 @@ import Markdown
 ///
 /// - ``Column``
 public final class Row: Semantic, AutomaticDirectiveConvertible, MarkupContaining {
+    public static let introducedVersion = "5.8"
     public let originalMarkup: BlockDirective
     
     /// The number of columns available in this row.
@@ -93,6 +94,7 @@ extension Row {
     ///
     /// Create a column inside a ``Row`` by nesting a `@Column` directive within the content for an `@Row` directive.
     public final class Column: Semantic, AutomaticDirectiveConvertible, MarkupContaining {
+        public static let introducedVersion = "5.8"
         public let originalMarkup: BlockDirective
         
         /// The size of this column.

--- a/Sources/SwiftDocC/Semantics/Reference/Small.swift
+++ b/Sources/SwiftDocC/Semantics/Reference/Small.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2022-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -33,6 +33,7 @@ import Markdown
 /// }
 /// ```
 public final class Small: Semantic, AutomaticDirectiveConvertible, MarkupContaining {
+    public static let introducedVersion = "5.8"
     public let originalMarkup: BlockDirective
     
     /// The inline markup that should be rendered in a small font.

--- a/Sources/SwiftDocC/Semantics/Reference/TabNavigator.swift
+++ b/Sources/SwiftDocC/Semantics/Reference/TabNavigator.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2022-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -36,6 +36,7 @@ import Markdown
 ///
 /// - ``Tab``
 public final class TabNavigator: Semantic, AutomaticDirectiveConvertible, MarkupContaining {
+    public static let introducedVersion = "5.8"
     public let originalMarkup: BlockDirective
     
     /// The tabs that make up this tab navigator.
@@ -64,6 +65,7 @@ extension TabNavigator {
     ///
     ///  To add a new tab to a ``TabNavigator``, add  a `@Tab` directive within the content of the `@TabNavigator` directive.
     public final class Tab: Semantic, AutomaticDirectiveConvertible, MarkupContaining {
+        public static let introducedVersion = "5.8"
         public let originalMarkup: BlockDirective
         
         /// The title that should identify the content in this tab when rendered.

--- a/Sources/SwiftDocC/Semantics/Snippets/Snippet.swift
+++ b/Sources/SwiftDocC/Semantics/Snippets/Snippet.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -13,6 +13,7 @@ import Markdown
 import SymbolKit
 
 public final class Snippet: Semantic, AutomaticDirectiveConvertible {
+    public static let introducedVersion = "5.6"
     public let originalMarkup: BlockDirective
     
     /// The path components of a symbol link that would be used to resolve a reference to a snippet,

--- a/Sources/SwiftDocC/Semantics/Symbol/DeprecationSummary.swift
+++ b/Sources/SwiftDocC/Semantics/Symbol/DeprecationSummary.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -13,6 +13,7 @@ import Markdown
 
 /// A directive to add custom deprecation summary to an already deprecated symbol.
 public final class DeprecationSummary: Semantic, AutomaticDirectiveConvertible {
+    public static let introducedVersion = "5.5"
     public let originalMarkup: BlockDirective
 
     /// The contents of the summary.

--- a/Sources/SwiftDocC/Semantics/Technology/Resources/Resources.swift
+++ b/Sources/SwiftDocC/Semantics/Technology/Resources/Resources.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -17,6 +17,7 @@ import Markdown
 /// such as references to sample code, videos, and external documentation.
 public final class Resources: Semantic, DirectiveConvertible, Abstracted, Redirected {
     public static let directiveName = "Resources"
+    public static let introducedVersion = "5.5"
     
     /// A user-facing title that describes the directive.
     public static let title = "Resources"

--- a/Sources/SwiftDocC/Semantics/Technology/Resources/Tile.swift
+++ b/Sources/SwiftDocC/Semantics/Technology/Resources/Tile.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -16,6 +16,8 @@ import Markdown
 /// A tile is a kind of thematic content block that contains links to resources
 /// such as sample code, videos, or forum topics.
 public final class Tile: Semantic, DirectiveConvertible {
+    public static let introducedVersion = "5.5"
+    
     /// A tile type to identify the tile during building page layout.
     public enum Identifier: String, Codable {
         /// Identifies a tile that links to documentation.

--- a/Sources/SwiftDocC/Semantics/Technology/Technology.swift
+++ b/Sources/SwiftDocC/Semantics/Technology/Technology.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -14,6 +14,7 @@ import Markdown
 /// An overview of the educational materials under a specific technology or technology area.
 public final class Technology: Semantic, DirectiveConvertible, Abstracted, Redirected {
     public static let directiveName = "Tutorials"
+    public static let introducedVersion = "5.5"
     public let originalMarkup: BlockDirective
     
     /// The name of the technology.

--- a/Sources/SwiftDocC/Semantics/Technology/Volume/Chapter/Chapter.swift
+++ b/Sources/SwiftDocC/Semantics/Technology/Volume/Chapter/Chapter.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -13,6 +13,7 @@ import Markdown
 
 /// A chapter containing ``Tutorial``s to complete.
 public final class Chapter: Semantic, AutomaticDirectiveConvertible, Abstracted, Redirected {
+    public static let introducedVersion = "5.5"
     public let originalMarkup: BlockDirective
     
     /// The name of the chapter.

--- a/Sources/SwiftDocC/Semantics/Technology/Volume/Chapter/TutorialReference.swift
+++ b/Sources/SwiftDocC/Semantics/Technology/Volume/Chapter/TutorialReference.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -13,6 +13,7 @@ import Markdown
 
 /// A reference to a ``Tutorial`` or ``TutorialArticle`` by `URL`.
 public final class TutorialReference: Semantic, AutomaticDirectiveConvertible {
+    public static let introducedVersion = "5.5"
     public var originalMarkup: BlockDirective
     
     /// The tutorial page or tutorial article to which this refers.

--- a/Sources/SwiftDocC/Semantics/Technology/Volume/Volume.swift
+++ b/Sources/SwiftDocC/Semantics/Technology/Volume/Volume.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -13,8 +13,8 @@ import Markdown
 
 /// A grouping of chapters within a larger collection of tutorials.
 public final class Volume: Semantic, DirectiveConvertible, Abstracted, Redirected {
-    // DirectiveConvertible
     public static let directiveName = "Volume"
+    public static let introducedVersion = "5.5"
     public let originalMarkup: BlockDirective
 
     /// The name of this volume.

--- a/Sources/SwiftDocC/Semantics/Tutorial/Assessments/Assessments.swift
+++ b/Sources/SwiftDocC/Semantics/Tutorial/Assessments/Assessments.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -13,6 +13,7 @@ import Markdown
 
 /// A collection of questions about the concepts the documentation presents.
 public final class Assessments: Semantic, AutomaticDirectiveConvertible {
+    public static let introducedVersion = "5.5"
     public let originalMarkup: BlockDirective
     
     /// The multiple-choice questions that make up the assessment.

--- a/Sources/SwiftDocC/Semantics/Tutorial/Assessments/Multiple Choice/Choice/Choice.swift
+++ b/Sources/SwiftDocC/Semantics/Tutorial/Assessments/Multiple Choice/Choice/Choice.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -15,6 +15,7 @@ import Markdown
  One of possibly many choices in a ``MultipleChoice`` question.
  */
 public final class Choice: Semantic, AutomaticDirectiveConvertible {
+    public static let introducedVersion = "5.5"
     public let originalMarkup: BlockDirective
     
     /// `true` if this choice is a correct one; there can be multiple correct choices.

--- a/Sources/SwiftDocC/Semantics/Tutorial/Assessments/Multiple Choice/Choice/Justification.swift
+++ b/Sources/SwiftDocC/Semantics/Tutorial/Assessments/Multiple Choice/Choice/Justification.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -15,6 +15,7 @@ import Markdown
  A short justification as to whether a ``Choice`` is correct for a question.
  */
 public final class Justification: Semantic, AutomaticDirectiveConvertible {
+    public static let introducedVersion = "5.5"
     public let originalMarkup: BlockDirective
     
     /// The explanatory content for this justification.

--- a/Sources/SwiftDocC/Semantics/Tutorial/Assessments/Multiple Choice/MultipleChoice.swift
+++ b/Sources/SwiftDocC/Semantics/Tutorial/Assessments/Multiple Choice/MultipleChoice.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -15,6 +15,7 @@ import Markdown
 ///
 /// A collection of multiple-choice questions that form an ``Assessments``.
 public final class MultipleChoice: Semantic, DirectiveConvertible {
+    public static let introducedVersion = "5.5"
     public static let directiveName = "MultipleChoice"
     
     /// The phrasing of the question.

--- a/Sources/SwiftDocC/Semantics/Tutorial/Tasks/Steps/Code.swift
+++ b/Sources/SwiftDocC/Semantics/Tutorial/Tasks/Steps/Code.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -15,6 +15,7 @@ import Markdown
 A code file to display alongside a ``Step``.
 */
 public final class Code: Semantic, DirectiveConvertible {
+    public static let introducedVersion = "5.5"
     public static let directiveName = "Code"
     
     /// The original `BlockDirective` node that was parsed into this semantic code.

--- a/Sources/SwiftDocC/Semantics/Tutorial/Tasks/Steps/Step.swift
+++ b/Sources/SwiftDocC/Semantics/Tutorial/Tasks/Steps/Step.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -16,8 +16,7 @@ import Markdown
  */
 public final class Step: Semantic, DirectiveConvertible {
     public static let directiveName = "Step"
-    /// The original `Markup` node that was parsed into this semantic step,
-    /// or `nil` if it was created elsewhere.
+    public static let introducedVersion = "5.5"
     public let originalMarkup: BlockDirective
     
     /// A piece of media associated with the step to display when selected.

--- a/Sources/SwiftDocC/Semantics/Tutorial/Tasks/Steps/Steps.swift
+++ b/Sources/SwiftDocC/Semantics/Tutorial/Tasks/Steps/Steps.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -14,7 +14,7 @@ import Markdown
 /// Wraps a series of ``Step``s in a tutorial task section.
 public final class Steps: Semantic, DirectiveConvertible {
     public static let directiveName = "Steps"
-
+    public static let introducedVersion = "5.5"
     public let originalMarkup: BlockDirective
     
     /// The ``Steps`` necessary to complete this section.

--- a/Sources/SwiftDocC/Semantics/Tutorial/Tasks/TutorialSection.swift
+++ b/Sources/SwiftDocC/Semantics/Tutorial/Tasks/TutorialSection.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -16,6 +16,7 @@ import Markdown
  */
 public final class TutorialSection: Semantic, DirectiveConvertible, Abstracted, Landmark, Redirected {
     public static let directiveName = "Section"
+    public static let introducedVersion = "5.5"
     public let originalMarkup: BlockDirective
     
     /// The title of the section.

--- a/Sources/SwiftDocC/Semantics/Tutorial/Tutorial.swift
+++ b/Sources/SwiftDocC/Semantics/Tutorial/Tutorial.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -15,6 +15,7 @@ import Markdown
  A tutorial to complete in order to gain knowledge of a ``Technology``.
  */
 public final class Tutorial: Semantic, AutomaticDirectiveConvertible, Abstracted, Titled, Timed, Redirected {
+    public static let introducedVersion = "5.5"
     public let originalMarkup: BlockDirective
     
     /// The estimated time in minutes that the containing ``Tutorial`` will take.

--- a/Sources/SwiftDocC/Semantics/Tutorial/XcodeRequirement.swift
+++ b/Sources/SwiftDocC/Semantics/Tutorial/XcodeRequirement.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -15,6 +15,7 @@ import Markdown
  An informal Xcode requirement for completing an instructional ``Tutorial``.
  */
 public final class XcodeRequirement: Semantic, AutomaticDirectiveConvertible {
+    public static let introducedVersion = "5.5"
     public let originalMarkup: BlockDirective
     
     /// Human readable title.

--- a/Sources/SwiftDocC/Semantics/TutorialArticle/Stack.swift
+++ b/Sources/SwiftDocC/Semantics/TutorialArticle/Stack.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -13,6 +13,7 @@ import Markdown
 
 /// A semantic model for a view that arranges its children in a row.
 public final class Stack: Semantic, AutomaticDirectiveConvertible {
+    public static let introducedVersion = "5.5"
     public let originalMarkup: BlockDirective
     
     /// The stack's children.

--- a/Sources/SwiftDocC/Semantics/TutorialArticle/TutorialArticle.swift
+++ b/Sources/SwiftDocC/Semantics/TutorialArticle/TutorialArticle.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -24,6 +24,7 @@ See ``Stack`` for more information about how to construct layouts. Markup outsid
  */
 public final class TutorialArticle: Semantic, DirectiveConvertible, Abstracted, Titled, Timed, Redirected {
     public static let directiveName = "Article"
+    public static let introducedVersion = "5.5"
     public let originalMarkup: BlockDirective
     
     public let durationMinutes: Int?

--- a/Sources/docc/DocCDocumentation.docc/DocC.symbols.json
+++ b/Sources/docc/DocCDocumentation.docc/DocC.symbols.json
@@ -1927,7 +1927,7 @@
           "domain" : "Swift-DocC",
           "introduced" : {
             "major" : 5,
-            "minor" : 6,
+            "minor" : 7,
             "patch" : 0
           }
         }
@@ -3474,7 +3474,7 @@
           "domain" : "Swift-DocC",
           "introduced" : {
             "major" : 5,
-            "minor" : 8,
+            "minor" : 9,
             "patch" : 0
           }
         }

--- a/Sources/docc/DocCDocumentation.docc/DocC.symbols.json
+++ b/Sources/docc/DocCDocumentation.docc/DocC.symbols.json
@@ -28,6 +28,16 @@
   "symbols" : [
     {
       "accessLevel" : "public",
+      "availability" : [
+        {
+          "domain" : "Swift-DocC",
+          "introduced" : {
+            "major" : 5,
+            "minor" : 5,
+            "patch" : 0
+          }
+        }
+      ],
       "declarationFragments" : [
         {
           "kind" : "typeIdentifier",
@@ -88,6 +98,16 @@
     },
     {
       "accessLevel" : "public",
+      "availability" : [
+        {
+          "domain" : "Swift-DocC",
+          "introduced" : {
+            "major" : 5,
+            "minor" : 5,
+            "patch" : 0
+          }
+        }
+      ],
       "declarationFragments" : [
         {
           "kind" : "typeIdentifier",
@@ -172,6 +192,16 @@
     },
     {
       "accessLevel" : "public",
+      "availability" : [
+        {
+          "domain" : "Swift-DocC",
+          "introduced" : {
+            "major" : 5,
+            "minor" : 8,
+            "patch" : 0
+          }
+        }
+      ],
       "declarationFragments" : [
         {
           "kind" : "typeIdentifier",
@@ -302,6 +332,16 @@
     },
     {
       "accessLevel" : "public",
+      "availability" : [
+        {
+          "domain" : "Swift-DocC",
+          "introduced" : {
+            "major" : 5,
+            "minor" : 8,
+            "patch" : 0
+          }
+        }
+      ],
       "declarationFragments" : [
         {
           "kind" : "typeIdentifier",
@@ -423,6 +463,16 @@
     },
     {
       "accessLevel" : "public",
+      "availability" : [
+        {
+          "domain" : "Swift-DocC",
+          "introduced" : {
+            "major" : 5,
+            "minor" : 8,
+            "patch" : 0
+          }
+        }
+      ],
       "declarationFragments" : [
         {
           "kind" : "typeIdentifier",
@@ -550,6 +600,16 @@
     },
     {
       "accessLevel" : "public",
+      "availability" : [
+        {
+          "domain" : "Swift-DocC",
+          "introduced" : {
+            "major" : 5,
+            "minor" : 8,
+            "patch" : 0
+          }
+        }
+      ],
       "declarationFragments" : [
         {
           "kind" : "typeIdentifier",
@@ -790,6 +850,16 @@
     },
     {
       "accessLevel" : "public",
+      "availability" : [
+        {
+          "domain" : "Swift-DocC",
+          "introduced" : {
+            "major" : 5,
+            "minor" : 8,
+            "patch" : 0
+          }
+        }
+      ],
       "declarationFragments" : [
         {
           "kind" : "typeIdentifier",
@@ -1120,6 +1190,16 @@
     },
     {
       "accessLevel" : "public",
+      "availability" : [
+        {
+          "domain" : "Swift-DocC",
+          "introduced" : {
+            "major" : 5,
+            "minor" : 5,
+            "patch" : 0
+          }
+        }
+      ],
       "declarationFragments" : [
         {
           "kind" : "typeIdentifier",
@@ -1334,6 +1414,16 @@
     },
     {
       "accessLevel" : "public",
+      "availability" : [
+        {
+          "domain" : "Swift-DocC",
+          "introduced" : {
+            "major" : 5,
+            "minor" : 5,
+            "patch" : 0
+          }
+        }
+      ],
       "declarationFragments" : [
         {
           "kind" : "typeIdentifier",
@@ -1498,6 +1588,16 @@
     },
     {
       "accessLevel" : "public",
+      "availability" : [
+        {
+          "domain" : "Swift-DocC",
+          "introduced" : {
+            "major" : 5,
+            "minor" : 5,
+            "patch" : 0
+          }
+        }
+      ],
       "declarationFragments" : [
         {
           "kind" : "typeIdentifier",
@@ -1558,6 +1658,16 @@
     },
     {
       "accessLevel" : "public",
+      "availability" : [
+        {
+          "domain" : "Swift-DocC",
+          "introduced" : {
+            "major" : 5,
+            "minor" : 8,
+            "patch" : 0
+          }
+        }
+      ],
       "declarationFragments" : [
         {
           "kind" : "typeIdentifier",
@@ -1688,6 +1798,16 @@
     },
     {
       "accessLevel" : "public",
+      "availability" : [
+        {
+          "domain" : "Swift-DocC",
+          "introduced" : {
+            "major" : 5,
+            "minor" : 5,
+            "patch" : 0
+          }
+        }
+      ],
       "declarationFragments" : [
         {
           "kind" : "typeIdentifier",
@@ -1740,6 +1860,16 @@
     },
     {
       "accessLevel" : "public",
+      "availability" : [
+        {
+          "domain" : "Swift-DocC",
+          "introduced" : {
+            "major" : 5,
+            "minor" : 5,
+            "patch" : 0
+          }
+        }
+      ],
       "declarationFragments" : [
         {
           "kind" : "typeIdentifier",
@@ -1792,6 +1922,16 @@
     },
     {
       "accessLevel" : "public",
+      "availability" : [
+        {
+          "domain" : "Swift-DocC",
+          "introduced" : {
+            "major" : 5,
+            "minor" : 6,
+            "patch" : 0
+          }
+        }
+      ],
       "declarationFragments" : [
         {
           "kind" : "typeIdentifier",
@@ -1994,6 +2134,16 @@
     },
     {
       "accessLevel" : "public",
+      "availability" : [
+        {
+          "domain" : "Swift-DocC",
+          "introduced" : {
+            "major" : 5,
+            "minor" : 5,
+            "patch" : 0
+          }
+        }
+      ],
       "declarationFragments" : [
         {
           "kind" : "typeIdentifier",
@@ -2054,6 +2204,16 @@
     },
     {
       "accessLevel" : "public",
+      "availability" : [
+        {
+          "domain" : "Swift-DocC",
+          "introduced" : {
+            "major" : 5,
+            "minor" : 5,
+            "patch" : 0
+          }
+        }
+      ],
       "declarationFragments" : [
         {
           "kind" : "typeIdentifier",
@@ -2206,6 +2366,16 @@
     },
     {
       "accessLevel" : "public",
+      "availability" : [
+        {
+          "domain" : "Swift-DocC",
+          "introduced" : {
+            "major" : 5,
+            "minor" : 5,
+            "patch" : 0
+          }
+        }
+      ],
       "declarationFragments" : [
         {
           "kind" : "typeIdentifier",
@@ -2266,6 +2436,16 @@
     },
     {
       "accessLevel" : "public",
+      "availability" : [
+        {
+          "domain" : "Swift-DocC",
+          "introduced" : {
+            "major" : 5,
+            "minor" : 5,
+            "patch" : 0
+          }
+        }
+      ],
       "declarationFragments" : [
         {
           "kind" : "typeIdentifier",
@@ -2326,6 +2506,16 @@
     },
     {
       "accessLevel" : "public",
+      "availability" : [
+        {
+          "domain" : "Swift-DocC",
+          "introduced" : {
+            "major" : 5,
+            "minor" : 5,
+            "patch" : 0
+          }
+        }
+      ],
       "declarationFragments" : [
         {
           "kind" : "typeIdentifier",
@@ -2476,6 +2666,16 @@
     },
     {
       "accessLevel" : "public",
+      "availability" : [
+        {
+          "domain" : "Swift-DocC",
+          "introduced" : {
+            "major" : 5,
+            "minor" : 5,
+            "patch" : 0
+          }
+        }
+      ],
       "declarationFragments" : [
         {
           "kind" : "typeIdentifier",
@@ -2587,6 +2787,16 @@
     },
     {
       "accessLevel" : "public",
+      "availability" : [
+        {
+          "domain" : "Swift-DocC",
+          "introduced" : {
+            "major" : 5,
+            "minor" : 5,
+            "patch" : 0
+          }
+        }
+      ],
       "declarationFragments" : [
         {
           "kind" : "typeIdentifier",
@@ -2702,6 +2912,16 @@
     },
     {
       "accessLevel" : "public",
+      "availability" : [
+        {
+          "domain" : "Swift-DocC",
+          "introduced" : {
+            "major" : 5,
+            "minor" : 8,
+            "patch" : 0
+          }
+        }
+      ],
       "declarationFragments" : [
         {
           "kind" : "typeIdentifier",
@@ -2897,6 +3117,16 @@
     },
     {
       "accessLevel" : "public",
+      "availability" : [
+        {
+          "domain" : "Swift-DocC",
+          "introduced" : {
+            "major" : 5,
+            "minor" : 5,
+            "patch" : 0
+          }
+        }
+      ],
       "declarationFragments" : [
         {
           "kind" : "typeIdentifier",
@@ -3007,6 +3237,16 @@
     },
     {
       "accessLevel" : "public",
+      "availability" : [
+        {
+          "domain" : "Swift-DocC",
+          "introduced" : {
+            "major" : 5,
+            "minor" : 5,
+            "patch" : 0
+          }
+        }
+      ],
       "declarationFragments" : [
         {
           "kind" : "typeIdentifier",
@@ -3059,6 +3299,16 @@
     },
     {
       "accessLevel" : "public",
+      "availability" : [
+        {
+          "domain" : "Swift-DocC",
+          "introduced" : {
+            "major" : 5,
+            "minor" : 8,
+            "patch" : 0
+          }
+        }
+      ],
       "declarationFragments" : [
         {
           "kind" : "typeIdentifier",
@@ -3219,6 +3469,16 @@
     },
     {
       "accessLevel" : "public",
+      "availability" : [
+        {
+          "domain" : "Swift-DocC",
+          "introduced" : {
+            "major" : 5,
+            "minor" : 8,
+            "patch" : 0
+          }
+        }
+      ],
       "declarationFragments" : [
         {
           "kind" : "typeIdentifier",
@@ -3397,6 +3657,16 @@
     },
     {
       "accessLevel" : "public",
+      "availability" : [
+        {
+          "domain" : "Swift-DocC",
+          "introduced" : {
+            "major" : 5,
+            "minor" : 8,
+            "patch" : 0
+          }
+        }
+      ],
       "declarationFragments" : [
         {
           "kind" : "typeIdentifier",
@@ -3478,7 +3748,7 @@
             "text" : "For example, use the page image directive to customize the icon used to represent this page in the navigation sidebar,"
           },
           {
-            "text" : "or the card image used to represent this page when using the ``Links`` directive and the ``Links\/detailedGrid``"
+            "text" : "or the card image used to represent this page when using the ``Links`` directive and the ``Links\/VisualStyle\/detailedGrid``"
           },
           {
             "text" : "visual style."
@@ -3602,6 +3872,16 @@
     },
     {
       "accessLevel" : "public",
+      "availability" : [
+        {
+          "domain" : "Swift-DocC",
+          "introduced" : {
+            "major" : 5,
+            "minor" : 8,
+            "patch" : 0
+          }
+        }
+      ],
       "declarationFragments" : [
         {
           "kind" : "typeIdentifier",
@@ -3762,6 +4042,16 @@
     },
     {
       "accessLevel" : "public",
+      "availability" : [
+        {
+          "domain" : "Swift-DocC",
+          "introduced" : {
+            "major" : 5,
+            "minor" : 5,
+            "patch" : 0
+          }
+        }
+      ],
       "declarationFragments" : [
         {
           "kind" : "typeIdentifier",
@@ -3814,6 +4104,16 @@
     },
     {
       "accessLevel" : "public",
+      "availability" : [
+        {
+          "domain" : "Swift-DocC",
+          "introduced" : {
+            "major" : 5,
+            "minor" : 8,
+            "patch" : 0
+          }
+        }
+      ],
       "declarationFragments" : [
         {
           "kind" : "typeIdentifier",
@@ -4083,6 +4383,16 @@
     },
     {
       "accessLevel" : "public",
+      "availability" : [
+        {
+          "domain" : "Swift-DocC",
+          "introduced" : {
+            "major" : 5,
+            "minor" : 5,
+            "patch" : 0
+          }
+        }
+      ],
       "declarationFragments" : [
         {
           "kind" : "typeIdentifier",
@@ -4143,6 +4453,16 @@
     },
     {
       "accessLevel" : "public",
+      "availability" : [
+        {
+          "domain" : "Swift-DocC",
+          "introduced" : {
+            "major" : 5,
+            "minor" : 5,
+            "patch" : 0
+          }
+        }
+      ],
       "declarationFragments" : [
         {
           "kind" : "typeIdentifier",
@@ -4203,6 +4523,16 @@
     },
     {
       "accessLevel" : "public",
+      "availability" : [
+        {
+          "domain" : "Swift-DocC",
+          "introduced" : {
+            "major" : 5,
+            "minor" : 8,
+            "patch" : 0
+          }
+        }
+      ],
       "declarationFragments" : [
         {
           "kind" : "typeIdentifier",
@@ -4322,6 +4652,16 @@
     },
     {
       "accessLevel" : "public",
+      "availability" : [
+        {
+          "domain" : "Swift-DocC",
+          "introduced" : {
+            "major" : 5,
+            "minor" : 5,
+            "patch" : 0
+          }
+        }
+      ],
       "declarationFragments" : [
         {
           "kind" : "typeIdentifier",
@@ -4406,6 +4746,16 @@
     },
     {
       "accessLevel" : "public",
+      "availability" : [
+        {
+          "domain" : "Swift-DocC",
+          "introduced" : {
+            "major" : 5,
+            "minor" : 5,
+            "patch" : 0
+          }
+        }
+      ],
       "declarationFragments" : [
         {
           "kind" : "typeIdentifier",
@@ -4458,6 +4808,16 @@
     },
     {
       "accessLevel" : "public",
+      "availability" : [
+        {
+          "domain" : "Swift-DocC",
+          "introduced" : {
+            "major" : 5,
+            "minor" : 5,
+            "patch" : 0
+          }
+        }
+      ],
       "declarationFragments" : [
         {
           "kind" : "typeIdentifier",
@@ -4510,6 +4870,16 @@
     },
     {
       "accessLevel" : "public",
+      "availability" : [
+        {
+          "domain" : "Swift-DocC",
+          "introduced" : {
+            "major" : 5,
+            "minor" : 8,
+            "patch" : 0
+          }
+        }
+      ],
       "declarationFragments" : [
         {
           "kind" : "typeIdentifier",
@@ -4682,6 +5052,16 @@
     },
     {
       "accessLevel" : "public",
+      "availability" : [
+        {
+          "domain" : "Swift-DocC",
+          "introduced" : {
+            "major" : 5,
+            "minor" : 8,
+            "patch" : 0
+          }
+        }
+      ],
       "declarationFragments" : [
         {
           "kind" : "typeIdentifier",
@@ -4807,6 +5187,16 @@
     },
     {
       "accessLevel" : "public",
+      "availability" : [
+        {
+          "domain" : "Swift-DocC",
+          "introduced" : {
+            "major" : 5,
+            "minor" : 8,
+            "patch" : 0
+          }
+        }
+      ],
       "declarationFragments" : [
         {
           "kind" : "typeIdentifier",
@@ -4987,6 +5377,16 @@
     },
     {
       "accessLevel" : "public",
+      "availability" : [
+        {
+          "domain" : "Swift-DocC",
+          "introduced" : {
+            "major" : 5,
+            "minor" : 5,
+            "patch" : 0
+          }
+        }
+      ],
       "declarationFragments" : [
         {
           "kind" : "typeIdentifier",
@@ -5063,6 +5463,16 @@
     },
     {
       "accessLevel" : "public",
+      "availability" : [
+        {
+          "domain" : "Swift-DocC",
+          "introduced" : {
+            "major" : 5,
+            "minor" : 9,
+            "patch" : 0
+          }
+        }
+      ],
       "declarationFragments" : [
         {
           "kind" : "typeIdentifier",
@@ -5112,7 +5522,7 @@
             "text" : ""
           },
           {
-            "text" : "@TitleHeading accepts an unnamed parameter containing containing the page's title heading."
+            "text" : "The `@TitleHeading` directive accepts an unnamed parameter containing containing the page's title heading."
           },
           {
             "text" : ""
@@ -5208,6 +5618,16 @@
     },
     {
       "accessLevel" : "public",
+      "availability" : [
+        {
+          "domain" : "Swift-DocC",
+          "introduced" : {
+            "major" : 5,
+            "minor" : 8,
+            "patch" : 0
+          }
+        }
+      ],
       "declarationFragments" : [
         {
           "kind" : "typeIdentifier",
@@ -5347,6 +5767,16 @@
     },
     {
       "accessLevel" : "public",
+      "availability" : [
+        {
+          "domain" : "Swift-DocC",
+          "introduced" : {
+            "major" : 5,
+            "minor" : 5,
+            "patch" : 0
+          }
+        }
+      ],
       "declarationFragments" : [
         {
           "kind" : "typeIdentifier",
@@ -5574,6 +6004,16 @@
     },
     {
       "accessLevel" : "public",
+      "availability" : [
+        {
+          "domain" : "Swift-DocC",
+          "introduced" : {
+            "major" : 5,
+            "minor" : 5,
+            "patch" : 0
+          }
+        }
+      ],
       "declarationFragments" : [
         {
           "kind" : "typeIdentifier",
@@ -5678,6 +6118,16 @@
     },
     {
       "accessLevel" : "public",
+      "availability" : [
+        {
+          "domain" : "Swift-DocC",
+          "introduced" : {
+            "major" : 5,
+            "minor" : 5,
+            "patch" : 0
+          }
+        }
+      ],
       "declarationFragments" : [
         {
           "kind" : "typeIdentifier",
@@ -5738,6 +6188,16 @@
     },
     {
       "accessLevel" : "public",
+      "availability" : [
+        {
+          "domain" : "Swift-DocC",
+          "introduced" : {
+            "major" : 5,
+            "minor" : 5,
+            "patch" : 0
+          }
+        }
+      ],
       "declarationFragments" : [
         {
           "kind" : "typeIdentifier",
@@ -5930,6 +6390,16 @@
     },
     {
       "accessLevel" : "public",
+      "availability" : [
+        {
+          "domain" : "Swift-DocC",
+          "introduced" : {
+            "major" : 5,
+            "minor" : 5,
+            "patch" : 0
+          }
+        }
+      ],
       "declarationFragments" : [
         {
           "kind" : "typeIdentifier",
@@ -5990,6 +6460,16 @@
     },
     {
       "accessLevel" : "public",
+      "availability" : [
+        {
+          "domain" : "Swift-DocC",
+          "introduced" : {
+            "major" : 5,
+            "minor" : 5,
+            "patch" : 0
+          }
+        }
+      ],
       "declarationFragments" : [
         {
           "kind" : "typeIdentifier",
@@ -6050,6 +6530,16 @@
     },
     {
       "accessLevel" : "public",
+      "availability" : [
+        {
+          "domain" : "Swift-DocC",
+          "introduced" : {
+            "major" : 5,
+            "minor" : 5,
+            "patch" : 0
+          }
+        }
+      ],
       "declarationFragments" : [
         {
           "kind" : "typeIdentifier",

--- a/Sources/generate-symbol-graph/main.swift
+++ b/Sources/generate-symbol-graph/main.swift
@@ -14,7 +14,9 @@ import SymbolKit
 
 struct Directive {
     var name: String
-
+    /// The earliest release of Swift-DocC that supports this directive.
+    var introducedVersion: String
+    
     /// The name of the type that implements this directive.
     ///
     /// This information is not presented in the documentation. It's only used to find undocumented directives.
@@ -26,9 +28,16 @@ struct Directive {
     /// `true` if the directive doesn't expect body content.
     var isLeaf: Bool
     
-    init(name: String, implementationName: String? = nil, acceptsArguments: Bool = true, isLeaf: Bool) {
+    init(
+        name: String,
+        implementationName: String? = nil,
+        introducedVersion: String,
+        acceptsArguments: Bool = true,
+        isLeaf: Bool
+    ) {
         self.name = name
         self.implementationName = implementationName ?? name
+        self.introducedVersion = introducedVersion
         self.acceptsArguments = acceptsArguments
         self.isLeaf = isLeaf
     }
@@ -75,73 +84,88 @@ let supportedDirectives: [Directive] = [
     .init(
         name: "Tutorials",
         implementationName: "Technology",
+        introducedVersion: "5.5",
         isLeaf: false
     ),
     .init(
         name: "Volume",
+        introducedVersion: "5.5",
         isLeaf: false
     ),
     .init(
         name: "Resources",
+        introducedVersion: "5.5",
         acceptsArguments: false,
         isLeaf: false
     ),
     .init(
         name: "Documentation",
         implementationName: "Tile",
+        introducedVersion: "5.5",
         isLeaf: false
     ),
     .init(
         name: "SampleCode",
         implementationName: "Tile",
+        introducedVersion: "5.5",
         isLeaf: false
     ),
     .init(
         name: "Downloads",
         implementationName: "Tile",
+        introducedVersion: "5.5",
         isLeaf: false
     ),
     .init(
         name: "Videos",
         implementationName: "Tile",
+        introducedVersion: "5.5",
         isLeaf: false
     ),
     .init(
         name: "Forums",
         implementationName: "Tile",
+        introducedVersion: "5.5",
         isLeaf: false
     ),
     .init(
         name: "Section",
         implementationName: "TutorialSection",
+        introducedVersion: "5.5",
         isLeaf: false
     ),
     .init(
         name: "Article",
         implementationName: "TutorialArticle",
+        introducedVersion: "5.5",
         isLeaf: false
     ),
     .init(
         name: "ContentAndMedia",
+        introducedVersion: "5.5",
         acceptsArguments: false,
         isLeaf: false
     ),
     .init(
         name: "Steps",
+        introducedVersion: "5.5",
         acceptsArguments: false,
         isLeaf: false
     ),
     .init(
         name: "Step",
+        introducedVersion: "5.5",
         acceptsArguments: false,
         isLeaf: false
     ),
     .init(
         name: "Code",
+        introducedVersion: "5.5",
         isLeaf: false
     ),
     .init(
         name: "MultipleChoice",
+        introducedVersion: "5.5",
         acceptsArguments: false,
         isLeaf: false
     ),
@@ -150,6 +174,7 @@ let supportedDirectives: [Directive] = [
 
     .init(
         name: "Comment",
+        introducedVersion: "5.5",
         acceptsArguments: false,
         isLeaf: false
     ),
@@ -159,6 +184,7 @@ let supportedDirectives: [Directive] = [
     .map { directive in
         return Directive(
             name: directive.name,
+            introducedVersion: directive.introducedVersion,
             acceptsArguments: !directive.documentableArguments.isEmpty,
             isLeaf: !directive.allowsMarkup && directive.childDirectives.isEmpty
         )
@@ -593,7 +619,20 @@ let symbols: [SymbolGraph.Symbol] = supportedDirectives.map { directive in
         mixins: [
             SymbolGraph.Symbol.DeclarationFragments.mixinKey: SymbolGraph.Symbol.DeclarationFragments(
                 declarationFragments: fragments
-            )
+            ),
+            SymbolGraph.Symbol.Availability.mixinKey: SymbolGraph.Symbol.Availability(availability: [
+                .init(
+                    domain: .init(rawValue: "Swift-DocC"),
+                    introducedVersion: .init(string: directive.introducedVersion),
+                    deprecatedVersion: nil,
+                    obsoletedVersion: nil,
+                    message: nil,
+                    renamed: nil,
+                    isUnconditionallyDeprecated: false,
+                    isUnconditionallyUnavailable: false,
+                    willEventuallyBeDeprecated: false
+                )
+            ]),
         ]
     )
 }

--- a/Tests/SwiftDocCTests/Semantics/General Purpose Analyses/HasAtLeastOneTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/General Purpose Analyses/HasAtLeastOneTests.swift
@@ -14,6 +14,7 @@ import Markdown
 
 final class TestParent: Semantic, DirectiveConvertible {
     static let directiveName = "Parent"
+    static let introducedVersion = "1.2.3"
     let originalMarkup: BlockDirective
     let testChildren: [TestChild]
     init?(from directive: BlockDirective, source: URL?, for bundle: DocumentationBundle, in context: DocumentationContext, problems: inout [Problem]) {
@@ -35,6 +36,7 @@ final class TestParent: Semantic, DirectiveConvertible {
 
 final class TestChild: Semantic, DirectiveConvertible {
     static let directiveName = "Child"
+    static let introducedVersion = "1.2.3"
     let originalMarkup: BlockDirective
     init?(from directive: BlockDirective, source: URL?, for bundle: DocumentationBundle, in context: DocumentationContext, problems: inout [Problem]) {
         precondition(TestChild.canConvertDirective(directive))


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://110036742

## Summary

This add an `introducedVersion` property to `DirectiveConvertible` so that each directive page shows what version of DocC is the earliest version to support that directive.

## Dependencies

None

## Testing

Run `swift run docc preview Sources/docc/DocCDocumentation.docc` and inspect the various directive documentation pages

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
