### PR TITLE
[5.10] Update swift-markdown and fix test case

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -78,7 +78,7 @@
       "location" : "https://github.com/apple/swift-markdown.git",
       "state" : {
         "branch" : "release/5.10",
-        "revision" : "3d4b36cff09f785adf5efb190d458a3d44e6df87"
+        "revision" : "636291555b65bd59b2b3279abc7d03a622aa7c55"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-docc-symbolkit",
       "state" : {
-        "branch" : "main",
-        "revision" : "53e5cb9b18222f66cb8d6fb684d7383e705e0936"
+        "branch" : "release/5.10",
+        "revision" : "1d5aba8186fc648e17b30631b34043110ca8dd19"
       }
     },
     {
@@ -68,7 +68,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-lmdb.git",
       "state" : {
-        "branch" : "main",
+        "branch" : "release/5.10",
         "revision" : "584941b1236b15bad74d8163785d389c028b1ad8"
       }
     },
@@ -77,7 +77,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-markdown.git",
       "state" : {
-        "branch" : "main",
+        "branch" : "release/5.10",
         "revision" : "3d4b36cff09f785adf5efb190d458a3d44e6df87"
       }
     },

--- a/Package.swift
+++ b/Package.swift
@@ -133,10 +133,10 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     // Building standalone, so fetch all dependencies remotely.
     package.dependencies += [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.53.0"),
-        .package(url: "https://github.com/apple/swift-markdown.git", branch: "main"),
-        .package(url: "https://github.com/apple/swift-lmdb.git", branch: "main"),
+        .package(url: "https://github.com/apple/swift-markdown.git", branch: "release/5.10"),
+        .package(url: "https://github.com/apple/swift-lmdb.git", branch: "release/5.10"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.2"),
-        .package(url: "https://github.com/apple/swift-docc-symbolkit", branch: "main"),
+        .package(url: "https://github.com/apple/swift-docc-symbolkit", branch: "release/5.10"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "2.5.0"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.2.0"),
     ]

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -177,9 +177,9 @@ class DocumentationContextTests: XCTestCase {
 │  │  │  │  ├─ Argument text segments:
 │  │  │  │  |    "source: figure1.png, alt: figure1 "
 │  │  │  ├─ Paragraph
-│  │  │  │  └─ Image source: "figure1" title: ""
+│  │  │  │  └─ Image source: "figure1"
 │  │  │  ├─ Paragraph
-│  │  │  │  └─ Image source: "images/figure1" title: ""
+│  │  │  │  └─ Image source: "images/figure1"
 │  │  │  └─ Paragraph
 │  │  │     └─ Text "Quis auctor elit sed vulputate mi sit amet."
 │  │  ├─ BlockDirective name: "Comment"
@@ -345,7 +345,7 @@ class DocumentationContextTests: XCTestCase {
 │  │  │  ├─ Paragraph
 │  │  │  │  └─ Text "Phasellus faucibus scelerisque eleifend donec pretium."
 │  │  │  ├─ Paragraph
-│  │  │  │  └─ Image source: "something.png" title: ""
+│  │  │  │  └─ Image source: "something.png"
 │  │  │  │     └─ Text "Diagram"
 │  │  │  ├─ CodeBlock language: swift
 │  │  │  │  let scene = ARSCNView()

--- a/Tests/SwiftDocCTests/Model/DocumentationMarkupTests.swift
+++ b/Tests/SwiftDocCTests/Model/DocumentationMarkupTests.swift
@@ -154,7 +154,7 @@ class DocumentationMarkupTests: XCTestCase {
             Discussion content.
             """
             let expected = """
-            Image source: "image.jpg" title: ""
+            Image source: "image.jpg"
             └─ Text "Image title"
             Text " Abstract."
             """

--- a/Tests/SwiftDocCTests/Rendering/RenderContentCompilerTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/RenderContentCompilerTests.swift
@@ -46,7 +46,7 @@ class RenderContentCompilerTests: XCTestCase {
         ├─ Paragraph
         │  └─ Link destination: "doc:article2"
         │     ├─ Text "Custom Image Content "
-        │     └─ Image source: "https://example.com/test.png" title: ""
+        │     └─ Image source: "https://example.com/test.png"
         │        └─ Text "random image"
         ├─ Paragraph
         │  └─ Link destination: "doc:UNRESOVLED"


### PR DESCRIPTION
Update Package.swift to use release branch + Cherry-pick of #708

> Actually IMO the Package.swift update should be committed right after the release/5.10 is cut off. 😄

- **Explanation**: Fix swift toolchain CI test case failing due to the swift-markdown breaking change PR.
- **Scope**: Test case fix
- **Dependency**: https://github.com/apple/swift-markdown/pull/147
- **GitHub Issue**: None
- **Risk**: Low
- **Testing**: None
- **Reviewer**: @eeckstein  