### PR TITLE
Use `extensionTo` and `declaredIn` relationships to add extensions to path hierarchy

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+PathComponent.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+PathComponent.swift
@@ -13,7 +13,16 @@ import SymbolKit
 /// All known symbol kind identifiers.
 ///
 /// This is used to identify parsed path components as kind information.
-private let knownSymbolKinds = Set(SymbolGraph.Symbol.KindIdentifier.allCases.map { $0.identifier })
+private let knownSymbolKinds = Set<String>(
+    (SymbolGraph.Symbol.KindIdentifier.allCases + [
+        .extendedProtocol,
+        .extendedStructure,
+        .extendedClass,
+        .extendedEnumeration,
+        .unknownExtendedType,
+        .extendedModule,
+    ]).map(\.identifier)
+)
 /// All known source language identifiers.
 ///
 /// This is used to skip language prefixes from kind disambiguation information.

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+PathComponent.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+PathComponent.swift
@@ -13,16 +13,19 @@ import SymbolKit
 /// All known symbol kind identifiers.
 ///
 /// This is used to identify parsed path components as kind information.
-private let knownSymbolKinds = Set<String>(
-    (SymbolGraph.Symbol.KindIdentifier.allCases + [
+private let knownSymbolKinds: Set<String> = {
+    // There's nowhere else that registers these extended symbol kinds and we need to know them in this list.
+    SymbolGraph.Symbol.KindIdentifier.register(
         .extendedProtocol,
         .extendedStructure,
         .extendedClass,
         .extendedEnumeration,
         .unknownExtendedType,
-        .extendedModule,
-    ]).map(\.identifier)
-)
+        .extendedModule
+    )
+    return Set(SymbolGraph.Symbol.KindIdentifier.allCases.map(\.identifier))
+}()
+
 /// All known source language identifiers.
 ///
 /// This is used to skip language prefixes from kind disambiguation information.

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
@@ -115,7 +115,7 @@ struct PathHierarchy {
             }
             
             var topLevelCandidates = nodes
-            for relationship in graph.relationships where [.memberOf, .requirementOf, .optionalRequirementOf, .extensionTo, .declaredIn].contains(relationship.kind) {
+            for relationship in graph.relationships where relationship.kind.formsHierarchy {
                 guard let sourceNode = nodes[relationship.source] else {
                     continue
                 }
@@ -466,5 +466,17 @@ extension PathHierarchy.DisambiguationContainer {
                 return lhsValue
             })
         }))
+    }
+}
+
+private extension SymbolGraph.Relationship.Kind {
+    /// Whether or not this relationship kind forms a hierarchical relationship between the source and the target.
+    var formsHierarchy: Bool {
+        switch self {
+        case .memberOf, .requirementOf, .optionalRequirementOf, .extensionTo, .declaredIn:
+            return true
+        default:
+            return false
+        }
     }
 }

--- a/Tests/SwiftDocCTests/Test Bundles/ShadowExtendedModuleWithLocalSymbol.docc/Outer.symbols.json
+++ b/Tests/SwiftDocCTests/Test Bundles/ShadowExtendedModuleWithLocalSymbol.docc/Outer.symbols.json
@@ -1,0 +1,85 @@
+{
+    "metadata": {
+        "formatVersion": {
+            "major": 0,
+            "minor": 6,
+            "patch": 0
+        },
+        "generator": "Apple Swift version 5.9 (swiftlang-5.9.0.128.108 clang-1500.0.40.1)"
+    },
+    "module": {
+        "name": "Outer",
+        "platform": {
+            "architecture": "arm64",
+            "operatingSystem": {
+                "minimumVersion": {
+                    "major": 14,
+                    "minor": 0
+                },
+                "name": "macosx"
+            },
+            "vendor": "apple"
+        }
+    },
+    "relationships": [],
+    "symbols": [
+        {
+            "accessLevel": "public",
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "struct"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "Inner"
+                }
+            ],
+            "identifier": {
+                "interfaceLanguage": "swift",
+                "precise": "s:5Outer5InnerV"
+            },
+            "kind": {
+                "displayName": "Structure",
+                "identifier": "swift.struct"
+            },
+            "location": {
+                "position": {
+                    "character": 14,
+                    "line": 11
+                },
+                "uri": "file:///Users/username/path/to/ShadowExtendedModuleWithLocalSymbol/Outer.swift"
+            },
+            "names": {
+                "navigator": [
+                    {
+                        "kind": "identifier",
+                        "spelling": "Inner"
+                    }
+                ],
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "struct"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "Inner"
+                    }
+                ],
+                "title": "Inner"
+            },
+            "pathComponents": [
+                "Inner"
+            ]
+        }
+    ]
+}

--- a/Tests/SwiftDocCTests/Test Bundles/ShadowExtendedModuleWithLocalSymbol.docc/Outer@Inner.symbols.json
+++ b/Tests/SwiftDocCTests/Test Bundles/ShadowExtendedModuleWithLocalSymbol.docc/Outer@Inner.symbols.json
@@ -1,0 +1,326 @@
+{
+    "metadata": {
+        "formatVersion": {
+            "major": 0,
+            "minor": 6,
+            "patch": 0
+        },
+        "generator": "Apple Swift version 5.9 (swiftlang-5.9.0.128.108 clang-1500.0.40.1)"
+    },
+    "module": {
+        "name": "Outer",
+        "platform": {
+            "architecture": "arm64",
+            "operatingSystem": {
+                "minimumVersion": {
+                    "major": 14,
+                    "minor": 0
+                },
+                "name": "macosx"
+            },
+            "vendor": "apple"
+        }
+    },
+    "relationships": [
+        {
+            "kind": "extensionTo",
+            "source": "s:e:s:5Inner0A6StructV5OuterE9somethingyyF",
+            "target": "s:5Inner0A6StructV",
+            "targetFallback": "Inner.InnerStruct"
+        },
+        {
+            "kind": "extensionTo",
+            "source": "s:e:s:5Inner0A5ClassC5OuterE9somethingyyF",
+            "target": "s:5Inner0A5ClassC",
+            "targetFallback": "Inner.InnerClass"
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:5Inner0A5ClassC5OuterE9somethingyyF",
+            "target": "s:e:s:5Inner0A5ClassC5OuterE9somethingyyF",
+            "targetFallback": "Inner.InnerClass"
+        },
+        {
+            "kind": "memberOf",
+            "source": "s:5Inner0A6StructV5OuterE9somethingyyF",
+            "target": "s:e:s:5Inner0A6StructV5OuterE9somethingyyF",
+            "targetFallback": "Inner.InnerStruct"
+        }
+    ],
+    "symbols": [
+        {
+            "accessLevel": "public",
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "something"
+                },
+                {
+                    "kind": "text",
+                    "spelling": "()"
+                }
+            ],
+            "functionSignature": {
+                "returns": [
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "identifier": {
+                "interfaceLanguage": "swift",
+                "precise": "s:5Inner0A5ClassC5OuterE9somethingyyF"
+            },
+            "kind": {
+                "displayName": "Instance Method",
+                "identifier": "swift.method"
+            },
+            "location": {
+                "position": {
+                    "character": 9,
+                    "line": 17
+                },
+                "uri": "file:///Users/username/path/to/ShadowExtendedModuleWithLocalSymbol/Outer.swift"
+            },
+            "names": {
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "something"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ],
+                "title": "something()"
+            },
+            "pathComponents": [
+                "InnerClass",
+                "something()"
+            ],
+            "swiftExtension": {
+                "extendedModule": "Inner",
+                "typeKind": "swift.class"
+            }
+        },
+        {
+            "accessLevel": "public",
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "func"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "something"
+                },
+                {
+                    "kind": "text",
+                    "spelling": "()"
+                }
+            ],
+            "functionSignature": {
+                "returns": [
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ]
+            },
+            "identifier": {
+                "interfaceLanguage": "swift",
+                "precise": "s:5Inner0A6StructV5OuterE9somethingyyF"
+            },
+            "kind": {
+                "displayName": "Instance Method",
+                "identifier": "swift.method"
+            },
+            "location": {
+                "position": {
+                    "character": 9,
+                    "line": 14
+                },
+                "uri": "file:///Users/username/path/to/ShadowExtendedModuleWithLocalSymbol/Outer.swift"
+            },
+            "names": {
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "func"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "something"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": "()"
+                    }
+                ],
+                "title": "something()"
+            },
+            "pathComponents": [
+                "InnerStruct",
+                "something()"
+            ],
+            "swiftExtension": {
+                "extendedModule": "Inner",
+                "typeKind": "swift.struct"
+            }
+        },
+        {
+            "accessLevel": "public",
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "extension"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "preciseIdentifier": "s:5Inner0A5ClassC",
+                    "spelling": "InnerClass"
+                }
+            ],
+            "identifier": {
+                "interfaceLanguage": "swift",
+                "precise": "s:e:s:5Inner0A5ClassC5OuterE9somethingyyF"
+            },
+            "kind": {
+                "displayName": "Extension",
+                "identifier": "swift.extension"
+            },
+            "location": {
+                "position": {
+                    "character": 7,
+                    "line": 16
+                },
+                "uri": "file:///Users/username/path/to/ShadowExtendedModuleWithLocalSymbol/Outer.swift"
+            },
+            "names": {
+                "navigator": [
+                    {
+                        "kind": "identifier",
+                        "spelling": "InnerClass"
+                    }
+                ],
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "extension"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "preciseIdentifier": "s:5Inner0A5ClassC",
+                        "spelling": "InnerClass"
+                    }
+                ],
+                "title": "InnerClass"
+            },
+            "pathComponents": [
+                "InnerClass"
+            ],
+            "swiftExtension": {
+                "extendedModule": "Inner",
+                "typeKind": "swift.class"
+            }
+        },
+        {
+            "accessLevel": "public",
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "extension"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "typeIdentifier",
+                    "preciseIdentifier": "s:5Inner0A6StructV",
+                    "spelling": "InnerStruct"
+                }
+            ],
+            "identifier": {
+                "interfaceLanguage": "swift",
+                "precise": "s:e:s:5Inner0A6StructV5OuterE9somethingyyF"
+            },
+            "kind": {
+                "displayName": "Extension",
+                "identifier": "swift.extension"
+            },
+            "location": {
+                "position": {
+                    "character": 7,
+                    "line": 13
+                },
+                "uri": "file:///Users/username/path/to/ShadowExtendedModuleWithLocalSymbol/Outer.swift"
+            },
+            "names": {
+                "navigator": [
+                    {
+                        "kind": "identifier",
+                        "spelling": "InnerStruct"
+                    }
+                ],
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "extension"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "typeIdentifier",
+                        "preciseIdentifier": "s:5Inner0A6StructV",
+                        "spelling": "InnerStruct"
+                    }
+                ],
+                "title": "InnerStruct"
+            },
+            "pathComponents": [
+                "InnerStruct"
+            ],
+            "swiftExtension": {
+                "extendedModule": "Inner",
+                "typeKind": "swift.struct"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://109307328

## Summary

This resolves the root cause of a crash that occurred when a module shadowed the name of a module that it extended two or more times. For example, and "Outer" target that extends an "Inner" target and also shadows the "Inner" name with a top-level symbol

```swift
//  Inner.swift
public struct InnerStruct {}
public class InnerClass {}
```
```swift
// Outer.swift
import Inner
 
// Shadow the Inner module with a local top-level symbol
public struct Inner {}

// extend two or more types in Inner.
public extension InnerStruct {
    func something() {}
}
public extension InnerClass {
    func something() {}
}
```

Because `extensionTo` and `declaredIn` relationships weren't used to build up the path hierarchy, the two extensions used a fallback code path that tries to find a location in the path hierarchy based on a symbol's path components. When the `Outer/Inner` path is ambiguous (could refer to the top-level struct or to the module extension) and there are multiple extensions, this ended up creating an inconsistent path hierarchy resulting in some symbol's in the hierarchy not being findable. 

In debug builds there are assertions that diagnose this issue where it happens. In release builds this hits a precondition later in the build when one of the symbols doesn't have a resolved topic reference (because the path to the symbol isn't known).
```
Symbol with identifier has no reference. A symbol will always have at least one reference.
```

While writing a test for this I also noticed that
- extension symbols can't disambiguate links with their kind ("enum.extension")
- collision where only one symbol matched the rest of the path didn't process the full path if the collision happened in an early path component
- links that omitted the module name in the path always raised a module-not-found error even if the module found a matching top-level symbol and later encountered a more specific error.

Since these 3 issues impacted the test that I wanted to write for the crash fix I also fixed them in this PR.

## Dependencies

None

## Testing

In a project with two targets where one imports the other. In the "outer" target, extend two symbols from the "inner" project and also define a public top-level struct, enum, or class with the same name as the "inner" module.

Build documentation for the "outer" target. This shouldn't crash.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
