### PR TITLE
Disable the DefaultDiagnosticConsoleFormatter because of index-out-of-bounds crash

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Diagnostics/DiagnosticConsoleWriter.swift
+++ b/Sources/SwiftDocC/Infrastructure/Diagnostics/DiagnosticConsoleWriter.swift
@@ -42,7 +42,8 @@ public final class DiagnosticConsoleWriter: DiagnosticFormattingConsumer {
         highlight: Bool? = nil
     ) {
         outputStream = stream
-        formattingOptions = options
+        // Reenable `DefaultDiagnosticConsoleFormatter` as the default formatter when the index-out-of-bounds crash is fixed. https://github.com/apple/swift-docc/issues/722
+        formattingOptions = [.formatConsoleOutputForTools]
         diagnosticFormatter = Self.makeDiagnosticFormatter(
             options,
             baseURL: baseURL,

--- a/Tests/SwiftDocCTests/Diagnostics/DiagnosticConsoleWriterDefaultFormattingTest.swift
+++ b/Tests/SwiftDocCTests/Diagnostics/DiagnosticConsoleWriterDefaultFormattingTest.swift
@@ -12,7 +12,8 @@ import XCTest
 import Markdown
 @testable import SwiftDocC
 
-class DiagnosticConsoleWriterDefaultFormattingTest: XCTestCase {
+// Reenable `DefaultDiagnosticConsoleFormatter` as the default formatter when the index-out-of-bounds crash is fixed. https://github.com/apple/swift-docc/issues/722
+class DiagnosticConsoleWriterDefaultFormattingTest/*: XCTestCase*/ {
 
     class Logger: TextOutputStream {
         var output = ""


### PR DESCRIPTION
Bug/issue #, if applicable: https://github.com/apple/swift-docc/issues/678 rdar://116943708

## Summary

Always use `IDEDiagnosticConsoleFormatter` to format diagnostics to avoid a crash.

This is a smaller change than it would be to revert the PR that introduced `DefaultDiagnosticConsoleFormatter`.

## Dependencies

None.

## Testing

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- ~[ ] Added tests~
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
