### PR TITLE
[5.10] Check symbols are deprecated on at least one platform before marking unconditionally deprecated

### DIFF
--- a/Sources/SwiftDocC/Model/AvailabilityParser.swift
+++ b/Sources/SwiftDocC/Model/AvailabilityParser.swift
@@ -39,8 +39,11 @@ struct AvailabilityParser {
         }
         
         // Check if the symbol is unconditionally deprecated
-        return availability.availability
+        let isUnconditionallyDeprecated = availability.availability
             .allSatisfy { $0.isUnconditionallyDeprecated || $0.isUnconditionallyUnavailable || $0.deprecatedVersion != nil }
+            // If a symbol is unavailable on all known platforms, it should not be marked unconditionally deprecated.
+            && availability.availability.contains(where: { $0.isUnconditionallyDeprecated || $0.deprecatedVersion != nil })
+        return isUnconditionallyDeprecated
     }
     
     /// Determines a symbol's deprecation message that either applies to a given platform or that applies to all platforms.

--- a/Tests/SwiftDocCTests/Model/AvailabilityParserTests.swift
+++ b/Tests/SwiftDocCTests/Model/AvailabilityParserTests.swift
@@ -154,4 +154,52 @@ class AvailabilityParserTests: XCTestCase {
         XCTAssertTrue(compiler.isDeprecated())
         XCTAssertEqual(compiler.deprecationMessage(), "deprecated")
     }
+    
+    func testUnavailableIsNotDeprecated() throws {
+        let json = """
+        [
+            {
+                "domain": "tvOS",
+                "isUnconditionallyUnavailable" : true
+            }
+        ]
+        """
+        let availability = try JSONDecoder().decode(Availability.self, from: json.data(using: .utf8)!)
+        
+        /// Test all platforms
+        let compiler = AvailabilityParser(availability)
+        XCTAssertFalse(compiler.isDeprecated())
+    }
+    
+    func testAllPlatformsUnavailableOrDeprecatedIsMarkedDeprecated() throws {
+        let json = """
+        [
+            {
+                "domain": "tvOS",
+                "isUnconditionallyUnavailable" : true
+            },
+            {
+                "domain": "macOS",
+                "message" : "deprecated",
+                "deprecated": { "major": 10, "minor": 17 }
+            },
+            {
+                "domain": "iOS",
+                "message" : "deprecated",
+                "deprecated": { "major": 10, "minor": 17 }
+            },
+            {
+                "domain": "watchOS",
+                "message" : "deprecated",
+                "deprecated": { "major": 10, "minor": 17 }
+            }
+        ]
+        """
+        let availability = try JSONDecoder().decode(Availability.self, from: json.data(using: .utf8)!)
+        
+        /// Test all platforms
+        let compiler = AvailabilityParser(availability)
+        XCTAssertTrue(compiler.isDeprecated())
+        XCTAssertEqual(compiler.deprecationMessage(), "deprecated")
+    }
 }

--- a/Tests/SwiftDocCTests/Test Bundles/AvailabilityOverrideBundle.docc/Info.plist
+++ b/Tests/SwiftDocCTests/Test Bundles/AvailabilityOverrideBundle.docc/Info.plist
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDisplayName</key>
+	<string>AvailabilityBundle</string>
+	<key>CFBundleIdentifier</key>
+	<string>org.swift.docc.availability</string>
+	<key>CFBundleVersion</key>
+	<string>0.1.0</string>
+	<key>CDAppleDefaultAvailability</key>
+	<dict>
+		<key>MyKit</key>
+		<array>
+			<dict>
+				<key>name</key>
+				<string>Mac Catalyst</string>
+				<key>version</key>
+				<string>13.0</string>
+			</dict>
+			<dict>
+				<key>name</key>
+				<string>iOS</string>
+				<key>version</key>
+				<string>13.0</string>
+			</dict>
+			<dict>
+				<key>name</key>
+				<string>tvOS</string>
+				<key>version</key>
+				<string>13.0</string>
+			</dict>
+			<dict>
+				<key>name</key>
+				<string>watchOS</string>
+				<key>version</key>
+				<string>6.0</string>
+			</dict>
+			<dict>
+				<key>name</key>
+				<string>macOS</string>
+				<key>version</key>
+				<string>10.15</string>
+			</dict>
+		</array>
+	</dict>
+</dict>
+</plist>

--- a/Tests/SwiftDocCTests/Test Bundles/AvailabilityOverrideBundle.docc/mykit-iOS.symbols.json
+++ b/Tests/SwiftDocCTests/Test Bundles/AvailabilityOverrideBundle.docc/mykit-iOS.symbols.json
@@ -1,0 +1,559 @@
+{
+  "metadata": {
+      "formatVersion" : {
+          "major" : 1
+      },
+      "generator" : "app/1.0"
+  },
+  "module" : {
+    "name" : "MyKit",
+    "platform" : {
+      "architecture" : "x86_64",
+      "vendor" : "apple",
+      "operatingSystem" : {
+        "name" : "ios",
+        "minimumVersion" : {
+          "major" : 13,
+          "minor" : 0,
+          "patch" : 0
+        }
+      }
+    }
+  },
+  "symbols" : [
+    {
+      "accessLevel" : "public",
+      "kind" : {
+        "identifier" : "swift.class",
+        "displayName" : "Class"
+      },
+      "names" : {
+        "title" : "MyClass",
+        "subHeading" : [
+            {
+              "kind" : "keyword",
+              "spelling" : "class"
+            },
+            {
+              "kind" : "text",
+              "spelling" : " "
+            },
+            {
+              "kind" : "identifier",
+              "spelling" : "MyClass"
+            }
+        ],
+        "navigator" : [
+            {
+              "kind" : "identifier",
+              "spelling" : "MyClassNavigator"
+            }
+        ]
+      },
+      "availability" : [
+        {
+          "domain": "macOS",
+          "deprecated": {
+            "major": 10,
+            "minor": 0
+          }
+        },
+        {
+          "domain": "watchOS",
+          "deprecated": {
+            "major": 6,
+            "minor": 0
+          }
+        },
+        {
+          "domain": "tvOS",
+          "isUnconditionallyUnavailable": true
+        },
+        {
+          "domain": "iOS",
+          "deprecated": {
+            "major": 13,
+            "minor": 0
+          }
+        }
+      ],
+      "pathComponents" : [
+        "MyClass"
+      ],
+      "identifier" : {
+        "precise" : "s:5MyKit0A5ClassC",
+        "interfaceLanguage": "swift"
+      },
+      "declarationFragments" : [
+        {
+          "kind" : "keyword",
+          "spelling" : "class"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " "
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "MyClass"
+        }
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "kind" : {
+        "identifier" : "swift.method",
+        "displayName" : "Instance Method"
+      },
+      "names" : {
+        "title" : "myFunction()"
+      },
+      "pathComponents" : [
+        "MyClass",
+        "myFunction()"
+      ],
+      "identifier" : {
+        "precise" : "s:5MyKit0A5ClassC10myFunctionyyF",
+        "interfaceLanguage": "swift"
+      },
+      "docComment" : {
+        "lines" : [
+          {
+            "text" : "A cool API to call."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "- Parameters:"
+          },
+          {
+            "text" : "  - name: A parameter"
+          },
+          {
+            "text" : "- Returns: Return value"
+          }
+        ]
+      },
+      "declarationFragments" : [
+        {
+          "kind" : "keyword",
+          "spelling" : "func"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " "
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "myFunction"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "("
+        },
+        {
+          "kind" : "externalParam",
+          "spelling" : "for"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " "
+        },
+        {
+          "kind" : "internalParam",
+          "spelling" : "name"
+        },
+        {
+          "kind" : "unhandledTokenKind",
+          "spelling" : "..."
+        },
+        {
+          "kind" : "text",
+          "spelling" : ")"
+        }
+      ],
+      "swiftExtension" : {
+        "extendedModule": "MyKit",
+        "constraints" : [
+          {
+            "kind" : "sameType",
+            "lhs" : "Label",
+            "rhs" : "Text"
+          },
+          {
+            "kind" : "superclass",
+            "lhs" : "Observer",
+            "rhs" : "NSObject"
+          },
+          {
+            "kind" : "conformance",
+            "lhs" : "S",
+            "rhs" : "StringProtocol"
+          }
+        ]
+      }
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "keyword",
+          "spelling" : "func"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " "
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "globalFunction"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "("
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "_"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "preciseIdentifier" : "s:10Foundation4DataV",
+          "spelling" : "Data"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ", "
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "considering"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "preciseIdentifier" : "s:Si",
+          "spelling" : "Int"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ")"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+
+        ]
+      },
+      "functionSignature" : {
+        "parameters" : [
+          {
+            "declarationFragments" : [
+              {
+                "kind" : "identifier",
+                "spelling" : "data"
+              },
+              {
+                "kind" : "text",
+                "spelling" : ": "
+              },
+              {
+                "kind" : "typeIdentifier",
+                "preciseIdentifier" : "s:10Foundation4DataV",
+                "spelling" : "Data"
+              }
+            ],
+            "name" : "data"
+          },
+          {
+            "declarationFragments" : [
+              {
+                "kind" : "identifier",
+                "spelling" : "considering"
+              },
+              {
+                "kind" : "text",
+                "spelling" : ": "
+              },
+              {
+                "kind" : "typeIdentifier",
+                "preciseIdentifier" : "s:Si",
+                "spelling" : "Int"
+              }
+            ],
+            "name" : "considering"
+          }
+        ],
+        "returns" : [
+          {
+            "kind" : "text",
+            "spelling" : "()"
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "s:5MyKit14globalFunction_11consideringy10Foundation4DataV_SitF"
+      },
+      "kind" : {
+        "displayName" : "Function",
+        "identifier" : "swift.func"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "keyword",
+            "spelling" : "func"
+          },
+          {
+            "kind" : "text",
+            "spelling" : " "
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "globalFunction"
+          },
+          {
+            "kind" : "text",
+            "spelling" : "("
+          },
+          {
+            "kind" : "typeIdentifier",
+            "preciseIdentifier" : "s:10Foundation4DataV",
+            "spelling" : "Data"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ", "
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "considering"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "preciseIdentifier" : "s:Si",
+            "spelling" : "Int"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ")"
+          },
+          {
+            "kind" : "text",
+            "spelling" : "\n"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "keyword",
+            "spelling" : "func"
+          },
+          {
+            "kind" : "text",
+            "spelling" : " "
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "globalFunction"
+          },
+          {
+            "kind" : "text",
+            "spelling" : "("
+          },
+          {
+            "kind" : "typeIdentifier",
+            "preciseIdentifier" : "s:10Foundation4DataV",
+            "spelling" : "Data"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ", "
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "considering"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "preciseIdentifier" : "s:Si",
+            "spelling" : "Int"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ")"
+          },
+          {
+            "kind" : "text",
+            "spelling" : "\n"
+          }
+        ],
+        "title" : "globalFunction(_:considering:)"
+      },
+      "pathComponents" : [
+        "globalFunction(_:considering:)"
+      ]
+    },
+    {
+      "accessLevel" : "internal",
+      "kind" : {
+        "identifier" : "swift.init",
+        "displayName" : "Initializer"
+      },
+      "names" : {
+        "title" : "init()"
+      },
+      "pathComponents" : [
+        "MyClass",
+        "init()"
+      ],
+      "identifier" : {
+        "precise" : "s:5MyKit0A5ClassCACycfc",
+        "interfaceLanguage": "swift"
+      }
+    },
+    {
+      "accessLevel" : "internal",
+      "kind" : {
+        "identifier" : "swift.init",
+        "displayName" : "Initializer"
+      },
+      "names" : {
+        "title" : "init()"
+      },
+      "pathComponents" : [
+        "MyClass",
+        "init()"
+      ],
+      "identifier" : {
+        "precise" : "s:5MyKit0A5ClassCACycfcDUPLICATE",
+        "interfaceLanguage" : "swift"
+      }
+    },
+    {
+      "accessLevel" : "public",
+      "kind" : {
+        "identifier" : "swift.protocol",
+        "displayName" : "Protocol"
+      },
+      "names" : {
+        "title" : "MyProtocol",
+        "navigator": [
+          {
+            "kind" : "identifier",
+            "spelling" : "MyProtocol"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind" : "keyword",
+            "spelling" : "protocol"
+          },
+          {
+            "kind" : "text",
+            "spelling" : " "
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "MyProtocol"
+          },
+          {
+            "kind" : "text",
+            "spelling" : " : "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "spelling" : "Hashable",
+            "preciseIdentifier" : "p:hPP"
+          }
+        ]
+      },
+      "pathComponents" : [
+        "MyProtocol"
+      ],
+      "identifier" : {
+        "precise" : "s:5MyKit0A5ProtocolP",
+        "interfaceLanguage": "swift"
+      },
+      "declarationFragments" : [
+        {
+          "kind" : "keyword",
+          "spelling" : "protocol"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " "
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "MyProtocol"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " : "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Hashable",
+          "preciseIdentifier" : "p:hPP"
+        }
+      ]
+    }
+  ],
+  "relationships" : [
+    {
+      "source" : "s:5MyKit0A5ProtocolP",
+      "target" : "s:5Foundation0A5NSCodableP",
+      "kind" : "conformsTo",
+      "targetFallback": "Foundation.NSCodable"
+    },
+    {
+      "source" : "s:5MyKit0A5ProtocolP",
+      "target" : "s:5Foundation0A5EarhartP",
+      "kind" : "conformsTo"
+    },
+    {
+      "source" : "s:5MyKit0A5ClassC",
+      "target" : "s:5MyKit0A5ProtocolP",
+      "kind" : "conformsTo",
+      "swiftConstraints" : [
+        {
+            "kind" : "conformance",
+            "lhs" : "Element",
+            "rhs" : "Equatable"
+        }
+      ]
+    },
+    {
+      "source" : "s:5MyKit0A5ClassC10myFunctionyyF",
+      "target" : "s:5MyKit0A5ClassC",
+      "kind" : "memberOf"
+    },
+    {
+      "source" : "s:5MyKit0A5ClassCACycfc",
+      "target" : "s:5MyKit0A5ClassC",
+      "kind" : "memberOf"
+    },
+    {
+      "source" : "s:5MyKit0A5ClassCACycfcDUPLICATE",
+      "target" : "s:5MyKit0A5ClassC",
+      "kind" : "memberOf"
+    }
+  ]
+}


### PR DESCRIPTION
Cherry pick of #712 

- Explanation:  If a symbol is marked unavailable on all the platforms DocC has availability information about, DocC can mark the symbol unconditionally deprecated. This commit adds a check that the symbol is deprecated on at least one platform before the symbol can be displayed as unconditionally deprecated.
- Scope: When no default availability is given to DocC, some symbols can be displayed as deprecated incorrectly.
- Issue: rdar://116485743
- Risk: Low
- Testing: Added unit tests to confirm a symbol has the correct deprecation with an unavailable platform and with both unavailable and deprecated platforms.
- Reviewer: @QuietMisdreavus 