### PR TITLE
[5.10] Fix render node decoder for single-article documentation archives

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/RenderNode/RenderNode+Codable.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNode/RenderNode+Codable.swift
@@ -22,7 +22,7 @@ extension RenderNode: Codable {
         
         identifier = try container.decode(ResolvedTopicReference.self, forKey: .identifier)
         sections = try container.decode([CodableRenderSection].self, forKey: .sections).map { $0.section }
-        references = try container.decode([String: CodableRenderReference].self, forKey: .references).mapValues({$0.reference})
+        references = try (container.decodeIfPresent([String: CodableRenderReference].self, forKey: .references) ?? [:]).mapValues({$0.reference})
         metadata = try container.decode(RenderMetadata.self, forKey: .metadata)
         kind = try container.decode(Kind.self, forKey: .kind)
         hierarchy = try container.decodeIfPresent(RenderHierarchy.self, forKey: .hierarchy)

--- a/Tests/SwiftDocCTests/Converter/RenderNodeCodableTests.swift
+++ b/Tests/SwiftDocCTests/Converter/RenderNodeCodableTests.swift
@@ -46,6 +46,10 @@ class RenderNodeCodableTests: XCTestCase {
             XCTAssertTrue(description.contains("schemaVersion"), "Missing key name in error description")
         }
     }
+    func testMissingReferenceKey() throws {
+        let renderNode = try! RenderNode.decode(fromJSON: missingReferenceKeyJSON)
+        XCTAssertNotNil(renderNode)
+    }
     
     func testTypeMismatchError() {
         do {
@@ -243,4 +247,7 @@ fileprivate let corruptedJSON = Data("{{}".utf8)
 fileprivate let emptyJSON = Data("{}".utf8)
 fileprivate let typeMismatch = Data("""
 {"schemaVersion":{"major":"type mismatch","minor":0,"patch":0}}
+""".utf8)
+fileprivate let missingReferenceKeyJSON = Data("""
+{"kind":"article","identifier":{"interfaceLanguage":"","url":"doc://org.swift.docc.example/documentation/Test-Bundle/article"},"abstract":[],"metadata":{},"schemaVersion":{"minor":3,"patch":0,"major":0},"sections":[],"hierarchy":{"paths":[[]]}}
 """.utf8)

--- a/Tests/SwiftDocCUtilitiesTests/Test Bundles/SingleArticleTestBundle.docc/Info.plist
+++ b/Tests/SwiftDocCUtilitiesTests/Test Bundles/SingleArticleTestBundle.docc/Info.plist
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleName</key>
+	<string>SingleArticleTestBundle</string>
+	<key>CFBundleDisplayName</key>
+	<string>SingleArticle Test Bundle</string>
+	<key>CFBundleIdentifier</key>
+	<string>org.swift.docc.example</string>
+	<key>CFBundleIconFile</key>
+	<string>DocumentationIcon</string>
+	<key>CFBundleIconName</key>
+	<string>DocumentationIcon</string>
+	<key>CFBundlePackageType</key>
+	<string>DOCS</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>0.1.0</string>
+	<key>CDDefaultCodeListingLanguage</key>
+	<string>swift</string>
+	<key>CFBundleShortVersionString</key>
+	<string>0.1.0</string>
+	<key>CDAppleDefaultAvailability</key>
+	<dict>
+		<key>FillIntroduced</key>
+		<array>
+			<dict>
+				<key>name</key>
+				<string>macOS</string>
+				<key>version</key>
+				<string>10.9</string>
+			</dict>
+			<dict>
+				<key>name</key>
+				<string>iOS</string>
+				<key>version</key>
+				<string>11.1</string>
+			</dict>
+			<dict>
+				<key>name</key>
+				<string>tvOS</string>
+				<key>version</key>
+				<string>12.2</string>
+			</dict>
+			<dict>
+				<key>name</key>
+				<string>watchOS</string>
+				<key>version</key>
+				<string>13.3</string>
+			</dict>
+		</array>
+	</dict>
+</dict>
+</plist>

--- a/Tests/SwiftDocCUtilitiesTests/Test Bundles/SingleArticleTestBundle.docc/article.md
+++ b/Tests/SwiftDocCUtilitiesTests/Test Bundles/SingleArticleTestBundle.docc/article.md
@@ -1,0 +1,14 @@
+# Article
+
+@Metadata {
+  @TechnologyRoot
+}
+
+This is an article.
+
+## Overview
+
+Overview
+
+
+<!-- Copyright (c) 2023 Apple Inc and the Swift Project authors. All Rights Reserved. -->


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift-docc/pull/692

- **Explanation:** Fix bug where the Render Node decoder was failing in the absence of the references key.
- Scope: Single-article catalogs don't get displayed properly in the Xcode doc viewer and single-article archives don't get the index generated correctly.
- **Issue:** https://github.com/apple/swift-docc/issues/711 / rdar://111186939
- **Risk:** Low.
- **Testing:** Added test that verifies the expected render node decoder doesn't fail in the absence of the `references` key and that the index gets generated as expected. Manually tested.
- **Reviewer:** @d-ronnqvist 