### PR TITLE
Use new SwiftPM flag to remove `$ORIGIN` from installed docc ELF executable runpath

### DIFF
--- a/build-script-helper.py
+++ b/build-script-helper.py
@@ -171,6 +171,8 @@ def get_swiftpm_options(action, args):
       # Library rpath for swift, dispatch, Foundation, etc. when installing
       '-Xlinker', '-rpath', '-Xlinker', '$ORIGIN/../lib/swift/' + build_os,
     ]
+    if action == 'install':
+      swiftpm_args += ['--disable-local-rpath']
   
   cross_compile_hosts = args.cross_compile_hosts
   if cross_compile_hosts:


### PR DESCRIPTION
The latest trunk snapshot toolchain shows five executables built by SwiftPM that incorrectly have this runpath, including `docc` from this repo:
```
> readelf -d swift-DEVELOPMENT-SNAPSHOT-2023-10-10-a-ubuntu20.04/usr/bin/*|ag "File:|runpath"|ag "ORIGIN[^/]" -B1
File: swift-DEVELOPMENT-SNAPSHOT-2023-10-10-a-ubuntu20.04/usr/bin/docc
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN:$ORIGIN/../lib/swift/linux]
File: swift-DEVELOPMENT-SNAPSHOT-2023-10-10-a-ubuntu20.04/usr/bin/sourcekit-lsp
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN:$ORIGIN/../lib/swift/linux]
File: swift-DEVELOPMENT-SNAPSHOT-2023-10-10-a-ubuntu20.04/usr/bin/swift-build-sdk-interfaces
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN:$ORIGIN/../lib/swift/linux]
File: swift-DEVELOPMENT-SNAPSHOT-2023-10-10-a-ubuntu20.04/usr/bin/swift-driver
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN:$ORIGIN/../lib/swift/linux]
File: swift-DEVELOPMENT-SNAPSHOT-2023-10-10-a-ubuntu20.04/usr/bin/swift-help
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN:$ORIGIN/../lib/swift/linux]
```
This will remove that unneeded runpath, as I just did for `swift-package` in apple/swift-package-manager#6947. I limited this to non-Darwin installs because I have no idea if this would be useful on Darwin too.