### PR TITLE
[5.10] Use new SwiftPM flag to remove `$ORIGIN` from installed docc ELF executable runpath (#738)

### DIFF
--- a/build-script-helper.py
+++ b/build-script-helper.py
@@ -171,6 +171,8 @@ def get_swiftpm_options(action, args):
       # Library rpath for swift, dispatch, Foundation, etc. when installing
       '-Xlinker', '-rpath', '-Xlinker', '$ORIGIN/../lib/swift/' + build_os,
     ]
+    if action == 'install':
+      swiftpm_args += ['--disable-local-rpath']
   
   cross_compile_hosts = args.cross_compile_hosts
   if cross_compile_hosts:


### PR DESCRIPTION
Cherrypick of #738

__Explanation:__ Without this flag, `docc` looks in `usr/bin/` first for shared libraries, but there are none in that executable directory.

__Scope:__ installed executable runpath

__Issue:__ none

__Risk:__ none, there were no shared libraries there

__Testing:__ SwiftPM merged using this flag into trunk and 5.10 last week, no problems with `swift-package` itself so far.

__Reviewer:__ @Kyle-Ye