### PR TITLE
[5.10] Fix duplicated diagnostic issue

### DIFF
--- a/Sources/SwiftDocC/Semantics/MarkupReferenceResolver.swift
+++ b/Sources/SwiftDocC/Semantics/MarkupReferenceResolver.swift
@@ -80,6 +80,13 @@ struct MarkupReferenceResolver: MarkupRewriter {
             return resolved
             
         case .failure(let unresolved, let error):
+            if let rangeLowerBoundSource = range?.lowerBound.source,
+               let rangeUpperBoundSource = range?.upperBound.source,
+               let source = source,
+               source != rangeLowerBoundSource || source != rangeUpperBoundSource {
+                return nil
+            }
+
             if let callback = problemForUnresolvedReference,
                let problem = callback(unresolved, source, range, fromSymbolLink, error.message) {
                 problems.append(problem)

--- a/Tests/SwiftDocCTests/Semantics/MarkupReferenceResolverTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/MarkupReferenceResolverTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2022-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -26,5 +26,15 @@ class MarkupReferenceResolverTests: XCTestCase {
         var resolver = MarkupReferenceResolver(context: context, bundle: bundle, source: nil, rootReference: context.rootModules[0])
         _ = resolver.visit(document)
         XCTAssertEqual(0, resolver.problems.count)
+    }
+
+    func testDuplicatedDiagnosticForExtensionFile() throws {
+        let (_, context) = try testBundleAndContext(named: "ExtensionArticleBundle")
+        // Before #733, symbols with documentation extension files emitted duplicated problems:
+        // - one with a source location in the in-source documentation comment
+        // - one with a source location in the documentation extension file.
+        // The source range was only valid for one of these diagnostics. This resulted in an index out of range crash in DefaultDiagnosticConsoleFormatter when displaying line that caused the problem to the user
+        XCTAssertEqual(1, context.problems.count)
+        XCTAssertEqual("Server.md", context.problems.first?.diagnostic.source?.lastPathComponent)
     }
 }

--- a/Tests/SwiftDocCTests/Test Bundles/ExtensionArticleBundle.docc/Server.md
+++ b/Tests/SwiftDocCTests/Test Bundles/ExtensionArticleBundle.docc/Server.md
@@ -1,0 +1,6 @@
+# ``Server``
+
+<!-- The correct signature is ``Server/echo(_:)``-->
+Check this awesome function ``Server/echo()``
+
+<!-- Copyright (c) 2023 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Tests/SwiftDocCTests/Test Bundles/ExtensionArticleBundle.docc/ServerKit.symbols.json
+++ b/Tests/SwiftDocCTests/Test Bundles/ExtensionArticleBundle.docc/ServerKit.symbols.json
@@ -1,0 +1,130 @@
+{
+    "metadata": {
+        "formatVersion": { "major": 0, "minor": 6, "patch": 0 },
+        "generator": "Apple Swift version 5.9 (swiftlang-5.9.0.128.108 clang-1500.0.40.1)"
+    },
+    "module": {
+        "name": "ServerKit",
+        "platform": {
+            "architecture": "arm64",
+            "vendor": "apple",
+            "operatingSystem": {
+                "name": "ios",
+                "minimumVersion": { "major": 12, "minor": 0 }
+            }
+        }
+    },
+    "symbols": [
+        {
+            "kind": {
+                "identifier": "swift.method",
+                "displayName": "Instance Method"
+            },
+            "identifier": {
+                "precise": "s:9ServerKit0A0C4echoyySSF",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": ["Server", "echo(_:)"],
+            "names": {
+                "title": "echo(_:)",
+                "subHeading": [
+                    { "kind": "keyword", "spelling": "func" },
+                    { "kind": "text", "spelling": " " },
+                    { "kind": "identifier", "spelling": "echo" },
+                    { "kind": "text", "spelling": "(" },
+                    {
+                        "kind": "typeIdentifier",
+                        "spelling": "String",
+                        "preciseIdentifier": "s:SS"
+                    },
+                    { "kind": "text", "spelling": ")" }
+                ]
+            },
+            "functionSignature": {
+                "parameters": [
+                    {
+                        "name": "message",
+                        "declarationFragments": [
+                            { "kind": "identifier", "spelling": "message" },
+                            { "kind": "text", "spelling": ": " },
+                            {
+                                "kind": "typeIdentifier",
+                                "spelling": "String",
+                                "preciseIdentifier": "s:SS"
+                            }
+                        ]
+                    }
+                ],
+                "returns": [{ "kind": "text", "spelling": "()" }]
+            },
+            "declarationFragments": [
+                { "kind": "keyword", "spelling": "func" },
+                { "kind": "text", "spelling": " " },
+                { "kind": "identifier", "spelling": "echo" },
+                { "kind": "text", "spelling": "(" },
+                { "kind": "externalParam", "spelling": "_" },
+                { "kind": "text", "spelling": " " },
+                { "kind": "internalParam", "spelling": "message" },
+                { "kind": "text", "spelling": ": " },
+                {
+                    "kind": "typeIdentifier",
+                    "spelling": "String",
+                    "preciseIdentifier": "s:SS"
+                },
+                { "kind": "text", "spelling": ")" }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///tmp/Server.swift",
+                "position": { "line": 2, "character": 16 }
+            }
+        },
+        {
+            "kind": { "identifier": "swift.class", "displayName": "Class" },
+            "identifier": {
+                "precise": "s:9ServerKit0A0C",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": ["Server"],
+            "names": {
+                "title": "Server",
+                "navigator": [{ "kind": "identifier", "spelling": "Server" }],
+                "subHeading": [
+                    { "kind": "keyword", "spelling": "class" },
+                    { "kind": "text", "spelling": " " },
+                    { "kind": "identifier", "spelling": "Server" }
+                ]
+            },
+            "docComment": {
+                "uri": "file:///tmp/Server.swift",
+                "module": "ServerKit",
+                "lines": [
+                    {
+                        "range": {
+                            "start": { "line": 0, "character": 4 },
+                            "end": { "line": 0, "character": 15 }
+                        },
+                        "text": "Hello World"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                { "kind": "keyword", "spelling": "class" },
+                { "kind": "text", "spelling": " " },
+                { "kind": "identifier", "spelling": "Server" }
+            ],
+            "accessLevel": "public",
+            "location": {
+                "uri": "file:///tmp/Server.swift",
+                "position": { "line": 1, "character": 13 }
+            }
+        }
+    ],
+    "relationships": [
+        {
+            "kind": "memberOf",
+            "source": "s:9ServerKit0A0C4echoyySSF",
+            "target": "s:9ServerKit0A0C"
+        }
+    ]
+}


### PR DESCRIPTION
Cherrypick of #733
- **Explanation**: Fix duplicated diagnostic issue
- **Scope**: Fix a potential index out of range crash in DefaultDiagnosticConsoleFormatter
- **GitHub Issue**: #729
- **Risk**: Low
- **Testing**: See `func testDuplicatedDiagnosticForExtensionFile()` in `MarkupReferenceResolverTests.swift`
- **Reviewer**: @d-ronnqvist 
