### PR TITLE
[5.10] Fix symbol link parsing bug for disambiguated subtraction operators

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+PathComponent.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+PathComponent.swift
@@ -108,10 +108,11 @@ extension PathHierarchy {
         if let dashIndex = name.lastIndex(of: "-") {
             let kind = String(name[dashIndex...].dropFirst())
             let name = String(name[..<dashIndex])
-            if let languagePrefix = knownLanguagePrefixes.first(where: { kind.starts(with: $0) }) {
-                return PathComponent(full: full, name: name, kind: String(kind.dropFirst(languagePrefix.count)), hash: hash)
-            } else {
+            if knownSymbolKinds.contains(kind) {
                 return PathComponent(full: full, name: name, kind: kind, hash: hash)
+            } else if let languagePrefix = knownLanguagePrefixes.first(where: { kind.starts(with: $0) }) {
+                let kindWithoutLanguage = String(kind.dropFirst(languagePrefix.count))
+                return PathComponent(full: full, name: name, kind: kindWithoutLanguage, hash: hash)
             }
         }
         return PathComponent(full: full, name: name, kind: nil, hash: hash)

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -1667,7 +1667,7 @@ let expected = """
             try """
             # ``Operators/MyNumber``
             
-            A documentation extension that curates symbosl with characters not allowed in a resolved reference URL.
+            A documentation extension that curates symbols with characters not allowed in a resolved reference URL.
 
             ## Topics
 
@@ -1675,6 +1675,9 @@ let expected = """
             - ``>(_:_:)``
             - ``<=(_:_:)``
             - ``>=(_:_:)``
+            - ``-(_:_:)-22pw2``
+            - ``-(_:)-9xdx0``
+            - ``-=(_:_:)-7w3vn``
             """.write(to: root.appendingPathComponent("doc-extension.md"), atomically: true, encoding: .utf8)
         }
         

--- a/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
@@ -1326,6 +1326,14 @@ class PathHierarchyTests: XCTestCase {
         XCTAssertEqual(try tree.findSymbol(path: "<=(_:_:)", parent: myNumberID).identifier.precise, "s:SLsE2leoiySbx_xtFZ::SYNTHESIZED::s:9Operators8MyNumberV")
         XCTAssertEqual(try tree.findSymbol(path: ">=(_:_:)", parent: myNumberID).identifier.precise, "s:SLsE2geoiySbx_xtFZ::SYNTHESIZED::s:9Operators8MyNumberV")
         
+        XCTAssertEqual(try tree.findSymbol(path: "-(_:_:)-22pw2", parent: myNumberID).identifier.precise, "s:9Operators8MyNumberV1soiyA2C_ACtFZ")
+        XCTAssertEqual(try tree.findSymbol(path: "-(_:)-9xdx0", parent: myNumberID).identifier.precise, "s:s13SignedNumericPsE1sopyxxFZ::SYNTHESIZED::s:9Operators8MyNumberV")
+        XCTAssertEqual(try tree.findSymbol(path: "-=(_:_:)-7w3vn", parent: myNumberID).identifier.precise, "s:s18AdditiveArithmeticPsE2seoiyyxz_xtFZ::SYNTHESIZED::s:9Operators8MyNumberV")
+        
+        XCTAssertEqual(try tree.findSymbol(path: "-(_:_:)-func.op", parent: myNumberID).identifier.precise, "s:9Operators8MyNumberV1soiyA2C_ACtFZ")
+        XCTAssertEqual(try tree.findSymbol(path: "-(_:)-func.op", parent: myNumberID).identifier.precise, "s:s13SignedNumericPsE1sopyxxFZ::SYNTHESIZED::s:9Operators8MyNumberV")
+        XCTAssertEqual(try tree.findSymbol(path: "-=(_:_:)-func.op", parent: myNumberID).identifier.precise, "s:s18AdditiveArithmeticPsE2seoiyyxz_xtFZ::SYNTHESIZED::s:9Operators8MyNumberV")
+        
         let paths = tree.caseInsensitiveDisambiguatedPaths()
         
         // Unmodified operator name in URL
@@ -1616,6 +1624,8 @@ class PathHierarchyTests: XCTestCase {
         assertParsedPathComponents("path-swift.type.property-hash", [("path", "type.property", "hash")])
         assertParsedPathComponents("path-type.property", [("path", "type.property", nil)])
         assertParsedPathComponents("path-swift.type.property", [("path", "type.property", nil)])
+        
+        assertParsedPathComponents("-(_:_:)-hash", [("-(_:_:)", nil, "hash")])
     }
     
     // MARK: Test helpers


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift-docc/pull/739

- **Explanation**: A link parsing inconsistency led to subtraction operators (`-(_:_:)`) not being findable if link had hash disambiguation but findable if it redundantly specified both the kind (`-func.op`) and the hash `-abc123`.
- **Scope**: Parsing of authored DocC symbol links.
- **Issue**: rdar://118234516 
- **Risk**: Low. 
- **Testing**: Added tests that both verify the specific parsing behavior and that verifies that such links resolve to the expected symbol when encountered in content.
- **Reviewer**: @patshaughnessy 