### PR TITLE
Fix problem where API Collections had no roleHeading assigned

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -736,9 +736,22 @@ public struct RenderNodeTranslator: SemanticVisitor {
         node.topicSectionsStyle = topicsSectionStyle(for: documentationNode)
         
         if shouldCreateAutomaticRoleHeading(for: documentationNode) {
+            // If there are no links to other nodes from the article,
+            // set the eyebrow for articles.
             if node.topicSections.isEmpty {
                 // Set an eyebrow for articles
                 node.metadata.roleHeading = "Article"
+            }
+            // If the article links to other nodes, set the eyebrow for
+            // API Collections if any linked node is a symbol.
+            else {
+                let isAPICollection = contentCompiler.collectedTopicReferences.contains { topicReference in
+                    context.topicGraph.nodeWithReference(topicReference)?.kind.isSymbol ?? false
+                }
+                if isAPICollection {
+                    // Set an eyebrow for API Collection
+                    node.metadata.roleHeading = "API Collection"
+                }
             }
             node.metadata.role = contentRenderer.roleForArticle(article, nodeKind: documentationNode.kind).rawValue
         }

--- a/Tests/SwiftDocCTests/Test Bundles/MixedManualAutomaticCuration.docc/Article.md
+++ b/Tests/SwiftDocCTests/Test Bundles/MixedManualAutomaticCuration.docc/Article.md
@@ -1,0 +1,7 @@
+# Article
+
+My Article Abstract.
+
+My Article Content.
+
+<!-- Copyright (c) 2023 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Tests/SwiftDocCTests/Test Bundles/MixedManualAutomaticCuration.docc/Collection.md
+++ b/Tests/SwiftDocCTests/Test Bundles/MixedManualAutomaticCuration.docc/Collection.md
@@ -1,0 +1,13 @@
+# Collection
+
+My Collection Abstract.
+
+My Collection Content.
+
+## Topics
+
+### Basics
+
+- <doc:MyArticle>
+
+<!-- Copyright (c) 2023 Apple Inc and the Swift Project authors. All Rights Reserved. -->


### PR DESCRIPTION
<!--
If you're opening a PR to cherry-pick a change for a release branch, use this template instead:
https://github.com/apple/swift-docc/blob/main/.github/PULL_REQUEST_TEMPLATE/CHERRY_PICK.md
-->

Bug/issue #, if applicable: rdar://90789460

## Summary

The eyebrow title for articles curating a list of symbols should display 'API Collection'. Prior to this fix, the eyebrow did not show anything.

'API Collection' now appears whenever one of the curated items in the Topics section is a symbol. If the entire list does not contain a symbol (i.e., it's a plain collection), we maintain the old behavior of not displaying anything as the eyebrow title.

## Dependencies

N/A

## Testing

Steps:
1. Create a markdown file inside a doc catalog that curates multiple symbols under the Topics section.
2. Preview the documentation
3. Check that the markdown file has an eyebrow title displaying 'API Collection'

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [ ] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary
