### PR TITLE
Add `optionalMemberOf` symbol under the correct container symbol

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
@@ -599,7 +599,7 @@ private extension SymbolGraph.Relationship.Kind {
     /// Whether or not this relationship kind forms a hierarchical relationship between the source and the target.
     var formsHierarchy: Bool {
         switch self {
-        case .memberOf, .requirementOf, .optionalRequirementOf, .extensionTo, .declaredIn:
+        case .memberOf, .optionalMemberOf, .requirementOf, .optionalRequirementOf, .extensionTo, .declaredIn:
             return true
         default:
             return false


### PR DESCRIPTION

<!--
If you're opening a PR to cherry-pick a change for a release branch, use this template instead:
https://github.com/apple/swift-docc/blob/main/.github/PULL_REQUEST_TEMPLATE/CHERRY_PICK.md
-->

Bug/issue #, if applicable: rdar://119183922

## Summary

Fix a bug where `optionalMemberOf` relationships weren't considered when building the path hierarchy, resulting in incorrect behavior if more than one symbol exist with the container's name.

## Dependencies

None

## Testing

_Describe how a reviewer can test the functionality of your PR. Provide test content to test with if
applicable._

Steps:
1. _Provide setup instructions._
2. _Explain in detail how the functionality can be tested._

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
