### PR TITLE
[5.10] Add `optionalMemberOf` symbol under the correct container symbol (#760)

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
@@ -527,7 +527,7 @@ private extension SymbolGraph.Relationship.Kind {
     /// Whether or not this relationship kind forms a hierarchical relationship between the source and the target.
     var formsHierarchy: Bool {
         switch self {
-        case .memberOf, .requirementOf, .optionalRequirementOf, .extensionTo, .declaredIn:
+        case .memberOf, .optionalMemberOf, .requirementOf, .optionalRequirementOf, .extensionTo, .declaredIn:
             return true
         default:
             return false

--- a/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
@@ -1612,6 +1612,35 @@ class PathHierarchyTests: XCTestCase {
         XCTAssertEqual(paths[memberID], "/ModuleName/ContainerName/MemberName")
     }
     
+    func testOptionalMemberUnderCorrectContainer() throws {
+        let containerID = "some-container-symbol-id"
+        let otherID = "some-other-symbol-id"
+        let memberID = "some-member-symbol-id"
+        
+        let exampleDocumentation = Folder(name: "unit-test.docc", content: [
+            JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(
+                moduleName: "ModuleName",
+                symbols: [
+                    (containerID, .swift, ["ContainerName"]),
+                    (otherID, .swift, ["ContainerName"]),
+                    (memberID, .swift, ["ContainerName", "MemberName1"]),
+                ],
+                relationships: [
+                    .init(source: memberID, target: containerID, kind: .optionalMemberOf, targetFallback: nil),
+                ]
+            ))
+        ])
+        
+        let tempURL = try createTempFolder(content: [exampleDocumentation])
+        let (_, _, context) = try loadBundle(from: tempURL)
+        let tree = try XCTUnwrap(context.hierarchyBasedLinkResolver?.pathHierarchy)
+        
+        let paths = tree.caseInsensitiveDisambiguatedPaths(includeDisambiguationForUnambiguousChildren: true)
+        XCTAssertEqual(paths[otherID], "/ModuleName/ContainerName-2vaqf")
+        XCTAssertEqual(paths[containerID], "/ModuleName/ContainerName-qwwf")
+        XCTAssertEqual(paths[memberID], "/ModuleName/ContainerName-qwwf/MemberName1")
+    }
+    
     func testMultiPlatformModuleWithExtension() throws {
         let (_, context) = try testBundleAndContext(named: "MultiPlatformModuleWithExtension")
         let tree = try XCTUnwrap(context.hierarchyBasedLinkResolver?.pathHierarchy)


### PR DESCRIPTION
Cherrypick of #760

**Explanation**: Fix a bug where `optionalMemberOf` relationships weren't considered when building the path hierarchy, resulting in incorrect behavior if more than one symbol existed with the container's name.
**Scope**: Incorrect behavior. Sometimes crashes.
**Issue**: <rdar://119183922>
**Risk**: Low. 
**Testing**: Added test, ran the existing tests, and manually tested with the project where this was originally found.
**Reviewer**: @franklinsch 
