### PR TITLE
Fix a crash when a topic section contained an unsupported directive

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -1022,9 +1022,12 @@ public struct RenderNodeTranslator: SemanticVisitor {
         contentCompiler: inout RenderContentCompiler
     ) -> [TaskGroupRenderSection] {
         return topics.taskGroups.compactMap { group in
-            let supportedLanguages = Set(group.directives.compactMap {
-                SupportedLanguage(from: $0, source: nil, for: bundle, in: context)?.language
-            })
+            let supportedLanguages = group.directives[SupportedLanguage.directiveName].map {
+                Set($0.compactMap {
+                    SupportedLanguage(from: $0, source: nil, for: bundle, in: context)?.language
+                })
+            } ?? []
+            
             
             // If the task group has a set of supported languages, see if it should render for the allowed traits.
             guard supportedLanguages.isEmpty || supportedLanguages.matchesOneOf(traits: allowedTraits) else {

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -1022,15 +1022,12 @@ public struct RenderNodeTranslator: SemanticVisitor {
         contentCompiler: inout RenderContentCompiler
     ) -> [TaskGroupRenderSection] {
         return topics.taskGroups.compactMap { group in
-            let supportedLanguages = group.directives[SupportedLanguage.directiveName].map {
-                Set($0.compactMap {
-                    SupportedLanguage(from: $0, source: nil, for: bundle, in: context)?.language
-                })
-            } ?? []
-            
+            let supportedLanguages = group.directives[SupportedLanguage.directiveName]?.compactMap {
+                SupportedLanguage(from: $0, source: nil, for: bundle, in: context)?.language
+            }
             
             // If the task group has a set of supported languages, see if it should render for the allowed traits.
-            guard supportedLanguages.isEmpty || supportedLanguages.matchesOneOf(traits: allowedTraits) else {
+            if supportedLanguages?.matchesOneOf(traits: allowedTraits) == false {
                 return nil
             }
             
@@ -1988,7 +1985,7 @@ extension ContentLayout: RenderTree {}
 
 extension ContentRenderSection: RenderTree {}
 
-private extension Set where Element == SourceLanguage {
+private extension Sequence where Element == SourceLanguage {
     func matchesOneOf(traits: Set<DocumentationDataVariantsTrait>) -> Bool {
         traits.contains(where: {
             guard let languageID = $0.interfaceLanguage,

--- a/Sources/SwiftDocC/Model/TaskGroup.swift
+++ b/Sources/SwiftDocC/Model/TaskGroup.swift
@@ -223,8 +223,8 @@ public struct TaskGroup {
         self.originalContent = content
     }
     
-    var directives: [BlockDirective] {
-        originalContent.compactMap { $0 as? BlockDirective }
+    var directives: [String: [BlockDirective]] {
+        .init(grouping: originalContent.compactMap { $0 as? BlockDirective }, by: \.name)
     }
 }
 


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://119279890

## Summary

Fix a crash when a topic section contained an unsupported directive. 

## Dependencies

None

## Testing

Add some directives other than `SupportedLanguage` to a topic section (before the links). See for example [this test content](https://github.com/apple/swift-docc/pull/763/files#diff-2f4773195a122c13ab57aa39efac9235a4c402cc5b0ab1037ee97a4515f88501R3361-R3371).

Building documentation for this content shouldn't crash.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
