### PR TITLE
add support for C++ symbol graphs and namespace symbols

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -57,10 +57,10 @@
     {
       "identity" : "swift-docc-symbolkit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-docc-symbolkit",
+      "location" : "https://github.com/QuietMisdreavus/swift-docc-symbolkit",
       "state" : {
-        "branch" : "main",
-        "revision" : "fb0c2d5e2be00558e5666fbda50105da2de839d1"
+        "branch" : "namespace-kind",
+        "revision" : "f3a076f987029ce12f42bb6936bfe1edd941656b"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -57,10 +57,10 @@
     {
       "identity" : "swift-docc-symbolkit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/QuietMisdreavus/swift-docc-symbolkit",
+      "location" : "https://github.com/apple/swift-docc-symbolkit",
       "state" : {
-        "branch" : "namespace-kind",
-        "revision" : "f3a076f987029ce12f42bb6936bfe1edd941656b"
+        "branch" : "main",
+        "revision" : "3889b9673fcf1f1e9651b9143289b6ede462c958"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -136,7 +136,9 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(url: "https://github.com/apple/swift-markdown.git", branch: "main"),
         .package(url: "https://github.com/apple/swift-lmdb.git", branch: "main"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.2"),
-        .package(url: "https://github.com/apple/swift-docc-symbolkit", branch: "main"),
+        // to be restored when the SymbolKit PR is merged
+//        .package(url: "https://github.com/apple/swift-docc-symbolkit", branch: "main"),
+        .package(url: "https://github.com/QuietMisdreavus/swift-docc-symbolkit", branch: "namespace-kind"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "2.5.0"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.2.0"),
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -136,9 +136,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(url: "https://github.com/apple/swift-markdown.git", branch: "main"),
         .package(url: "https://github.com/apple/swift-lmdb.git", branch: "main"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.2"),
-        // to be restored when the SymbolKit PR is merged
-//        .package(url: "https://github.com/apple/swift-docc-symbolkit", branch: "main"),
-        .package(url: "https://github.com/QuietMisdreavus/swift-docc-symbolkit", branch: "namespace-kind"),
+        .package(url: "https://github.com/apple/swift-docc-symbolkit", branch: "main"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "2.5.0"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.2.0"),
     ]

--- a/Sources/SwiftDocC/Infrastructure/Topic Graph/AutomaticCuration.swift
+++ b/Sources/SwiftDocC/Infrastructure/Topic Graph/AutomaticCuration.swift
@@ -205,6 +205,7 @@ extension AutomaticCuration {
             case .ivar: return "Instance Variables"
             case .macro: return "Macros"
             case .`method`: return "Instance Methods"
+            case .namespace: return "Namespaces"
             case .`property`: return "Instance Properties"
             case .`protocol`: return "Protocols"
             case .`struct`: return "Structures"
@@ -230,6 +231,8 @@ extension AutomaticCuration {
     /// Add a symbol kind to `KindIdentifier.noPageKinds` if it should not generate a page in the
     /// documentation hierarchy.
     static let groupKindOrder: [SymbolGraph.Symbol.KindIdentifier] = [
+        .namespace,
+
         .`class`,
         .`protocol`,
         .`struct`,

--- a/Sources/SwiftDocC/Model/DocumentationNode.swift
+++ b/Sources/SwiftDocC/Model/DocumentationNode.swift
@@ -533,6 +533,7 @@ public struct DocumentationNode {
         case .ivar: return .instanceVariable
         case .macro: return .macro
         case .`method`: return .instanceMethod
+        case .namespace: return .namespace
         case .`property`: return .instanceProperty
         case .`protocol`: return .protocol
         case .snippet: return .snippet

--- a/Sources/SwiftDocC/Model/Kind.swift
+++ b/Sources/SwiftDocC/Model/Kind.swift
@@ -95,7 +95,9 @@ extension DocumentationNode.Kind {
     public static let dictionary = DocumentationNode.Kind(name: "Dictionary", id: "org.swift.docc.kind.dictionary", isSymbol: true)
     /// Documentation about an HTTP request.
     public static let httpRequest = DocumentationNode.Kind(name: "HTTP Request", id: "org.swift.docc.kind.httpRequest", isSymbol: true)
-    
+    /// Documentation about a namespace.
+    public static let namespace = DocumentationNode.Kind(name: "Namespace", id: "org.swift.docc.kind.namespace", isSymbol: true)
+
     // Leaves
     
     /// Documentation about a local variable.
@@ -192,7 +194,7 @@ extension DocumentationNode.Kind {
         // Conceptual
         .root, .module, .article, .sampleCode, .technologyOverview, .volume, .chapter, .tutorial, .tutorialArticle, .onPageLandmark,
         // Containers
-        .class, .structure, .enumeration, .protocol, .technology, .extension, .dictionary, .httpRequest,
+        .class, .structure, .enumeration, .protocol, .technology, .extension, .dictionary, .httpRequest, .namespace,
         // Leaves
         .localVariable, .globalVariable, .typeAlias, .typeDef, .typeConstant, .associatedType, .function, .operator, .macro, .union,
         // Member-only leaves

--- a/Sources/SwiftDocC/Model/SourceLanguage.swift
+++ b/Sources/SwiftDocC/Model/SourceLanguage.swift
@@ -135,7 +135,10 @@ public struct SourceLanguage: Hashable, Codable {
             "objective-c",
             "objc",
             "c", // FIXME: DocC should display C as its own language (github.com/apple/swift-docc/issues/169).
-            "c++",
+            "c++", // FIXME: DocC should display C++ and Objective-C++ as their own languages (https://github.com/apple/swift-docc/issues/767)
+            "objective-c++",
+            "objc++",
+            "occ++",
         ],
         linkDisambiguationID: "c"
     )

--- a/Sources/SwiftDocC/Model/SourceLanguage.swift
+++ b/Sources/SwiftDocC/Model/SourceLanguage.swift
@@ -135,6 +135,7 @@ public struct SourceLanguage: Hashable, Codable {
             "objective-c",
             "objc",
             "c", // FIXME: DocC should display C as its own language (github.com/apple/swift-docc/issues/169).
+            "c++",
         ],
         linkDisambiguationID: "c"
     )

--- a/Tests/SwiftDocCTests/Infrastructure/AutomaticCurationTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/AutomaticCurationTests.swift
@@ -539,7 +539,34 @@ class AutomaticCurationTests: XCTestCase {
             ]
         )
     }
-    
+
+    func testNamespacesAreCuratedProperly() throws {
+        let (bundle, context) = try testBundleAndContext(named: "CxxNamespaces")
+
+        let rootDocumentationNode = try context.entity(
+            with: .init(
+                bundleIdentifier: bundle.identifier,
+                path: "/documentation/CxxNamespaces",
+                sourceLanguage: .objectiveC
+            )
+        )
+        let topics = try AutomaticCuration.topics(
+            for: rootDocumentationNode,
+            withTraits: [.objectiveC],
+            context: context
+        )
+
+        XCTAssertEqual(
+            topics.flatMap { taskGroup in
+                [taskGroup.title] + taskGroup.references.map(\.path)
+            },
+            [
+                "Namespaces",
+                "/documentation/CxxNamespaces/Foo",
+            ]
+        )
+    }
+
     // Ensures that manually curated sample code articles are not also
     // automatically curated.
     func testSampleCodeArticlesRespectManualCuration() throws {

--- a/Tests/SwiftDocCTests/Test Bundles/CxxNamespaces.docc/CxxNamespaces.md
+++ b/Tests/SwiftDocCTests/Test Bundles/CxxNamespaces.docc/CxxNamespaces.md
@@ -1,0 +1,6 @@
+# ``CxxNamespaces``
+
+This bundle contains a small symbol graph that demonstrates a C++ namespace, as reflected in the
+current implementation on Clang's main branch.
+
+<!-- Copyright (c) 2023 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Tests/SwiftDocCTests/Test Bundles/CxxNamespaces.docc/CxxNamespaces.symbols.json
+++ b/Tests/SwiftDocCTests/Test Bundles/CxxNamespaces.docc/CxxNamespaces.symbols.json
@@ -1,0 +1,144 @@
+{
+  "metadata": {
+    "formatVersion": {
+      "major": 0,
+      "minor": 5,
+      "patch": 3
+    },
+    "generator": "?"
+  },
+  "module": {
+    "name": "CxxNamespaces",
+    "platform": {
+      "architecture": "arm64",
+      "operatingSystem": {
+        "minimumVersion": {
+          "major": 11,
+          "minor": 0,
+          "patch": 0
+        },
+        "name": "macosx"
+      },
+      "vendor": "apple"
+    }
+  },
+  "relationships": [
+    {
+      "kind": "memberOf",
+      "source": "c:@N@Foo@S@Bar",
+      "target": "c:@N@Foo",
+      "targetFallback": "Foo"
+    }
+  ],
+  "symbols": [
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "keyword",
+          "spelling": "namespace"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "Foo"
+        },
+        {
+          "kind": "text",
+          "spelling": ";"
+        }
+      ],
+      "identifier": {
+        "interfaceLanguage": "c++",
+        "precise": "c:@N@Foo"
+      },
+      "kind": {
+        "displayName": "Namespace",
+        "identifier": "c++.namespace"
+      },
+      "location": {
+        "position": {
+          "character": 10,
+          "line": 0
+        },
+        "uri": "file:///path/to/namespace.cpp.tmp/input.h"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "Foo"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "Foo"
+          }
+        ],
+        "title": "Foo"
+      },
+      "pathComponents": [
+        "Foo"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "keyword",
+          "spelling": "class"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "Bar"
+        },
+        {
+          "kind": "text",
+          "spelling": ";"
+        }
+      ],
+      "identifier": {
+        "interfaceLanguage": "c++",
+        "precise": "c:@N@Foo@S@Bar"
+      },
+      "kind": {
+        "displayName": "Class",
+        "identifier": "c++.class"
+      },
+      "location": {
+        "position": {
+          "character": 8,
+          "line": 1
+        },
+        "uri": "file:///path/to/namespace.cpp.tmp/input.h"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "Bar"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "Bar"
+          }
+        ],
+        "title": "Bar"
+      },
+      "pathComponents": [
+        "Foo",
+        "Bar"
+      ]
+    }
+  ]
+}

--- a/Tests/SwiftDocCTests/Test Bundles/CxxNamespaces.docc/Info.plist
+++ b/Tests/SwiftDocCTests/Test Bundles/CxxNamespaces.docc/Info.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleVersion</key>
+	<string>0.1.0</string>
+	<key>CFBundleIdentifier</key>
+	<string>org.swift.docc.example</string>
+	<key>CFBundleDisplayName</key>
+	<string>C++ Namespaces</string>
+	<key>CFBundleName</key>
+	<string>CxxNamespaces</string>
+</dict>
+</plist>


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://117904448

## Summary

This PR starts adding support for C++ symbol graphs, based on Clang's initial support. For the moment, the `c++` symbol language is currently lumped into "Objective-C" alongside C itself; proper standalone support for a "C++" language kind should be coordinated with Swift-DocC-Render to ensure that there is full support.

In addition, this PR also introduces support for namespace symbols, as those are new in C++ compared to Objective-C.

## Dependencies

https://github.com/apple/swift-docc-symbolkit/pull/65

## Testing

As C++ symbol graphs are in a state of preliminary support in Clang (they are currently on the main branch of `llvm/llvm-project` and are [being integrated into `apple/llvm-project`](https://github.com/apple/llvm-project/pull/7856)), a basic symbol graph is included in this PR to test automatic curation. This can be used for testing as follows:

Steps:
1. `swift run docc preview 'Tests/SwiftDocCTests/Test Bundles/CxxNamespaces.docc'`
2. Load the preview, and ensure that the `Foo` namespace is properly curated and displayed, with class `Bar` underneath it.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ n/a ] Updated documentation if necessary
