### PR TITLE
check-source: don't scan HTML inside docc-build directories

### DIFF
--- a/bin/check-source
+++ b/bin/check-source
@@ -87,6 +87,7 @@ EOF
 EOF
       ;;
       html)
+        exceptions=( -path "*/.docc-build/*" )
         matching_files=( -name '*.html' )
         cat > "$tmp" <<"EOF"
 <!--


### PR DESCRIPTION
Bug/issue #, if applicable: None

## Summary

Often, while double-checking some behavior, i'll run `docc preview` directly on a path in the repo. This leaves behind a `.docc-build` directory, which ordinarily isn't tracked by Git. However, the `check-source` script will complain about the generated HTML files in these directories. This PR updates the script to pass over `.docc-build` directories when looking for HTML files.

## Dependencies

None

## Testing

Steps:
1. `swift run docc convert 'Tests/SwiftDocCTests/Test Bundles/AlternateDeclarations.docc'`
2. `bin/check-source`
3. Ensure that check-source completes successfully.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ n/a ] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ n/a ] Updated documentation if necessary
