### PR TITLE
[5.10] Fix bugs with symbol links to `/(_:_:)` operators (#717)

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+DisambiguatedPaths.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+DisambiguatedPaths.swift
@@ -10,7 +10,7 @@
 
 import Foundation
 
-private let nonAllowedPathCharacters = CharacterSet.urlPathAllowed.inverted
+private let nonAllowedPathCharacters = CharacterSet.urlPathAllowed.inverted.union(["/"])
 
 private func symbolFileName(_ symbolName: String) -> String {
     return symbolName.components(separatedBy: nonAllowedPathCharacters).joined(separator: "_")

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+Error.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+Error.swift
@@ -19,15 +19,16 @@ extension PathHierarchy {
         ///
         /// Includes information about:
         /// - The node that was found
-        /// - The remaining portion of the path.
-        typealias PartialResult = (node: Node, path: [PathComponent])
+        /// - The portion of the path up and including to the found node and its trailing path separator.
+        typealias PartialResult = (node: Node, pathPrefix: Substring)
         
         /// No element was found at the beginning of the path.
         ///
         /// Includes information about:
+        /// - The portion of the path up to the first path component.
         /// - The remaining portion of the path. This may be empty
         /// - A list of the names for the top level elements.
-        case notFound(remaining: [PathComponent], availableChildren: Set<String>)
+        case notFound(pathPrefix: Substring, remaining: [PathComponent], availableChildren: Set<String>)
         
         /// Matched node does not correspond to a documentation page.
         ///
@@ -35,7 +36,10 @@ extension PathHierarchy {
         case unfindableMatch(Node)
         
         /// A symbol link found a non-symbol match.
-        case nonSymbolMatchForSymbolLink
+        ///
+        /// Includes information about:
+        /// - The path to the non-symbol match.
+        case nonSymbolMatchForSymbolLink(path: Substring)
         
         /// Encountered an unknown disambiguation for a found node.
         ///
@@ -64,46 +68,31 @@ extension PathHierarchy {
 }
 
 extension PathHierarchy.Error {
-    /// Generate a ``TopicReferenceResolutionError`` from this error using the given `context` and `originalReference`.
-    ///
-    /// The resulting ``TopicReferenceResolutionError`` is human-readable and provides helpful solutions.
-    ///
+    /// Creates a value with structured information that can be used to present diagnostics about the error.
     /// - Parameters:
-    ///     - context: The ``DocumentationContext`` the `originalReference` was resolved in.
-    ///     - originalReference: The raw input string that represents the body of the reference that failed to resolve. This string is
-    ///     used to calculate the proper replacement-ranges for fixits.
-    ///
-    /// - Note: `Replacement`s produced by this function use `SourceLocation`s relative to the `originalReference`, i.e. the beginning
-    /// of the _body_ of the original reference.
-    func asTopicReferenceResolutionErrorInfo(context: DocumentationContext, originalReference: String) -> TopicReferenceResolutionErrorInfo {
-        
-        // This is defined inline because it captures `context`.
+    ///   - fullNameOfNode: A closure that determines the full name of a node, to be displayed in collision diagnostics to precisely identify symbols and other pages.
+    /// - Note: `Replacement`s produced by this function use `SourceLocation`s relative to the link text excluding its surrounding syntax.
+    func makeTopicReferenceResolutionErrorInfo(fullNameOfNode: (PathHierarchy.Node) -> String) -> TopicReferenceResolutionErrorInfo {
+        // This is defined inline because it captures `fullNameOfNode`.
         func collisionIsBefore(_ lhs: (node: PathHierarchy.Node, disambiguation: String), _ rhs: (node: PathHierarchy.Node, disambiguation: String)) -> Bool {
-            return lhs.node.fullNameOfValue(context: context) + lhs.disambiguation
-                 < rhs.node.fullNameOfValue(context: context) + rhs.disambiguation
+            return fullNameOfNode(lhs.node) + lhs.disambiguation
+                 < fullNameOfNode(rhs.node) + rhs.disambiguation
         }
         
         switch self {
-        case .notFound(remaining: let remaining, availableChildren: let availableChildren):
+        case .notFound(pathPrefix: let pathPrefix, remaining: let remaining, availableChildren: let availableChildren):
             guard let firstPathComponent = remaining.first else {
                 return TopicReferenceResolutionErrorInfo(
                     "No local documentation matches this reference"
                 )
             }
             
-            let solutions: [Solution]
-            if let pathComponentIndex = originalReference.range(of: firstPathComponent.full) {
-                let startColumn = originalReference.distance(from: originalReference.startIndex, to: pathComponentIndex.lowerBound)
-                let replacementRange = SourceRange.makeRelativeRange(startColumn: startColumn, length: firstPathComponent.full.count)
-                
-                let nearMisses = NearMiss.bestMatches(for: availableChildren, against: firstPathComponent.name)
-                solutions = nearMisses.map { candidate in
-                    Solution(summary: "\(Self.replacementOperationDescription(from: firstPathComponent.full, to: candidate))", replacements: [
-                        Replacement(range: replacementRange, replacement: candidate)
-                    ])
-                }
-            } else {
-                solutions = []
+            let replacementRange = SourceRange.makeRelativeRange(startColumn: pathPrefix.count, length: firstPathComponent.full.count)
+            let nearMisses = NearMiss.bestMatches(for: availableChildren, against: String(firstPathComponent.name))
+            let solutions = nearMisses.map { candidate in
+                Solution(summary: "\(Self.replacementOperationDescription(from: firstPathComponent.full, to: candidate))", replacements: [
+                    Replacement(range: replacementRange, replacement: candidate)
+                ])
             }
             
             return TopicReferenceResolutionErrorInfo("""
@@ -117,23 +106,19 @@ extension PathHierarchy.Error {
                 \(node.name.singleQuoted) can't be linked to in a partial documentation build
             """)
 
-        case .nonSymbolMatchForSymbolLink:
+        case .nonSymbolMatchForSymbolLink(path: let path):
             return TopicReferenceResolutionErrorInfo("Symbol links can only resolve symbols", solutions: [
                 Solution(summary: "Use a '<doc:>' style reference.", replacements: [
                     // the SourceRange points to the opening double-backtick
                     Replacement(range: .makeRelativeRange(startColumn: -2, endColumn: 0), replacement: "<doc:"),
                     // the SourceRange points to the closing double-backtick
-                    Replacement(range: .makeRelativeRange(startColumn: originalReference.count, endColumn: originalReference.count+2), replacement: ">"),
+                    Replacement(range: .makeRelativeRange(startColumn: path.count, endColumn: path.count+2), replacement: ">"),
                 ])
             ])
             
         case .unknownDisambiguation(partialResult: let partialResult, remaining: let remaining, candidates: let candidates):
             let nextPathComponent = remaining.first!
-            var validPrefix = ""
-            if !partialResult.path.isEmpty {
-                validPrefix += PathHierarchy.joined(partialResult.path) + "/"
-            }
-            validPrefix += nextPathComponent.name
+            let validPrefix = partialResult.pathPrefix + nextPathComponent.name
             
             let disambiguations = nextPathComponent.full.dropFirst(nextPathComponent.name.count)
             let replacementRange = SourceRange.makeRelativeRange(startColumn: validPrefix.count, length: disambiguations.count)
@@ -141,7 +126,7 @@ extension PathHierarchy.Error {
             let solutions: [Solution] = candidates
                 .sorted(by: collisionIsBefore)
                 .map { (node: PathHierarchy.Node, disambiguation: String) -> Solution in
-                    return Solution(summary: "\(Self.replacementOperationDescription(from: disambiguations.dropFirst(), to: disambiguation)) for\n\(node.fullNameOfValue(context: context).singleQuoted)", replacements: [
+                    return Solution(summary: "\(Self.replacementOperationDescription(from: disambiguations.dropFirst(), to: disambiguation)) for\n\(fullNameOfNode(node).singleQuoted)", replacements: [
                         Replacement(range: replacementRange, replacement: "-" + disambiguation)
                     ])
                 }
@@ -155,22 +140,19 @@ extension PathHierarchy.Error {
             
         case .unknownName(partialResult: let partialResult, remaining: let remaining, availableChildren: let availableChildren):
             let nextPathComponent = remaining.first!
-            let nearMisses = NearMiss.bestMatches(for: availableChildren, against: nextPathComponent.name)
+            let nearMisses = NearMiss.bestMatches(for: availableChildren, against: String(nextPathComponent.name))
             
             // Use the authored disambiguation to try and reduce the possible near misses. For example, if the link was disambiguated with `-struct` we should
             // only make suggestions for similarly spelled structs.
             let filteredNearMisses = nearMisses.filter { name in
-                (try? partialResult.node.children[name]?.find(nextPathComponent.kind, nextPathComponent.hash)) != nil
+                (try? partialResult.node.children[name]?.find(nextPathComponent.kind.map(String.init), nextPathComponent.hash.map(String.init))) != nil
             }
 
-            var validPrefix = ""
-            if !partialResult.path.isEmpty {
-                validPrefix += PathHierarchy.joined(partialResult.path) + "/"
-            }
+            let pathPrefix = partialResult.pathPrefix
             let solutions: [Solution]
             if filteredNearMisses.isEmpty {
                 // If there are no near-misses where the authored disambiguation narrow down the results, replace the full path component
-                let replacementRange = SourceRange.makeRelativeRange(startColumn: validPrefix.count, length: nextPathComponent.full.count)
+                let replacementRange = SourceRange.makeRelativeRange(startColumn: pathPrefix.count, length: nextPathComponent.full.count)
                 solutions = nearMisses.map { candidate in
                     Solution(summary: "\(Self.replacementOperationDescription(from: nextPathComponent.full, to: candidate))", replacements: [
                         Replacement(range: replacementRange, replacement: candidate)
@@ -178,7 +160,7 @@ extension PathHierarchy.Error {
                 }
             } else {
                 // If the authored disambiguation narrows down the possible near-misses, only replace the name part of the path component
-                let replacementRange = SourceRange.makeRelativeRange(startColumn: validPrefix.count, length: nextPathComponent.name.count)
+                let replacementRange = SourceRange.makeRelativeRange(startColumn: pathPrefix.count, length: nextPathComponent.name.count)
                 solutions = filteredNearMisses.map { candidate in
                     Solution(summary: "\(Self.replacementOperationDescription(from: nextPathComponent.name, to: candidate))", replacements: [
                         Replacement(range: replacementRange, replacement: candidate)
@@ -190,23 +172,19 @@ extension PathHierarchy.Error {
                 \(nextPathComponent.full.singleQuoted) doesn't exist at \(partialResult.node.pathWithoutDisambiguation().singleQuoted)
                 """,
                 solutions: solutions,
-                rangeAdjustment: .makeRelativeRange(startColumn: validPrefix.count, length: nextPathComponent.full.count)
+                rangeAdjustment: .makeRelativeRange(startColumn: pathPrefix.count, length: nextPathComponent.full.count)
             )
             
         case .lookupCollision(partialResult: let partialResult, remaining: let remaining, collisions: let collisions):
             let nextPathComponent = remaining.first!
             
-            var validPrefix = ""
-            if !partialResult.path.isEmpty {
-                validPrefix += PathHierarchy.joined(partialResult.path) + "/"
-            }
-            validPrefix += nextPathComponent.name
+            let pathPrefix = partialResult.pathPrefix + nextPathComponent.name
 
             let disambiguations = nextPathComponent.full.dropFirst(nextPathComponent.name.count)
-            let replacementRange = SourceRange.makeRelativeRange(startColumn: validPrefix.count, length: disambiguations.count)
+            let replacementRange = SourceRange.makeRelativeRange(startColumn: pathPrefix.count, length: disambiguations.count)
             
             let solutions: [Solution] = collisions.sorted(by: collisionIsBefore).map { (node: PathHierarchy.Node, disambiguation: String) -> Solution in
-                return Solution(summary: "\(Self.replacementOperationDescription(from: disambiguations.dropFirst(), to: disambiguation)) for\n\(node.fullNameOfValue(context: context).singleQuoted)", replacements: [
+                return Solution(summary: "\(Self.replacementOperationDescription(from: disambiguations.dropFirst(), to: disambiguation)) for\n\(fullNameOfNode(node).singleQuoted)", replacements: [
                     Replacement(range: replacementRange, replacement: "-" + disambiguation)
                 ])
             }
@@ -215,7 +193,7 @@ extension PathHierarchy.Error {
                 \(nextPathComponent.full.singleQuoted) is ambiguous at \(partialResult.node.pathWithoutDisambiguation().singleQuoted)
                 """,
                 solutions: solutions,
-                rangeAdjustment: .makeRelativeRange(startColumn: validPrefix.count - nextPathComponent.full.count, length: nextPathComponent.full.count)
+                rangeAdjustment: .makeRelativeRange(startColumn: pathPrefix.count - nextPathComponent.full.count, length: nextPathComponent.full.count)
             )
         }
     }
@@ -243,26 +221,6 @@ private extension PathHierarchy.Node {
             node = parent
         }
         return "/" + components.joined(separator: "/")
-    }
-    
-    /// Determines the full name of a node's value using information from the documentation context.
-    ///
-    /// > Note: This value is only intended for error messages and other presentation.
-    func fullNameOfValue(context: DocumentationContext) -> String {
-        guard let identifier = identifier else { return name }
-        if let symbol = symbol {
-            if let fragments = symbol[mixin: SymbolGraph.Symbol.DeclarationFragments.self]?.declarationFragments {
-                return fragments.map(\.spelling).joined().split(whereSeparator: { $0.isWhitespace || $0.isNewline }).joined(separator: " ")
-            }
-            return context.nodeWithSymbolIdentifier(symbol.identifier.precise)!.name.description
-        }
-        // This only gets called for PathHierarchy error messages, so hierarchyBasedLinkResolver is never nil.
-        let reference = context.hierarchyBasedLinkResolver.resolvedReferenceMap[identifier]!
-        if reference.fragment != nil {
-            return context.nodeAnchorSections[reference]!.title
-        } else {
-            return context.documentationCache[reference]!.name.description
-        }
     }
 }
 

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+Find.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+Find.swift
@@ -23,7 +23,7 @@ extension PathHierarchy {
             throw Error.unfindableMatch(node)
         }
         if onlyFindSymbols, node.symbol == nil {
-            throw Error.nonSymbolMatchForSymbolLink
+            throw Error.nonSymbolMatchForSymbolLink(path: rawPath[...])
         }
         return node.identifier
     }
@@ -33,9 +33,9 @@ extension PathHierarchy {
         // - First, parse the path into structured path components.
         // - Second, find nodes that match the beginning of the path as starting points for the search
         // - Third, traverse the hierarchy from those starting points to search for the node.
-        let (path, isAbsolute) = Self.parse(path: rawPath)
+        let (path, isAbsolute) = PathParser.parse(path: rawPath)
         guard !path.isEmpty else {
-            throw Error.notFound(remaining: [], availableChildren: [])
+            throw Error.notFound(pathPrefix: rawPath[...], remaining: [], availableChildren: [])
         }
         
         var remaining = path[...]
@@ -49,12 +49,7 @@ extension PathHierarchy {
         }
         
         guard let firstComponent = remaining.first else {
-            throw Error.notFound(remaining: [], availableChildren: [])
-        }
-        
-        // A function to avoid eagerly computing the full path unless it needs to be presented in an error message.
-        func parsedPathForError() -> [PathComponent] {
-            Self.parse(path: rawPath, omittingEmptyComponents: false).components
+            throw Error.notFound(pathPrefix: rawPath[...], remaining: [], availableChildren: [])
         }
         
         if !onlyFindSymbols {
@@ -69,33 +64,33 @@ extension PathHierarchy {
                             break lookForArticleRoot
                         }
                     }
-                    return try searchForNode(descendingFrom: articlesContainer, pathComponents: remaining.dropFirst(), parsedPathForError: parsedPathForError, onlyFindSymbols: onlyFindSymbols)
+                    return try searchForNode(descendingFrom: articlesContainer, pathComponents: remaining.dropFirst(), onlyFindSymbols: onlyFindSymbols, rawPathForError: rawPath)
                 } else if articlesContainer.anyChildMatches(firstComponent) {
-                    return try searchForNode(descendingFrom: articlesContainer, pathComponents: remaining, parsedPathForError: parsedPathForError, onlyFindSymbols: onlyFindSymbols)
+                    return try searchForNode(descendingFrom: articlesContainer, pathComponents: remaining, onlyFindSymbols: onlyFindSymbols, rawPathForError: rawPath)
                 }
             }
             if !isKnownDocumentationPath {
                 if tutorialContainer.matches(firstComponent) {
-                    return try searchForNode(descendingFrom: tutorialContainer, pathComponents: remaining.dropFirst(), parsedPathForError: parsedPathForError, onlyFindSymbols: onlyFindSymbols)
+                    return try searchForNode(descendingFrom: tutorialContainer, pathComponents: remaining.dropFirst(), onlyFindSymbols: onlyFindSymbols, rawPathForError: rawPath)
                 } else if tutorialContainer.anyChildMatches(firstComponent)  {
-                    return try searchForNode(descendingFrom: tutorialContainer, pathComponents: remaining, parsedPathForError: parsedPathForError, onlyFindSymbols: onlyFindSymbols)
+                    return try searchForNode(descendingFrom: tutorialContainer, pathComponents: remaining, onlyFindSymbols: onlyFindSymbols, rawPathForError: rawPath)
                 }
                 // The parent for tutorial overviews / technologies is "tutorials" which has already been removed above, so no need to check against that name.
                 else if tutorialOverviewContainer.anyChildMatches(firstComponent)  {
-                    return try searchForNode(descendingFrom: tutorialOverviewContainer, pathComponents: remaining, parsedPathForError: parsedPathForError, onlyFindSymbols: onlyFindSymbols)
+                    return try searchForNode(descendingFrom: tutorialOverviewContainer, pathComponents: remaining, onlyFindSymbols: onlyFindSymbols, rawPathForError: rawPath)
                 }
             }
         }
         
         // A function to avoid repeating the
         func searchForNodeInModules() throws -> Node {
-            // Note: This captures `parentID`, `remaining`, and `parsedPathForError`.
-            if let moduleMatch = modules[firstComponent.full] ?? modules[firstComponent.name] {
-                return try searchForNode(descendingFrom: moduleMatch, pathComponents: remaining.dropFirst(), parsedPathForError: parsedPathForError, onlyFindSymbols: onlyFindSymbols)
+            // Note: This captures `parentID`, `remaining`, and `rawPathForError`.
+            if let moduleMatch = modules[firstComponent.full]  ?? modules[String(firstComponent.name)] {
+                return try searchForNode(descendingFrom: moduleMatch, pathComponents: remaining.dropFirst(), onlyFindSymbols: onlyFindSymbols, rawPathForError: rawPath)
             }
             if modules.count == 1 {
                 do {
-                    return try searchForNode(descendingFrom: modules.first!.value, pathComponents: remaining, parsedPathForError: parsedPathForError, onlyFindSymbols: onlyFindSymbols)
+                    return try searchForNode(descendingFrom: modules.first!.value, pathComponents: remaining, onlyFindSymbols: onlyFindSymbols, rawPathForError: rawPath)
                 } catch let error as PathHierarchy.Error {
                     switch error {
                     case .notFound:
@@ -120,7 +115,11 @@ extension PathHierarchy {
                 }
             }
             let topLevelNames = Set(modules.keys + [articlesContainer.name, tutorialContainer.name])
-            throw Error.notFound(remaining: Array(remaining), availableChildren: topLevelNames)
+            throw Error.notFound(
+                pathPrefix: pathForError(of: rawPath, droppingLast: remaining.count),
+                remaining: Array(remaining),
+                availableChildren: topLevelNames
+            )
         }
         
         // A recursive function to traverse up the path hierarchy searching for the matching node
@@ -132,7 +131,7 @@ extension PathHierarchy {
                 } catch {
                     // If the node couldn't be found in the modules, search the non-matching parent to achieve a more specific error message
                     if let parentID = parentID {
-                        return try searchForNode(descendingFrom: lookup[parentID]!, pathComponents: path, parsedPathForError: parsedPathForError, onlyFindSymbols: onlyFindSymbols)
+                        return try searchForNode(descendingFrom: lookup[parentID]!, pathComponents: path, onlyFindSymbols: onlyFindSymbols, rawPathForError: rawPath)
                     }
                     throw error
                 }
@@ -147,7 +146,7 @@ extension PathHierarchy {
             // If the starting point's children match this component, descend the path hierarchy from there.
             if possibleStartingPoint.anyChildMatches(firstComponent) {
                 do {
-                    return try searchForNode(descendingFrom: possibleStartingPoint, pathComponents: path, parsedPathForError: parsedPathForError, onlyFindSymbols: onlyFindSymbols)
+                    return try searchForNode(descendingFrom: possibleStartingPoint, pathComponents: path, onlyFindSymbols: onlyFindSymbols, rawPathForError: rawPath)
                 } catch {
                     innerMostError = error
                 }
@@ -155,7 +154,7 @@ extension PathHierarchy {
             // It's possible that the component is ambiguous at the parent. Checking if this node matches the first component avoids that ambiguity.
             if possibleStartingPoint.matches(firstComponent) {
                 do {
-                    return try searchForNode(descendingFrom: possibleStartingPoint, pathComponents: path.dropFirst(), parsedPathForError: parsedPathForError, onlyFindSymbols: onlyFindSymbols)
+                    return try searchForNode(descendingFrom: possibleStartingPoint, pathComponents: path.dropFirst(), onlyFindSymbols: onlyFindSymbols, rawPathForError: rawPath)
                 } catch {
                     if innerMostError == nil {
                         innerMostError = error
@@ -180,8 +179,8 @@ extension PathHierarchy {
     private func searchForNode(
         descendingFrom startingPoint: Node,
         pathComponents: ArraySlice<PathComponent>,
-        parsedPathForError: () -> [PathComponent],
-        onlyFindSymbols: Bool
+        onlyFindSymbols: Bool,
+        rawPathForError: String
     ) throws -> Node {
         var node = startingPoint
         var remaining = pathComponents[...]
@@ -194,12 +193,12 @@ extension PathHierarchy {
         
         // Search for the remaining components from the node
         while true {
-            let (children, pathComponent) = try findChildTree(node: &node, parsedPath: parsedPathForError(), remaining: remaining)
+            let (children, pathComponent) = try findChildContainer(node: &node, remaining: remaining, rawPathForError: rawPathForError)
             
             do {
                 guard let child = try children.find(pathComponent.kind, pathComponent.hash) else {
                     // The search has ended with a node that doesn't have a child matching the next path component.
-                    throw makePartialResultError(node: node, parsedPath: parsedPathForError(), remaining: remaining)
+                    throw makePartialResultError(node: node, remaining: remaining, rawPathForError: rawPathForError)
                 }
                 node = child
                 remaining = remaining.dropFirst()
@@ -209,7 +208,7 @@ extension PathHierarchy {
                 }
             } catch DisambiguationContainer.Error.lookupCollision(let collisions) {
                 func handleWrappedCollision() throws -> Node {
-                    try handleCollision(node: node, parsedPath: parsedPathForError, remaining: remaining, collisions: collisions, onlyFindSymbols: onlyFindSymbols)
+                    try handleCollision(node: node, remaining: remaining, collisions: collisions, onlyFindSymbols: onlyFindSymbols, rawPathForError: rawPathForError)
                 }
                 
                 // When there's a collision, use the remaining path components to try and narrow down the possible collisions.
@@ -243,7 +242,7 @@ extension PathHierarchy {
                 // Look ahead one path component to narrow down the list of collisions. 
                 // For each collision where the next path component can be found unambiguously, return that matching node one level down.
                 let possibleMatchesOneLevelDown = collisions.compactMap {
-                    return try? $0.node.children[nextPathComponent.name]?.find(nextPathComponent.kind, nextPathComponent.hash)
+                    return try? $0.node.children[String(nextPathComponent.name)]?.find(nextPathComponent.kind, nextPathComponent.hash)
                 }
                 let onlyPossibleMatch: Node?
                 
@@ -272,17 +271,17 @@ extension PathHierarchy {
                 }
                 
                 // Couldn't resolve the collision by look ahead.
-                return try handleCollision(node: node, parsedPath: parsedPathForError, remaining: remaining, collisions: collisions, onlyFindSymbols: onlyFindSymbols)
+                return try handleCollision(node: node, remaining: remaining, collisions: collisions, onlyFindSymbols: onlyFindSymbols, rawPathForError: rawPathForError)
             }
         }
     }
                         
     private func handleCollision(
         node: Node,
-        parsedPath: () -> [PathComponent],
         remaining: ArraySlice<PathComponent>,
         collisions: [(node: PathHierarchy.Node, disambiguation: String)],
-        onlyFindSymbols: Bool
+        onlyFindSymbols: Bool,
+        rawPathForError: String
     ) throws -> Node {
         if let favoredMatch = collisions.singleMatch({ $0.node.isDisfavoredInCollision == false }) {
             return favoredMatch.node
@@ -310,7 +309,7 @@ extension PathHierarchy {
         throw Error.lookupCollision(
             partialResult: (
                 node,
-                Array(parsedPath().dropLast(remaining.count))
+                pathForError(of: rawPathForError, droppingLast: remaining.count)
             ),
             remaining: Array(remaining),
             collisions: collisions.map { ($0.node, $0.disambiguation) }
@@ -319,14 +318,14 @@ extension PathHierarchy {
     
     private func makePartialResultError(
         node: Node,
-        parsedPath: [PathComponent],
-        remaining: ArraySlice<PathComponent>
+        remaining: ArraySlice<PathComponent>,
+        rawPathForError: String
     ) -> Error {
-        if let disambiguationTree = node.children[remaining.first!.name] {
+        if let disambiguationTree = node.children[String(remaining.first!.name)] {
             return Error.unknownDisambiguation(
                 partialResult: (
                     node,
-                    Array(parsedPath.dropLast(remaining.count))
+                    pathForError(of: rawPathForError, droppingLast: remaining.count)
                 ),
                 remaining: Array(remaining),
                 candidates: disambiguationTree.disambiguatedValues().map {
@@ -338,19 +337,37 @@ extension PathHierarchy {
         return Error.unknownName(
             partialResult: (
                 node,
-                Array(parsedPath.dropLast(remaining.count))
+                pathForError(of: rawPathForError, droppingLast: remaining.count)
             ),
             remaining: Array(remaining),
             availableChildren: Set(node.children.keys)
         )
     }
     
-    /// Finds the child disambiguation tree for a given node that match the remaining path components.
+    private func pathForError(
+        of rawPath: String,
+        droppingLast trailingComponentsToDrop: Int
+    ) -> Substring {
+        guard trailingComponentsToDrop > 0 else { return rawPath[...] }
+        
+        // Drop 1 less than the requested amount to keep the trailing path separator in the returned path prefix.
+        let componentSubstrings = PathParser.split(rawPath).componentSubstrings.dropLast(trailingComponentsToDrop - 1)
+        guard let lastSubstring = componentSubstrings.last else { return "" }
+        
+        return rawPath[..<lastSubstring.startIndex]
+    }
+    
+    /// Finds the child disambiguation container for a given node that match the remaining path components.
     /// - Parameters:
     ///   - node: The current node.
     ///   - remaining: The remaining path components.
-    /// - Returns: The child disambiguation tree and path component.
-    private func findChildTree(node: inout Node, parsedPath: @autoclosure () -> [PathComponent], remaining: ArraySlice<PathComponent>) throws -> (DisambiguationContainer, PathComponent) {
+    ///   - rawPathForError: The raw path for presentation in potential error messages.
+    /// - Returns: The child disambiguation container and path component it matched.
+    private func findChildContainer(
+        node: inout Node,
+        remaining: ArraySlice<PathComponent>,
+        rawPathForError: String
+    ) throws -> (DisambiguationContainer, PathComponent) {
         var pathComponent = remaining.first!
         if let match = node.children[pathComponent.full] {
             // The path component parsing may treat dash separated words as disambiguation information.
@@ -358,11 +375,11 @@ extension PathHierarchy {
             pathComponent.kind = nil
             pathComponent.hash = nil
             return (match, pathComponent)
-        } else if let match = node.children[pathComponent.name] {
+        } else if let match = node.children[String(pathComponent.name)] {
             return (match, pathComponent)
         }
         // The search has ended with a node that doesn't have a child matching the next path component.
-        throw makePartialResultError(node: node, parsedPath: parsedPath(), remaining: remaining)
+        throw makePartialResultError(node: node, remaining: remaining, rawPathForError: rawPathForError)
     }
 }
 
@@ -377,6 +394,9 @@ extension PathHierarchy.DisambiguationContainer {
         case lookupCollision([(node: PathHierarchy.Node, disambiguation: String)])
     }
     
+    fileprivate func find(_ kind: Substring?, _ hash: Substring?) throws -> PathHierarchy.Node? {
+        try find(kind.map(String.init), hash.map(String.init))
+    }
     /// Attempts to find a value in the disambiguation tree based on partial disambiguation information.
     ///
     /// There are 3 possible results:
@@ -446,9 +466,16 @@ private extension Sequence {
 private extension PathHierarchy.Node {
     func matches(_ component: PathHierarchy.PathComponent) -> Bool {
         if let symbol = symbol {
-            return name == component.name
-            && (component.kind == nil || component.kind == symbol.kind.identifier.identifier)
-            && (component.hash == nil || component.hash == symbol.identifier.precise.stableHashString)
+            guard name == component.name else {
+                return false
+            }
+            if let kind = component.kind, kind != symbol.kind.identifier.identifier {
+                return false
+            }
+            if let hash = component.hash, hash != symbol.identifier.precise.stableHashString {
+                return false
+            }
+            return true
         } else {
             return name == component.full
         }
@@ -456,6 +483,7 @@ private extension PathHierarchy.Node {
     
     func anyChildMatches(_ component: PathHierarchy.PathComponent) -> Bool {
         let keys = children.keys
-        return keys.contains(component.name) || keys.contains(component.full)
+        return keys.contains(component.full)
+            || keys.contains(String(component.name))
     }
 }

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+PathComponent.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+PathComponent.swift
@@ -37,88 +37,444 @@ extension PathHierarchy {
         /// The full original path component
         let full: String
         /// The parsed entity name
-        let name: String
+        let name: Substring
         /// The parsed entity kind, if any.
-        var kind: String?
+        var kind: Substring?
         /// The parsed entity hash, if any.
-        var hash: String?
+        var hash: Substring?
     }
     
+    enum PathParser {
+        typealias PathComponent = PathHierarchy.PathComponent
+    }
+}
+ 
+extension PathHierarchy.PathParser {
     /// Parsed a documentation link path (and optional fragment) string into structured path component values.
     /// - Parameters:
     ///   - path: The documentation link string, containing a path and an optional fragment.
-    ///   - omittingEmptyComponents: If empty path components should be omitted from the parsed path. By default the are omitted.
     /// - Returns: A pair of the parsed path components and a flag that indicate if the documentation link is absolute or not.
-    static func parse(path: String, omittingEmptyComponents: Bool = true) -> (components: [PathComponent], isAbsolute: Bool) {
+    static func parse(path: String) -> (components: [PathComponent], isAbsolute: Bool) {
         guard !path.isEmpty else { return ([], true) }
-        var components = path.split(separator: "/", omittingEmptySubsequences: omittingEmptyComponents)
-        let isAbsolute = path.first == "/"
-            || String(components.first ?? "") == NodeURLGenerator.Path.documentationFolderName
-            || String(components.first ?? "") == NodeURLGenerator.Path.tutorialsFolderName
-
-        // If there is a # character in the last component, split that into two components
-        if let hashIndex = components.last?.firstIndex(of: "#") {
-            let last = components.removeLast()
-            // Allow anrhor-only links where there's nothing before #.
-            // In case the pre-# part is empty, and we're omitting empty components, don't add it in.
-            let pathName = last[..<hashIndex]
-            if !pathName.isEmpty || !omittingEmptyComponents {
-                components.append(pathName)
-            }
-            
-            let fragment = String(last[hashIndex...].dropFirst())
-            return (components.map(Self.parse(pathComponent:)) + [PathComponent(full: fragment, name: fragment, kind: nil, hash: nil)], isAbsolute)
-        }
         
+        let (components, isAbsolute) = self.split(path)
         return (components.map(Self.parse(pathComponent:)), isAbsolute)
     }
     
     /// Parses a single path component string into a structured format.
-     static func parse(pathComponent original: Substring) -> PathComponent {
+    static func parse(pathComponent original: Substring) -> PathComponent {
         let full = String(original)
         guard let dashIndex = original.lastIndex(of: "-") else {
-            return PathComponent(full: full, name: full, kind: nil, hash: nil)
+            return PathComponent(full: full, name: full[...], kind: nil, hash: nil)
         }
         
-        let hash = String(original[dashIndex...].dropFirst())
-        let name = String(original[..<dashIndex])
+        let hash = original[dashIndex...].dropFirst()
+        let name = original[..<dashIndex]
         
-        func isValidHash(_ hash: String) -> Bool {
+        func isValidHash(_ hash: Substring) -> Bool {
             var index: UInt8 = 0
             for char in hash.utf8 {
                 guard index <= 5, (48...57).contains(char) || (97...122).contains(char) else { return false }
                 index += 1
             }
-            return true
+            return index > 0
         }
         
-        if knownSymbolKinds.contains(hash) {
+        if knownSymbolKinds.contains(String(hash)) {
             // The parsed hash value is a symbol kind
             return PathComponent(full: full, name: name, kind: hash, hash: nil)
         }
         if let languagePrefix = knownLanguagePrefixes.first(where: { hash.starts(with: $0) }) {
             // The hash is actually a symbol kind with a language prefix
-            return PathComponent(full: full, name: name, kind: String(hash.dropFirst(languagePrefix.count)), hash: nil)
+            return PathComponent(full: full, name: name, kind: hash.dropFirst(languagePrefix.count), hash: nil)
         }
         if !isValidHash(hash) {
             // The parsed hash is neither a symbol not a valid hash. It's probably a hyphen-separated name.
-            return PathComponent(full: full, name: full, kind: nil, hash: nil)
+            return PathComponent(full: full, name: full[...], kind: nil, hash: nil)
         }
         
         if let dashIndex = name.lastIndex(of: "-") {
-            let kind = String(name[dashIndex...].dropFirst())
-            let name = String(name[..<dashIndex])
-            if knownSymbolKinds.contains(kind) {
+            let kind = name[dashIndex...].dropFirst()
+            let name = name[..<dashIndex]
+            if knownSymbolKinds.contains(String(kind)) {
                 return PathComponent(full: full, name: name, kind: kind, hash: hash)
             } else if let languagePrefix = knownLanguagePrefixes.first(where: { kind.starts(with: $0) }) {
-                let kindWithoutLanguage = String(kind.dropFirst(languagePrefix.count))
+                let kindWithoutLanguage = kind.dropFirst(languagePrefix.count)
                 return PathComponent(full: full, name: name, kind: kindWithoutLanguage, hash: hash)
             }
         }
         return PathComponent(full: full, name: name, kind: nil, hash: hash)
     }
     
-    static func joined<PathComponents>(_ pathComponents: PathComponents) -> String where PathComponents: Sequence, PathComponents.Element == PathComponent {
-        return pathComponents.map(\.full).joined(separator: "/")
+    static func split(_ path: String) -> (componentSubstrings: [Substring], isAbsolute: Bool) {
+        var components: [Substring] = self.split(path)
+        
+        let isAbsolute: Bool
+        if path.first == PathComponentScanner.separator {
+            guard let maybeModuleName = components.first?.dropFirst(), !maybeModuleName.isEmpty else {
+                return ([], true)
+            }
+            isAbsolute = maybeModuleName.isValidModuleName()
+            assert(NodeURLGenerator.Path.documentationFolderName.isValidModuleName())
+            assert(NodeURLGenerator.Path.tutorialsFolderName.isValidModuleName())
+            if isAbsolute {
+                _ = components[components.startIndex].removeFirst()
+            }
+        } else {
+            let name = components.first.map(String.init)
+            isAbsolute = name == NodeURLGenerator.Path.documentationFolderName
+                      || name == NodeURLGenerator.Path.tutorialsFolderName
+        }
+        
+        return (components, isAbsolute)
+    }
+    
+    private static func split(_ path: String) -> [Substring] {
+        var result = [Substring]()
+        var scanner = PathComponentScanner(path[...])
+        
+        let anchorResult = scanner.scanAnchorComponent()
+        
+        while !scanner.isEmpty {
+            let component = scanner.scanPathComponent()
+            if !component.isEmpty {
+                result.append(component)
+            }
+        }
+        
+        if let anchorResult = anchorResult{
+            result.append(anchorResult)
+        }
+
+        return result
+    }
+}
+
+private struct PathComponentScanner {
+    private var remaining: Substring
+    
+    static let separator: Character = "/"
+    private static let anchorSeparator: Character = "#"
+    private static let operatorEnd: Character = ")"
+    
+    init(_ original: Substring) {
+        remaining = original
+    }
+    
+    var isEmpty: Bool {
+        remaining.isEmpty
+    }
+    
+    mutating func scanPathComponent() -> Substring {
+        // If the next component is an operator, parse the full operator before splitting on "/" ("/" may appear in the operator name)
+        if remaining.unicodeScalars.prefix(3).allSatisfy(\.isValidOperatorHead) {
+            guard let operatorEndIndex = remaining.firstIndex(of: Self.operatorEnd) else {
+                defer { remaining.removeAll() }
+                return remaining
+            }
+            
+            var component = remaining[..<operatorEndIndex]
+            remaining = remaining[operatorEndIndex...]
+            
+            guard let index = remaining.firstIndex(of: Self.separator) else {
+                defer { remaining.removeAll() }
+                return component + remaining
+            }
+            
+            component += remaining[..<index]
+            remaining = remaining[index...].dropFirst() // drop the slash
+            return component
+            
+        }
+        
+        if remaining.first == Self.separator {
+            guard let index = remaining.firstIndex(where: { $0 != Self.separator }) else {
+                defer { remaining.removeAll() }
+                return remaining
+            }
+            let slashPrefix = remaining[..<index]
+            remaining = remaining[index...]
+            return slashPrefix + scanPathComponent()
+        }
+        
+        // If the string doesn't contain a slash then the rest of the string is the component
+        guard let index = remaining.firstIndex(of: Self.separator) else {
+            defer { remaining.removeAll() }
+            return remaining
+        }
+        
+        defer {
+            remaining = remaining[index...].dropFirst() // drop the slash
+        }
+        return remaining[..<index]
+    }
+    
+    mutating func scanAnchorComponent() -> Substring? {
+        guard let index = remaining.firstIndex(of: Self.anchorSeparator) else {
+            return nil
+        }
+        
+        defer { remaining = remaining[..<index] }
+        return remaining[index...].dropFirst() // drop the anchor separator
+    }
+}
+
+private extension StringProtocol {
+    /// Checks if a this string is a valid module name.
+    ///
+    /// Both Swift and Clang require module names to be a valid C99 Extended Identifier.
+    func isValidModuleName() -> Bool {
+        unicodeScalars.allSatisfy {
+            // "-" isn't allowed in module names themselves but it's allowed in link components to separate the disambiguation.
+            $0 == "-" || $0.isValidC99ExtendedIdentifier
+        }
+    }
+}
+
+private extension Unicode.Scalar {
+    /// Checks if this unicode scalar is a valid C99 Extended Identifier.
+    var isValidC99ExtendedIdentifier: Bool {
+        // These is based on "swift-tools-support-core/Sources/TSCUtility/StringMangling.swift"
+        // but that repo is deprecated and not recommended as a dependency.
+        switch value {
+        case
+            // A-Z
+            0x0041...0x005A,
+            // a-z
+            0x0061...0x007A,
+            // 0-9
+            0x0030...0x0039,
+            // _
+            0x005F,
+            // Latin (1)
+            0x00AA...0x00AA,
+            // Special characters (1)
+            0x00B5...0x00B5, 0x00B7...0x00B7,
+            // Latin (2)
+            0x00BA...0x00BA, 0x00C0...0x00D6, 0x00D8...0x00F6,
+            0x00F8...0x01F5, 0x01FA...0x0217, 0x0250...0x02A8,
+            // Special characters (2)
+            0x02B0...0x02B8, 0x02BB...0x02BB, 0x02BD...0x02C1,
+            0x02D0...0x02D1, 0x02E0...0x02E4, 0x037A...0x037A,
+            // Greek (1)
+            0x0386...0x0386, 0x0388...0x038A, 0x038C...0x038C,
+            0x038E...0x03A1, 0x03A3...0x03CE, 0x03D0...0x03D6,
+            0x03DA...0x03DA, 0x03DC...0x03DC, 0x03DE...0x03DE,
+            0x03E0...0x03E0, 0x03E2...0x03F3,
+            // Cyrillic
+            0x0401...0x040C, 0x040E...0x044F, 0x0451...0x045C,
+            0x045E...0x0481, 0x0490...0x04C4, 0x04C7...0x04C8,
+            0x04CB...0x04CC, 0x04D0...0x04EB, 0x04EE...0x04F5,
+            0x04F8...0x04F9,
+            // Armenian (1)
+            0x0531...0x0556,
+            // Special characters (3)
+            0x0559...0x0559,
+            // Armenian (2)
+            0x0561...0x0587,
+            // Hebrew
+            0x05B0...0x05B9, 0x05BB...0x05BD, 0x05BF...0x05BF,
+            0x05C1...0x05C2, 0x05D0...0x05EA, 0x05F0...0x05F2,
+            // Arabic (1)
+            0x0621...0x063A, 0x0640...0x0652,
+            // Digits (1)
+            0x0660...0x0669,
+            // Arabic (2)
+            0x0670...0x06B7, 0x06BA...0x06BE, 0x06C0...0x06CE,
+            0x06D0...0x06DC, 0x06E5...0x06E8, 0x06EA...0x06ED,
+            // Digits (2)
+            0x06F0...0x06F9,
+            // Devanagari and Special character 0x093D.
+            0x0901...0x0903, 0x0905...0x0939, 0x093D...0x094D,
+            0x0950...0x0952, 0x0958...0x0963,
+            // Digits (3)
+            0x0966...0x096F,
+            // Bengali (1)
+            0x0981...0x0983, 0x0985...0x098C, 0x098F...0x0990,
+            0x0993...0x09A8, 0x09AA...0x09B0, 0x09B2...0x09B2,
+            0x09B6...0x09B9, 0x09BE...0x09C4, 0x09C7...0x09C8,
+            0x09CB...0x09CD, 0x09DC...0x09DD, 0x09DF...0x09E3,
+            // Digits (4)
+            0x09E6...0x09EF,
+            // Bengali (2)
+            0x09F0...0x09F1,
+            // Gurmukhi (1)
+            0x0A02...0x0A02, 0x0A05...0x0A0A, 0x0A0F...0x0A10,
+            0x0A13...0x0A28, 0x0A2A...0x0A30, 0x0A32...0x0A33,
+            0x0A35...0x0A36, 0x0A38...0x0A39, 0x0A3E...0x0A42,
+            0x0A47...0x0A48, 0x0A4B...0x0A4D, 0x0A59...0x0A5C,
+            0x0A5E...0x0A5E,
+            // Digits (5)
+            0x0A66...0x0A6F,
+            // Gurmukhi (2)
+            0x0A74...0x0A74,
+            // Gujarti
+            0x0A81...0x0A83, 0x0A85...0x0A8B, 0x0A8D...0x0A8D,
+            0x0A8F...0x0A91, 0x0A93...0x0AA8, 0x0AAA...0x0AB0,
+            0x0AB2...0x0AB3, 0x0AB5...0x0AB9, 0x0ABD...0x0AC5,
+            0x0AC7...0x0AC9, 0x0ACB...0x0ACD, 0x0AD0...0x0AD0,
+            0x0AE0...0x0AE0,
+            // Digits (6)
+            0x0AE6...0x0AEF,
+            // Oriya and Special character 0x0B3D
+            0x0B01...0x0B03, 0x0B05...0x0B0C, 0x0B0F...0x0B10,
+            0x0B13...0x0B28, 0x0B2A...0x0B30, 0x0B32...0x0B33,
+            0x0B36...0x0B39, 0x0B3D...0x0B43, 0x0B47...0x0B48,
+            0x0B4B...0x0B4D, 0x0B5C...0x0B5D, 0x0B5F...0x0B61,
+            // Digits (7)
+            0x0B66...0x0B6F,
+            // Tamil
+            0x0B82...0x0B83, 0x0B85...0x0B8A, 0x0B8E...0x0B90,
+            0x0B92...0x0B95, 0x0B99...0x0B9A, 0x0B9C...0x0B9C,
+            0x0B9E...0x0B9F, 0x0BA3...0x0BA4, 0x0BA8...0x0BAA,
+            0x0BAE...0x0BB5, 0x0BB7...0x0BB9, 0x0BBE...0x0BC2,
+            0x0BC6...0x0BC8, 0x0BCA...0x0BCD,
+            // Digits (8)
+            0x0BE7...0x0BEF,
+            // Telugu
+            0x0C01...0x0C03, 0x0C05...0x0C0C, 0x0C0E...0x0C10,
+            0x0C12...0x0C28, 0x0C2A...0x0C33, 0x0C35...0x0C39,
+            0x0C3E...0x0C44, 0x0C46...0x0C48, 0x0C4A...0x0C4D,
+            0x0C60...0x0C61,
+            // Digits (9)
+            0x0C66...0x0C6F,
+            // Kannada
+            0x0C82...0x0C83, 0x0C85...0x0C8C, 0x0C8E...0x0C90,
+            0x0C92...0x0CA8, 0x0CAA...0x0CB3, 0x0CB5...0x0CB9,
+            0x0CBE...0x0CC4, 0x0CC6...0x0CC8, 0x0CCA...0x0CCD,
+            0x0CDE...0x0CDE, 0x0CE0...0x0CE1,
+            // Digits (10)
+            0x0CE6...0x0CEF,
+            // Malayam
+            0x0D02...0x0D03, 0x0D05...0x0D0C, 0x0D0E...0x0D10,
+            0x0D12...0x0D28, 0x0D2A...0x0D39, 0x0D3E...0x0D43,
+            0x0D46...0x0D48, 0x0D4A...0x0D4D, 0x0D60...0x0D61,
+            // Digits (11)
+            0x0D66...0x0D6F,
+            // Thai...including Digits 0x0E50...0x0E59 }
+            0x0E01...0x0E3A, 0x0E40...0x0E5B,
+            // Lao (1)
+            0x0E81...0x0E82, 0x0E84...0x0E84, 0x0E87...0x0E88,
+            0x0E8A...0x0E8A, 0x0E8D...0x0E8D, 0x0E94...0x0E97,
+            0x0E99...0x0E9F, 0x0EA1...0x0EA3, 0x0EA5...0x0EA5,
+            0x0EA7...0x0EA7, 0x0EAA...0x0EAB, 0x0EAD...0x0EAE,
+            0x0EB0...0x0EB9, 0x0EBB...0x0EBD, 0x0EC0...0x0EC4,
+            0x0EC6...0x0EC6, 0x0EC8...0x0ECD,
+            // Digits (12)
+            0x0ED0...0x0ED9,
+            // Lao (2)
+            0x0EDC...0x0EDD,
+            // Tibetan (1)
+            0x0F00...0x0F00, 0x0F18...0x0F19,
+            // Digits (13)
+            0x0F20...0x0F33,
+            // Tibetan (2)
+            0x0F35...0x0F35, 0x0F37...0x0F37, 0x0F39...0x0F39,
+            0x0F3E...0x0F47, 0x0F49...0x0F69, 0x0F71...0x0F84,
+            0x0F86...0x0F8B, 0x0F90...0x0F95, 0x0F97...0x0F97,
+            0x0F99...0x0FAD, 0x0FB1...0x0FB7, 0x0FB9...0x0FB9,
+            // Georgian
+            0x10A0...0x10C5, 0x10D0...0x10F6,
+            // Latin (3)
+            0x1E00...0x1E9B, 0x1EA0...0x1EF9,
+            // Greek (2)
+            0x1F00...0x1F15, 0x1F18...0x1F1D, 0x1F20...0x1F45,
+            0x1F48...0x1F4D, 0x1F50...0x1F57, 0x1F59...0x1F59,
+            0x1F5B...0x1F5B, 0x1F5D...0x1F5D, 0x1F5F...0x1F7D,
+            0x1F80...0x1FB4, 0x1FB6...0x1FBC,
+            // Special characters (4)
+            0x1FBE...0x1FBE,
+            // Greek (3)
+            0x1FC2...0x1FC4, 0x1FC6...0x1FCC, 0x1FD0...0x1FD3,
+            0x1FD6...0x1FDB, 0x1FE0...0x1FEC, 0x1FF2...0x1FF4,
+            0x1FF6...0x1FFC,
+            // Special characters (5)
+            0x203F...0x2040,
+            // Latin (4)
+            0x207F...0x207F,
+            // Special characters (6)
+            0x2102...0x2102, 0x2107...0x2107, 0x210A...0x2113,
+            0x2115...0x2115, 0x2118...0x211D, 0x2124...0x2124,
+            0x2126...0x2126, 0x2128...0x2128, 0x212A...0x2131,
+            0x2133...0x2138, 0x2160...0x2182, 0x3005...0x3007,
+            0x3021...0x3029,
+            // Hiragana
+            0x3041...0x3093, 0x309B...0x309C,
+            // Katakana
+            0x30A1...0x30F6, 0x30FB...0x30FC,
+            // Bopmofo [sic]
+            0x3105...0x312C,
+            // CJK Unified Ideographs
+            0x4E00...0x9FA5,
+            // Hangul,
+            0xAC00...0xD7A3:
+            return true
+        default:
+            return false
+        }
+    }
+        
+    var isValidOperatorHead: Bool {
+        // See https://docs.swift.org/swift-book/documentation/the-swift-programming-language/lexicalstructure#Operators
+        switch value {
+        case 
+            // ! % & & * + - . / < = > ? ^| ~
+            0x21, 0x25, 0x26, 0x2A, 0x2B, 0x2D...0x2F, 0x3C, 0x3D...0x3F, 0x5E, 0x7C, 0x7E,
+            // ¡ ¢ £ ¤ ¥ ¦ §
+            0xA1 ... 0xA7,
+            // © «
+            0xA9, 0xAB ,
+            // ¬ ®
+            0xAC, 0xAE ,
+            // ° ±
+            0xB0 ... 0xB1,
+            // ¶ » ¿ × ÷
+            0xB6, 0xBB, 0xBF, 0xD7, 0xF7 ,
+            // ‖ ‗
+            0x2016 ... 0x2017,
+            // † ‡ • ‣ ․ ‥ … ‧
+            0x2020 ... 0x2027,
+            // ‰ ‱ ′ ″ ‴ ‵ ‶ ‷ ‸ ‹ › ※ ‼ ‽ ‾
+            0x2030 ... 0x203E,
+            // ⁁ ⁂ ⁃ ⁄ ⁅ ⁆ ⁇ ⁈ ⁉ ⁊ ⁋ ⁌ ⁍ ⁎ ⁏ ⁐ ⁑ ⁒ ⁓
+            0x2041 ... 0x2053,
+            // ⁕ ⁖ ⁗ ⁘ ⁙ ⁚ ⁛ ⁜ ⁝ ⁞
+            0x2055 ... 0x205E,
+            // Box Drawing
+            0x2500 ... 0x257F,
+            // Block Elements
+            0x2580 ... 0x259F,
+            // Geometric Shapes,
+            0x25A0 ... 0x25FF,
+            // Miscellaneous Symbols
+            0x2600 ... 0x26FF,
+            // Dingbats
+            0x2700 ... 0x27BF,
+            // Miscellaneous Mathematical Symbols-A
+            0x27C0 ... 0x27EF,
+            // Supplemental Arrows-A
+            0x27F0 ... 0x27FF,
+            // Braille Patterns
+            0x2800 ... 0x28FF,
+            // Supplemental Arrows-B
+            0x2900 ... 0x297F,
+            // Miscellaneous Mathematical Symbols-B
+            0x2980 ... 0x29FF,
+            // Supplemental Mathematical Operators
+            0x2A00 ... 0x2AFF,
+            // Miscellaneous Symbols and Arrows
+            0x2B00 ... 0x2BFF,
+            // Supplemental Punctuation
+            0x2E00 ... 0x2E7F,
+            // 、 。 〃
+            0x3001 ... 0x3003,
+            //〈 〉 《 》 「 」 『 』 【 】 〒 〓 〔 〕 〖 〗 〘 〙 〚 〛 〜 〝 〞 〟 〠
+            0x3008 ... 0x3020,
+            // 〰
+            0x3030:
+            return true
+        default:
+            return false
+        }
     }
 }

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
@@ -194,10 +194,10 @@ struct PathHierarchy {
                         parent.children[components.first!] == nil,
                         "Shouldn't create a new sparse node when symbol node already exist. This is an indication that a symbol is missing a relationship."
                     )
-                    let component = Self.parse(pathComponent: component[...])
-                    let nodeWithoutSymbol = Node(name: component.name)
+                    let component = PathParser.parse(pathComponent: component[...])
+                    let nodeWithoutSymbol = Node(name: String(component.name))
                     nodeWithoutSymbol.isDisfavoredInCollision = true
-                    parent.add(child: nodeWithoutSymbol, kind: component.kind, hash: component.hash)
+                    parent.add(child: nodeWithoutSymbol, kind: component.kind.map(String.init), hash: component.hash.map(String.init))
                     parent = nodeWithoutSymbol
                 }
                 parent.add(symbolChild: node)
@@ -220,6 +220,10 @@ struct PathHierarchy {
             """
         )
         
+        assert(
+            allNodes.allSatisfy({ $0.value[0].parent != nil || roots[$0.key] != nil }),
+            "Every node should either have a parent node or be a root node. This wasn't true for \(allNodes.filter({ $0.value[0].parent != nil || roots[$0.key] != nil }).map(\.key).sorted())"
+        )
         allNodes.removeAll()
         
         // build the lookup list by traversing the hierarchy and adding identifiers to each node

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -1456,7 +1456,7 @@ let expected = """
         // Get a node
         let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/tutorials/Test-Bundle/TestTutorial", sourceLanguage: .swift))
         
-        // Get the breacrumbs as paths
+        // Get the breadcrumbs as paths
         let paths = context.pathsTo(node.reference).sorted { (path1, path2) -> Bool in
             return path1.count < path2.count
         }
@@ -1670,7 +1670,9 @@ let expected = """
             A documentation extension that curates symbols with characters not allowed in a resolved reference URL.
 
             ## Topics
-
+            
+            ### Operator name only
+            
             - ``<(_:_:)``
             - ``>(_:_:)``
             - ``<=(_:_:)``
@@ -1678,11 +1680,60 @@ let expected = """
             - ``-(_:_:)-22pw2``
             - ``-(_:)-9xdx0``
             - ``-=(_:_:)-7w3vn``
+            - ``/(_:_:)``
+            - ``/=(_:_:)``
+            
+            ### Prefixes with containing type name
+            
+            - ``MyNumber/<(_:_:)``
+            - ``MyNumber/>(_:_:)``
+            - ``MyNumber/<=(_:_:)``
+            - ``MyNumber/>=(_:_:)``
+            - ``MyNumber/-(_:_:)-22pw2``
+            - ``MyNumber/-(_:)-9xdx0``
+            - ``MyNumber/-=(_:_:)-7w3vn``
+            - ``MyNumber//(_:_:)``
+            - ``MyNumber//=(_:_:)``
             """.write(to: root.appendingPathComponent("doc-extension.md"), atomically: true, encoding: .utf8)
         }
         
         let unresolvedTopicProblems = context.problems.filter({ $0.diagnostic.identifier == "org.swift.docc.unresolvedTopicReference" })
         XCTAssertEqual(unresolvedTopicProblems.map(\.diagnostic.summary), [], "All links should resolve without warnings")
+    }
+    
+    func testOperatorReferences() throws {
+        let (_, context) = try testBundleAndContext(named: "InheritedOperators")
+        
+        let pageIdentifiersAndNames = Dictionary(uniqueKeysWithValues: try context.knownPages.map { reference in
+            (key: reference.path, value: try context.entity(with: reference).name.description)
+        })
+        
+        // Operators where all characters in the operator name are also allowed in URL paths
+        XCTAssertEqual("!=(_:_:)",  pageIdentifiersAndNames["/documentation/Operators/MyNumber/!=(_:_:)"])
+        XCTAssertEqual("*(_:_:)",   pageIdentifiersAndNames["/documentation/Operators/MyNumber/*(_:_:)"])
+        XCTAssertEqual("*=(_:_:)",  pageIdentifiersAndNames["/documentation/Operators/MyNumber/*=(_:_:)"])
+        XCTAssertEqual("+(_:)",     pageIdentifiersAndNames["/documentation/Operators/MyNumber/+(_:)"])
+        XCTAssertEqual("+(_:_:)",   pageIdentifiersAndNames["/documentation/Operators/MyNumber/+(_:_:)"])
+        XCTAssertEqual("+=(_:_:)",  pageIdentifiersAndNames["/documentation/Operators/MyNumber/+=(_:_:)"])
+        XCTAssertEqual("-(_:)",     pageIdentifiersAndNames["/documentation/Operators/MyNumber/-(_:)"])
+        XCTAssertEqual("-(_:_:)",   pageIdentifiersAndNames["/documentation/Operators/MyNumber/-(_:_:)"])
+        XCTAssertEqual("-=(_:_:)",  pageIdentifiersAndNames["/documentation/Operators/MyNumber/-=(_:_:)"])
+        XCTAssertEqual("...(_:_:)", pageIdentifiersAndNames["/documentation/Operators/MyNumber/...(_:_:)"])
+        XCTAssertEqual("..<(_:)",   pageIdentifiersAndNames["/documentation/Operators/MyNumber/.._(_:)"])
+        XCTAssertEqual("..<(_:_:)", pageIdentifiersAndNames["/documentation/Operators/MyNumber/.._(_:_:)"])
+        // Operators with the same name have disambiguation in their paths
+        XCTAssertEqual("...(_:)",   pageIdentifiersAndNames["/documentation/Operators/MyNumber/...(_:)-28faz"])
+        XCTAssertEqual("...(_:)",   pageIdentifiersAndNames["/documentation/Operators/MyNumber/...(_:)-8ooeh"])
+        
+        // Characters that are not allowed in URL paths are replaced with "_" (adding disambiguation if the replacement introduces conflicts)
+        XCTAssertEqual("<(_:_:)",   pageIdentifiersAndNames["/documentation/Operators/MyNumber/_(_:_:)-736gk"])
+        XCTAssertEqual("<=(_:_:)",  pageIdentifiersAndNames["/documentation/Operators/MyNumber/_=(_:_:)-9uewk"])
+        XCTAssertEqual(">(_:_:)",   pageIdentifiersAndNames["/documentation/Operators/MyNumber/_(_:_:)-21jxf"])
+        XCTAssertEqual(">=(_:_:)",  pageIdentifiersAndNames["/documentation/Operators/MyNumber/_=(_:_:)-70j0d"])
+        
+        // "/" is a separator in URL paths so it's replaced with with "_" (adding disambiguation if the replacement introduces conflicts)
+        XCTAssertEqual("/(_:_:)",   pageIdentifiersAndNames["/documentation/Operators/MyNumber/_(_:_:)-7am4"])
+        XCTAssertEqual("/=(_:_:)",  pageIdentifiersAndNames["/documentation/Operators/MyNumber/_=(_:_:)-3m4ko"])
     }
     
     func testSpecialCharactersInLinks() throws {

--- a/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
@@ -825,6 +825,62 @@ class PathHierarchyTests: XCTestCase {
             "/MixedFramework/CollisionsWithDifferentSubscriptArguments/subscript(_:)-757cj")
     }
     
+    func testDisambiguatedOperatorPaths() throws {
+        let (_, context) = try testBundleAndContext(named: "InheritedOperators")
+        let tree = try XCTUnwrap(context.hierarchyBasedLinkResolver?.pathHierarchy)
+        
+        let paths = tree.caseInsensitiveDisambiguatedPaths()
+        
+        // Operators where all characters in the operator name are also allowed in URL paths
+        
+        XCTAssertEqual(
+            // static func * (lhs: MyNumber, rhs: MyNumber) -> MyNumber
+            paths["s:9Operators8MyNumberV1moiyA2C_ACtFZ"],
+            "/Operators/MyNumber/*(_:_:)")
+        XCTAssertEqual(
+            // static func *= (lhs: inout MyNumber, rhs: MyNumber)
+            paths["s:9Operators8MyNumberV2meoiyyACz_ACtFZ"],
+            "/Operators/MyNumber/*=(_:_:)")
+        XCTAssertEqual(
+            // static func - (lhs: MyNumber, rhs: MyNumber) -> MyNumber
+            paths["s:9Operators8MyNumberV1soiyA2C_ACtFZ"],
+            "/Operators/MyNumber/-(_:_:)")
+        XCTAssertEqual(
+            // static func + (lhs: MyNumber, rhs: MyNumber) -> MyNumber
+            paths["s:9Operators8MyNumberV1poiyA2C_ACtFZ"],
+            "/Operators/MyNumber/+(_:_:)")
+        
+        // Characters that are not allowed in URL paths are replaced with "_" (adding disambiguation if the replacement introduces conflicts)
+        
+        XCTAssertEqual(
+            // static func < (lhs: MyNumber, rhs: MyNumber) -> Bool
+            paths["s:9Operators8MyNumberV1loiySbAC_ACtFZ"],
+            "/Operators/MyNumber/_(_:_:)-736gk")
+        XCTAssertEqual(
+            // static func <= (lhs: Self, rhs: Self) -> Bool
+            paths["s:SLsE2leoiySbx_xtFZ::SYNTHESIZED::s:9Operators8MyNumberV"],
+            "/Operators/MyNumber/_=(_:_:)-9uewk")
+        XCTAssertEqual(
+            // static func > (lhs: Self, rhs: Self) -> Bool
+            paths["s:SLsE1goiySbx_xtFZ::SYNTHESIZED::s:9Operators8MyNumberV"],
+            "/Operators/MyNumber/_(_:_:)-21jxf")
+        XCTAssertEqual(
+            // static func >= (lhs: Self, rhs: Self) -> Bool
+            paths["s:SLsE2geoiySbx_xtFZ::SYNTHESIZED::s:9Operators8MyNumberV"],
+            "/Operators/MyNumber/_=(_:_:)-70j0d")
+        
+        // "/" is a separator in URL paths so it's replaced with with "_" (adding disambiguation if the replacement introduces conflicts)
+        
+        XCTAssertEqual(
+            // static func / (lhs: MyNumber, rhs: MyNumber) -> MyNumber
+            paths["s:9Operators8MyNumberV1doiyA2C_ACtFZ"],
+            "/Operators/MyNumber/_(_:_:)-7am4")
+        XCTAssertEqual(
+            // static func /= (lhs: inout MyNumber, rhs: MyNumber) -> MyNumber
+            paths["s:9Operators8MyNumberV2deoiyA2Cz_ACtFZ"],
+            "/Operators/MyNumber/_=(_:_:)-3m4ko")
+    }
+    
     func testFindingRelativePaths() throws {
         let (_, context) = try testBundleAndContext(named: "MixedLanguageFrameworkWithLanguageRefinements")
         let tree = try XCTUnwrap(context.hierarchyBasedLinkResolver?.pathHierarchy)
@@ -1298,6 +1354,8 @@ class PathHierarchyTests: XCTestCase {
         let tree = try XCTUnwrap(context.hierarchyBasedLinkResolver?.pathHierarchy)
         
         // public struct MyNumber: SignedNumeric, Comparable, Equatable, Hashable {
+        //    public static func / (lhs: MyNumber, rhs: MyNumber) -> MyNumber { ... }
+        //    public static func /= (lhs: inout MyNumber, rhs: MyNumber) -> MyNumber { ... }
         //     ... stub minimal conformance
         // }
         let myNumberID = try tree.find(path: "/Operators/MyNumber", onlyFindSymbols: true)
@@ -1314,6 +1372,9 @@ class PathHierarchyTests: XCTestCase {
         
         XCTAssertEqual(try tree.findSymbol(path: "*(_:_:)", parent: myNumberID).identifier.precise, "s:9Operators8MyNumberV1moiyA2C_ACtFZ")
         XCTAssertEqual(try tree.findSymbol(path: "*=(_:_:)", parent: myNumberID).identifier.precise, "s:9Operators8MyNumberV2meoiyyACz_ACtFZ")
+        
+        XCTAssertEqual(try tree.findSymbol(path: "/(_:_:)", parent: myNumberID).identifier.precise, "s:9Operators8MyNumberV1doiyA2C_ACtFZ")
+        XCTAssertEqual(try tree.findSymbol(path: "/=(_:_:)", parent: myNumberID).identifier.precise, "s:9Operators8MyNumberV2deoiyA2Cz_ACtFZ")
         
         XCTAssertEqual(try tree.findSymbol(path: "...(_:)-28faz", parent: myNumberID).identifier.precise, "s:SLsE3zzzoPys16PartialRangeFromVyxGxFZ::SYNTHESIZED::s:9Operators8MyNumberV")
         XCTAssertEqual(try tree.findSymbol(path: "...(_:)-8ooeh", parent: myNumberID).identifier.precise, "s:SLsE3zzzopys19PartialRangeThroughVyxGxFZ::SYNTHESIZED::s:9Operators8MyNumberV")
@@ -1359,6 +1420,10 @@ class PathHierarchyTests: XCTestCase {
         XCTAssertEqual("/Operators/MyNumber/_(_:_:)-21jxf",  /* >(_:_:) */ paths["s:SLsE1goiySbx_xtFZ::SYNTHESIZED::s:9Operators8MyNumberV"])
         XCTAssertEqual("/Operators/MyNumber/_=(_:_:)-9uewk", /* <=(_:_:) */ paths["s:SLsE2leoiySbx_xtFZ::SYNTHESIZED::s:9Operators8MyNumberV"])
         XCTAssertEqual("/Operators/MyNumber/_=(_:_:)-70j0d", /* >=(_:_:) */ paths["s:SLsE2geoiySbx_xtFZ::SYNTHESIZED::s:9Operators8MyNumberV"])
+        
+        // "/" is an allowed character in URL paths.
+        XCTAssertEqual("/Operators/MyNumber/_(_:_:)-7am4", paths["s:9Operators8MyNumberV1doiyA2C_ACtFZ"])
+        XCTAssertEqual("/Operators/MyNumber/_=(_:_:)-3m4ko", paths["s:9Operators8MyNumberV2deoiyA2Cz_ACtFZ"])
     }
     
     func testSameNameForSymbolAndContainer() throws {
@@ -1655,9 +1720,11 @@ class PathHierarchyTests: XCTestCase {
         assertParsedPathComponents("/", [])
         assertParsedPathComponents("/first", [("first", nil, nil)])
         assertParsedPathComponents("first", [("first", nil, nil)])
-        assertParsedPathComponents("first/second/third", [("first", nil, nil), ("second", nil, nil), ("third", nil, nil)])
         assertParsedPathComponents("first/", [("first", nil, nil)])
-        assertParsedPathComponents("first//second", [("first", nil, nil), ("second", nil, nil)])
+        assertParsedPathComponents("first/second/third", [("first", nil, nil), ("second", nil, nil), ("third", nil, nil)])
+        assertParsedPathComponents("/first/second/third", [("first", nil, nil), ("second", nil, nil), ("third", nil, nil)])
+        assertParsedPathComponents("first/", [("first", nil, nil)])
+        assertParsedPathComponents("first//second", [("first", nil, nil), ("/second", nil, nil)])
         assertParsedPathComponents("first/second#third", [("first", nil, nil), ("second", nil, nil), ("third", nil, nil)])
         assertParsedPathComponents("#first", [("first", nil, nil)])
 
@@ -1678,6 +1745,19 @@ class PathHierarchyTests: XCTestCase {
         assertParsedPathComponents("path-swift.type.property", [("path", "type.property", nil)])
         
         assertParsedPathComponents("-(_:_:)-hash", [("-(_:_:)", nil, "hash")])
+        assertParsedPathComponents("/=(_:_:)", [("/=(_:_:)", nil, nil)])
+        assertParsedPathComponents("/(_:_:)-func.op", [("/(_:_:)", "func.op", nil)])
+        assertParsedPathComponents("//(_:_:)-hash", [("//(_:_:)", nil, "hash")])
+        assertParsedPathComponents("+/-(_:_:)", [("+/-(_:_:)", nil, nil)])
+        assertParsedPathComponents("+/-(_:_:)-hash", [("+/-(_:_:)", nil, "hash")])
+        assertParsedPathComponents("+/-(_:_:)-func.op", [("+/-(_:_:)", "func.op", nil)])
+        assertParsedPathComponents("+/-(_:_:)-func.op-hash", [("+/-(_:_:)", "func.op", "hash")])
+        assertParsedPathComponents("+/-(_:_:)/+/-(_:_:)/+/-(_:_:)/+/-(_:_:)", [("+/-(_:_:)", nil, nil), ("+/-(_:_:)", nil, nil), ("+/-(_:_:)", nil, nil), ("+/-(_:_:)", nil, nil)])
+        assertParsedPathComponents("+/-(_:_:)-hash/+/-(_:_:)-func.op/+/-(_:_:)-func.op-hash/+/-(_:_:)", [("+/-(_:_:)", nil, "hash"), ("+/-(_:_:)", "func.op", nil), ("+/-(_:_:)", "func.op", "hash"), ("+/-(_:_:)", nil, nil)])
+        
+        assertParsedPathComponents("MyNumber//=(_:_:)", [("MyNumber", nil, nil), ("/=(_:_:)", nil, nil)])
+        assertParsedPathComponents("MyNumber////=(_:_:)", [("MyNumber", nil, nil), ("///=(_:_:)", nil, nil)])
+        assertParsedPathComponents("MyNumber/+/-(_:_:)", [("MyNumber", nil, nil), ("+/-(_:_:)", nil, nil)])
     }
     
     // MARK: Test helpers
@@ -1760,19 +1840,19 @@ class PathHierarchyTests: XCTestCase {
     private func assertPathRaisesErrorMessage(_ path: String, in tree: PathHierarchy, context: DocumentationContext, expectedErrorMessage: String, file: StaticString = #file, line: UInt = #line, _ additionalAssertion: (TopicReferenceResolutionErrorInfo) -> Void = { _ in }) throws {
         XCTAssertThrowsError(try tree.findSymbol(path: path), "Finding path \(path) didn't raise an error.",file: file,line: line) { untypedError in
             let error = untypedError as! PathHierarchy.Error
-            let referenceError = error.asTopicReferenceResolutionErrorInfo(context: context, originalReference: path)
+            let referenceError = error.makeTopicReferenceResolutionErrorInfo() { context.hierarchyBasedLinkResolver.fullName(of: $0, in: context) }
             XCTAssertEqual(referenceError.message, expectedErrorMessage, file: file, line: line)
             additionalAssertion(referenceError)
         }
     }
     
     private func assertParsedPathComponents(_ path: String, _ expected: [(String, String?, String?)], file: StaticString = #file, line: UInt = #line) {
-        let (actual, _) = PathHierarchy.parse(path: path)
+        let (actual, _) = PathHierarchy.PathParser.parse(path: path)
         XCTAssertEqual(actual.count, expected.count, file: file, line: line)
         for (actualComponents, expectedComponents) in zip(actual, expected) {
-            XCTAssertEqual(actualComponents.name, expectedComponents.0, "Incorrect path component", file: file, line: line)
-            XCTAssertEqual(actualComponents.kind, expectedComponents.1, "Incorrect kind disambiguation", file: file, line: line)
-            XCTAssertEqual(actualComponents.hash, expectedComponents.2, "Incorrect hash disambiguation", file: file, line: line)
+            XCTAssertEqual(String(actualComponents.name), expectedComponents.0, "Incorrect path component", file: file, line: line)
+            XCTAssertEqual(actualComponents.kind.map(String.init), expectedComponents.1, "Incorrect kind disambiguation", file: file, line: line)
+            XCTAssertEqual(actualComponents.hash.map(String.init), expectedComponents.2, "Incorrect hash disambiguation", file: file, line: line)
         }
     }
 }

--- a/Tests/SwiftDocCTests/Test Bundles/InheritedOperators.docc/Operators.symbols.json
+++ b/Tests/SwiftDocCTests/Test Bundles/InheritedOperators.docc/Operators.symbols.json
@@ -271,6 +271,18 @@
                 "identifier": "s:s18AdditiveArithmeticP1soiyxx_xtFZ"
             },
             "target": "s:9Operators8MyNumberV"
+        },
+        {
+            "kind" : "memberOf",
+            "source" : "s:9Operators8MyNumberV1doiyA2C_ACtFZ",
+            "target" : "s:9Operators8MyNumberV",
+            "targetFallback" : null
+        },
+        {
+            "kind" : "memberOf",
+            "source" : "s:9Operators8MyNumberV2deoiyA2Cz_ACtFZ",
+            "target" : "s:9Operators8MyNumberV",
+            "targetFallback" : null
         }
     ],
     "symbols": [
@@ -5241,6 +5253,430 @@
             "swiftExtension": {
                 "extendedModule": "Swift"
             }
+        },
+        {
+            "accessLevel" : "public",
+            "declarationFragments" : [
+                {
+                    "kind" : "keyword",
+                    "spelling" : "static"
+                },
+                {
+                    "kind" : "text",
+                    "spelling" : " "
+                },
+                {
+                    "kind" : "keyword",
+                    "spelling" : "func"
+                },
+                {
+                    "kind" : "text",
+                    "spelling" : " "
+                },
+                {
+                    "kind" : "identifier",
+                    "spelling" : "\/"
+                },
+                {
+                    "kind" : "text",
+                    "spelling" : " "
+                },
+                {
+                    "kind" : "text",
+                    "spelling" : "("
+                },
+                {
+                    "kind" : "internalParam",
+                    "spelling" : "lhs"
+                },
+                {
+                    "kind" : "text",
+                    "spelling" : ": "
+                },
+                {
+                    "kind" : "typeIdentifier",
+                    "preciseIdentifier" : "s:9Operators8MyNumberV",
+                    "spelling" : "MyNumber"
+                },
+                {
+                    "kind" : "text",
+                    "spelling" : ", "
+                },
+                {
+                    "kind" : "internalParam",
+                    "spelling" : "rhs"
+                },
+                {
+                    "kind" : "text",
+                    "spelling" : ": "
+                },
+                {
+                    "kind" : "typeIdentifier",
+                    "preciseIdentifier" : "s:9Operators8MyNumberV",
+                    "spelling" : "MyNumber"
+                },
+                {
+                    "kind" : "text",
+                    "spelling" : ") -> "
+                },
+                {
+                    "kind" : "typeIdentifier",
+                    "preciseIdentifier" : "s:9Operators8MyNumberV",
+                    "spelling" : "MyNumber"
+                }
+            ],
+            "functionSignature" : {
+                "parameters" : [
+                    {
+                        "children" : [
+                            
+                        ],
+                        "declarationFragments" : [
+                            {
+                                "kind" : "identifier",
+                                "spelling" : "lhs"
+                            },
+                            {
+                                "kind" : "text",
+                                "spelling" : ": "
+                            },
+                            {
+                                "kind" : "typeIdentifier",
+                                "preciseIdentifier" : "s:9Operators8MyNumberV",
+                                "spelling" : "MyNumber"
+                            }
+                        ],
+                        "name" : "lhs"
+                    },
+                    {
+                        "children" : [
+                            
+                        ],
+                        "declarationFragments" : [
+                            {
+                                "kind" : "identifier",
+                                "spelling" : "rhs"
+                            },
+                            {
+                                "kind" : "text",
+                                "spelling" : ": "
+                            },
+                            {
+                                "kind" : "typeIdentifier",
+                                "preciseIdentifier" : "s:9Operators8MyNumberV",
+                                "spelling" : "MyNumber"
+                            }
+                        ],
+                        "name" : "rhs"
+                    }
+                ],
+                "returns" : [
+                    {
+                        "kind" : "typeIdentifier",
+                        "preciseIdentifier" : "s:9Operators8MyNumberV",
+                        "spelling" : "MyNumber"
+                    }
+                ]
+            },
+            "identifier" : {
+                "interfaceLanguage" : "swift",
+                "precise" : "s:9Operators8MyNumberV1doiyA2C_ACtFZ"
+            },
+            "kind" : {
+                "displayName" : "Operator",
+                "identifier" : "func.op"
+            },
+            "location" : {
+                "position" : {
+                    "character" : 23,
+                    "line" : 10
+                },
+                "uri" : "file:\/\/\/Users\/droennqvist\/Desktop\/Operators\/Operators\/MyNumber.swift"
+            },
+            "names" : {
+                "subHeading" : [
+                    {
+                        "kind" : "keyword",
+                        "spelling" : "static"
+                    },
+                    {
+                        "kind" : "text",
+                        "spelling" : " "
+                    },
+                    {
+                        "kind" : "keyword",
+                        "spelling" : "func"
+                    },
+                    {
+                        "kind" : "text",
+                        "spelling" : " "
+                    },
+                    {
+                        "kind" : "identifier",
+                        "spelling" : "\/"
+                    },
+                    {
+                        "kind" : "text",
+                        "spelling" : " "
+                    },
+                    {
+                        "kind" : "text",
+                        "spelling" : "("
+                    },
+                    {
+                        "kind" : "typeIdentifier",
+                        "preciseIdentifier" : "s:9Operators8MyNumberV",
+                        "spelling" : "MyNumber"
+                    },
+                    {
+                        "kind" : "text",
+                        "spelling" : ", "
+                    },
+                    {
+                        "kind" : "typeIdentifier",
+                        "preciseIdentifier" : "s:9Operators8MyNumberV",
+                        "spelling" : "MyNumber"
+                    },
+                    {
+                        "kind" : "text",
+                        "spelling" : ") -> "
+                    },
+                    {
+                        "kind" : "typeIdentifier",
+                        "preciseIdentifier" : "s:9Operators8MyNumberV",
+                        "spelling" : "MyNumber"
+                    }
+                ],
+                "title" : "\/(_:_:)"
+            },
+            "pathComponents" : [
+                "MyNumber",
+                "\/(_:_:)"
+            ]
+        },
+        {
+            "accessLevel" : "public",
+            "declarationFragments" : [
+                {
+                    "kind" : "keyword",
+                    "spelling" : "static"
+                },
+                {
+                    "kind" : "text",
+                    "spelling" : " "
+                },
+                {
+                    "kind" : "keyword",
+                    "spelling" : "func"
+                },
+                {
+                    "kind" : "text",
+                    "spelling" : " "
+                },
+                {
+                    "kind" : "identifier",
+                    "spelling" : "\/="
+                },
+                {
+                    "kind" : "text",
+                    "spelling" : " "
+                },
+                {
+                    "kind" : "text",
+                    "spelling" : "("
+                },
+                {
+                    "kind" : "internalParam",
+                    "spelling" : "lhs"
+                },
+                {
+                    "kind" : "text",
+                    "spelling" : ": "
+                },
+                {
+                    "kind" : "keyword",
+                    "spelling" : "inout"
+                },
+                {
+                    "kind" : "text",
+                    "spelling" : " "
+                },
+                {
+                    "kind" : "typeIdentifier",
+                    "preciseIdentifier" : "s:9Operators8MyNumberV",
+                    "spelling" : "MyNumber"
+                },
+                {
+                    "kind" : "text",
+                    "spelling" : ", "
+                },
+                {
+                    "kind" : "internalParam",
+                    "spelling" : "rhs"
+                },
+                {
+                    "kind" : "text",
+                    "spelling" : ": "
+                },
+                {
+                    "kind" : "typeIdentifier",
+                    "preciseIdentifier" : "s:9Operators8MyNumberV",
+                    "spelling" : "MyNumber"
+                },
+                {
+                    "kind" : "text",
+                    "spelling" : ") -> "
+                },
+                {
+                    "kind" : "typeIdentifier",
+                    "preciseIdentifier" : "s:9Operators8MyNumberV",
+                    "spelling" : "MyNumber"
+                }
+            ],
+            "functionSignature" : {
+                "parameters" : [
+                    {
+                        "children" : [
+                            
+                        ],
+                        "declarationFragments" : [
+                            {
+                                "kind" : "identifier",
+                                "spelling" : "lhs"
+                            },
+                            {
+                                "kind" : "text",
+                                "spelling" : ": "
+                            },
+                            {
+                                "kind" : "keyword",
+                                "spelling" : "inout"
+                            },
+                            {
+                                "kind" : "text",
+                                "spelling" : " "
+                            },
+                            {
+                                "kind" : "typeIdentifier",
+                                "preciseIdentifier" : "s:9Operators8MyNumberV",
+                                "spelling" : "MyNumber"
+                            }
+                        ],
+                        "name" : "lhs"
+                    },
+                    {
+                        "children" : [
+                            
+                        ],
+                        "declarationFragments" : [
+                            {
+                                "kind" : "identifier",
+                                "spelling" : "rhs"
+                            },
+                            {
+                                "kind" : "text",
+                                "spelling" : ": "
+                            },
+                            {
+                                "kind" : "typeIdentifier",
+                                "preciseIdentifier" : "s:9Operators8MyNumberV",
+                                "spelling" : "MyNumber"
+                            }
+                        ],
+                        "name" : "rhs"
+                    }
+                ],
+                "returns" : [
+                    {
+                        "kind" : "typeIdentifier",
+                        "preciseIdentifier" : "s:9Operators8MyNumberV",
+                        "spelling" : "MyNumber"
+                    }
+                ]
+            },
+            "identifier" : {
+                "interfaceLanguage" : "swift",
+                "precise" : "s:9Operators8MyNumberV2deoiyA2Cz_ACtFZ"
+            },
+            "kind" : {
+                "displayName" : "Operator",
+                "identifier" : "func.op"
+            },
+            "location" : {
+                "position" : {
+                    "character" : 23,
+                    "line" : 14
+                },
+                "uri" : "file:\/\/\/Users\/droennqvist\/Desktop\/Operators\/Operators\/MyNumber.swift"
+            },
+            "names" : {
+                "subHeading" : [
+                    {
+                        "kind" : "keyword",
+                        "spelling" : "static"
+                    },
+                    {
+                        "kind" : "text",
+                        "spelling" : " "
+                    },
+                    {
+                        "kind" : "keyword",
+                        "spelling" : "func"
+                    },
+                    {
+                        "kind" : "text",
+                        "spelling" : " "
+                    },
+                    {
+                        "kind" : "identifier",
+                        "spelling" : "\/="
+                    },
+                    {
+                        "kind" : "text",
+                        "spelling" : " "
+                    },
+                    {
+                        "kind" : "text",
+                        "spelling" : "("
+                    },
+                    {
+                        "kind" : "keyword",
+                        "spelling" : "inout"
+                    },
+                    {
+                        "kind" : "text",
+                        "spelling" : " "
+                    },
+                    {
+                        "kind" : "typeIdentifier",
+                        "preciseIdentifier" : "s:9Operators8MyNumberV",
+                        "spelling" : "MyNumber"
+                    },
+                    {
+                        "kind" : "text",
+                        "spelling" : ", "
+                    },
+                    {
+                        "kind" : "typeIdentifier",
+                        "preciseIdentifier" : "s:9Operators8MyNumberV",
+                        "spelling" : "MyNumber"
+                    },
+                    {
+                        "kind" : "text",
+                        "spelling" : ") -> "
+                    },
+                    {
+                        "kind" : "typeIdentifier",
+                        "preciseIdentifier" : "s:9Operators8MyNumberV",
+                        "spelling" : "MyNumber"
+                    }
+                ],
+                "title" : "\/=(_:_:)"
+            },
+            "pathComponents" : [
+                "MyNumber",
+                "\/=(_:_:)"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Cherrypick of #717 

**Explanation:** Fixes two bugs where operators with a "/" in the name couldn't be linked to and where their data files in the output archive could collide with other pages's data files.
**Scope:** Symbols with "/" in the name, for example `/(_:_:)` and `/=(_:_:)`.
**Issue:** rdar://112555102
**Risk:** Low.
**Testing:** Added test, ran the existing tests, and manually tested in different scenarios.
**Reviewer:** @patshaughnessy 
