### PR TITLE
Replace spaces with dashes in links to articles

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchyBasedLinkResolver.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchyBasedLinkResolver.swift
@@ -271,3 +271,19 @@ final class PathHierarchyBasedLinkResolver {
         return result
     }
 }
+
+/// Creates a more writable version of an articles file name for use in documentation links.
+///
+/// Compared to `urlReadablePath(_:)` this preserves letters in other written languages.
+private func linkName<S: StringProtocol>(filename: S) -> String {
+    // It would be a nice enhancement to also remove punctuation from the filename to allow an article in a file named "One, two, & three!"
+    // to be referenced with a link as `"One-two-three"` instead of `"One,-two-&-three!"` (rdar://120722917)
+    return filename
+        // Replace continuous whitespace and dashes
+        .components(separatedBy: whitespaceAndDashes)
+        .filter({ !$0.isEmpty })
+        .joined(separator: "-")
+}
+
+private let whitespaceAndDashes = CharacterSet.whitespaces
+    .union(CharacterSet(charactersIn: "-–—")) // hyphen, en dash, em dash

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchyBasedLinkResolver.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchyBasedLinkResolver.swift
@@ -106,7 +106,7 @@ final class PathHierarchyBasedLinkResolver {
     }
     
     private func addTutorial(reference: ResolvedTopicReference, source: URL, landmarks: [Landmark]) {
-        let tutorialID = pathHierarchy.addTutorial(name: urlReadablePath(source.deletingPathExtension().lastPathComponent))
+        let tutorialID = pathHierarchy.addTutorial(name: linkName(filename: source.deletingPathExtension().lastPathComponent))
         resolvedReferenceMap[tutorialID] = reference
         
         for landmark in landmarks {
@@ -119,7 +119,7 @@ final class PathHierarchyBasedLinkResolver {
     func addTechnology(_ technology: DocumentationContext.SemanticResult<Technology>) {
         let reference = technology.topicGraphNode.reference
 
-        let technologyID = pathHierarchy.addTutorialOverview(name: urlReadablePath(technology.source.deletingPathExtension().lastPathComponent))
+        let technologyID = pathHierarchy.addTutorialOverview(name: linkName(filename: technology.source.deletingPathExtension().lastPathComponent))
         resolvedReferenceMap[technologyID] = reference
         
         var anonymousVolumeID: ResolvedIdentifier?
@@ -149,21 +149,20 @@ final class PathHierarchyBasedLinkResolver {
     
     /// Adds a technology root article and its headings to the path hierarchy.
     func addRootArticle(_ article: DocumentationContext.SemanticResult<Article>, anchorSections: [AnchorSection]) {
-        let articleID = pathHierarchy.addTechnologyRoot(name: article.source.deletingPathExtension().lastPathComponent)
+        let linkName = linkName(filename: article.source.deletingPathExtension().lastPathComponent)
+        let articleID = pathHierarchy.addTechnologyRoot(name: linkName)
         resolvedReferenceMap[articleID] = article.topicGraphNode.reference
         addAnchors(anchorSections, to: articleID)
     }
     
     /// Adds an article and its headings to the path hierarchy.
     func addArticle(_ article: DocumentationContext.SemanticResult<Article>, anchorSections: [AnchorSection]) {
-        let articleID = pathHierarchy.addArticle(name: article.source.deletingPathExtension().lastPathComponent)
-        resolvedReferenceMap[articleID] = article.topicGraphNode.reference
-        addAnchors(anchorSections, to: articleID)
+        addArticle(filename: article.source.deletingPathExtension().lastPathComponent, reference: article.topicGraphNode.reference, anchorSections: anchorSections)
     }
     
     /// Adds an article and its headings to the path hierarchy.
     func addArticle(filename: String, reference: ResolvedTopicReference, anchorSections: [AnchorSection]) {
-        let articleID = pathHierarchy.addArticle(name: filename)
+        let articleID = pathHierarchy.addArticle(name: linkName(filename: filename))
         resolvedReferenceMap[articleID] = reference
         addAnchors(anchorSections, to: articleID)
     }
@@ -186,7 +185,7 @@ final class PathHierarchyBasedLinkResolver {
     /// Adds a task group on a given page to the documentation hierarchy.
     func addTaskGroup(named name: String, reference: ResolvedTopicReference, to parent: ResolvedTopicReference) {
         let parentID = resolvedReferenceMap[parent]!
-        let taskGroupID = pathHierarchy.addNonSymbolChild(parent: parentID, name: urlReadablePath(name), kind: "taskGroup")
+        let taskGroupID = pathHierarchy.addNonSymbolChild(parent: parentID, name: urlReadableFragment(name), kind: "taskGroup")
         resolvedReferenceMap[taskGroupID] = reference
     }
     

--- a/Sources/SwiftDocC/Model/Identifier.swift
+++ b/Sources/SwiftDocC/Model/Identifier.swift
@@ -671,16 +671,3 @@ func urlReadableFragment<S: StringProtocol>(_ fragment: S) -> String {
     return fragment
 }
 
-/// Creates a more writable version of an articles file name for use in documentation links.
-///
-/// Compared to `urlReadablePath(_:)` this also removes most punctuation characters.
-/// For example, a filename like `"One, two, & three!"` is converted to `"One-two-three"` instead of `"One,-two-&-three!"`.
-func linkName<S: StringProtocol>(filename: S) -> String {
-    // It would be a nice enhancement to also remove punctuation from the filename to allow an article in a file named "One, two, & three!"
-    // to be referenced with a link as `"One-two-three"` instead of `"One,-two-&-three!"` (rdar://120722917)
-    return filename
-        // Replace continuous whitespace and dashes
-        .components(separatedBy: .whitespaceAndDashes)
-        .filter({ !$0.isEmpty })
-        .joined(separator: "-")
-}

--- a/Sources/SwiftDocC/Model/Identifier.swift
+++ b/Sources/SwiftDocC/Model/Identifier.swift
@@ -649,10 +649,6 @@ private extension CharacterSet {
         .subtracting(CharacterSet(charactersIn: "-")) // Don't remove hyphens. They are used as a whitespace replacement.
     static let whitespaceAndDashes = CharacterSet.whitespaces
         .union(CharacterSet(charactersIn: "-–—")) // hyphen, en dash, em dash
-    
-    // For article link names
-    static let charactersToRemoveFromArticleLinkNames = CharacterSet.whitespacesAndPunctuation
-        .union(CharacterSet(charactersIn: "`")) // Also consider back-ticks as punctuation. They are used as quotes around symbols or other code.
 }
 
 /// Creates a more readable version of a fragment by replacing characters that are not allowed in the fragment of a URL with hyphens.
@@ -680,9 +676,11 @@ func urlReadableFragment<S: StringProtocol>(_ fragment: S) -> String {
 /// Compared to `urlReadablePath(_:)` this also removes most punctuation characters.
 /// For example, a filename like `"One, two, & three!"` is converted to `"One-two-three"` instead of `"One,-two-&-three!"`.
 func linkName<S: StringProtocol>(filename: S) -> String {
+    // It would be a nice enhancement to also remove punctuation from the filename to allow an article in a file named "One, two, & three!"
+    // to be referenced with a link as `"One-two-three"` instead of `"One,-two-&-three!"` (rdar://120722917)
     return filename
         // Replace continuous whitespace and dashes
-        .components(separatedBy: .charactersToRemoveFromArticleLinkNames)
+        .components(separatedBy: .whitespaceAndDashes)
         .filter({ !$0.isEmpty })
         .joined(separator: "-")
 }

--- a/Sources/SwiftDocC/Model/Identifier.swift
+++ b/Sources/SwiftDocC/Model/Identifier.swift
@@ -643,11 +643,16 @@ func urlReadablePath<S: StringProtocol>(_ path: S) -> String {
 }
 
 private extension CharacterSet {
+    // For fragments
     static let fragmentCharactersToRemove = CharacterSet.punctuationCharacters // Remove punctuation from fragments
         .union(CharacterSet(charactersIn: "`"))       // Also consider back-ticks as punctuation. They are used as quotes around symbols or other code.
         .subtracting(CharacterSet(charactersIn: "-")) // Don't remove hyphens. They are used as a whitespace replacement.
     static let whitespaceAndDashes = CharacterSet.whitespaces
         .union(CharacterSet(charactersIn: "-–—")) // hyphen, en dash, em dash
+    
+    // For article link names
+    static let charactersToRemoveFromArticleLinkNames = CharacterSet.whitespacesAndPunctuation
+        .union(CharacterSet(charactersIn: "`")) // Also consider back-ticks as punctuation. They are used as quotes around symbols or other code.
 }
 
 /// Creates a more readable version of a fragment by replacing characters that are not allowed in the fragment of a URL with hyphens.
@@ -668,4 +673,16 @@ func urlReadableFragment<S: StringProtocol>(_ fragment: S) -> String {
     fragment.unicodeScalars.removeAll(where: CharacterSet.fragmentCharactersToRemove.contains)
     
     return fragment
+}
+
+/// Creates a more writable version of an articles file name for use in documentation links.
+///
+/// Compared to `urlReadablePath(_:)` this also removes most punctuation characters.
+/// For example, a filename like `"One, two, & three!"` is converted to `"One-two-three"` instead of `"One,-two-&-three!"`.
+func linkName<S: StringProtocol>(filename: S) -> String {
+    return filename
+        // Replace continuous whitespace and dashes
+        .components(separatedBy: .charactersToRemoveFromArticleLinkNames)
+        .filter({ !$0.isEmpty })
+        .joined(separator: "-")
 }

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -1763,14 +1763,14 @@ let expected = """
                 The punctuation is not removed from the reference, so this has a unique reference.
                 """),
                 
-                TextFile(name: "Hello; world?.md", utf8Content: """
+                TextFile(name: "Hello. world?.md", utf8Content: """
                 # Space and different punctuation
                 
                 The punctuation is not removed from the reference, so this has a unique reference.
                 """),
             ])
         ])
-        let (_, bundle, context) = try loadBundle(from: tempURL)
+        let (_, _, context) = try loadBundle(from: tempURL)
 
         XCTAssertEqual(context.problems.map(\.diagnostic.summary), ["Redeclaration of 'Hello world.md'; this file will be skipped"])
         
@@ -1779,7 +1779,7 @@ let expected = """
             "doc://unit-test/documentation/unit-test/Hello,-world!",
             "doc://unit-test/documentation/unit-test/Hello--world",
             "doc://unit-test/documentation/unit-test/Hello-world",
-            "doc://unit-test/documentation/unit-test/Hello;-world-",
+            "doc://unit-test/documentation/unit-test/Hello.-world-",
         ])
     }
     

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -1822,8 +1822,8 @@ let expected = """
             - <doc:article-with-emoji-in-heading#Hello-🌍>
             - <doc:article-with-😃-in-filename>
             - <doc:article-with-😃-in-filename#Hello-world>
-            - <doc:Article-with-various-whitespace-punctuation-in-filename>
-            - <doc:Article-with-various-whitespace-punctuation-in-filename#Hello-world>
+            - <doc:Article:-with-various!-whitespace-&-punctuation.-in,-filename>
+            - <doc:Article:-with-various!-whitespace-&-punctuation.-in,-filename#Hello-world>
             
             Now test the same links in topic curation.
             
@@ -1833,7 +1833,7 @@ let expected = """
             
             - ``MyClass/myFunc🙂()``
             - <doc:article-with-😃-in-filename>
-            - <doc:Article-with-various-whitespace-punctuation-in-filename>
+            - <doc:Article:-with-various!-whitespace-&-punctuation.-in,-filename>
             """),
         ])
         let bundleURL = try testBundle.write(inside: createTemporaryDirectory())

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -1805,7 +1805,7 @@ let expected = """
             ### Hello world
             """),
             
-            TextFile(name: "Article: with - various! whitespace & punctuation; in, filename.md", utf8Content: """
+            TextFile(name: "Article: with - various! whitespace & punctuation. in, filename.md", utf8Content: """
             # Article with various whitespace and punctuation in its filename
             
             Abstract
@@ -1852,7 +1852,7 @@ let expected = """
         XCTAssertEqual(topicSection.links.map(\.destination), [
             "doc://special-characters/documentation/MyKit/MyClass/myFunc_()",
             "doc://special-characters/documentation/special-characters/article-with---in-filename",
-            "doc://special-characters/documentation/special-characters/Article:-with---various!-whitespace-&-punctuation;-in,-filename",
+            "doc://special-characters/documentation/special-characters/Article:-with---various!-whitespace-&-punctuation.-in,-filename",
         ])
         
         // Verify that all resolved link exist in the context.
@@ -1871,7 +1871,7 @@ let expected = """
         XCTAssertEqual(renderNode.topicSections.first?.identifiers, [
             "doc://special-characters/documentation/MyKit/MyClass/myFunc_()",
             "doc://special-characters/documentation/special-characters/article-with---in-filename",
-            "doc://special-characters/documentation/special-characters/Article:-with---various!-whitespace-&-punctuation;-in,-filename",
+            "doc://special-characters/documentation/special-characters/Article:-with---various!-whitespace-&-punctuation.-in,-filename",
         ])
         
         
@@ -1927,13 +1927,13 @@ let expected = """
             XCTAssertEqual(overridingTitleInlineContent, nil)
         }
         withContentAsReference(list.items.dropFirst(4).first) { identifier, isActive, overridingTitle, overridingTitleInlineContent in
-            XCTAssertEqual(identifier.identifier, "doc://special-characters/documentation/special-characters/Article:-with---various!-whitespace-&-punctuation;-in,-filename")
+            XCTAssertEqual(identifier.identifier, "doc://special-characters/documentation/special-characters/Article:-with---various!-whitespace-&-punctuation.-in,-filename")
             XCTAssertEqual(isActive, true)
             XCTAssertEqual(overridingTitle, nil)
             XCTAssertEqual(overridingTitleInlineContent, nil)
         }
         withContentAsReference(list.items.dropFirst(5).first) { identifier, isActive, overridingTitle, overridingTitleInlineContent in
-            XCTAssertEqual(identifier.identifier, "doc://special-characters/documentation/special-characters/Article:-with---various!-whitespace-&-punctuation;-in,-filename#Hello-world")
+            XCTAssertEqual(identifier.identifier, "doc://special-characters/documentation/special-characters/Article:-with---various!-whitespace-&-punctuation.-in,-filename#Hello-world")
             XCTAssertEqual(isActive, true)
             XCTAssertEqual(overridingTitle, nil)
             XCTAssertEqual(overridingTitleInlineContent, nil)
@@ -1957,11 +1957,11 @@ let expected = """
             "Hello world"
         )
         XCTAssertEqual(
-            (renderNode.references["doc://special-characters/documentation/special-characters/Article:-with---various!-whitespace-&-punctuation;-in,-filename"] as? TopicRenderReference)?.title,
+            (renderNode.references["doc://special-characters/documentation/special-characters/Article:-with---various!-whitespace-&-punctuation.-in,-filename"] as? TopicRenderReference)?.title,
             "Article with various whitespace and punctuation in its filename"
         )
         XCTAssertEqual(
-            (renderNode.references["doc://special-characters/documentation/special-characters/Article:-with---various!-whitespace-&-punctuation;-in,-filename#Hello-world"] as? TopicRenderReference)?.title,
+            (renderNode.references["doc://special-characters/documentation/special-characters/Article:-with---various!-whitespace-&-punctuation.-in,-filename#Hello-world"] as? TopicRenderReference)?.title,
             "Hello world"
         )
     }

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -1751,7 +1751,15 @@ let expected = """
             """),
             
             TextFile(name: "article-with-😃-in-filename.md", utf8Content: """
-            # Article with 😃 emoji in file name
+            # Article with 😃 emoji in its filename
+            
+            Abstract
+            
+            ### Hello world
+            """),
+            
+            TextFile(name: "Article: with - various! whitespace & punctuation; in, filename.md", utf8Content: """
+            # Article with various whitespace and punctuation in its filename
             
             Abstract
             
@@ -1767,6 +1775,8 @@ let expected = """
             - <doc:article-with-emoji-in-heading#Hello-🌍>
             - <doc:article-with-😃-in-filename>
             - <doc:article-with-😃-in-filename#Hello-world>
+            - <doc:Article-with-various-whitespace-punctuation-in-filename>
+            - <doc:Article-with-various-whitespace-punctuation-in-filename#Hello-world>
             
             Now test the same links in topic curation.
             
@@ -1776,6 +1786,7 @@ let expected = """
             
             - ``MyClass/myFunc🙂()``
             - <doc:article-with-😃-in-filename>
+            - <doc:Article-with-various-whitespace-punctuation-in-filename>
             """),
         ])
         let bundleURL = try testBundle.write(inside: createTemporaryDirectory())
@@ -1789,11 +1800,12 @@ let expected = """
         
         let moduleSymbol = try XCTUnwrap(entity.semantic as? Symbol)
         let topicSection = try XCTUnwrap(moduleSymbol.topics?.taskGroups.first)
-        
+
         // Verify that all the links in the topic section resolved
         XCTAssertEqual(topicSection.links.map(\.destination), [
             "doc://special-characters/documentation/MyKit/MyClass/myFunc_()",
             "doc://special-characters/documentation/special-characters/article-with---in-filename",
+            "doc://special-characters/documentation/special-characters/Article:-with---various!-whitespace-&-punctuation;-in,-filename",
         ])
         
         // Verify that all resolved link exist in the context.
@@ -1808,10 +1820,11 @@ let expected = """
         let renderNode = translator.visit(moduleSymbol) as! RenderNode
         
         // Verify that the resolved links rendered as links
-        XCTAssertEqual(renderNode.topicSections.first?.identifiers.count, 2)
+        XCTAssertEqual(renderNode.topicSections.first?.identifiers.count, 3)
         XCTAssertEqual(renderNode.topicSections.first?.identifiers, [
             "doc://special-characters/documentation/MyKit/MyClass/myFunc_()",
             "doc://special-characters/documentation/special-characters/article-with---in-filename",
+            "doc://special-characters/documentation/special-characters/Article:-with---various!-whitespace-&-punctuation;-in,-filename",
         ])
         
         
@@ -1826,7 +1839,7 @@ let expected = """
         
         XCTAssertEqual(lists.count, 1)
         let list = try XCTUnwrap(lists.first)
-        XCTAssertEqual(list.items.count, 4, "Unexpected list items: \(list.items.map(\.content))")
+        XCTAssertEqual(list.items.count, 6, "Unexpected list items: \(list.items.map(\.content))")
         
         func withContentAsReference(_ listItem: RenderBlockContent.ListItem?, verify: (RenderReferenceIdentifier, Bool, String?, [RenderInlineContent]?) -> Void) {
             guard let listItem = listItem else {
@@ -1866,7 +1879,19 @@ let expected = """
             XCTAssertEqual(overridingTitle, nil)
             XCTAssertEqual(overridingTitleInlineContent, nil)
         }
-        
+        withContentAsReference(list.items.dropFirst(4).first) { identifier, isActive, overridingTitle, overridingTitleInlineContent in
+            XCTAssertEqual(identifier.identifier, "doc://special-characters/documentation/special-characters/Article:-with---various!-whitespace-&-punctuation;-in,-filename")
+            XCTAssertEqual(isActive, true)
+            XCTAssertEqual(overridingTitle, nil)
+            XCTAssertEqual(overridingTitleInlineContent, nil)
+        }
+        withContentAsReference(list.items.dropFirst(5).first) { identifier, isActive, overridingTitle, overridingTitleInlineContent in
+            XCTAssertEqual(identifier.identifier, "doc://special-characters/documentation/special-characters/Article:-with---various!-whitespace-&-punctuation;-in,-filename#Hello-world")
+            XCTAssertEqual(isActive, true)
+            XCTAssertEqual(overridingTitle, nil)
+            XCTAssertEqual(overridingTitleInlineContent, nil)
+        }
+    
         // Verify that the topic render references have titles with special characters when the original content contained special characters
         XCTAssertEqual(
             (renderNode.references["doc://special-characters/documentation/MyKit/MyClass/myFunc_()"] as? TopicRenderReference)?.title,
@@ -1878,10 +1903,18 @@ let expected = """
         )
         XCTAssertEqual(
             (renderNode.references["doc://special-characters/documentation/special-characters/article-with---in-filename"] as? TopicRenderReference)?.title,
-            "Article with 😃 emoji in file name"
+            "Article with 😃 emoji in its filename"
         )
         XCTAssertEqual(
             (renderNode.references["doc://special-characters/documentation/special-characters/article-with---in-filename#Hello-world"] as? TopicRenderReference)?.title,
+            "Hello world"
+        )
+        XCTAssertEqual(
+            (renderNode.references["doc://special-characters/documentation/special-characters/Article:-with---various!-whitespace-&-punctuation;-in,-filename"] as? TopicRenderReference)?.title,
+            "Article with various whitespace and punctuation in its filename"
+        )
+        XCTAssertEqual(
+            (renderNode.references["doc://special-characters/documentation/special-characters/Article:-with---various!-whitespace-&-punctuation;-in,-filename#Hello-world"] as? TopicRenderReference)?.title,
             "Hello world"
         )
     }


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://119577248

## Summary

Use dashes in the link component if an article file name contains whitespaces

## Dependencies

None

## Testing

In any project; create an article with whitespace in the filename.

Write a documentation link to that article where the sequences of whitespace is replaced with dashes.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
