### PR TITLE
Fix bug where DocC no longer emits warnings for unresolved links in article files.

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -599,7 +599,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
 
                     var problems = resolver.problems
 
-                    if case .sourceCode(_, let offset) = doc.source {
+                    if case .sourceCode(_, let offset) = doc.source, documentationNode.kind.isSymbol {
                         // Offset all problem ranges by the start location of the
                         // source comment in the context of the complete file.
                         if let docRange = offset {

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -4030,6 +4030,55 @@ let expected = """
         let range = try XCTUnwrap(problem.diagnostic.range)
         XCTAssertEqual(start..<end, range)
     }
+    
+    func testUnresolvedLinkWarnings() throws {
+        var (_, _, context) = try testBundleAndContext(copying: "TestBundle") { url in
+            let extensionFile = """
+            # ``SideKit``
+
+            myFunction abstract
+
+            ## Overview
+
+            This is unresolvable: <doc:Does-Not-Exist>.
+            
+            ## Topics
+            
+            - <doc:NonExistingDoc>
+
+            """
+            let fileURL = url.appendingPathComponent("documentation").appendingPathComponent("myFunction.md")
+            try extensionFile.write(to: fileURL, atomically: true, encoding: .utf8)
+        }
+        var problems = context.diagnosticEngine.problems
+        var linkResolutionProblems = problems.filter { $0.diagnostic.source?.relativePath.hasSuffix("myFunction.md") == true }
+        XCTAssertEqual(linkResolutionProblems.count, 3)
+        var problem = try XCTUnwrap(linkResolutionProblems.last)
+        XCTAssertEqual(problem.diagnostic.summary, "\'NonExistingDoc\' doesn\'t exist at \'/SideKit\'")
+        (_, _, context) = try testBundleAndContext(copying: "BookLikeContent") { url in
+            let extensionFile = """
+            # My Article
+
+            Abstract
+
+            ## Overview
+
+            Overview
+            
+            ## Topics
+            
+            - <doc:NonExistingDoc>
+
+            """
+            let fileURL = url.appendingPathComponent("MyArticle.md")
+            try extensionFile.write(to: fileURL, atomically: true, encoding: .utf8)
+        }
+        problems = context.diagnosticEngine.problems
+        linkResolutionProblems = problems.filter { $0.diagnostic.source?.relativePath.hasSuffix("MyArticle.md") == true }
+        XCTAssertEqual(linkResolutionProblems.count, 1)
+        problem = try XCTUnwrap(linkResolutionProblems.last)
+        XCTAssertEqual(problem.diagnostic.summary, "\'NonExistingDoc\' doesn\'t exist at \'/BestBook/MyArticle\'")
+    }
 }
 
 func assertEqualDumps(_ lhs: String, _ rhs: String, file: StaticString = #file, line: UInt = #line) {


### PR DESCRIPTION
Bug/issue #, if applicable:  rdar://119603319

## Summary

Regression was presumably introduced in da16aa9. When the node is an article we don’t want to check the offset because is not a source file.

Before the fix, the logic was removing all problems because it wouldn’t contain an offset, falling through the else condition.

## Dependencies

N/A

## Testing

Steps:
1. From an article inside a doc catalog link to an non-existing symbol or article
2. Preview the doc catalog
3. Check the console for `doesn't exist at` warnings 

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary (N/A)
