### PR TITLE
[5.10] Fix regression where DocC no longer emits warnings for unresolved links. (#774)

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -623,7 +623,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
 
                     var problems = resolver.problems
 
-                    if case .sourceCode(_, let offset) = doc.source {
+                    if case .sourceCode(_, let offset) = doc.source, documentationNode.kind.isSymbol {
                         // Offset all problem ranges by the start location of the
                         // source comment in the context of the complete file.
                         if let docRange = offset {

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -3981,6 +3981,55 @@ let expected = """
         let range = try XCTUnwrap(problem.diagnostic.range)
         XCTAssertEqual(start..<end, range)
     }
+    
+    func testUnresolvedLinkWarnings() throws {
+        var (_, _, context) = try testBundleAndContext(copying: "TestBundle") { url in
+            let extensionFile = """
+            # ``SideKit``
+
+            myFunction abstract
+
+            ## Overview
+
+            This is unresolvable: <doc:Does-Not-Exist>.
+            
+            ## Topics
+            
+            - <doc:NonExistingDoc>
+
+            """
+            let fileURL = url.appendingPathComponent("documentation").appendingPathComponent("myFunction.md")
+            try extensionFile.write(to: fileURL, atomically: true, encoding: .utf8)
+        }
+        var problems = context.diagnosticEngine.problems
+        var linkResolutionProblems = problems.filter { $0.diagnostic.source?.relativePath.hasSuffix("myFunction.md") == true }
+        XCTAssertEqual(linkResolutionProblems.count, 3)
+        var problem = try XCTUnwrap(linkResolutionProblems.last)
+        XCTAssertEqual(problem.diagnostic.summary, "\'NonExistingDoc\' doesn\'t exist at \'/SideKit\'")
+        (_, _, context) = try testBundleAndContext(copying: "BookLikeContent") { url in
+            let extensionFile = """
+            # My Article
+
+            Abstract
+
+            ## Overview
+
+            Overview
+            
+            ## Topics
+            
+            - <doc:NonExistingDoc>
+
+            """
+            let fileURL = url.appendingPathComponent("MyArticle.md")
+            try extensionFile.write(to: fileURL, atomically: true, encoding: .utf8)
+        }
+        problems = context.diagnosticEngine.problems
+        linkResolutionProblems = problems.filter { $0.diagnostic.source?.relativePath.hasSuffix("MyArticle.md") == true }
+        XCTAssertEqual(linkResolutionProblems.count, 1)
+        problem = try XCTUnwrap(linkResolutionProblems.last)
+        XCTAssertEqual(problem.diagnostic.summary, "\'NonExistingDoc\' doesn\'t exist at \'/BestBook/MyArticle\'")
+    }
 }
 
 func assertEqualDumps(_ lhs: String, _ rhs: String, file: StaticString = #file, line: UInt = #line) {


### PR DESCRIPTION
Cherry pick of #774

**Explanation:** Fixes regression where DocC no longer emits warnings for unresolved links.
**Scope:** Warnings for unresolved links in article files will now be registered and emitted.
**Issue:** rdar://119603319
**Risk:** Low.
**Testing:** Added unit test, ran the existing tests, and manually tested in different scenarios.
**Reviewer:** @d-ronnqvist 