### PR TITLE
Validate and filter parameter and return value documentation

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -57,10 +57,10 @@
     {
       "identity" : "swift-docc-symbolkit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-docc-symbolkit",
+      "location" : "https://github.com/d-ronnqvist/swift-docc-symbolkit",
       "state" : {
-        "branch" : "main",
-        "revision" : "3889b9673fcf1f1e9651b9143289b6ede462c958"
+        "branch" : "function-signature-internal-param",
+        "revision" : "aa0a6e9136b17c1248f1715739b81c3d803d319b"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -136,7 +136,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(url: "https://github.com/apple/swift-markdown.git", branch: "main"),
         .package(url: "https://github.com/apple/swift-lmdb.git", branch: "main"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.2"),
-        .package(url: "https://github.com/apple/swift-docc-symbolkit", branch: "main"),
+        .package(url: "https://github.com/d-ronnqvist/swift-docc-symbolkit", branch: "function-signature-internal-param"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "2.5.0"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.2.0"),
     ]

--- a/Sources/SwiftDocC/Model/ParametersAndReturnValidator.swift
+++ b/Sources/SwiftDocC/Model/ParametersAndReturnValidator.swift
@@ -1,0 +1,455 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2023 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+import SymbolKit
+import Markdown
+
+/// A type that validates and filters a symbol's parameter and return value documentation based on the symbol's function signature.
+struct ParametersAndReturnValidator {
+    /// The engine that collects problems encountered while validating the parameter and return value documentation.
+    var diagnosticEngine: DiagnosticEngine
+    /// The list of sources for this symbol's documentation.
+    let docChunkSources: [DocumentationNode.DocumentationChunk.Source]
+    
+    /// Creates validated parameter section variants and returns section variants for the symbol.
+    ///
+    /// The validator processes the parameter and return value documentation in 3 ways:
+    ///  - Any parameter or return value that's not applicable to one language representation's function signature is skipped in that variant.
+    ///  - Objective-C error parameters or return values that are not documented are synthesized if any other parameters are documented.
+    ///  - Problems are emitted for parameters that are misspelled, not found, or repeated and for return values for symbols that return void in all language representations.
+    ///
+    /// > Note:
+    /// > If the symbol doesn't document any of its parameters or return values, the validator doesn't check for undocumented parameters.
+    ///
+    /// - Parameters:
+    ///   - parameters: The symbol's documented parameters.
+    ///   - returns: The symbol's return value documentation.
+    ///   - unifiedSymbol: The unified symbol to validate parameters and returns sections for.
+    /// - Returns: Parameter section variants and returns section variants containing only the values that exist in each language representation's function signature.
+    func makeParametersAndReturnsSections(
+        _ parameters: [Parameter]?,
+        _ returns: [Return]?,
+        _ unifiedSymbol: UnifiedSymbolGraph.Symbol?
+    ) -> (
+        parameterSection: DocumentationDataVariants<ParametersSection>,
+        returnsSection: DocumentationDataVariants<ReturnsSection>
+    ) {
+        guard FeatureFlags.current.isExperimentalParametersAndReturnsValidationEnabled,
+              let symbol = unifiedSymbol,
+              !hasInheritedDocumentationComment(symbol: symbol),
+              let signatures = Self.traitSpecificSignatures(symbol)
+        else {
+            return (
+                DocumentationDataVariants(defaultVariantValue: parameters.map { ParametersSection(parameters: $0) }),
+                DocumentationDataVariants(defaultVariantValue: returns?.first.map { ReturnsSection(content: $0.contents) })
+            )
+        }
+        
+        return (
+            makeParametersSectionVariants(parameters, signatures, symbol.documentedSymbol?.kind, hasDocumentedReturnValues: returns != nil),
+            makeReturnsSectionVariants(returns?.first, signatures, symbol.documentedSymbol?.kind, hasDocumentedParameters: parameters != nil)
+        )
+    }
+    
+    /// Creates a validated parameter section containing only the parameters that exist in each language representation's function signature.
+    ///
+    /// - Parameters:
+    ///   - parameters: The symbol's documented parameters.
+    ///   - signatures: The symbol's containing only the values that exist in that language representation's function signature.
+    ///   - symbolKind: The documented symbol's kind, for use in diagnostics.
+    ///   - hasDocumentedReturnValues: `true` if the symbol has documented its return values; otherwise `false`.
+    /// - Returns: A parameter section variant containing only the parameters that exist in each language representation's function signature.
+    private func makeParametersSectionVariants(
+        _ parameters: [Parameter]?,
+        _ signatures: Signatures,
+        _ symbolKind: SymbolGraph.Symbol.Kind?,
+        hasDocumentedReturnValues: Bool
+    ) -> DocumentationDataVariants<ParametersSection> {
+        guard let parameters = parameters, !parameters.isEmpty else {
+            guard hasDocumentedReturnValues, Self.shouldAddObjectiveCErrorParameter(signatures, parameters) else {
+                // The symbol has no parameter documentation or return value documentation and none should be synthesized.
+                return DocumentationDataVariants(defaultVariantValue: nil)
+            }
+            // Since the symbol documented its return value synthesize an "error" parameter for it.
+            return DocumentationDataVariants(values: [
+                .objectiveC: ParametersSection(parameters: [Parameter(name: "error", contents: Self.objcErrorDescription)]) // This parameter is synthesized and doesn't have a source range.
+            ])
+        }
+        
+        var variants = DocumentationDataVariants<ParametersSection>()
+        var allKnownParameterNames: Set<String> = []
+        var argumentLabelsAndPossibleParameterNames: [String: Set<String>] = [:]
+        // Group the parameters by name to be able to diagnose parameters documented more than once.
+        let parametersByName = [String: [Parameter]](grouping: parameters, by: \.name)
+        
+        for (trait, signature) in signatures {
+            // Collect all language representations's parameter information from the function signatures.
+            let knownParameterNames = Set(signature.parameters.map(\.name))
+            allKnownParameterNames.formUnion(knownParameterNames)
+            for parameter in signature.parameters {
+                if let externalName = parameter.externalName {
+                    argumentLabelsAndPossibleParameterNames[externalName, default: []].insert(parameter.name)
+                }
+            }
+            
+            // Remove documented parameters that don't apply to this language representation's function signature.
+            var languageApplicableParameters = parametersByName.filter { knownParameterNames.contains($0.key) }
+            guard !languageApplicableParameters.isEmpty else { continue }
+            
+            // Add a missing error parameter documentation if needed.
+            if trait == .objectiveC, Self.shouldAddObjectiveCErrorParameter(signatures, parameters) {
+                languageApplicableParameters["error"] = [Parameter(name: "error", contents: Self.objcErrorDescription)] // This parameter is synthesized and doesn't have a source range.
+            }
+            
+            // Ensure that the parameters are displayed in the order that they're declared.
+            var sortedParameters: [Parameter] = []
+            sortedParameters.reserveCapacity(languageApplicableParameters.count)
+            for parameter in signature.parameters {
+                if let foundParameter = languageApplicableParameters[parameter.name]?.first {
+                    sortedParameters.append(foundParameter)
+                }
+            }
+            
+            variants[trait] = ParametersSection(parameters: sortedParameters)
+        }
+        
+        // Diagnose documented parameters that's not found in any language representation's function signature.
+        for parameter in parameters where !allKnownParameterNames.contains(parameter.name) {
+            if let matchingParameterNames = argumentLabelsAndPossibleParameterNames[parameter.name] {
+                diagnosticEngine.emit(externalParameterNameProblem(parameter, knownParameterNamesForArgumentLabel: matchingParameterNames.sorted()))
+            } else {
+                diagnosticEngine.emit(extraParameterProblem(parameter, knownParameterNames: allKnownParameterNames, symbolKind: symbolKind))
+            }
+        }
+        
+        // Diagnose parameters that are documented more than once.
+        for (name, parameters) in parametersByName where allKnownParameterNames.contains(name) && parameters.count > 1 {
+            let first = parameters.first! // Each group is guaranteed to be non-empty.
+            for parameter in parameters.dropFirst() {
+                diagnosticEngine.emit(duplicateParameterProblem(parameter, previous: first, symbolKind: symbolKind))
+            }
+        }
+        
+        // Diagnose missing parameters, based on the language representation with the most parameters.
+        if let parameterOrder = signatures.values.map(\.parameters).max(by: { $0.count < $1.count })?.map(\.name) {
+            let parametersEndLocation = parameters.last?.range?.upperBound
+            
+            for parameterName in allKnownParameterNames.subtracting(["error"]) where parametersByName[parameterName] == nil {
+                // Look for the parameter that should come after the missing parameter to insert the placeholder documentation in the right location.
+                let parameterAfter = parameterOrder.drop(while: { $0 != parameterName }).dropFirst()
+                    .mapFirst(where: { parametersByName[$0]?.first! /* Each group is guaranteed to be non-empty */ })
+                
+                // Match the placeholder formatting with the other parameters; either as a standalone parameter or as an item in a parameters outline.
+                let standalone = parameterAfter?.isStandalone ?? parametersByName.first?.value.first?.isStandalone ?? false
+                diagnosticEngine.emit(missingParameterProblem(name: parameterName, before: parameterAfter, standalone: standalone, location: parametersEndLocation, symbolKind: symbolKind))
+            }
+        }
+        
+        return variants
+    }
+    
+    /// Creates a validated returns section containing only the return values that exist in each language representation's function signature.
+    ///
+    /// - Parameters:
+    ///   - returns: The symbol's documented return values.
+    ///   - signatures: The symbol's containing only the values that exist in that language representation's function signature.
+    ///   - symbolKind: The documented symbol's kind, for use in diagnostics.
+    ///   - hasDocumentedParameters: `true` if the symbol has documented any of its parameters; otherwise `false`.
+    /// - Returns: A returns section variant containing only the return values that exist in each language representation's function signature.
+    private func makeReturnsSectionVariants(
+        _ returns: Return?,
+        _ signatures: Signatures,
+        _ symbolKind: SymbolGraph.Symbol.Kind?,
+        hasDocumentedParameters: Bool
+    ) -> DocumentationDataVariants<ReturnsSection> {
+        let returnsSection = returns.map { ReturnsSection(content: $0.contents) }
+        var variants = DocumentationDataVariants<ReturnsSection>()
+        
+        var traitsWithNonVoidReturnValues = Set(signatures.keys)
+        for (trait, signature) in signatures where !signature.returns.isEmpty {
+            // Don't display any return value documentation for language representations that only return void.
+            if let language = trait.interfaceLanguage.flatMap(SourceLanguage.init(knownLanguageIdentifier:)),
+               let voidReturnValues = Self.knownVoidReturnValues[language],
+               signature.returns.allSatisfy({ voidReturnValues.contains($0) })
+            {
+                traitsWithNonVoidReturnValues.remove(trait)
+                continue
+            }
+            
+            variants[trait] = returnsSection
+        }
+        
+        //
+        if returns != nil || hasDocumentedParameters, let newContent = Self.newObjectiveCReturnsContent(signatures, returns: returns) {
+            variants[.objectiveC] = ReturnsSection(content: newContent)
+        }
+        
+        // Diagnose if the symbol had documented its return values but all language representations only return void.
+        if let returns = returns, traitsWithNonVoidReturnValues.isEmpty {
+            diagnosticEngine.emit(extraReturnsProblem(returns, symbolKind: symbolKind))
+        }
+        return variants
+    }
+    
+    // MARK: Helpers
+    
+    /// Checks if the symbol's documentation is inherited from another source location.
+    private func hasInheritedDocumentationComment(symbol: UnifiedSymbolGraph.Symbol) -> Bool {
+        let symbolLocationURI = symbol.documentedSymbol?.mixins.getValueIfPresent(for: SymbolGraph.Symbol.Location.self)?.uri
+        for case .sourceCode(let location, _) in docChunkSources {
+            // Check if the symbol has documentation from another source location
+            return location?.uri != symbolLocationURI
+        }
+        // If the symbol didn't have any in-source documentation, check if there's a extension file override.
+        return docChunkSources.isEmpty
+    }
+    
+    private typealias Signatures = [DocumentationDataVariantsTrait: SymbolGraph.Symbol.FunctionSignature]
+    
+    /// Returns the symbol's function signatures for each variant trait, or `nil` if the symbol doesn't have any function signature data.
+    private static func traitSpecificSignatures(_ symbol: UnifiedSymbolGraph.Symbol) -> Signatures? {
+        var signatures: [DocumentationDataVariantsTrait: SymbolGraph.Symbol.FunctionSignature] = [:]
+        for (selector, mixin) in symbol.mixins {
+            guard let signature = mixin.getValueIfPresent(for: SymbolGraph.Symbol.FunctionSignature.self) else {
+                continue
+            }
+            signatures[DocumentationDataVariantsTrait(for: selector)] = signature
+        }
+        return signatures.isEmpty ? nil : signatures
+    }
+    
+    /// Checks if the language specific function signatures describe a throwing function in Swift that bridges to an Objective-C method with a trailing error parameter.
+    private static func hasSwiftThrowsObjectiveCErrorBridging(_ signatures: Signatures) -> Bool {
+        guard let objcSignature = signatures[.objectiveC],
+              objcSignature.parameters.last?.name == "error",
+              objcSignature.returns != knownVoidReturnValues[.objectiveC]!
+        else {
+            return false
+        }
+        guard let swiftSignature = signatures[.swift],
+                swiftSignature.parameters.last?.name != "error"
+        else {
+            return false
+        }
+        
+        return true
+    }
+    
+    /// Checks if the validator should synthesize documentation for an Objective-C error parameter.
+    private static func shouldAddObjectiveCErrorParameter(_ signatures: Signatures, _ parameters: [Parameter]?) -> Bool {
+        parameters?.last?.name != "error" && hasSwiftThrowsObjectiveCErrorBridging(signatures)
+    }
+    
+    /// Returns the updated return value content, with an added description of what happens when an error occurs, if needed.
+    private static func newObjectiveCReturnsContent(_ signatures: Signatures, returns: Return?) -> [Markup]? {
+        guard hasSwiftThrowsObjectiveCErrorBridging(signatures) else { return nil }
+        
+        guard let returns = returns, !returns.contents.isEmpty else {
+            if signatures[.objectiveC]?.returns == [.init(kind: .typeIdentifier, spelling: "BOOL", preciseIdentifier: "c:@T@BOOL")] {
+                // There is no documented return value and the Objective-C signature returns BOOL
+                return objcBoolErrorDescription
+            } else {
+                return nil
+            }
+        }
+        
+        if returns.contents.contains(where: { $0.format().lowercased().contains("error") }) {
+            // If the existing returns value documentation mentions "error" at all, don't add anything
+            return nil
+        }
+        
+        return returns.contents + objcObjectErrorAddition(endPreviousSentence: returns.contents.last?.format().removingTrailingWhitespace().last != ".")
+    }
+    
+    private static var knownVoidReturnValues: [SourceLanguage: [SymbolGraph.Symbol.DeclarationFragments.Fragment]] = [
+        .swift: [
+            // The Swift symbol graph extractor uses one of these values depending on if the return value is explicitly defined or not.
+            .init(kind: .text, spelling: "()", preciseIdentifier: nil),
+            .init(kind: .typeIdentifier, spelling: "Void", preciseIdentifier: "s:s4Voida"),
+        ],
+        .objectiveC: [
+            .init(kind: .typeIdentifier, spelling: "void", preciseIdentifier: "c:v"),
+        ]
+    ]
+    
+    /// Translates a relative documentation comment source range to the absolute location in that source file.
+    private func adjusted(_ range: SourceRange?) -> SourceRange? {
+        range.map { adjusted($0) }
+    }
+    
+    /// Translates a relative documentation comment source range to the absolute location in that source file.
+    private func adjusted(_ range: SourceRange) -> SourceRange {
+        var range = range
+        if let source = range.source {
+            for case let .sourceCode(location?, offset?) in docChunkSources where location.url == source {
+                range.offsetWithRange(offset)
+                return range
+            }
+        }
+        return range
+    }
+    
+    // MARK: Diagnostics
+    
+    private func extraReturnsProblem(_ returns: Return, symbolKind: SymbolGraph.Symbol.Kind?) -> Problem {
+        return Problem(
+            diagnostic: Diagnostic(
+                source: returns.range?.source,
+                severity: .warning,
+                range: adjusted(returns.range),
+                identifier: "org.swift.docc.VoidReturnDocumented",
+                summary: "Return value documented for \(symbolKind?.displayName.lowercased() ?? "symbol") returning void"
+            ),
+            possibleSolutions: [
+                Solution(
+                    summary: "Remove return value documentation",
+                    replacements: returns.range.map { [Replacement(range: adjusted($0), replacement: "")] } ?? []
+                )
+            ]
+        )
+    }
+    
+    private func extraParameterProblem(_ parameter: Parameter, knownParameterNames: Set<String>, symbolKind: SymbolGraph.Symbol.Kind?) -> Problem {
+        let source = parameter.range?.source
+        
+        let summary = "Parameter \(parameter.name.singleQuoted) not found in \(symbolKind.map { $0.displayName.lowercased() } ?? "the") declaration"
+        let identifier = "org.swift.docc.DocumentedParameterNotFound"
+        
+        let nearMisses = NearMiss.bestMatches(for: knownParameterNames, against: parameter.name)
+        
+        if nearMisses.isEmpty {
+            // If this parameter doesn't resemble any of this symbols parameters, suggest to remove it.
+            return Problem(
+                diagnostic: Diagnostic(source: source, severity: .warning, range: adjusted(parameter.range), identifier: identifier, summary: summary),
+                possibleSolutions: [
+                    Solution(
+                        summary: "Remove \(parameter.name.singleQuoted) parameter documentation",
+                        replacements: parameter.range.map { [Replacement(range: adjusted($0), replacement: "")] } ?? []
+                    )
+                ]
+            )
+        }
+        
+        // Otherwise, suggest to replace the documented parameter name with the one of the similarly named parameters.
+        return Problem(
+            diagnostic: Diagnostic(source: source, severity: .warning, range: adjusted(parameter.nameRange), identifier: identifier, summary: summary),
+            possibleSolutions: nearMisses.map { candidate in
+                Solution(
+                    summary: "Replace \(parameter.name.singleQuoted) with \(candidate.singleQuoted)",
+                    replacements: parameter.nameRange.map { [Replacement(range: adjusted($0), replacement: candidate)] } ?? []
+                )
+            }
+        )
+    }
+    
+    private func externalParameterNameProblem(_ parameter: Parameter, knownParameterNamesForArgumentLabel: [String]) -> Problem {
+        return Problem(
+            diagnostic: Diagnostic(
+                source: parameter.range?.source,
+                severity: .warning,
+                range: adjusted(parameter.nameRange),
+                identifier: "org.swift.docc.DocumentedArgumentLabel",
+                summary: "Argument label \(parameter.name.singleQuoted) used to document parameter"
+            ),
+            // Suggest to replace the documented argument label with the one of the parameter names.
+            possibleSolutions: knownParameterNamesForArgumentLabel.map { candidate in
+                Solution(
+                    summary: "Replace \(parameter.name.singleQuoted) with \(candidate.singleQuoted)",
+                    replacements: parameter.nameRange.map { [Replacement(range: adjusted($0), replacement: candidate)] } ?? []
+                )
+            }
+        )
+    }
+    
+    private func duplicateParameterProblem(_ parameter: Parameter, previous: Parameter, symbolKind: SymbolGraph.Symbol.Kind?) -> Problem {
+        let notes: [DiagnosticNote]
+        if let previousRange = previous.range, let source = previousRange.source {
+            notes = [DiagnosticNote(source: source, range: adjusted(previousRange), message: "Previously documented here")]
+        } else {
+            notes = []
+        }
+        
+        return Problem(
+            diagnostic: Diagnostic(
+                source: parameter.range?.source,
+                severity: .warning,
+                range: adjusted(parameter.range),
+                identifier: "org.swift.docc.DuplicateParameterDocumentation",
+                summary: "Parameter \(parameter.name.singleQuoted) is already documented",
+                notes: notes
+            ),
+            possibleSolutions: [
+                Solution(
+                    summary: "Remove duplicate parameter documentation",
+                    replacements: parameter.range.map { [Replacement(range: adjusted($0), replacement: "")] } ?? []
+                )
+            ]
+        )
+    }
+    
+    private func missingParameterProblem(name: String, before nextParameter: Parameter?, standalone: Bool, location: SourceLocation?, symbolKind: SymbolGraph.Symbol.Kind?) -> Problem {
+        let solutions: [Solution]
+        if let insertLocation = nextParameter?.range?.lowerBound ?? location {
+            let extraWhitespace = "\n" + String(repeating: " ", count: (nextParameter?.range?.lowerBound.column ?? 1 + (standalone ? 0 : 2) /* indent items in a parameter outline by 2 spaces */) - 1)
+            let replacement: String
+            if nextParameter != nil {
+                // /// - Paramaters:
+                // ///   - nextParameter: Description
+                //      ^inserting "- parameterName: placeholder\n  "
+                //                                              ^^^^ add newline after to insert before the other parameter
+                replacement = Self.newParameterDescription(name: name, standalone: standalone) + extraWhitespace
+            } else {
+                // /// - Paramaters:
+                // ///   - otherParameter: Description
+                //                                    ^inserting "\n  - parameterName: placeholder"
+                //                                                ^^^^ add newline before to insert after the last parameter
+                replacement = extraWhitespace + Self.newParameterDescription(name: name, standalone: standalone)
+            }
+            solutions = [
+                Solution(
+                    summary: "Document \(name.singleQuoted) parameter",
+                    replacements: [
+                        Replacement(range: adjusted(insertLocation ..< insertLocation), replacement: replacement)
+                    ]
+                )
+            ]
+        } else {
+            solutions = []
+        }
+        
+        return Problem(
+            diagnostic: Diagnostic(
+                source: location?.source ?? nextParameter?.range?.source,
+                severity: .warning,
+                range: adjusted(location.map { $0 ..< $0 }),
+                identifier: "org.swift.docc.MissingParameterDocumentation",
+                summary: "Parameter \(name.singleQuoted) is missing documentation"
+            ),
+            possibleSolutions: solutions
+        )
+    }
+    
+    // MARK: Generated content
+    
+    private static let objcErrorDescription: [Markup] = [
+        Text("On input, a pointer to an error object. If an error occurs, this pointer is set to an actual error object containing the error information.")
+    ]
+    private static let objcBoolErrorDescription: [Markup] = [
+        InlineCode("YES"), Text(" if successful, or "), InlineCode("NO"), Text(" if an error occurred.")
+    ]
+    private static func objcObjectErrorAddition(endPreviousSentence: Bool) -> [Markup] {
+        [Text("\(endPreviousSentence ? "." : "") If an error occurs, this method returns "), InlineCode("nil"), Text(" and assigns an appropriate error object to the "), InlineCode("error"), Text(" parameter.")]
+    }
+    
+    private static func newParameterDescription(name: String, standalone: Bool) -> String {
+        "- \(standalone ? "Parameter " : "")\(name): <#parameter description#>"
+    }
+}

--- a/Sources/SwiftDocC/Model/Semantics/Parameter.swift
+++ b/Sources/SwiftDocC/Model/Semantics/Parameter.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -16,14 +16,23 @@ public struct Parameter {
     public var name: String
     /// The content that describe the parameter.
     public var contents: [Markup]
+    /// The text range where the parameter name was parsed.
+    var nameRange: SourceRange?
+    /// The text range where this parameter was parsed.
+    var range: SourceRange?
+    /// Whether the parameter is documented standalone or as a member of a parameters outline.
+    var isStandalone: Bool
     
     /// Initialize a value to describe documentation about a parameter for a symbol.
     /// - Parameters:
     ///   - name: The name of this parameter.
     ///   - contents: The content that describe this parameter.
-    public init(name: String, contents: [Markup]) {
+    public init(name: String, nameRange: SourceRange? = nil, contents: [Markup], range: SourceRange? = nil, isStandalone: Bool = false) {
         self.name = name
+        self.nameRange = nameRange
         self.contents = contents
+        self.range = range
+        self.isStandalone = isStandalone
     }
 
     /// Initialize a value to describe documentation about a symbol's parameter via a Doxygen `\param` command.
@@ -31,6 +40,9 @@ public struct Parameter {
     /// - Parameter doxygenParameter: A parsed Doxygen `\param` command.
     public init(_ doxygenParameter: DoxygenParameter) {
         self.name = doxygenParameter.name
+        self.nameRange = nil
         self.contents = Array(doxygenParameter.children)
+        self.range = doxygenParameter.range
+        self.isStandalone = true // Each Doxygen parameter has a `\param` command.
     }
 }

--- a/Sources/SwiftDocC/Model/Semantics/Return.swift
+++ b/Sources/SwiftDocC/Model/Semantics/Return.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -14,11 +14,14 @@ import Markdown
 public struct Return {
     /// The content that describe the return value for a symbol.
     public var contents: [Markup]
+    /// The text range where this return value was parsed.
+    var range: SourceRange?
     
     /// Initialize a value to describe documentation about a symbol's return value.
     /// - Parameter contents: The content that describe the return value for this symbol.
-    public init(contents: [Markup]) {
+    public init(contents: [Markup], range: SourceRange? = nil) {
         self.contents = contents
+        self.range = range
     }
 
     /// Initialize a value to describe documentation about a symbol's return value.
@@ -26,5 +29,6 @@ public struct Return {
     /// - Parameter doxygenReturns: A parsed Doxygen `\returns` command.
     public init(_ doxygenReturns: DoxygenReturns) {
         self.contents = Array(doxygenReturns.children)
+        self.range = doxygenReturns.range
     }
 }

--- a/Sources/SwiftDocC/Model/TaskGroup.swift
+++ b/Sources/SwiftDocC/Model/TaskGroup.swift
@@ -241,8 +241,3 @@ extension TaskGroup {
     }
 }
 
-private extension SourceRange {
-    var source: URL? {
-        lowerBound.source ?? upperBound.source
-    }
-}

--- a/Sources/SwiftDocC/Semantics/ReferenceResolver.swift
+++ b/Sources/SwiftDocC/Semantics/ReferenceResolver.swift
@@ -438,7 +438,7 @@ struct ReferenceResolver: SemanticVisitor {
         }
         let newParametersVariants = symbol.parametersSectionVariants.map { parametersSection -> ParametersSection in
             let parameters = parametersSection.parameters.map {
-                Parameter(name: $0.name, contents: $0.contents.map { visitMarkup($0) })
+                Parameter(name: $0.name, nameRange: $0.nameRange, contents: $0.contents.map { visitMarkup($0) }, range: $0.range, isStandalone: $0.isStandalone)
             }
             return ParametersSection(parameters: parameters)
         }

--- a/Sources/SwiftDocC/Utility/FeatureFlags.swift
+++ b/Sources/SwiftDocC/Utility/FeatureFlags.swift
@@ -24,6 +24,9 @@ public struct FeatureFlags: Codable {
     /// Whether or not experimental support for emitting a serialized version of the local link resolution information is enabled.
     public var isExperimentalLinkHierarchySerializationEnabled = false
     
+    /// Whether or not experimental support validating parameters and return value documentation is enabled.
+    public var isExperimentalParametersAndReturnsValidationEnabled = false
+    
     /// Creates a set of feature flags with the given values.
     ///
     /// - Parameters:

--- a/Sources/SwiftDocC/Utility/MarkupExtensions/ListItemExtractor.swift
+++ b/Sources/SwiftDocC/Utility/MarkupExtensions/ListItemExtractor.swift
@@ -48,9 +48,10 @@ let simpleListItemTags = [
     "recommendedover",
 ]
 
-extension Collection where Element == InlineMarkup {
-    private func splitNameAndContent() -> (String, [Markup])? {
-        guard let initialTextNode = first as? Text else {
+extension Sequence where Element == InlineMarkup {
+    private func splitNameAndContent() -> (name: String, nameRange: SourceRange?, content: [Markup], range: SourceRange?)? {
+        var iterator = makeIterator()
+        guard let initialTextNode = iterator.next() as? Text else {
             return nil
         }
 
@@ -59,49 +60,68 @@ extension Collection where Element == InlineMarkup {
             return nil
         }
 
-        let parameterName = initialText.prefix(upTo: colonIndex)
+        let nameStartIndex = initialText[...colonIndex].lastIndex(of: " ").map { initialText.index(after: $0) } ?? initialText.startIndex
+        let parameterName = initialText[nameStartIndex..<colonIndex]
         guard !parameterName.isEmpty else {
             return nil
         }
         let remainingInitialText = initialText.suffix(from: initialText.index(after: colonIndex)).drop { $0 == " " }
-        let remainingChildren = self.dropFirst()
 
-        let newContent: [Markup] = [
-            Paragraph([Text(String(remainingInitialText))] + Array(remainingChildren))
-        ]
-        return (String(parameterName), newContent)
+        var newInlineContent: [InlineMarkup] = [Text(String(remainingInitialText))]
+        while let more = iterator.next() {
+            newInlineContent.append(more)
+        }
+        let newContent: [Markup] = [Paragraph(newInlineContent)]
+        
+        let nameRange: SourceRange? = initialTextNode.range.map { fullRange in
+            var start = fullRange.lowerBound
+            start.column += initialText.utf8.distance(from: initialText.startIndex, to: nameStartIndex)
+            var end = start
+            end.column += parameterName.utf8.count
+            return start ..< end
+        }
+        
+        let itemRange: SourceRange? = sequence(first: initialTextNode as Markup, next: { $0.parent })
+            .mapFirst(where: { $0 as? ListItem })?.range
+        
+        return (
+            String(parameterName),
+            nameRange,
+            newContent,
+            itemRange
+        )
     }
     
-    func extractParameter() -> Parameter? {
-        if let (name, content) = splitNameAndContent() {
-            return Parameter(name: name, contents: content)
+    func extractParameter(standalone: Bool) -> Parameter? {
+        if let (name, nameRange, content, itemRange) = splitNameAndContent() {
+            return Parameter(name: name, nameRange: nameRange, contents: content, range: itemRange, isStandalone: standalone)
         }
         return nil
     }
     
     func extractDictionaryKey() -> DictionaryKey? {
-        if let (name, content) = splitNameAndContent() {
+        if let (name, _, content, _) = splitNameAndContent() {
             return DictionaryKey(name: name, contents: content)
         }
         return nil
     }
     
     func extractHTTPParameter() -> HTTPParameter? {
-        if let (name, content) = splitNameAndContent() {
+        if let (name, _, content, _) = splitNameAndContent() {
             return HTTPParameter(name: name, source: nil, contents: content)
         }
         return nil
     }
     
     func extractHTTPBodyParameter() -> HTTPParameter? {
-        if let (name, content) = splitNameAndContent() {
+        if let (name, _, content, _) = splitNameAndContent() {
             return HTTPParameter(name: name, source: "body", contents: content)
         }
         return nil
     }
     
     func extractHTTPResponse() -> HTTPResponse? {
-        if let (name, content) = splitNameAndContent() {
+        if let (name, _, content, _) = splitNameAndContent() {
             let statusCode = UInt(name) ?? 0
             return HTTPResponse(statusCode: statusCode, reason: nil, mediaType: nil, contents: content)
         }
@@ -404,11 +424,11 @@ extension ListItem {
      ```
      */
     func extractStandaloneParameter() -> Parameter? {
-        guard let remainder = extractTag(TaggedListItemExtractor.parameterTag) else {
+        guard extractTag(TaggedListItemExtractor.parameterTag) != nil else {
             return nil
         }
-        return remainder.extractParameter()
-
+        // Don't use the return value from `extractTag` here. It drops the range and source information from the markup which means that we can't present diagnostics about the parameter.
+        return (child(at: 0) as? Paragraph)?.inlineChildren.extractParameter(standalone: true)
     }
 
     /**
@@ -442,13 +462,13 @@ extension ListItem {
             for child in parameterList.children {
                 guard let listItem = child as? ListItem,
                       let firstParagraph = listItem.child(at: 0) as? Paragraph,
-                      let parameter = Array(firstParagraph.inlineChildren).extractParameter() else {
+                      var parameter = Array(firstParagraph.inlineChildren).extractParameter(standalone: false) else {
                     continue
                 }
                 // Don't forget the rest of the content under this parameter list item.
-                let contents = parameter.contents + Array(listItem.children.dropFirst(1))
+                parameter.contents += Array(listItem.children.dropFirst(1))
 
-                parameters.append(Parameter(name: parameter.name, contents: contents))
+                parameters.append(parameter)
             }
         }
         return parameters
@@ -483,7 +503,7 @@ extension ListItem {
         guard let remainder = extractTag(TaggedListItemExtractor.returnsTag + ":") else {
             return nil
         }
-        return Return(contents: [Paragraph(remainder)])
+        return Return(contents: [Paragraph(remainder)], range: range)
     }
 
     /**

--- a/Sources/SwiftDocC/Utility/MarkupExtensions/SourceRangeExtensions.swift
+++ b/Sources/SwiftDocC/Utility/MarkupExtensions/SourceRangeExtensions.swift
@@ -10,6 +10,7 @@
 
 import Markdown
 import SymbolKit
+import Foundation
 
 extension SourceRange {
     /// Offsets the `SourceRange` using a SymbolKit `SourceRange`.
@@ -25,17 +26,21 @@ extension SourceRange {
                                                             column: symbolGrapSourceRange.end.character,
                                                             source: nil)
     }
-}
 
-extension SourceRange {
     /// Offsets the `SourceRange` using another `SourceRange`.
     ///
     /// - Warning: Absolute `SourceRange`s index line and column from 1. Thus, at least one
     /// of `self` or `range` must be a relative range indexed from 0.
     mutating func offsetWithRange(_ range: SourceRange) {
-        let start = SourceLocation(line: lowerBound.line + range.lowerBound.line, column: lowerBound.column + range.lowerBound.column, source: nil)
-        let end = SourceLocation(line: upperBound.line + range.lowerBound.line, column: upperBound.column + range.lowerBound.column, source: nil)
+        let start = SourceLocation(line: lowerBound.line + range.lowerBound.line, column: lowerBound.column + range.lowerBound.column, source: lowerBound.source)
+        let end = SourceLocation(line: upperBound.line + range.lowerBound.line, column: upperBound.column + range.lowerBound.column, source: upperBound.source)
         
         self = start..<end
+    }
+    
+    
+    /// The source file for which this range applies, if it came from an accessible location.
+    var source: URL? {
+        lowerBound.source ?? upperBound.source
     }
 }

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/ActionExtensions/ConvertAction+CommandInitialization.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/ActionExtensions/ConvertAction+CommandInitialization.swift
@@ -22,6 +22,7 @@ extension ConvertAction {
         
         FeatureFlags.current.isExperimentalDeviceFrameSupportEnabled = convert.enableExperimentalDeviceFrameSupport
         FeatureFlags.current.isExperimentalLinkHierarchySerializationEnabled = convert.enableExperimentalLinkHierarchySerialization
+        FeatureFlags.current.isExperimentalParametersAndReturnsValidationEnabled = convert.enableExperimentalParametersAndReturnsValidation
         
         // If the user-provided a URL for an external link resolver, attempt to
         // initialize an `OutOfProcessReferenceResolver` with the provided URL.

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Convert.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Convert.swift
@@ -529,6 +529,14 @@ extension Docc {
             )
             var enableExperimentalLinkHierarchySerialization = false
             
+            @Flag(
+                name: .customLong("enable-experimental-parameters-and-returns-validation"),
+                help: ArgumentHelp("Validate parameter and return value documentation", discussion: """
+                Validates and filters symbols' parameter and return value documentation based on the symbol's function signature in each language representation.
+                """)
+            )
+            var enableExperimentalParametersAndReturnsValidation = false
+            
             @Flag(help: "Write additional metadata files to the output directory.")
             var emitDigest = false
         
@@ -600,6 +608,12 @@ extension Docc {
         public var enableExperimentalLinkHierarchySerialization: Bool {
             get { featureFlags.enableExperimentalLinkHierarchySerialization }
             set { featureFlags.enableExperimentalLinkHierarchySerialization = newValue }
+        }
+        
+        /// A user-provided value that is true if the user enables experimental validation for parameters and return value documentation.
+        public var enableExperimentalParametersAndReturnsValidation: Bool {
+            get { featureFlags.enableExperimentalParametersAndReturnsValidation }
+            set { featureFlags.enableExperimentalParametersAndReturnsValidation = newValue }
         }
 
         /// A user-provided value that is true if additional metadata files should be produced.

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -4019,10 +4019,14 @@ let expected = """
         // One doc comment in the Obj-C header file contains an invalid doc
         // link on line 24, columns 56-63:
         // "Log a hello world message. This line contains an ``invalid`` link."
-        let (_, _, context) = try testBundleAndContext(copying: "ObjCFrameworkWithInvalidLink")
+        let (_, context) = try testBundleAndContext(named: "ObjCFrameworkWithInvalidLink")
         let problems = context.problems
-        XCTAssertEqual(1, problems.count)
-        let problem = try XCTUnwrap(problems.first)
+        if FeatureFlags.current.isExperimentalParametersAndReturnsValidationEnabled {
+            XCTAssertEqual(5, problems.count)
+        } else {
+            XCTAssertEqual(1, problems.count)
+        }
+        let problem = try XCTUnwrap(problems.first(where: { $0.diagnostic.identifier == "org.swift.docc.unresolvedTopicReference" }))
         let basename = try XCTUnwrap(problem.diagnostic.source?.lastPathComponent)
         XCTAssertEqual("HelloWorldFramework.h", basename)
         let start = Markdown.SourceLocation(line: 24, column: 56, source: nil)

--- a/Tests/SwiftDocCTests/Model/ParametersAndReturnValidatorTests.swift
+++ b/Tests/SwiftDocCTests/Model/ParametersAndReturnValidatorTests.swift
@@ -1,0 +1,390 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2023 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+import XCTest
+import Markdown
+@testable import SymbolKit
+@testable import SwiftDocC
+import SwiftDocCTestUtilities
+
+class ParametersAndReturnValidatorTests: XCTestCase {
+    
+    private var originalFeatureFlagsState: FeatureFlags!
+    
+    override func setUp() {
+        super.setUp()
+        originalFeatureFlagsState = FeatureFlags.current
+        FeatureFlags.current.isExperimentalParametersAndReturnsValidationEnabled = true
+    }
+    
+    override func tearDown() {
+        FeatureFlags.current = originalFeatureFlagsState
+        originalFeatureFlagsState = nil
+        super.tearDown()
+    }
+    
+    func testFiltersParameters() throws {
+        let (bundle, context) = try testBundleAndContext(named: "ErrorParameters")
+        
+        // /// - Parameters:
+        // ///   - someValue: Some value.
+        // ///   - error: On input, a pointer to an error object. If an error occurs, this pointer is set to an actual error object containing the error information.
+        // /// - Returns: `YES` if doing something was successful, or `NO` if an error occurred.
+        // - (void)doSomethingWith:(NSInteger)someValue error:(NSError **)error;
+        do {
+            let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ErrorParameters/MyClassInObjectiveC/doSomething(with:)", sourceLanguage: .swift)
+            let node = try context.entity(with: reference)
+            let symbol = try XCTUnwrap(node.semantic as? Symbol)
+            
+            let titles = symbol.titleVariants
+            XCTAssertEqual(titles[.swift], "doSomething(with:)")
+            XCTAssertEqual(titles[.objectiveC], "doSomethingWith:error:")
+            
+            let parameterSections = symbol.parametersSectionVariants
+            XCTAssertEqual(parameterSections[.swift]?.parameters.map(\.name), ["someValue"], "The Swift variant has no error parameter")
+            XCTAssertEqual(parameterSections[.objectiveC]?.parameters.map(\.name), ["someValue", "error"])
+            
+            let returnsSections = symbol.returnsSectionVariants
+            XCTAssertEqual(returnsSections[.swift]?.content.map({ $0.format() }).joined(), nil, "The Swift variant returns Void")
+            XCTAssertEqual(returnsSections[.objectiveC]?.content.map({ $0.format() }).joined(), "`YES` if doing something was successful, or `NO` if an error occurred.", "The Objective-C variant returns BOOL")
+        }
+        
+        // /// - Parameter error: On input, a pointer to an error object. If an error occurs, this pointer is set to an actual error object containing the error information.
+        // /// - Returns: Some string. If an error occurs, this method returns `nil` and assigns an appropriate error object to the `error` parameter.
+        // - (nullable NSString *)returnSomethingAndReturnError:(NSError **)error;
+        do {
+            let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ErrorParameters/MyClassInObjectiveC/returnSomething()", sourceLanguage: .swift)
+            let node = try context.entity(with: reference)
+            let symbol = try XCTUnwrap(node.semantic as? Symbol)
+            
+            let titles = symbol.titleVariants
+            XCTAssertEqual(titles[.swift], "returnSomething()")
+            XCTAssertEqual(titles[.objectiveC], "returnSomethingAndReturnError:")
+            
+            let parameterSections = symbol.parametersSectionVariants
+            XCTAssertEqual(parameterSections[.swift]?.parameters.map(\.name), nil, "The Swift variant has no parameters")
+            XCTAssertEqual(parameterSections[.objectiveC]?.parameters.map(\.name), ["error"])
+            
+            let returnsSections = symbol.returnsSectionVariants
+            XCTAssertEqual(returnsSections[.swift]?.content.map({ $0.format() }).joined(), "Some string. If an error occurs, this method returns `nil` and assigns an appropriate error object to the `error` parameter.")
+            XCTAssertEqual(returnsSections[.objectiveC]?.content.map({ $0.format() }).joined(), "Some string. If an error occurs, this method returns `nil` and assigns an appropriate error object to the `error` parameter.")
+        }
+        
+        // /// - Parameter someValue: Some value.
+        // /// - Throws: Some error if something does wrong
+        // @objc public func doSomething(with someValue: Int) throws { }
+        do {
+            let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ErrorParameters/MyClassInSwift/doSomething(with:)", sourceLanguage: .swift)
+            let node = try context.entity(with: reference)
+            let symbol = try XCTUnwrap(node.semantic as? Symbol)
+            
+            let titles = symbol.titleVariants
+            XCTAssertEqual(titles[.swift], "doSomething(with:)")
+            XCTAssertEqual(titles[.objectiveC], "doSomethingWith:error:")
+            
+            let parameterSections = symbol.parametersSectionVariants
+            XCTAssertEqual(parameterSections[.swift]?.parameters.map(\.name), ["someValue"], "The Swift variant has no error parameter")
+            XCTAssertEqual(parameterSections[.swift]?.parameters.first?.contents.map({ $0.format() }).joined(), "Some value.")
+            XCTAssertEqual(parameterSections[.objectiveC]?.parameters.map(\.name), ["someValue", "error"])
+            XCTAssertEqual(parameterSections[.objectiveC]?.parameters.first?.contents.map({ $0.format() }).joined(), "Some value.")
+            XCTAssertEqual(parameterSections[.objectiveC]?.parameters.last?.contents.map({ $0.format() }).joined(), "On input, a pointer to an error object. If an error occurs, this pointer is set to an actual error object containing the error information.")
+            
+            let returnsSections = symbol.returnsSectionVariants
+            XCTAssertEqual(returnsSections[.swift]?.content.map({ $0.format() }).joined(), nil, "The method has no return value documentation")
+            XCTAssertEqual(returnsSections[.objectiveC]?.content.map({ $0.format() }).joined(), "`YES` if successful, or `NO` if an error occurred.", "The Objective-C variant returns BOOL")
+        }
+        
+        // /// Returns something from Swift.
+        // /// - Returns: Some string.
+        // /// - Throws: Some error if something does wrong
+        // @objc public func returnSomething() throws -> String { "" }
+        do {
+            let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ErrorParameters/MyClassInSwift/returnSomething()", sourceLanguage: .swift)
+            let node = try context.entity(with: reference)
+            let symbol = try XCTUnwrap(node.semantic as? Symbol)
+            
+            let titles = symbol.titleVariants
+            XCTAssertEqual(titles[.swift], "returnSomething()")
+            XCTAssertEqual(titles[.objectiveC], "returnSomethingAndReturnError:")
+            
+            let parameterSections = symbol.parametersSectionVariants
+            XCTAssertEqual(parameterSections[.swift]?.parameters.map(\.name), nil, "The documentation comment has no parameter documentation")
+            XCTAssertEqual(parameterSections[.objectiveC]?.parameters.map(\.name), ["error"], "A generated error description is added because the symbol has documented the return value.")
+            
+            let returnsSections = symbol.returnsSectionVariants
+            XCTAssertEqual(returnsSections[.swift]?.content.map({ $0.format() }).joined(), "Some string.")
+            XCTAssertEqual(returnsSections[.objectiveC]?.content.map({ $0.format() }).joined(), "Some string. If an error occurs, this method returns `nil` and assigns an appropriate error object to the `error` parameter.")
+        }
+    }
+    
+    func testParameterDiagnosticsInDocumentationExtension() throws {
+        let (url, _, context) = try testBundleAndContext(copying: "ErrorParameters") { url in
+            try """
+            # ``MyClassInObjectiveC/doSomethingWith:error:``
+            
+            @Metadata {
+              @DocumentationExtension(mergeBehavior: override)
+            }
+            
+            Override the documentation with a parameter section that raise warnings.
+            
+            - Parameters:
+              - someValue: First description
+              - someValue: second description
+              - somevalue: Lowercase parameter name that doesn't exist
+              - somethingElse: Another parameter that isn't similar to any found parameter
+            """.write(to: url.appendingPathComponent("extension.md"), atomically: true, encoding: .utf8)
+            
+            try """
+            # ``MyClassInSwift/doSomething(with:)``
+            
+            @Metadata {
+              @DocumentationExtension(mergeBehavior: override)
+            }
+            
+            Override the documentation with a parameter section that raise warnings.
+            
+            - Parameter with: Documented using argument label
+            - Parameter error: Error description
+            """.write(to: url.appendingPathComponent("swift-extension.md"), atomically: true, encoding: .utf8)
+        }
+        
+        do {
+            XCTAssertEqual(context.problems.count, 5)
+            
+            let parameterNearMissProblem = try XCTUnwrap(context.problems.first(where: { $0.diagnostic.summary == "Parameter 'somevalue' not found in instance method declaration" }))
+            XCTAssertEqual(parameterNearMissProblem.diagnostic.source, url.appendingPathComponent("extension.md"))
+            XCTAssertEqual(parameterNearMissProblem.diagnostic.range?.lowerBound.line, 12)
+            XCTAssertEqual(parameterNearMissProblem.diagnostic.range?.lowerBound.column, 5)
+            XCTAssertEqual(parameterNearMissProblem.diagnostic.range?.upperBound.line, 12)
+            XCTAssertEqual(parameterNearMissProblem.diagnostic.range?.upperBound.column, 14)
+            
+            XCTAssertEqual(parameterNearMissProblem.possibleSolutions.first?.summary, "Replace 'somevalue' with 'someValue'")
+            XCTAssertEqual(parameterNearMissProblem.possibleSolutions.first?.replacements.first?.range, parameterNearMissProblem.diagnostic.range)
+            
+            let parameterNotFoundProblem = try XCTUnwrap(context.problems.first(where: { $0.diagnostic.summary == "Parameter 'somethingElse' not found in instance method declaration" }))
+            XCTAssertEqual(parameterNotFoundProblem.diagnostic.source, url.appendingPathComponent("extension.md"))
+            XCTAssertEqual(parameterNotFoundProblem.diagnostic.range?.lowerBound.line, 13)
+            XCTAssertEqual(parameterNotFoundProblem.diagnostic.range?.lowerBound.column, 3)
+            XCTAssertEqual(parameterNotFoundProblem.diagnostic.range?.upperBound.line, 13)
+            XCTAssertEqual(parameterNotFoundProblem.diagnostic.range?.upperBound.column, 79)
+            
+            XCTAssertEqual(parameterNotFoundProblem.possibleSolutions.first?.summary, "Remove 'somethingElse' parameter documentation")
+            XCTAssertEqual(parameterNotFoundProblem.possibleSolutions.first?.replacements.first?.range, parameterNotFoundProblem.diagnostic.range)
+            
+            let duplicateParameterProblem = try XCTUnwrap(context.problems.first(where: { $0.diagnostic.summary == "Parameter 'someValue' is already documented" }))
+            XCTAssertEqual(duplicateParameterProblem.diagnostic.source, url.appendingPathComponent("extension.md"))
+            XCTAssertEqual(duplicateParameterProblem.diagnostic.range?.lowerBound.line, 11)
+            XCTAssertEqual(duplicateParameterProblem.diagnostic.range?.lowerBound.column, 3)
+            XCTAssertEqual(duplicateParameterProblem.diagnostic.range?.upperBound.line, 11)
+            XCTAssertEqual(duplicateParameterProblem.diagnostic.range?.upperBound.column, 34)
+            
+            XCTAssertEqual(duplicateParameterProblem.possibleSolutions.first?.summary, "Remove duplicate parameter documentation")
+            XCTAssertEqual(duplicateParameterProblem.possibleSolutions.first?.replacements.first?.range, duplicateParameterProblem.diagnostic.range)
+            
+            XCTAssertEqual(duplicateParameterProblem.diagnostic.notes.first?.message, "Previously documented here")
+            XCTAssertEqual(duplicateParameterProblem.diagnostic.notes.first?.source, duplicateParameterProblem.diagnostic.source)
+            XCTAssertEqual(duplicateParameterProblem.diagnostic.notes.first?.range.lowerBound.line, 10)
+            XCTAssertEqual(duplicateParameterProblem.diagnostic.notes.first?.range.lowerBound.column, 3)
+            XCTAssertEqual(duplicateParameterProblem.diagnostic.notes.first?.range.upperBound.line, 10)
+            XCTAssertEqual(duplicateParameterProblem.diagnostic.notes.first?.range.upperBound.column, 33)
+            
+            let argumentLabelProblem = try XCTUnwrap(context.problems.first(where: { $0.diagnostic.summary == "Argument label 'with' used to document parameter" }))
+            XCTAssertEqual(argumentLabelProblem.diagnostic.source, url.appendingPathComponent("swift-extension.md"))
+            XCTAssertEqual(argumentLabelProblem.diagnostic.range?.lowerBound.line, 9)
+            XCTAssertEqual(argumentLabelProblem.diagnostic.range?.lowerBound.column, 13)
+            XCTAssertEqual(argumentLabelProblem.diagnostic.range?.upperBound.line, 9)
+            XCTAssertEqual(argumentLabelProblem.diagnostic.range?.upperBound.column, 17)
+            
+            XCTAssertEqual(argumentLabelProblem.possibleSolutions.first?.summary, "Replace 'with' with 'someValue'")
+            XCTAssertEqual(argumentLabelProblem.possibleSolutions.first?.replacements.first?.range, argumentLabelProblem.diagnostic.range)
+            XCTAssertEqual(argumentLabelProblem.possibleSolutions.first?.replacements.first?.replacement, "someValue")
+            
+            let undocumentedParameterProblem = try XCTUnwrap(context.problems.first(where: { $0.diagnostic.summary == "Parameter 'someValue' is missing documentation" }))
+            XCTAssertEqual(undocumentedParameterProblem.diagnostic.source, url.appendingPathComponent("swift-extension.md"))
+            XCTAssertEqual(undocumentedParameterProblem.diagnostic.range?.lowerBound.line, 10)
+            XCTAssertEqual(undocumentedParameterProblem.diagnostic.range?.lowerBound.column, 37)
+            XCTAssertEqual(undocumentedParameterProblem.diagnostic.range?.upperBound.line, 10)
+            XCTAssertEqual(undocumentedParameterProblem.diagnostic.range?.upperBound.column, 37)
+            
+            XCTAssertEqual(undocumentedParameterProblem.possibleSolutions.first?.summary, "Document 'someValue' parameter")
+            XCTAssertEqual(undocumentedParameterProblem.possibleSolutions.first?.replacements.first?.range.source, url.appendingPathComponent("swift-extension.md"))
+            XCTAssertEqual(undocumentedParameterProblem.possibleSolutions.first?.replacements.first?.range.lowerBound.line, 10)
+            XCTAssertEqual(undocumentedParameterProblem.possibleSolutions.first?.replacements.first?.range.lowerBound.column, 1)
+            XCTAssertEqual(undocumentedParameterProblem.possibleSolutions.first?.replacements.first?.range.upperBound.line, 10)
+            XCTAssertEqual(undocumentedParameterProblem.possibleSolutions.first?.replacements.first?.range.upperBound.column, 1)
+            XCTAssertEqual(undocumentedParameterProblem.possibleSolutions.first?.replacements.first?.replacement, "- Parameter someValue: <#parameter description#>\n")
+        }
+    }
+    
+    func testNoParameterDiagnosticWithoutFunctionSignature() throws {
+        var symbolGraph = makeSymbolGraph(docComment: """
+            Some function description
+            
+            - Parameters:
+              - secondParameter: One description
+              - thirdParameter: Another description
+            """)
+        
+        symbolGraph.symbols["symbol-id"]?.mixins[SymbolGraph.Symbol.FunctionSignature.mixinKey] = nil
+        
+        let url = try createTempFolder(content: [
+            Folder(name: "unit-test.docc", content: [
+                JSONFile(name: "ModuleName.symbols.json", content: symbolGraph)
+            ])
+        ])
+        let (_, _, context) = try loadBundle(from: url)
+        
+        XCTAssertEqual(context.problems.count, 0)
+    }
+    
+    func testNoParameterDiagnosticWithoutDocumentationComment() throws {
+        let symbolGraph = makeSymbolGraph(docComment: """
+            Some function description
+            
+            No parameters section
+            """)
+        
+        let url = try createTempFolder(content: [
+            Folder(name: "unit-test.docc", content: [
+                JSONFile(name: "ModuleName.symbols.json", content: symbolGraph)
+            ])
+        ])
+        let (_, _, context) = try loadBundle(from: url)
+        
+        XCTAssertEqual(context.problems.count, 0)
+    }
+    
+    func testMissingParametersInDocCommentDiagnostics() throws {
+        let symbolGraph = makeSymbolGraph(docComment: """
+            Some function description
+            
+            - Parameters:
+              - secondParameter: One description
+              - thirdParameter: Another description
+            """)
+        let url = try createTempFolder(content: [
+            Folder(name: "unit-test.docc", content: [
+                JSONFile(name: "ModuleName.symbols.json", content: symbolGraph)
+            ])
+        ])
+        let (_, _, context) = try loadBundle(from: url)
+        
+        XCTAssertEqual(context.problems.count, 2)
+        let endOfParameterSectionLocation = SourceLocation(line: start.line + 5, column: start.character + 40, source: symbolURL)
+        
+        let oneMissingParameterProblem = try XCTUnwrap(context.problems.first(where: { $0.diagnostic.summary == "Parameter 'firstParameter' is missing documentation" }))
+        XCTAssertEqual(oneMissingParameterProblem.diagnostic.source, symbolURL)
+        XCTAssertEqual(oneMissingParameterProblem.diagnostic.range?.lowerBound, endOfParameterSectionLocation)
+        XCTAssertEqual(oneMissingParameterProblem.diagnostic.range?.upperBound, endOfParameterSectionLocation)
+        
+        // The missing `firstParameter` should be added before 'secondParameter'
+        XCTAssertEqual(oneMissingParameterProblem.possibleSolutions.first?.summary, "Document 'firstParameter' parameter")
+        let startOfParameterTwoLocation = SourceLocation(line: start.line + 4, column: start.character + 3, source: symbolURL)
+        XCTAssertEqual(oneMissingParameterProblem.possibleSolutions.first?.replacements.first?.range.lowerBound, startOfParameterTwoLocation)
+        XCTAssertEqual(oneMissingParameterProblem.possibleSolutions.first?.replacements.first?.range.upperBound, startOfParameterTwoLocation)
+        XCTAssertEqual(oneMissingParameterProblem.possibleSolutions.first?.replacements.first?.replacement, "- firstParameter: <#parameter description#>\n  ")
+        
+        let otherMissingParameterProblem = try XCTUnwrap(context.problems.first(where: { $0.diagnostic.summary == "Parameter 'fourthParameter' is missing documentation" }))
+        XCTAssertEqual(otherMissingParameterProblem.diagnostic.source, symbolURL)
+        XCTAssertEqual(otherMissingParameterProblem.diagnostic.range?.lowerBound, endOfParameterSectionLocation)
+        XCTAssertEqual(otherMissingParameterProblem.diagnostic.range?.upperBound, endOfParameterSectionLocation)
+        
+        // The missing 'fourthParameter' should be added after the 'thirdParameter'
+        XCTAssertEqual(otherMissingParameterProblem.possibleSolutions.first?.summary, "Document 'fourthParameter' parameter")
+        XCTAssertEqual(otherMissingParameterProblem.possibleSolutions.first?.replacements.first?.range.lowerBound, endOfParameterSectionLocation)
+        XCTAssertEqual(otherMissingParameterProblem.possibleSolutions.first?.replacements.first?.range.upperBound, endOfParameterSectionLocation)
+        XCTAssertEqual(otherMissingParameterProblem.possibleSolutions.first?.replacements.first?.replacement, "\n  - fourthParameter: <#parameter description#>")
+    }
+    
+    func testMissingSeparateParametersInDocCommentDiagnostics() throws {
+        let symbolGraph = makeSymbolGraph(docComment: """
+            Some function description
+            
+            - Parameter secondParameter: One description
+            - Parameter thirdParameter: Another description
+            """)
+        let url = try createTempFolder(content: [
+            Folder(name: "unit-test.docc", content: [
+                JSONFile(name: "ModuleName.symbols.json", content: symbolGraph)
+            ])
+        ])
+        let (_, _, context) = try loadBundle(from: url)
+        
+        XCTAssertEqual(context.problems.count, 2)
+        let endOfParameterSectionLocation = SourceLocation(line: start.line + 4, column: start.character + 48, source: symbolURL)
+        
+        let oneMissingParameterProblem = try XCTUnwrap(context.problems.first(where: { $0.diagnostic.summary == "Parameter 'firstParameter' is missing documentation" }))
+        XCTAssertEqual(oneMissingParameterProblem.diagnostic.source, symbolURL)
+        XCTAssertEqual(oneMissingParameterProblem.diagnostic.range?.lowerBound, endOfParameterSectionLocation)
+        XCTAssertEqual(oneMissingParameterProblem.diagnostic.range?.upperBound, endOfParameterSectionLocation)
+        
+        // The missing `firstParameter` should be added before 'secondParameter'
+        XCTAssertEqual(oneMissingParameterProblem.possibleSolutions.first?.summary, "Document 'firstParameter' parameter")
+        let startOfParameterTwoLocation = SourceLocation(line: start.line + 3, column: start.character + 1, source: symbolURL)
+        XCTAssertEqual(oneMissingParameterProblem.possibleSolutions.first?.replacements.first?.range.lowerBound, startOfParameterTwoLocation)
+        XCTAssertEqual(oneMissingParameterProblem.possibleSolutions.first?.replacements.first?.range.upperBound, startOfParameterTwoLocation)
+        XCTAssertEqual(oneMissingParameterProblem.possibleSolutions.first?.replacements.first?.replacement, "- Parameter firstParameter: <#parameter description#>\n")
+        
+        let otherMissingParameterProblem = try XCTUnwrap(context.problems.first(where: { $0.diagnostic.summary == "Parameter 'fourthParameter' is missing documentation" }))
+        XCTAssertEqual(otherMissingParameterProblem.diagnostic.source, symbolURL)
+        XCTAssertEqual(otherMissingParameterProblem.diagnostic.range?.lowerBound, endOfParameterSectionLocation)
+        XCTAssertEqual(otherMissingParameterProblem.diagnostic.range?.upperBound, endOfParameterSectionLocation)
+        
+        // The missing 'fourthParameter' should be added after the 'thirdParameter'
+        XCTAssertEqual(otherMissingParameterProblem.possibleSolutions.first?.summary, "Document 'fourthParameter' parameter")
+        XCTAssertEqual(otherMissingParameterProblem.possibleSolutions.first?.replacements.first?.range.lowerBound, endOfParameterSectionLocation)
+        XCTAssertEqual(otherMissingParameterProblem.possibleSolutions.first?.replacements.first?.range.upperBound, endOfParameterSectionLocation)
+        XCTAssertEqual(otherMissingParameterProblem.possibleSolutions.first?.replacements.first?.replacement, "\n- Parameter fourthParameter: <#parameter description#>")
+    }
+    
+    private let start = SymbolGraph.LineList.SourceRange.Position(line: 7, character: 3) // an arbitrary non-zero start position
+    private let symbolURL =  URL(fileURLWithPath: "/path/to/SomeFile.swift")
+    
+    private func makeSymbolGraph(docComment: String) -> SymbolGraph {
+        let uri = symbolURL.absoluteString // we want to include the file:// scheme here
+        func makeLineList(text: String) -> SymbolGraph.LineList {
+            
+            return .init(text.splitByNewlines.enumerated().map { lineOffset, line in
+                    .init(text: line, range: .init(start: .init(line: start.line + lineOffset, character: start.character),
+                                                   end: .init(line: start.line + lineOffset, character: start.character + line.count)))
+            }, uri: uri)
+        }
+        
+        return makeSymbolGraph(
+            moduleName: "ModuleName",
+            symbols: [
+                .init(
+                    identifier: .init(precise: "symbol-id", interfaceLanguage: "swift"),
+                    names: .init(title: "functionName(...)", navigator: nil, subHeading: nil, prose: nil),
+                    pathComponents: ["functionName(...)"],
+                    docComment: makeLineList(text: docComment),
+                    accessLevel: .public, kind: .init(parsedIdentifier: .func, displayName: "Function"),
+                    mixins: [
+                        SymbolGraph.Symbol.Location.mixinKey: SymbolGraph.Symbol.Location(uri: uri, position: start),
+                        
+                        SymbolGraph.Symbol.FunctionSignature.mixinKey: SymbolGraph.Symbol.FunctionSignature(
+                            parameters: [
+                                .init(name: "firstParameter", externalName: nil, declarationFragments: [], children: []),
+                                .init(name: "secondParameter", externalName: nil, declarationFragments: [], children: []),
+                                .init(name: "thirdParameter", externalName: nil, declarationFragments: [], children: []),
+                                .init(name: "fourthParameter", externalName: nil, declarationFragments: [], children: []),
+                            ],
+                            returns: [
+                                .init(kind: .typeIdentifier, spelling: "ReturnValue", preciseIdentifier: "return-value-id")
+                            ]
+                        )
+                    ]
+                )
+            ]
+        )
+    }
+}

--- a/Tests/SwiftDocCTests/Test Bundles/ErrorParameters.docc/clang/ErrorParameters.symbols.json
+++ b/Tests/SwiftDocCTests/Test Bundles/ErrorParameters.docc/clang/ErrorParameters.symbols.json
@@ -1,0 +1,1492 @@
+{
+  "metadata": {
+    "formatVersion": {
+      "major": 0,
+      "minor": 5,
+      "patch": 3
+    },
+    "generator": "Apple clang version 15.0.0 (clang-1500.0.40.1)"
+  },
+  "module": {
+    "name": "ErrorParameters",
+    "platform": {
+      "architecture": "arm64",
+      "operatingSystem": {
+        "minimumVersion": {
+          "major": 11,
+          "minor": 0,
+          "patch": 0
+        },
+        "name": "macosx"
+      },
+      "vendor": "apple"
+    }
+  },
+  "relationships": [
+    {
+      "kind": "memberOf",
+      "source": "c:objc(cs)MyClassInObjectiveC(im)doSomethingWith:error:",
+      "target": "c:objc(cs)MyClassInObjectiveC",
+      "targetFallback": "MyClassInObjectiveC"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:objc(cs)MyClassInObjectiveC(im)returnSomethingAndReturnError:",
+      "target": "c:objc(cs)MyClassInObjectiveC",
+      "targetFallback": "MyClassInObjectiveC"
+    },
+    {
+      "kind": "inheritsFrom",
+      "source": "c:objc(cs)MyClassInObjectiveC",
+      "target": "c:objc(cs)NSObject",
+      "targetFallback": "NSObject"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:@M@ErrorParameters@objc(cs)MyClassInSwift(im)doSomethingWith:error:",
+      "target": "c:@M@ErrorParameters@objc(cs)MyClassInSwift",
+      "targetFallback": "MyClassInSwift"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:@M@ErrorParameters@objc(cs)MyClassInSwift(im)returnSomethingAndReturnError:",
+      "target": "c:@M@ErrorParameters@objc(cs)MyClassInSwift",
+      "targetFallback": "MyClassInSwift"
+    },
+    {
+      "kind": "inheritsFrom",
+      "source": "c:@M@ErrorParameters@objc(cs)MyClassInSwift",
+      "target": "c:objc(cs)NSObject",
+      "targetFallback": "NSObject"
+    }
+  ],
+  "symbols": [
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "keyword",
+          "spelling": "extern"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:d",
+          "spelling": "double"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "ErrorParametersVersionNumber"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 48,
+                "line": 10
+              },
+              "start": {
+                "character": 5,
+                "line": 10
+              }
+            },
+            "text": "Project version number for ErrorParameters."
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c",
+        "precise": "c:@ErrorParametersVersionNumber"
+      },
+      "kind": {
+        "displayName": "Global Variable",
+        "identifier": "objective-c.var"
+      },
+      "location": {
+        "position": {
+          "character": 26,
+          "line": 11
+        },
+        "uri": "file:///Users/username/path/to/ErrorParameters/ErrorParameters.h"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "ErrorParametersVersionNumber"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "ErrorParametersVersionNumber"
+          }
+        ],
+        "title": "ErrorParametersVersionNumber"
+      },
+      "pathComponents": [
+        "ErrorParametersVersionNumber"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "keyword",
+          "spelling": "extern"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "keyword",
+          "spelling": "const"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:c",
+          "spelling": "unsigned char"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "ErrorParametersVersionString"
+        },
+        {
+          "kind": "text",
+          "spelling": "[]"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 48,
+                "line": 13
+              },
+              "start": {
+                "character": 5,
+                "line": 13
+              }
+            },
+            "text": "Project version string for ErrorParameters."
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c",
+        "precise": "c:@ErrorParametersVersionString"
+      },
+      "kind": {
+        "displayName": "Global Variable",
+        "identifier": "objective-c.var"
+      },
+      "location": {
+        "position": {
+          "character": 39,
+          "line": 14
+        },
+        "uri": "file:///Users/username/path/to/ErrorParameters/ErrorParameters.h"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "ErrorParametersVersionString"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "ErrorParametersVersionString"
+          }
+        ],
+        "title": "ErrorParametersVersionString"
+      },
+      "pathComponents": [
+        "ErrorParametersVersionString"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "keyword",
+          "spelling": "@interface"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "MyClassInObjectiveC"
+        },
+        {
+          "kind": "text",
+          "spelling": " : "
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:objc(cs)NSObject",
+          "spelling": "NSObject"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 67,
+                "line": 12
+              },
+              "start": {
+                "character": 5,
+                "line": 12
+              }
+            },
+            "text": "An Objective-C class with two functions that can raise errors."
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c",
+        "precise": "c:objc(cs)MyClassInObjectiveC"
+      },
+      "kind": {
+        "displayName": "Class",
+        "identifier": "objective-c.class"
+      },
+      "location": {
+        "position": {
+          "character": 12,
+          "line": 13
+        },
+        "uri": "file:///Users/username/path/to/ErrorParameters/MyClassInObjectiveC.h"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "MyClassInObjectiveC"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "MyClassInObjectiveC"
+          }
+        ],
+        "title": "MyClassInObjectiveC"
+      },
+      "pathComponents": [
+        "MyClassInObjectiveC"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "text",
+          "spelling": "- ("
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@T@BOOL",
+          "spelling": "BOOL"
+        },
+        {
+          "kind": "text",
+          "spelling": ") "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "doSomethingWith:"
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@T@NSInteger",
+          "spelling": "NSInteger"
+        },
+        {
+          "kind": "text",
+          "spelling": ") "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "someValue"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "error:"
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:objc(cs)NSError",
+          "spelling": "NSError"
+        },
+        {
+          "kind": "text",
+          "spelling": " * *) "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "error"
+        },
+        {
+          "kind": "text",
+          "spelling": ";"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 34,
+                "line": 15
+              },
+              "start": {
+                "character": 5,
+                "line": 15
+              }
+            },
+            "text": "Does something in Objective-C"
+          },
+          {
+            "range": {
+              "end": {
+                "character": 18,
+                "line": 16
+              },
+              "start": {
+                "character": 5,
+                "line": 16
+              }
+            },
+            "text": "- Parameters:"
+          },
+          {
+            "range": {
+              "end": {
+                "character": 31,
+                "line": 17
+              },
+              "start": {
+                "character": 5,
+                "line": 17
+              }
+            },
+            "text": "  - someValue: Some value."
+          },
+          {
+            "range": {
+              "end": {
+                "character": 155,
+                "line": 18
+              },
+              "start": {
+                "character": 5,
+                "line": 18
+              }
+            },
+            "text": "  - error: On input, a pointer to an error object. If an error occurs, this pointer is set to an actual error object containing the error information."
+          },
+          {
+            "range": {
+              "end": {
+                "character": 86,
+                "line": 19
+              },
+              "start": {
+                "character": 5,
+                "line": 19
+              }
+            },
+            "text": "- Returns: `YES` if doing something was successful, or `NO` if an error occurred."
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "declarationFragments": [
+              {
+                "kind": "text",
+                "spelling": "("
+              },
+              {
+                "kind": "typeIdentifier",
+                "preciseIdentifier": "c:@T@NSInteger",
+                "spelling": "NSInteger"
+              },
+              {
+                "kind": "text",
+                "spelling": ") "
+              },
+              {
+                "kind": "internalParam",
+                "spelling": "someValue"
+              }
+            ],
+            "name": "someValue"
+          },
+          {
+            "declarationFragments": [
+              {
+                "kind": "text",
+                "spelling": "("
+              },
+              {
+                "kind": "typeIdentifier",
+                "preciseIdentifier": "c:objc(cs)NSError",
+                "spelling": "NSError"
+              },
+              {
+                "kind": "text",
+                "spelling": " * *) "
+              },
+              {
+                "kind": "internalParam",
+                "spelling": "error"
+              }
+            ],
+            "name": "error"
+          }
+        ],
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:@T@BOOL",
+            "spelling": "BOOL"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c",
+        "precise": "c:objc(cs)MyClassInObjectiveC(im)doSomethingWith:error:"
+      },
+      "kind": {
+        "displayName": "Instance Method",
+        "identifier": "objective-c.method"
+      },
+      "location": {
+        "position": {
+          "character": 1,
+          "line": 20
+        },
+        "uri": "file:///Users/username/path/to/ErrorParameters/MyClassInObjectiveC.h"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "doSomethingWith:error:"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "text",
+            "spelling": "- "
+          },
+          {
+            "kind": "identifier",
+            "spelling": "doSomethingWith:error:"
+          }
+        ],
+        "title": "doSomethingWith:error:"
+      },
+      "pathComponents": [
+        "MyClassInObjectiveC",
+        "doSomethingWith:error:"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "text",
+          "spelling": "- ("
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:objc(cs)NSString",
+          "spelling": "NSString"
+        },
+        {
+          "kind": "text",
+          "spelling": " *) "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "returnSomethingAndReturnError:"
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:objc(cs)NSError",
+          "spelling": "NSError"
+        },
+        {
+          "kind": "text",
+          "spelling": " * *) "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "error"
+        },
+        {
+          "kind": "text",
+          "spelling": ";"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 40,
+                "line": 23
+              },
+              "start": {
+                "character": 5,
+                "line": 23
+              }
+            },
+            "text": "Returns something from Objective-C."
+          },
+          {
+            "range": {
+              "end": {
+                "character": 163,
+                "line": 24
+              },
+              "start": {
+                "character": 5,
+                "line": 24
+              }
+            },
+            "text": "- Parameter error: On input, a pointer to an error object. If an error occurs, this pointer is set to an actual error object containing the error information."
+          },
+          {
+            "range": {
+              "end": {
+                "character": 140,
+                "line": 25
+              },
+              "start": {
+                "character": 5,
+                "line": 25
+              }
+            },
+            "text": "- Returns: Some string. If an error occurs, this method returns `nil` and assigns an appropriate error object to the `error` parameter."
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "declarationFragments": [
+              {
+                "kind": "text",
+                "spelling": "("
+              },
+              {
+                "kind": "typeIdentifier",
+                "preciseIdentifier": "c:objc(cs)NSError",
+                "spelling": "NSError"
+              },
+              {
+                "kind": "text",
+                "spelling": " * *) "
+              },
+              {
+                "kind": "internalParam",
+                "spelling": "error"
+              }
+            ],
+            "name": "error"
+          }
+        ],
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:objc(cs)NSString",
+            "spelling": "NSString"
+          },
+          {
+            "kind": "text",
+            "spelling": " *"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c",
+        "precise": "c:objc(cs)MyClassInObjectiveC(im)returnSomethingAndReturnError:"
+      },
+      "kind": {
+        "displayName": "Instance Method",
+        "identifier": "objective-c.method"
+      },
+      "location": {
+        "position": {
+          "character": 1,
+          "line": 26
+        },
+        "uri": "file:///Users/username/path/to/ErrorParameters/MyClassInObjectiveC.h"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "returnSomethingAndReturnError:"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "text",
+            "spelling": "- "
+          },
+          {
+            "kind": "identifier",
+            "spelling": "returnSomethingAndReturnError:"
+          }
+        ],
+        "title": "returnSomethingAndReturnError:"
+      },
+      "pathComponents": [
+        "MyClassInObjectiveC",
+        "returnSomethingAndReturnError:"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "keyword",
+          "spelling": "@interface"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "MyClassInSwift"
+        },
+        {
+          "kind": "text",
+          "spelling": " : "
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:objc(cs)NSObject",
+          "spelling": "NSObject"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 45,
+                "line": 303
+              },
+              "start": {
+                "character": 5,
+                "line": 303
+              }
+            },
+            "text": "A Swift class with 2 throwing functions."
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c",
+        "precise": "c:@M@ErrorParameters@objc(cs)MyClassInSwift"
+      },
+      "kind": {
+        "displayName": "Class",
+        "identifier": "objective-c.class"
+      },
+      "location": {
+        "position": {
+          "character": 12,
+          "line": 305
+        },
+        "uri": "file:///Users/droennqvist/Library/Developer/Xcode/DerivedData/ErrorParameters-gazxganyiilhgcducsyxdoxeciia/Build/Products/Debug/ErrorParameters.framework/Headers/ErrorParameters-Swift.h"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "MyClassInSwift"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "MyClassInSwift"
+          }
+        ],
+        "title": "MyClassInSwift"
+      },
+      "pathComponents": [
+        "MyClassInSwift"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "text",
+          "spelling": "- ("
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@T@BOOL",
+          "spelling": "BOOL"
+        },
+        {
+          "kind": "text",
+          "spelling": ") "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "doSomethingWith:"
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@T@NSInteger",
+          "spelling": "NSInteger"
+        },
+        {
+          "kind": "text",
+          "spelling": ") "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "someValue"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "error:"
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:objc(cs)NSError",
+          "spelling": "NSError"
+        },
+        {
+          "kind": "text",
+          "spelling": " * *) "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "error"
+        },
+        {
+          "kind": "text",
+          "spelling": ";"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 29,
+                "line": 308
+              },
+              "start": {
+                "character": 5,
+                "line": 308
+              }
+            },
+            "text": "Does something in Swift."
+          },
+          {
+            "range": {
+              "end": {
+                "character": 33,
+                "line": 309
+              },
+              "start": {
+                "character": 5,
+                "line": 309
+              }
+            },
+            "text": "\\param someValue Some value."
+          },
+          {
+            "range": {
+              "end": {
+                "character": 4,
+                "line": 310
+              },
+              "start": {
+                "character": 4,
+                "line": 310
+              }
+            },
+            "text": ""
+          },
+          {
+            "range": {
+              "end": {
+                "character": 4,
+                "line": 311
+              },
+              "start": {
+                "character": 4,
+                "line": 311
+              }
+            },
+            "text": ""
+          },
+          {
+            "range": {
+              "end": {
+                "character": 12,
+                "line": 312
+              },
+              "start": {
+                "character": 5,
+                "line": 312
+              }
+            },
+            "text": "throws:"
+          },
+          {
+            "range": {
+              "end": {
+                "character": 39,
+                "line": 313
+              },
+              "start": {
+                "character": 5,
+                "line": 313
+              }
+            },
+            "text": "Some error if something does wrong"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "declarationFragments": [
+              {
+                "kind": "text",
+                "spelling": "("
+              },
+              {
+                "kind": "typeIdentifier",
+                "preciseIdentifier": "c:@T@NSInteger",
+                "spelling": "NSInteger"
+              },
+              {
+                "kind": "text",
+                "spelling": ") "
+              },
+              {
+                "kind": "internalParam",
+                "spelling": "someValue"
+              }
+            ],
+            "name": "someValue"
+          },
+          {
+            "declarationFragments": [
+              {
+                "kind": "text",
+                "spelling": "("
+              },
+              {
+                "kind": "typeIdentifier",
+                "preciseIdentifier": "c:objc(cs)NSError",
+                "spelling": "NSError"
+              },
+              {
+                "kind": "text",
+                "spelling": " * *) "
+              },
+              {
+                "kind": "internalParam",
+                "spelling": "error"
+              }
+            ],
+            "name": "error"
+          }
+        ],
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:@T@BOOL",
+            "spelling": "BOOL"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c",
+        "precise": "c:@M@ErrorParameters@objc(cs)MyClassInSwift(im)doSomethingWith:error:"
+      },
+      "kind": {
+        "displayName": "Instance Method",
+        "identifier": "objective-c.method"
+      },
+      "location": {
+        "position": {
+          "character": 1,
+          "line": 314
+        },
+        "uri": "file:///Users/droennqvist/Library/Developer/Xcode/DerivedData/ErrorParameters-gazxganyiilhgcducsyxdoxeciia/Build/Products/Debug/ErrorParameters.framework/Headers/ErrorParameters-Swift.h"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "doSomethingWith:error:"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "text",
+            "spelling": "- "
+          },
+          {
+            "kind": "identifier",
+            "spelling": "doSomethingWith:error:"
+          }
+        ],
+        "title": "doSomethingWith:error:"
+      },
+      "pathComponents": [
+        "MyClassInSwift",
+        "doSomethingWith:error:"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "text",
+          "spelling": "- ("
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:objc(cs)NSString",
+          "spelling": "NSString"
+        },
+        {
+          "kind": "text",
+          "spelling": " *) "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "returnSomethingAndReturnError:"
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:objc(cs)NSError",
+          "spelling": "NSError"
+        },
+        {
+          "kind": "text",
+          "spelling": " * *) "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "error"
+        },
+        {
+          "kind": "text",
+          "spelling": ";"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 34,
+                "line": 315
+              },
+              "start": {
+                "character": 5,
+                "line": 315
+              }
+            },
+            "text": "Returns something from Swift."
+          },
+          {
+            "range": {
+              "end": {
+                "character": 4,
+                "line": 316
+              },
+              "start": {
+                "character": 4,
+                "line": 316
+              }
+            },
+            "text": ""
+          },
+          {
+            "range": {
+              "end": {
+                "character": 12,
+                "line": 317
+              },
+              "start": {
+                "character": 5,
+                "line": 317
+              }
+            },
+            "text": "throws:"
+          },
+          {
+            "range": {
+              "end": {
+                "character": 39,
+                "line": 318
+              },
+              "start": {
+                "character": 5,
+                "line": 318
+              }
+            },
+            "text": "Some error if something does wrong"
+          },
+          {
+            "range": {
+              "end": {
+                "character": 4,
+                "line": 319
+              },
+              "start": {
+                "character": 4,
+                "line": 319
+              }
+            },
+            "text": ""
+          },
+          {
+            "range": {
+              "end": {
+                "character": 13,
+                "line": 320
+              },
+              "start": {
+                "character": 5,
+                "line": 320
+              }
+            },
+            "text": "returns:"
+          },
+          {
+            "range": {
+              "end": {
+                "character": 17,
+                "line": 321
+              },
+              "start": {
+                "character": 5,
+                "line": 321
+              }
+            },
+            "text": "Some string."
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "declarationFragments": [
+              {
+                "kind": "text",
+                "spelling": "("
+              },
+              {
+                "kind": "typeIdentifier",
+                "preciseIdentifier": "c:objc(cs)NSError",
+                "spelling": "NSError"
+              },
+              {
+                "kind": "text",
+                "spelling": " * *) "
+              },
+              {
+                "kind": "internalParam",
+                "spelling": "error"
+              }
+            ],
+            "name": "error"
+          }
+        ],
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:objc(cs)NSString",
+            "spelling": "NSString"
+          },
+          {
+            "kind": "text",
+            "spelling": " *"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c",
+        "precise": "c:@M@ErrorParameters@objc(cs)MyClassInSwift(im)returnSomethingAndReturnError:"
+      },
+      "kind": {
+        "displayName": "Instance Method",
+        "identifier": "objective-c.method"
+      },
+      "location": {
+        "position": {
+          "character": 1,
+          "line": 322
+        },
+        "uri": "file:///Users/droennqvist/Library/Developer/Xcode/DerivedData/ErrorParameters-gazxganyiilhgcducsyxdoxeciia/Build/Products/Debug/ErrorParameters.framework/Headers/ErrorParameters-Swift.h"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "returnSomethingAndReturnError:"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "text",
+            "spelling": "- "
+          },
+          {
+            "kind": "identifier",
+            "spelling": "returnSomethingAndReturnError:"
+          }
+        ],
+        "title": "returnSomethingAndReturnError:"
+      },
+      "pathComponents": [
+        "MyClassInSwift",
+        "returnSomethingAndReturnError:"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "keyword",
+          "spelling": "#define"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "ERRORPARAMETERS_SWIFT_H"
+        }
+      ],
+      "identifier": {
+        "interfaceLanguage": "objective-c",
+        "precise": "c:ErrorParameters-Swift.h@168@macro@ERRORPARAMETERS_SWIFT_H"
+      },
+      "kind": {
+        "displayName": "Macro",
+        "identifier": "objective-c.macro"
+      },
+      "location": {
+        "position": {
+          "character": 9,
+          "line": 5
+        },
+        "uri": "file:///Users/droennqvist/Library/Developer/Xcode/DerivedData/ErrorParameters-gazxganyiilhgcducsyxdoxeciia/Build/Products/Debug/ErrorParameters.framework/Headers/ErrorParameters-Swift.h"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "ERRORPARAMETERS_SWIFT_H"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "ERRORPARAMETERS_SWIFT_H"
+          }
+        ],
+        "title": "ERRORPARAMETERS_SWIFT_H"
+      },
+      "pathComponents": [
+        "ERRORPARAMETERS_SWIFT_H"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "keyword",
+          "spelling": "#define"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "SWIFT_ENUM_NAMED"
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "_type"
+        },
+        {
+          "kind": "text",
+          "spelling": ", "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "_name"
+        },
+        {
+          "kind": "text",
+          "spelling": ", "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "SWIFT_NAME"
+        },
+        {
+          "kind": "text",
+          "spelling": ", "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "_extensibility"
+        },
+        {
+          "kind": "text",
+          "spelling": ")"
+        }
+      ],
+      "identifier": {
+        "interfaceLanguage": "objective-c",
+        "precise": "c:ErrorParameters-Swift.h@6388@macro@SWIFT_ENUM_NAMED"
+      },
+      "kind": {
+        "displayName": "Macro",
+        "identifier": "objective-c.macro"
+      },
+      "location": {
+        "position": {
+          "character": 11,
+          "line": 196
+        },
+        "uri": "file:///Users/droennqvist/Library/Developer/Xcode/DerivedData/ErrorParameters-gazxganyiilhgcducsyxdoxeciia/Build/Products/Debug/ErrorParameters.framework/Headers/ErrorParameters-Swift.h"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "SWIFT_ENUM_NAMED"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "SWIFT_ENUM_NAMED"
+          }
+        ],
+        "title": "SWIFT_ENUM_NAMED"
+      },
+      "pathComponents": [
+        "SWIFT_ENUM_NAMED"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "keyword",
+          "spelling": "typedef"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@T@uint_least16_t",
+          "spelling": "uint_least16_t"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "char16_t"
+        },
+        {
+          "kind": "text",
+          "spelling": ";"
+        }
+      ],
+      "identifier": {
+        "interfaceLanguage": "objective-c",
+        "precise": "c:ErrorParameters-Swift.h@T@char16_t"
+      },
+      "kind": {
+        "displayName": "Type Alias",
+        "identifier": "objective-c.typealias"
+      },
+      "location": {
+        "position": {
+          "character": 24,
+          "line": 65
+        },
+        "uri": "file:///Users/droennqvist/Library/Developer/Xcode/DerivedData/ErrorParameters-gazxganyiilhgcducsyxdoxeciia/Build/Products/Debug/ErrorParameters.framework/Headers/ErrorParameters-Swift.h"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "char16_t"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "char16_t"
+          }
+        ],
+        "title": "char16_t"
+      },
+      "pathComponents": [
+        "char16_t"
+      ],
+      "type": "c:@T@uint_least16_t"
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "keyword",
+          "spelling": "typedef"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@T@uint_least32_t",
+          "spelling": "uint_least32_t"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "char32_t"
+        },
+        {
+          "kind": "text",
+          "spelling": ";"
+        }
+      ],
+      "identifier": {
+        "interfaceLanguage": "objective-c",
+        "precise": "c:ErrorParameters-Swift.h@T@char32_t"
+      },
+      "kind": {
+        "displayName": "Type Alias",
+        "identifier": "objective-c.typealias"
+      },
+      "location": {
+        "position": {
+          "character": 24,
+          "line": 66
+        },
+        "uri": "file:///Users/droennqvist/Library/Developer/Xcode/DerivedData/ErrorParameters-gazxganyiilhgcducsyxdoxeciia/Build/Products/Debug/ErrorParameters.framework/Headers/ErrorParameters-Swift.h"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "char32_t"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "char32_t"
+          }
+        ],
+        "title": "char32_t"
+      },
+      "pathComponents": [
+        "char32_t"
+      ],
+      "type": "c:@T@uint_least32_t"
+    }
+  ]
+}

--- a/Tests/SwiftDocCTests/Test Bundles/ErrorParameters.docc/swift/ErrorParameters.symbols.json
+++ b/Tests/SwiftDocCTests/Test Bundles/ErrorParameters.docc/swift/ErrorParameters.symbols.json
@@ -1,0 +1,832 @@
+{
+  "metadata": {
+    "formatVersion": {
+      "major": 0,
+      "minor": 6,
+      "patch": 0
+    },
+    "generator": "Apple Swift version 5.9 (swiftlang-5.9.0.128.108 clang-1500.0.40.1)"
+  },
+  "module": {
+    "name": "ErrorParameters",
+    "platform": {
+      "architecture": "arm64",
+      "vendor": "apple",
+      "operatingSystem": {
+        "name": "macosx",
+        "minimumVersion": {
+          "major": 14,
+          "minor": 0
+        }
+      }
+    }
+  },
+  "symbols": [
+    {
+      "kind": {
+        "identifier": "swift.class",
+        "displayName": "Class"
+      },
+      "identifier": {
+        "precise": "c:objc(cs)MyClassInObjectiveC",
+        "interfaceLanguage": "swift"
+      },
+      "pathComponents": [
+        "MyClassInObjectiveC"
+      ],
+      "names": {
+        "title": "MyClassInObjectiveC",
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "MyClassInObjectiveC"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "keyword",
+            "spelling": "class"
+          },
+          {
+            "kind": "text",
+            "spelling": " "
+          },
+          {
+            "kind": "identifier",
+            "spelling": "MyClassInObjectiveC"
+          }
+        ]
+      },
+      "declarationFragments": [
+        {
+          "kind": "keyword",
+          "spelling": "class"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "MyClassInObjectiveC"
+        }
+      ],
+      "accessLevel": "open"
+    },
+    {
+      "kind": {
+        "identifier": "swift.method",
+        "displayName": "Instance Method"
+      },
+      "identifier": {
+        "precise": "c:@M@ErrorParameters@objc(cs)MyClassInSwift(im)returnSomethingAndReturnError:",
+        "interfaceLanguage": "swift"
+      },
+      "pathComponents": [
+        "MyClassInSwift",
+        "returnSomething()"
+      ],
+      "names": {
+        "title": "returnSomething()",
+        "subHeading": [
+          {
+            "kind": "keyword",
+            "spelling": "func"
+          },
+          {
+            "kind": "text",
+            "spelling": " "
+          },
+          {
+            "kind": "identifier",
+            "spelling": "returnSomething"
+          },
+          {
+            "kind": "text",
+            "spelling": "() "
+          },
+          {
+            "kind": "keyword",
+            "spelling": "throws"
+          },
+          {
+            "kind": "text",
+            "spelling": " -> "
+          },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "String",
+            "preciseIdentifier": "s:SS"
+          }
+        ]
+      },
+      "docComment": {
+        "uri": "file:///Users/username/path/to/ErrorParameters/MyClassInSwift.swift",
+        "module": "ErrorParameters",
+        "lines": [
+          {
+            "range": {
+              "start": {
+                "line": 22,
+                "character": 8
+              },
+              "end": {
+                "line": 22,
+                "character": 37
+              }
+            },
+            "text": "Returns something from Swift."
+          },
+          {
+            "range": {
+              "start": {
+                "line": 23,
+                "character": 8
+              },
+              "end": {
+                "line": 23,
+                "character": 31
+              }
+            },
+            "text": "- Returns: Some string."
+          },
+          {
+            "range": {
+              "start": {
+                "line": 24,
+                "character": 8
+              },
+              "end": {
+                "line": 24,
+                "character": 52
+              }
+            },
+            "text": "- Throws: Some error if something does wrong"
+          }
+        ]
+      },
+      "functionSignature": {
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "spelling": "String",
+            "preciseIdentifier": "s:SS"
+          }
+        ]
+      },
+      "declarationFragments": [
+        {
+          "kind": "attribute",
+          "spelling": "@objc"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "keyword",
+          "spelling": "func"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "returnSomething"
+        },
+        {
+          "kind": "text",
+          "spelling": "() "
+        },
+        {
+          "kind": "keyword",
+          "spelling": "throws"
+        },
+        {
+          "kind": "text",
+          "spelling": " -> "
+        },
+        {
+          "kind": "typeIdentifier",
+          "spelling": "String",
+          "preciseIdentifier": "s:SS"
+        }
+      ],
+      "accessLevel": "public",
+      "location": {
+        "uri": "file:///Users/username/path/to/ErrorParameters/MyClassInSwift.swift",
+        "position": {
+          "line": 25,
+          "character": 22
+        }
+      }
+    },
+    {
+      "kind": {
+        "identifier": "swift.method",
+        "displayName": "Instance Method"
+      },
+      "identifier": {
+        "precise": "c:objc(cs)MyClassInObjectiveC(im)doSomethingWith:error:",
+        "interfaceLanguage": "swift"
+      },
+      "pathComponents": [
+        "MyClassInObjectiveC",
+        "doSomething(with:)"
+      ],
+      "names": {
+        "title": "doSomething(with:)",
+        "subHeading": [
+          {
+            "kind": "keyword",
+            "spelling": "func"
+          },
+          {
+            "kind": "text",
+            "spelling": " "
+          },
+          {
+            "kind": "identifier",
+            "spelling": "doSomething"
+          },
+          {
+            "kind": "text",
+            "spelling": "("
+          },
+          {
+            "kind": "externalParam",
+            "spelling": "with"
+          },
+          {
+            "kind": "text",
+            "spelling": ": "
+          },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "Int",
+            "preciseIdentifier": "s:Si"
+          },
+          {
+            "kind": "text",
+            "spelling": ") "
+          },
+          {
+            "kind": "keyword",
+            "spelling": "throws"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "name": "with",
+            "internalName": "someValue",
+            "declarationFragments": [
+              {
+                "kind": "identifier",
+                "spelling": "someValue"
+              },
+              {
+                "kind": "text",
+                "spelling": ": "
+              },
+              {
+                "kind": "typeIdentifier",
+                "spelling": "Int",
+                "preciseIdentifier": "s:Si"
+              }
+            ]
+          }
+        ],
+        "returns": [
+          {
+            "kind": "text",
+            "spelling": "()"
+          }
+        ]
+      },
+      "declarationFragments": [
+        {
+          "kind": "keyword",
+          "spelling": "func"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "doSomething"
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "externalParam",
+          "spelling": "with"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "someValue"
+        },
+        {
+          "kind": "text",
+          "spelling": ": "
+        },
+        {
+          "kind": "typeIdentifier",
+          "spelling": "Int",
+          "preciseIdentifier": "s:Si"
+        },
+        {
+          "kind": "text",
+          "spelling": ") "
+        },
+        {
+          "kind": "keyword",
+          "spelling": "throws"
+        }
+      ],
+      "accessLevel": "open"
+    },
+    {
+      "kind": {
+        "identifier": "swift.class",
+        "displayName": "Class"
+      },
+      "identifier": {
+        "precise": "c:@M@ErrorParameters@objc(cs)MyClassInSwift",
+        "interfaceLanguage": "swift"
+      },
+      "pathComponents": [
+        "MyClassInSwift"
+      ],
+      "names": {
+        "title": "MyClassInSwift",
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "MyClassInSwift"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "keyword",
+            "spelling": "class"
+          },
+          {
+            "kind": "text",
+            "spelling": " "
+          },
+          {
+            "kind": "identifier",
+            "spelling": "MyClassInSwift"
+          }
+        ]
+      },
+      "docComment": {
+        "uri": "file:///Users/username/path/to/ErrorParameters/MyClassInSwift.swift",
+        "module": "ErrorParameters",
+        "lines": [
+          {
+            "range": {
+              "start": {
+                "line": 9,
+                "character": 4
+              },
+              "end": {
+                "line": 9,
+                "character": 44
+              }
+            },
+            "text": "A Swift class with 2 throwing functions."
+          }
+        ]
+      },
+      "declarationFragments": [
+        {
+          "kind": "attribute",
+          "spelling": "@objc"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "keyword",
+          "spelling": "class"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "MyClassInSwift"
+        }
+      ],
+      "accessLevel": "public",
+      "location": {
+        "uri": "file:///Users/username/path/to/ErrorParameters/MyClassInSwift.swift",
+        "position": {
+          "line": 10,
+          "character": 19
+        }
+      }
+    },
+    {
+      "kind": {
+        "identifier": "swift.method",
+        "displayName": "Instance Method"
+      },
+      "identifier": {
+        "precise": "c:objc(cs)MyClassInObjectiveC(im)returnSomethingAndReturnError:",
+        "interfaceLanguage": "swift"
+      },
+      "pathComponents": [
+        "MyClassInObjectiveC",
+        "returnSomething()"
+      ],
+      "names": {
+        "title": "returnSomething()",
+        "subHeading": [
+          {
+            "kind": "keyword",
+            "spelling": "func"
+          },
+          {
+            "kind": "text",
+            "spelling": " "
+          },
+          {
+            "kind": "identifier",
+            "spelling": "returnSomething"
+          },
+          {
+            "kind": "text",
+            "spelling": "() "
+          },
+          {
+            "kind": "keyword",
+            "spelling": "throws"
+          },
+          {
+            "kind": "text",
+            "spelling": " -> "
+          },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "String",
+            "preciseIdentifier": "s:SS"
+          }
+        ]
+      },
+      "functionSignature": {
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "spelling": "String",
+            "preciseIdentifier": "s:SS"
+          }
+        ]
+      },
+      "declarationFragments": [
+        {
+          "kind": "keyword",
+          "spelling": "func"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "returnSomething"
+        },
+        {
+          "kind": "text",
+          "spelling": "() "
+        },
+        {
+          "kind": "keyword",
+          "spelling": "throws"
+        },
+        {
+          "kind": "text",
+          "spelling": " -> "
+        },
+        {
+          "kind": "typeIdentifier",
+          "spelling": "String",
+          "preciseIdentifier": "s:SS"
+        }
+      ],
+      "accessLevel": "open"
+    },
+    {
+      "kind": {
+        "identifier": "swift.method",
+        "displayName": "Instance Method"
+      },
+      "identifier": {
+        "precise": "c:@M@ErrorParameters@objc(cs)MyClassInSwift(im)doSomethingWith:error:",
+        "interfaceLanguage": "swift"
+      },
+      "pathComponents": [
+        "MyClassInSwift",
+        "doSomething(with:)"
+      ],
+      "names": {
+        "title": "doSomething(with:)",
+        "subHeading": [
+          {
+            "kind": "keyword",
+            "spelling": "func"
+          },
+          {
+            "kind": "text",
+            "spelling": " "
+          },
+          {
+            "kind": "identifier",
+            "spelling": "doSomething"
+          },
+          {
+            "kind": "text",
+            "spelling": "("
+          },
+          {
+            "kind": "externalParam",
+            "spelling": "with"
+          },
+          {
+            "kind": "text",
+            "spelling": ": "
+          },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "Int",
+            "preciseIdentifier": "s:Si"
+          },
+          {
+            "kind": "text",
+            "spelling": ") "
+          },
+          {
+            "kind": "keyword",
+            "spelling": "throws"
+          }
+        ]
+      },
+      "docComment": {
+        "uri": "file:///Users/username/path/to/ErrorParameters/MyClassInSwift.swift",
+        "module": "ErrorParameters",
+        "lines": [
+          {
+            "range": {
+              "start": {
+                "line": 16,
+                "character": 8
+              },
+              "end": {
+                "line": 16,
+                "character": 32
+              }
+            },
+            "text": "Does something in Swift."
+          },
+          {
+            "range": {
+              "start": {
+                "line": 17,
+                "character": 8
+              },
+              "end": {
+                "line": 17,
+                "character": 42
+              }
+            },
+            "text": "- Parameter someValue: Some value."
+          },
+          {
+            "range": {
+              "start": {
+                "line": 18,
+                "character": 8
+              },
+              "end": {
+                "line": 18,
+                "character": 52
+              }
+            },
+            "text": "- Throws: Some error if something does wrong"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "name": "with",
+            "internalName": "someValue",
+            "declarationFragments": [
+              {
+                "kind": "identifier",
+                "spelling": "someValue"
+              },
+              {
+                "kind": "text",
+                "spelling": ": "
+              },
+              {
+                "kind": "typeIdentifier",
+                "spelling": "Int",
+                "preciseIdentifier": "s:Si"
+              }
+            ]
+          }
+        ],
+        "returns": [
+          {
+            "kind": "text",
+            "spelling": "()"
+          }
+        ]
+      },
+      "declarationFragments": [
+        {
+          "kind": "attribute",
+          "spelling": "@objc"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "keyword",
+          "spelling": "func"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "doSomething"
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "externalParam",
+          "spelling": "with"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "someValue"
+        },
+        {
+          "kind": "text",
+          "spelling": ": "
+        },
+        {
+          "kind": "typeIdentifier",
+          "spelling": "Int",
+          "preciseIdentifier": "s:Si"
+        },
+        {
+          "kind": "text",
+          "spelling": ") "
+        },
+        {
+          "kind": "keyword",
+          "spelling": "throws"
+        }
+      ],
+      "accessLevel": "public",
+      "location": {
+        "uri": "file:///Users/username/path/to/ErrorParameters/MyClassInSwift.swift",
+        "position": {
+          "line": 19,
+          "character": 22
+        }
+      }
+    }
+  ],
+  "relationships": [
+    {
+      "kind": "conformsTo",
+      "source": "c:@M@ErrorParameters@objc(cs)MyClassInSwift",
+      "target": "s:SQ",
+      "targetFallback": "Swift.Equatable"
+    },
+    {
+      "kind": "conformsTo",
+      "source": "c:objc(cs)MyClassInObjectiveC",
+      "target": "s:s23CustomStringConvertibleP",
+      "targetFallback": "Swift.CustomStringConvertible"
+    },
+    {
+      "kind": "conformsTo",
+      "source": "c:objc(cs)MyClassInObjectiveC",
+      "target": "s:SH",
+      "targetFallback": "Swift.Hashable"
+    },
+    {
+      "kind": "conformsTo",
+      "source": "c:objc(cs)MyClassInObjectiveC",
+      "target": "s:s7CVarArgP",
+      "targetFallback": "Swift.CVarArg"
+    },
+    {
+      "kind": "conformsTo",
+      "source": "c:objc(cs)MyClassInObjectiveC",
+      "target": "s:s28CustomDebugStringConvertibleP",
+      "targetFallback": "Swift.CustomDebugStringConvertible"
+    },
+    {
+      "kind": "inheritsFrom",
+      "source": "c:@M@ErrorParameters@objc(cs)MyClassInSwift",
+      "target": "c:objc(cs)NSObject",
+      "targetFallback": "ObjectiveC.NSObject"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:@M@ErrorParameters@objc(cs)MyClassInSwift(im)returnSomethingAndReturnError:",
+      "target": "c:@M@ErrorParameters@objc(cs)MyClassInSwift"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:objc(cs)MyClassInObjectiveC(im)returnSomethingAndReturnError:",
+      "target": "c:objc(cs)MyClassInObjectiveC"
+    },
+    {
+      "kind": "conformsTo",
+      "source": "c:@M@ErrorParameters@objc(cs)MyClassInSwift",
+      "target": "c:objc(pl)NSObject",
+      "targetFallback": "ObjectiveC.NSObjectProtocol"
+    },
+    {
+      "kind": "conformsTo",
+      "source": "c:@M@ErrorParameters@objc(cs)MyClassInSwift",
+      "target": "s:s23CustomStringConvertibleP",
+      "targetFallback": "Swift.CustomStringConvertible"
+    },
+    {
+      "kind": "conformsTo",
+      "source": "c:objc(cs)MyClassInObjectiveC",
+      "target": "s:SQ",
+      "targetFallback": "Swift.Equatable"
+    },
+    {
+      "kind": "conformsTo",
+      "source": "c:@M@ErrorParameters@objc(cs)MyClassInSwift",
+      "target": "s:SH",
+      "targetFallback": "Swift.Hashable"
+    },
+    {
+      "kind": "conformsTo",
+      "source": "c:@M@ErrorParameters@objc(cs)MyClassInSwift",
+      "target": "s:s7CVarArgP",
+      "targetFallback": "Swift.CVarArg"
+    },
+    {
+      "kind": "conformsTo",
+      "source": "c:@M@ErrorParameters@objc(cs)MyClassInSwift",
+      "target": "s:s28CustomDebugStringConvertibleP",
+      "targetFallback": "Swift.CustomDebugStringConvertible"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:@M@ErrorParameters@objc(cs)MyClassInSwift(im)doSomethingWith:error:",
+      "target": "c:@M@ErrorParameters@objc(cs)MyClassInSwift"
+    },
+    {
+      "kind": "conformsTo",
+      "source": "c:objc(cs)MyClassInObjectiveC",
+      "target": "c:objc(pl)NSObject",
+      "targetFallback": "ObjectiveC.NSObjectProtocol"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:objc(cs)MyClassInObjectiveC(im)doSomethingWith:error:",
+      "target": "c:objc(cs)MyClassInObjectiveC"
+    },
+    {
+      "kind": "inheritsFrom",
+      "source": "c:objc(cs)MyClassInObjectiveC",
+      "target": "c:objc(cs)NSObject",
+      "targetFallback": "ObjectiveC.NSObject"
+    }
+  ]
+}


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://118739612

## Summary

This adds validation and filtering of parameter and return value documentation based on a symbol's function signature in each language representation.

This results in 3 new behaviors:
- A parameter or return value that's not applicable to a specific language representation of a symbol isn't displayed in that language's variant of the page.
- Objective-C error parameters or return values that are not documented for symbols defined in other languages are synthesized if any other parameters are documented.
- User facing diagnostics with fixits are emitted for parameters that are misspelled, not found, or repeated and for return values for symbols that return void in all language representations.

### Filtering parameters

If a symbol has different parameters and return values in different languages, then each language's version of that symbol's page will only display the parameters that's applicable to that language. 

This is for example relevant for API with errors in Objective-C that bridge to API that `throws` in Swift;

```objc
/// Does something in Objective-C
/// - Parameters:
///   - someValue: Some value.
///   - error: On input, a pointer to an error object. If an error occurs, this pointer is set to an actual error object containing the error information.
/// - Returns: `YES` if doing something was successful, or `NO` if an error occurred.
- (BOOL)doSomethingWith:(NSInteger)someValue
                  error:(NSError **)error;
```

This method become `func doSomething(with someValue: Int) throws` in Swift which returns `Void` and doesn't have an `error` parameter, so displaying documentation for the error parameter and the return value wouldn't be helpful for someone reading the Swift version of that method's documentation. 

Before this PR we displayed all documented parameters in all language variants of a symbol's page. With these changes, the Swift page won't display the "error" parameter documentation or the return value documentation.

### Adding Objective-C error documentation

The above works well for functions defined in Objective-C that document parameters and return values that aren't available in Swift, but it doesn't work in the other direction;

```swift
/// Does something in Swift.
/// - Parameter someValue: Some value.
/// - Throws: Some error if something does wrong
@objc public func doSomething(with someValue: Int) throws { }
```

This becomes `- (BOOL)doSomethingWith:(NSInteger)someValue error:(NSError **)error;` in Objective-C but the Swift documentation comment doesn't have any documentation for the Objective-C "error" parameter or the Objective-C specific return value.

Before this PR we only displayed the developer documented parameters. With these changes, the Objective-C page will display a synthesized "error" parameter documentation with the generic description:

> **error**
> On input, a pointer to an error object. If an error occurs, this pointer is set to an actual error object containing the error information. 

and a synthesized return value documentation with the generic description:
> **Return Value**
>`YES` if successful, or `NO` if an error occurred.

If the throwing Swift function was defined with a non-null return value that bridges to a nullable return value in Objective-C;

```swift
/// Returns something from Swift.
/// - Returns: Some string.
/// - Throws: Some error if something does wrong
@objc public func returnSomething() throws -> String { "" }
```

Then the Objective-C return value documentation is appended with a generic description of this automatic bridging behavior:

> **Return Value**
> Some string. If an error occurs, this method returns `nil` and assigns an appropriate error object to the `error` parameter.

### Parameter and return value diagnostics 

If the symbol documents at least one parameter or its return value, then DocC will validate that symbol's parameters section and return value section. Specifically, DocC will warn in 5 cases:
1. A parameter is documented more than once
2. A parameter that doesn't exist in the function signature is documented
3. A parameter from the function signature isn't documented
4. A parameter is documented using its argument label instead of its parameter name
5. A symbol that returns `Void` has documented a return value

The Swift function below shows minimal examples of each of these cases:

```swift
/// - Parameters:
///   - first: Something
///   - first: Something else (1)
///   - with: Something (4)
///   - third: Something (2)
///  (3)
/// - Returns: Something (5)
func doSomething(with first: Int, and second: Int) { }
```

## Dependencies

https://github.com/apple/swift-docc-symbolkit/pull/64

## Testing

- In a multi-language project, add:
  - Objective-C API with errors with documentation for all parameters and return values
  - Swift `@objc` API that `throws` with documentation for the Swift parameters.

- Build documentation for the project and pass `--enable-experimental-parameters-and-returns-validation`.

- View both the Swift and Objective-C versions of the documentation pages for both the API defined in Objective-C and the API defined in Swift. 
  - Each language variant of the documentation pages should only display the parameters and return values applicable to that language. 

- Add parameter documentation for parameters that doesn't exist to the Swift and Objective-C definitions and build documentation again. 

- View both the Swift and Objective-C versions of the documentation pages for both the API defined in Objective-C and the API defined in Swift. 
  - The documentation for the parameters that doesn't exist shouldn't be displayed on either languages's variant of the documentation page.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
