### PR TITLE
Make `@TechnologyRoot` optional in article-only documentation

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -1874,6 +1874,13 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
         }
     }
     
+    /// Registers a synthesized root page for a catalog with only non-root articles.
+    ///
+    /// If the catalog only has one article or has an article with the same name as the catalog itself, that article is turned into the root page instead of creating a new article.
+    ///
+    /// - Parameters:
+    ///   - articles: On input, a list of articles. If an article is used as a root it is removed from this list.
+    ///   - bundle: The bundle containing the articles.
     private func synthesizeArticleOnlyRootPage(articles: inout [DocumentationContext.SemanticResult<Article>], bundle: DocumentationBundle) {
         let title = bundle.displayName
         let metadataDirectiveMarkup = BlockDirective(name: "Metadata", children: [
@@ -1892,6 +1899,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
             nameMatch.value = Article(markup: nameMatch.value.markup, metadata: metadata, redirects: nameMatch.value.redirects, options: nameMatch.value.options)
             registerRootPages(from: [nameMatch], in: bundle)
         } else {
+            // There's no particular article to make into the root. Instead, create a new minimal root page.
             let path = NodeURLGenerator.Path.documentation(path: title).stringValue
             let sourceLanguage = DocumentationContext.defaultLanguage(in: [])
             

--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -96,9 +96,6 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
         /// The bundle registration operation is cancelled externally.
         case registrationDisabled
         
-        /// The bundle registration failed to synthesize a root page for a catalog with only articles.
-        case unableToSynthesizeRootPage
-        
         public var errorDescription: String {
             switch self {
                 case .notFound(let url):
@@ -109,8 +106,6 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
                     return "Declaration without operating system name for symbol \(symbolIdentifier) cannot be merged with more declarations with operating system name for the same symbol"
                 case .registrationDisabled:
                     return "The bundle registration operation is cancelled externally."
-                case .unableToSynthesizeRootPage:
-                    return "Couldn't synthesize a root page for this article-only catalog."
             }
         }
     }
@@ -1879,33 +1874,20 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
         }
     }
     
-    private func synthesizeArticleOnlyRootPage(articles: inout [DocumentationContext.SemanticResult<Article>], bundle: DocumentationBundle) throws {
+    private func synthesizeArticleOnlyRootPage(articles: inout [DocumentationContext.SemanticResult<Article>], bundle: DocumentationBundle) {
         let title = bundle.displayName
-        let markup = Document(
-            parsing: """
-                # \(title)
-                
-                @Metadata {
-                  @TechnologyRoot
-                }
-                """,
-            source: nil,
-            options: .parseBlockDirectives
-        )
+        let metadataDirectiveMarkup = BlockDirective(name: "Metadata", children: [
+            BlockDirective(name: "TechnologyRoot", children: [])
+        ])
+        let metadata = Metadata(from: metadataDirectiveMarkup, for: bundle, in: self)
         
-        guard markup.childCount == 2,
-              let blockDirective = markup.child(at: 1) as? BlockDirective,
-              let metadata = Metadata(from: blockDirective, for: bundle, in: self)
-        else {
-            throw ContextError.unableToSynthesizeRootPage
-        }
         if articles.count == 1 {
             // This catalog only has one article, so we make that the root.
             var onlyArticle = articles.removeFirst()
             onlyArticle.value = Article(markup: onlyArticle.value.markup, metadata: metadata, redirects: onlyArticle.value.redirects, options: onlyArticle.value.options)
             registerRootPages(from: [onlyArticle], in: bundle)
         } else if let nameMatchIndex = articles.firstIndex(where: { $0.source.deletingPathExtension().lastPathComponent == title }) {
-            // This catalog has an article with the same name as the catalog itself,  so we make that the root.
+            // This catalog has an article with the same name as the catalog itself, so we make that the root.
             var nameMatch = articles.remove(at: nameMatchIndex)
             nameMatch.value = Article(markup: nameMatch.value.markup, metadata: metadata, redirects: nameMatch.value.redirects, options: nameMatch.value.options)
             registerRootPages(from: [nameMatch], in: bundle)
@@ -1917,6 +1899,12 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
             
             let graphNode = TopicGraph.Node(reference: reference, kind: .module, source: .external, title: title)
             topicGraph.addNode(graphNode)
+            
+            // Build up the "full" markup for an empty technology root article 
+            let markup = Document(
+                Heading(level: 1, Text(title)),
+                metadataDirectiveMarkup
+            )
             
             let article = Article(markup: markup, metadata: metadata, redirects: nil, options: [:])
             let documentationNode = DocumentationNode(
@@ -2206,7 +2194,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
         try shouldContinueRegistration()
         
         if topicGraph.nodes.isEmpty, !otherArticles.isEmpty, !allowsRegisteringArticlesWithoutTechnologyRoot {
-            try synthesizeArticleOnlyRootPage(articles: &otherArticles, bundle: bundle)
+            synthesizeArticleOnlyRootPage(articles: &otherArticles, bundle: bundle)
         }
             
         // Keep track of the root modules registered from symbol graph files, we'll need them to automatically

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContext+RootPageTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContext+RootPageTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContext+RootPageTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContext+RootPageTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -96,4 +96,104 @@ class DocumentationContext_RootPageTests: XCTestCase {
         XCTAssertEqual(solution.replacements.first?.range.upperBound.line, 3)
     }
     
+    func testSingleArticleWithoutTechnologyRootDirective() throws {
+        let tempFolderURL = try createTempFolder(content: [
+            Folder(name: "Something.docc", content: [
+                TextFile(name: "Article.md", utf8Content: """
+                # My article
+                
+                A regular article without an explicit `@TechnologyRoot` directive.
+                """)
+            ]),
+        ])
+        
+        let workspace = DocumentationWorkspace()
+        let context = try DocumentationContext(dataProvider: workspace)
+        let dataProvider = try LocalFileSystemDataProvider(rootURL: tempFolderURL)
+        try workspace.registerProvider(dataProvider)
+        
+        XCTAssertEqual(context.knownPages.map(\.absoluteString), ["doc://Something/documentation/Article"])
+        XCTAssertEqual(context.rootModules.map(\.absoluteString), ["doc://Something/documentation/Article"])
+        
+        XCTAssertEqual(context.problems.count, 0)
+    }
+    
+    func testMultipleArticlesWithoutTechnologyRootDirective() throws {
+        let tempFolderURL = try createTempFolder(content: [
+            Folder(name: "Something.docc", content: [
+                TextFile(name: "First.md", utf8Content: """
+                # My first article
+                
+                A regular article without an explicit `@TechnologyRoot` directive.
+                """),
+                
+                TextFile(name: "Second.md", utf8Content: """
+                # My second article
+                
+                Another regular article without an explicit `@TechnologyRoot` directive.
+                """),
+                
+                TextFile(name: "Third.md", utf8Content: """
+                # My third article
+                
+                Yet another regular article without an explicit `@TechnologyRoot` directive.
+                """),
+            ]),
+        ])
+        
+        let workspace = DocumentationWorkspace()
+        let context = try DocumentationContext(dataProvider: workspace)
+        let dataProvider = try LocalFileSystemDataProvider(rootURL: tempFolderURL)
+        try workspace.registerProvider(dataProvider)
+        
+        XCTAssertEqual(context.knownPages.map(\.absoluteString).sorted(), [
+            "doc://Something/documentation/Something", // A synthesized root
+            "doc://Something/documentation/Something/First",
+            "doc://Something/documentation/Something/Second",
+            "doc://Something/documentation/Something/Third",
+        ])
+        XCTAssertEqual(context.rootModules.map(\.absoluteString), ["doc://Something/documentation/Something"], "If no single article is a clear root, the root page is synthesized")
+        
+        XCTAssertEqual(context.problems.count, 0)
+    }
+    
+    func testMultipleArticlesWithoutTechnologyRootDirectiveWithOneMatchingTheCatalogName() throws {
+        let tempFolderURL = try createTempFolder(content: [
+            Folder(name: "Something.docc", content: [
+                TextFile(name: "Something.md", utf8Content: """
+                # Some article
+                
+                A regular article without an explicit `@TechnologyRoot` directive.
+                
+                The name of this article file matches the name of the catalog.
+                """),
+                
+                TextFile(name: "Second.md", utf8Content: """
+                # My second article
+                
+                Another regular article without an explicit `@TechnologyRoot` directive.
+                """),
+                
+                TextFile(name: "Third.md", utf8Content: """
+                # My third article
+                
+                Yet another regular article without an explicit `@TechnologyRoot` directive.
+                """),
+            ]),
+        ])
+        
+        let workspace = DocumentationWorkspace()
+        let context = try DocumentationContext(dataProvider: workspace)
+        let dataProvider = try LocalFileSystemDataProvider(rootURL: tempFolderURL)
+        try workspace.registerProvider(dataProvider)
+        
+        XCTAssertEqual(context.knownPages.map(\.absoluteString).sorted(), [
+            "doc://Something/documentation/Something", // This article became the root
+            "doc://Something/documentation/Something/Second",
+            "doc://Something/documentation/Something/Third",
+        ])
+        XCTAssertEqual(context.rootModules.map(\.absoluteString), ["doc://Something/documentation/Something"])
+        
+        XCTAssertEqual(context.problems.count, 0)
+    }
 }

--- a/bin/check-source
+++ b/bin/check-source
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
+# Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information
@@ -18,7 +18,7 @@ here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 function replace_acceptable_years() {
     # this needs to replace all acceptable forms with 'YEARS'
-    sed -e 's/20[12][7890123]-20[12][890123]/YEARS/' -e 's/20[12][890123]/YEARS/'
+    sed -e 's/20[12][78901234]-20[12][8901234]/YEARS/' -e 's/20[12][8901234]/YEARS/'
 }
 
 printf "=> Checking for unacceptable language… "


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

This makes `@TechnologyRoot` optional in article-only documentation.

When building documentation for a catalog of only articles with no explicit root article, DocC will follow the following logic to find a root:
- If there's only a single article in the catalog, that becomes the root.
- Otherwise, if there's an article with the same file name as the catalog name, that's becomes the root.
- Otherwise, synthesize a minimal root with the same name as the catalog.

If this looks like a decent approach then we should document this behavior somewhere before merging.

## Dependencies

None.

## Testing


### One article 

- Create a new documentation catalog: 
  `mkdir MyCatalog.docc`
- Add a minimal article without a technology root: 
  `echo "# One article\n\nArticle abstract" > MyCatalog.docc/MyArticle.md` 
- Preview documentation for the new catalog
  `swift run docc preview MyCatalog.docc`
  - DocC should preview the article at <http://localhost:8080/documentation/myarticle>
  **Question: should this path be "documentation/mycatalog" instead?**
- Stop the preview server.

### Article with same name as catalog 

- Add another article without a technology root to the catalog, with the same name as the catalog this time:
  `echo "# Another article\n\nArticle abstract" > MyCatalog.docc/MyCatalog.md` 
- Preview documentation for the catalog:
  `swift run docc preview MyCatalog.docc`
  - DocC should preview the article at <http://localhost:8080/documentation/mycatalog>
  - MyArticle should be automatically curated.
- Stop the preview server.

### Synthesized root page

- Rename the second article so that it's no longer named the same as the catalog:
  `mv MyCatalog.docc/MyCatalog.md MyCatalog.docc/OtherArticle.md` 
- Preview documentation for the catalog:
  `swift run docc preview MyCatalog.docc`
  - DocC should preview the article at <http://localhost:8080/documentation/mycatalog>
  - A new empty root page should be synthesized.
  - Both MyArticle and OtherArticle should be automatically curated.
- Stop the preview server.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary
