### PR TITLE
Support documentation extensions on Linux for symbols with spaces in their name 

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -1261,7 +1261,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
                     diagnosticEngine.emit(Problem(diagnostic: diagnostic))
                     continue
                 }
-                guard let url = ValidatedURL(parsingExact: destination) else {
+                guard let url = ValidatedURL(parsingAuthoredLink: destination) else {
                     let diagnostic = Diagnostic(source: documentationExtension.source, severity: .warning, range: link.range, identifier: "org.swift.docc.invalidLinkDestination", summary: """
                         \(destination.singleQuoted) is not a valid RFC 3986 URL.
                         """, explanation: nil, notes: [])

--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -1263,7 +1263,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
                 }
                 guard let url = ValidatedURL(parsingExact: destination) else {
                     let diagnostic = Diagnostic(source: documentationExtension.source, severity: .warning, range: link.range, identifier: "org.swift.docc.invalidLinkDestination", summary: """
-                        \(destination.singleQuoted) is
+                        \(destination.singleQuoted) is not a valid RFC 3986 URL.
                         """, explanation: nil, notes: [])
                     diagnosticEngine.emit(Problem(diagnostic: diagnostic))
                     continue

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -1984,6 +1984,42 @@ let expected = """
         XCTAssertEqual(unmatchedSidecarDiagnostic.severity, .warning)
     }
     
+    func testExtendingSymbolWithSpaceInName() throws {
+        let exampleDocumentation = Folder(name: "unit-test.docc", content: [
+            JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(
+                moduleName: "ModuleName",
+                symbols: [
+                    SymbolGraph.Symbol(
+                        identifier: .init(precise: "symbol-id", interfaceLanguage: "swift"),
+                        names: .init(title: "Symbol Name", navigator: nil, subHeading: nil, prose: nil),
+                        pathComponents: ["Symbol Name"],
+                        docComment: nil,
+                        accessLevel: .public,
+                        kind: .init(parsedIdentifier: .class, displayName: "Kind Display Name"),
+                        mixins: [:]
+                    )
+                ]
+            )),
+            
+            TextFile(name: "Extension.md", utf8Content: """
+            # ``Symbol Name``
+            
+            Extend a symbol with a space in its name.
+            """),
+            
+            TextFile(name: "Article.md", utf8Content: """
+            # Article
+            
+            Link in content to a symbol with a space in its name: ``Symbol Name``.
+            """),
+        ])
+        
+        let tempURL = try createTempFolder(content: [exampleDocumentation])
+        let (_, _, context) = try loadBundle(from: tempURL)
+        
+        XCTAssert(context.problems.isEmpty, "Unexpected problems: \(context.problems.map(\.diagnostic.summary).joined(separator: "\n"))")
+    }
+    
     func testUncuratedArticleDiagnostics() throws {
         var unknownSymbolSidecarURL: URL!
         

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -2015,9 +2015,14 @@ let expected = """
         ])
         
         let tempURL = try createTempFolder(content: [exampleDocumentation])
-        let (_, _, context) = try loadBundle(from: tempURL)
+        let (_, bundle, context) = try loadBundle(from: tempURL)
         
         XCTAssert(context.problems.isEmpty, "Unexpected problems: \(context.problems.map(\.diagnostic.summary).joined(separator: "\n"))")
+        
+        let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ModuleName/Symbol_Name", sourceLanguage: .swift)
+        let node = try context.entity(with: reference)
+        
+        XCTAssertEqual((node.semantic as? Symbol)?.abstract?.plainText, "Extend a symbol with a space in its name.")
     }
     
     func testUncuratedArticleDiagnostics() throws {


### PR DESCRIPTION
<!--
If you're opening a PR to cherry-pick a change for a release branch, use this template instead:
https://github.com/apple/swift-docc/blob/main/.github/PULL_REQUEST_TEMPLATE/CHERRY_PICK.md
-->

Bug/issue #, if applicable: rdar://118477834 & rdar://118478212

## Summary

This fixes an issue on Linux where documentation extensions didn't match symbols if the symbol has spaces in its name. 

## Dependencies

None

## Testing

Since neither Swift not C/Objective-C has whitespace in symbol names you'll need to hand craft a JSON file with a symbol with a space in its name to test this. Once you have such a symbol graph file, create a documentation catalog with an extension file for the symbol with the space in its name and build documentation for it on Linux. The content in the extension file should be added to the symbol.

(Note that the added test performs these same steps)


## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
