### PR TITLE
Fix a crash when configuring a `@DisplayName` for a non-symbol

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/External Data/OutOfProcessReferenceResolver.swift
+++ b/Sources/SwiftDocC/Infrastructure/External Data/OutOfProcessReferenceResolver.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information

--- a/Sources/SwiftDocC/Infrastructure/External Data/OutOfProcessReferenceResolver.swift
+++ b/Sources/SwiftDocC/Infrastructure/External Data/OutOfProcessReferenceResolver.swift
@@ -276,7 +276,7 @@ public class OutOfProcessReferenceResolver: ExternalReferenceResolver, FallbackR
         // with a render node.
         
         if let topicImages = resolvedInformation.topicImages, !topicImages.isEmpty {
-            let metadata = node.metadata ?? Metadata(originalMarkup: BlockDirective(name: "Metadata", children: []), documentationExtension: nil, technologyRoot: nil, displayName: nil, titleHeading: nil)
+            let metadata = node.metadata ?? Metadata._make(originalMarkup: BlockDirective(name: "Metadata", children: []))
             
             metadata.pageImages = topicImages.map { topicImage in
                 let purpose: PageImage.Purpose

--- a/Sources/SwiftDocC/Semantics/Article/Article.swift
+++ b/Sources/SwiftDocC/Semantics/Article/Article.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information

--- a/Sources/SwiftDocC/Semantics/Article/Article.swift
+++ b/Sources/SwiftDocC/Semantics/Article/Article.swift
@@ -217,8 +217,8 @@ public final class Article: Semantic, MarkupConvertible, Abstracted, Redirected,
             
             problems.append(Problem(diagnostic: diagnostic, possibleSolutions: solutions))
             
-            // Remove the display name customization from the article's metadata.
-            optionalMetadata = Metadata(originalMarkup: metadata.originalMarkup, documentationExtension: metadata.documentationOptions, technologyRoot: metadata.technologyRoot, displayName: nil, titleHeading: metadata.titleHeading)
+            metadata.displayName = nil
+            optionalMetadata = metadata
         }
         
         self.init(

--- a/Sources/SwiftDocC/Semantics/Metadata/Metadata.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/Metadata.swift
@@ -194,7 +194,7 @@ public final class Metadata: Semantic, AutomaticDirectiveConvertible {
     /// Don't use this outside of ``OutOfProcessReferenceResolver/entity(with:)`` .
     ///
     /// Directives aren't meant to be created from non-markup but the out-of-process resolver needs to create a ``Metadata`` to hold the ``PageImage``
-    /// values that it creates to associate topic images with external pages. This is because DocC renderers external content in the local context. (rdar://78718811)
+    /// values that it creates to associate topic images with external pages. This is because DocC renders external content in the local context. (rdar://78718811)
     /// https://github.com/apple/swift-docc/issues/468
     ///
     /// This is intentionally defined as an underscore prefixed static function instead of an initializer to make it less likely that it's used in other places.
@@ -229,7 +229,7 @@ public final class Metadata: Semantic, AutomaticDirectiveConvertible {
         )
     }
     
-    // This initializer only exist to be called by `_make` above.
+    // This initializer only exists to be called by `_make` above.
     private init(
         originalMarkup: BlockDirective,
         documentationOptions: DocumentationExtension?,

--- a/Sources/SwiftDocC/Semantics/Metadata/Metadata.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/Metadata.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information

--- a/Sources/SwiftDocC/Semantics/Metadata/Metadata.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/Metadata.swift
@@ -89,21 +89,6 @@ public final class Metadata: Semantic, AutomaticDirectiveConvertible {
         "titleHeading"          : \Metadata._titleHeading,
     ]
     
-    /// Creates a metadata object with a given markup, documentation extension, and technology root.
-    /// - Parameters:
-    ///   - originalMarkup: The original markup for this metadata directive.
-    ///   - documentationExtension: Optional configuration that describes how this documentation extension file merges or overrides the in-source documentation.
-    ///   - technologyRoot: Optional configuration to make this page root-level documentation.
-    ///   - displayName: Optional configuration to customize this page's symbol's display name.
-    ///   - titleHeading: Optional configuration to customize the text of this page's title heading.
-    init(originalMarkup: BlockDirective, documentationExtension: DocumentationExtension?, technologyRoot: TechnologyRoot?, displayName: DisplayName?, titleHeading: TitleHeading?) {
-        self.originalMarkup = originalMarkup
-        self.documentationOptions = documentationExtension
-        self.technologyRoot = technologyRoot
-        self.displayName = displayName
-        self.titleHeading = titleHeading
-    }
-    
     @available(*, deprecated, message: "Do not call directly. Required for 'AutomaticDirectiveConvertible'.")
     init(originalMarkup: BlockDirective) {
         self.originalMarkup = originalMarkup
@@ -202,6 +187,77 @@ public final class Metadata: Semantic, AutomaticDirectiveConvertible {
         }
         
         return true
+    }
+    
+    // MARK: Private API for OutOfProcessReferenceResolver
+    
+    /// Don't use this outside of ``OutOfProcessReferenceResolver/entity(with:)`` .
+    ///
+    /// Directives aren't meant to be created from non-markup but the out-of-process resolver needs to create a ``Metadata`` to hold the ``PageImage``
+    /// values that it creates to associate topic images with external pages. This is because DocC renderers external content in the local context. (rdar://78718811)
+    /// https://github.com/apple/swift-docc/issues/468
+    ///
+    /// This is intentionally defined as an underscore prefixed static function instead of an initializer to make it less likely that it's used in other places.
+    static func _make(
+        originalMarkup: BlockDirective,
+        documentationOptions: DocumentationExtension? = nil,
+        technologyRoot: TechnologyRoot? = nil,
+        displayName: DisplayName? = nil,
+        pageImages: [PageImage] = [],
+        customMetadata: [CustomMetadata] = [],
+        callToAction: CallToAction? = nil,
+        availability: [Metadata.Availability] = [],
+        pageKind: Metadata.PageKind? = nil,
+        supportedLanguages: [SupportedLanguage] = [],
+        _pageColor: PageColor? = nil,
+        titleHeading: TitleHeading? = nil
+    ) -> Metadata {
+        // FIXME: https://github.com/apple/swift-docc/issues/468
+        return Metadata(
+            originalMarkup: originalMarkup,
+            documentationOptions: documentationOptions,
+            technologyRoot: technologyRoot,
+            displayName: displayName,
+            pageImages: pageImages,
+            customMetadata: customMetadata,
+            callToAction: callToAction,
+            availability: availability,
+            pageKind: pageKind,
+            supportedLanguages: supportedLanguages,
+            _pageColor: _pageColor,
+            titleHeading: titleHeading
+        )
+    }
+    
+    // This initializer only exist to be called by `_make` above.
+    private init(
+        originalMarkup: BlockDirective,
+        documentationOptions: DocumentationExtension?,
+        technologyRoot: TechnologyRoot?,
+        displayName: DisplayName?,
+        pageImages: [PageImage],
+        customMetadata: [CustomMetadata],
+        callToAction: CallToAction?,
+        availability: [Metadata.Availability],
+        pageKind: Metadata.PageKind?,
+        supportedLanguages: [SupportedLanguage],
+        _pageColor: PageColor?,
+        titleHeading: TitleHeading?
+    ) {
+        self.originalMarkup = originalMarkup
+        self.documentationOptions = documentationOptions
+        self.technologyRoot = technologyRoot
+        self.displayName = displayName
+        self.callToAction = callToAction
+        self._pageColor = _pageColor
+        self.pageKind = pageKind
+        self.titleHeading = titleHeading
+        // Non-optional child directives need to be set after `super.init()`.
+        super.init()
+        self.customMetadata = customMetadata
+        self.pageImages = pageImages
+        self.availability = availability
+        self.supportedLanguages = supportedLanguages
     }
 }
 

--- a/Tests/SwiftDocCTests/Infrastructure/TestExternalReferenceResolvers.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/TestExternalReferenceResolvers.swift
@@ -159,7 +159,7 @@ class TestMultiResultExternalReferenceResolver: ExternalReferenceResolver, Fallb
         // This is a workaround for how external content is processed. See details in OutOfProcessReferenceResolver.addImagesAndCacheMediaReferences(to:from:)
         
         if let topicImages = entityInfo.topicImages {
-            let metadata = node.metadata ?? Metadata(originalMarkup: BlockDirective(name: "Metadata", children: []), documentationExtension: nil, technologyRoot: nil, displayName: nil, titleHeading: nil)
+            let metadata = node.metadata ?? Metadata._make(originalMarkup: BlockDirective(name: "Metadata", children: []))
             
             metadata.pageImages = topicImages.map { topicImage, alt in
                 let purpose: PageImage.Purpose

--- a/Tests/SwiftDocCTests/Infrastructure/TestExternalReferenceResolvers.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/TestExternalReferenceResolvers.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2023 Apple Inc. and the Swift project authors
+ Copyright (c) 2023-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information

--- a/Tests/SwiftDocCTests/Semantics/ArticleTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/ArticleTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information

--- a/Tests/SwiftDocCTests/Semantics/ArticleTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/ArticleTests.swift
@@ -231,11 +231,11 @@ class ArticleTests: XCTestCase {
         ])
         
         let semantic = try XCTUnwrap(article)
-        XCTAssertNotNil(semantic.metadata, "Article has a @Metadata directive")
-        XCTAssertNotNil(semantic.metadata?.technologyRoot, "Article has a @TechnologyRoot configuration")
-        XCTAssertNotNil(semantic.metadata?.pageColor, "Article has a @PageColor configuration")
+        XCTAssertNotNil(semantic.metadata, "Article should have a metadata container since the markup has a @Metadata directive")
+        XCTAssertNotNil(semantic.metadata?.technologyRoot, "Article should have a technology root configuration since the markup has a @TechnologyRoot directive")
+        XCTAssertNotNil(semantic.metadata?.pageColor, "Article should have a page color configuration since the markup has a @PageColor directive")
         
-        XCTAssertNil(semantic.metadata?.displayName, "Articles configure their name in the level-1 header instead of using @DisplayName")
+        XCTAssertNil(semantic.metadata?.displayName, "Articles shouldn't have a display name metadata configuration, even though the markup has a @DisplayName directive. Article names are specified by the level-1 header instead of a metadata directive.")
         
         // Non-optional child directives should be initialized.
         XCTAssertEqual(semantic.metadata?.pageImages, [])


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://114654594

## Summary

Fix a crash when configuring a `@DisplayName` for a non-symbol.

The crash happened because the article created a new `Metadata` value to remove the `DisplayName` but didn't properly initialize all the properties which was only possible because the `ChildDirective` property wrapper deferred the initialization through an implicitly unwrapped optional.

A directive that conforms to `AutomaticDirectiveConvertible` is really only intended to be created that way so this other `Metadata` initializer shouldn't exist. Unfortunately it _has_ to exist to support the workaround for <rdar://78718811> (#468) but we can hide it better to make sure that it's only used in that specific place.

## Dependencies

None.

## Testing

Create a documentation catalog with a root page that also has a `@DisplayName` configuration:
```md
# Root

@Metadata {
  @TechnologyRoot
  @DisplayName("Something")
}

This shouldn't crash.
```

Building documentation for the catalog with that one root page shouldn't crash (but should raise a warning informing the developer that `@DisplayName` isn't supported in articles.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
