### PR TITLE
Fix link syntax issue in public documentation page

### DIFF
--- a/Sources/docc/DocCDocumentation.docc/DocC.symbols.json
+++ b/Sources/docc/DocCDocumentation.docc/DocC.symbols.json
@@ -669,7 +669,7 @@
             "text" : ""
           },
           {
-            "text" : "`@Available` is analagous to the `@available` attribute in Swift: It allows you to specify a"
+            "text" : "`@Available` is analogous to the `@available` attribute in Swift: It allows you to specify a"
           },
           {
             "text" : "platform version that the page relates to. To specify a platform and version, list the platform"
@@ -3183,6 +3183,9 @@
             "text" : "- ``PageImage``"
           },
           {
+            "text" : "- ``PageColor``"
+          },
+          {
             "text" : "- ``CallToAction``"
           },
           {
@@ -5112,7 +5115,7 @@
             "text" : ""
           },
           {
-            "text" : " To add a new tab to a ``TabNavigator``, add  a `@Tab` directive within the content of the `@TabNavigator` directive."
+            "text" : "To add a new tab to a ``TabNavigator``, add a `@Tab` directive within the content of the `@TabNavigator` directive."
           },
           {
             "text" : "- Parameters:"
@@ -5296,7 +5299,7 @@
             "text" : ""
           },
           {
-            "text" : "   @Tab(\"Excerise routines\") {"
+            "text" : "   @Tab(\"Exercise routines\") {"
           },
           {
             "text" : "      ![A sloth relaxing and enjoying a good book.](sloth-exercise)"

--- a/Sources/docc/DocCDocumentation.docc/documenting-a-swift-framework-or-package.md
+++ b/Sources/docc/DocCDocumentation.docc/documenting-a-swift-framework-or-package.md
@@ -28,8 +28,8 @@ To build documentation for your Swift framework or package, use the DocC command
 
 ![A screenshot showing the Sloth structure documentation in its rendered form.](1_sloth)
 
-> Tip: You can also use the Swift-DocC Plugin to 
-[build a documentation archive for a Swift package][plugin-docs].
+> Tip: You can also use the Swift-DocC Plugin to [build a documentation archive for a Swift package][plugin-docs].
+
 [plugin-docs]: https://apple.github.io/swift-docc-plugin/documentation/swiftdoccplugin/generating-documentation-for-hosting-online/
 
 DocC uses the comments you write in your source code as the content for the 
@@ -85,4 +85,4 @@ You can also use the DocC command-line interface, as described in <doc:distribut
 
 - <doc:writing-symbol-documentation-in-your-source-files>
 
-<!-- Copyright (c) 2021-2023 Apple Inc and the Swift Project authors. All Rights Reserved. -->
+<!-- Copyright (c) 2021-2024 Apple Inc and the Swift Project authors. All Rights Reserved. -->


### PR DESCRIPTION
<!--
If you're opening a PR to cherry-pick a change for a release branch, use this template instead:
https://github.com/apple/swift-docc/blob/main/.github/PULL_REQUEST_TEMPLATE/CHERRY_PICK.md
-->

Bug/issue #, if applicable: rdar://119959258 

## Summary

This fixes a syntax issue that prevented a link from displaying in the Tip aside on https://www.swift.org/documentation/docc/documenting-a-swift-framework-or-package

## Dependencies

None

## Testing

1. `docc preview Sources/docc`
2. Go to documentation/docc/documenting-a-swift-framework-or-package in the local preview
The Tip aside should link to "[build a documentation archive for a Swift package](https://apple.github.io/swift-docc-plugin/documentation/swiftdoccplugin/generating-documentation-for-hosting-online/)."

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- ~[ ] Added tests~
- ~[ ] Ran the `./bin/test` script and it succeeded~
- [x] Updated documentation if necessary
