### PR TITLE
Keep external links to non-symbols in generated See Also sections

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/DocumentationContentRenderer.swift
+++ b/Sources/SwiftDocC/Model/Rendering/DocumentationContentRenderer.swift
@@ -494,12 +494,7 @@ public class DocumentationContentRenderer {
                 
                 // For external links, verify they've resolved successfully and return `nil` otherwise.
                 if linkHost != reference.bundleIdentifier {
-                    let externalReference = ResolvedTopicReference(
-                        bundleIdentifier: linkHost,
-                        path: destination.path,
-                        sourceLanguages: node.availableSourceLanguages
-                    )
-                    if documentationContext.externallyResolvedSymbols.contains(externalReference) {
+                    if let url = ValidatedURL(destination), case .success(let externalReference) = documentationContext.externallyResolvedLinks[url] {
                         return externalReference
                     }
                     return nil

--- a/Tests/SwiftDocCTests/Infrastructure/ExternalReferenceResolverTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/ExternalReferenceResolverTests.swift
@@ -1069,4 +1069,123 @@ Document @1:1-1:35
             XCTAssertEqual(deprecatedSection.first?.format().trimmingCharacters(in: .whitespaces), "Use <doc://com.external.testbundle/externally/resolved/path> instead.", "The link should have been resolved")
         }
     }
+    
+    func testExternalLinkInGeneratedSeeAlso() throws {
+        let exampleDocumentation = Folder(name: "unit-test.docc", content: [
+            TextFile(name: "Root.md", utf8Content: """
+            # Root
+            
+            @Metadata {
+              @TechnologyRoot
+            }
+            
+            Curate two local articles and one external link
+            
+            ## Topics
+            
+            - <doc:First>
+            - <doc://com.external.testbundle/something>
+            - <doc:Second>
+            """),
+            
+            TextFile(name: "First.md", utf8Content: """
+            # First
+            
+            One article.
+            """),
+            TextFile(name: "Second.md", utf8Content: """
+            # Second
+            
+            Another article.
+            """),
+        ])
+        
+        let resolver = TestExternalReferenceResolver()
+        
+        let tempURL = try createTempFolder(content: [exampleDocumentation])
+        let (_, bundle, context) = try loadBundle(from: tempURL, externalResolvers: [resolver.bundleIdentifier: resolver])
+        
+        XCTAssert(context.problems.isEmpty, "Unexpected problems: \(context.problems.map(\.diagnostic.summary))")
+        
+        // Check the curation on the root page
+        let rootNode = try context.entity(with: XCTUnwrap(context.soleRootModuleReference))
+        let topics = try XCTUnwrap((rootNode.semantic as? Article)?.topics)
+        XCTAssertEqual(topics.taskGroups.count, 1, "The Root page should only have one task group because all the other pages are curated in one group so there are no automatic groups.")
+        let taskGroup = try XCTUnwrap(topics.taskGroups.first)
+        XCTAssertEqual(taskGroup.links.map(\.destination), [
+            "doc://unit-test/documentation/unit-test/First",
+            "doc://com.external.testbundle/externally/resolved/path",
+            "doc://unit-test/documentation/unit-test/Second",
+        ])
+        
+        // Check the rendered SeeAlso sections for the two curated articles.
+        let converter = DocumentationNodeConverter(bundle: bundle, context: context)
+        
+        do {
+            let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/unit-test/First", sourceLanguage: .swift)
+            let node = try context.entity(with: reference)
+            let rendered = try converter.convert(node, at: nil)
+            
+            XCTAssertEqual(rendered.seeAlsoSections.count, 1, "The page should only have the automatic See Also section created based on the curation on the Root page.")
+            let seeAlso = try XCTUnwrap(rendered.seeAlsoSections.first)
+            
+            XCTAssertEqual(seeAlso.identifiers, [
+                "doc://com.external.testbundle/externally/resolved/path",
+                "doc://unit-test/documentation/unit-test/Second",
+            ])
+        }
+        
+        do {
+            let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/unit-test/Second", sourceLanguage: .swift)
+            let node = try context.entity(with: reference)
+            let rendered = try converter.convert(node, at: nil)
+            
+            XCTAssertEqual(rendered.seeAlsoSections.count, 1, "The page should only have the automatic See Also section created based on the curation on the Root page.")
+            let seeAlso = try XCTUnwrap(rendered.seeAlsoSections.first)
+            
+            XCTAssertEqual(seeAlso.identifiers, [
+                "doc://unit-test/documentation/unit-test/First",
+                "doc://com.external.testbundle/externally/resolved/path",
+            ])
+        }
+    }
+    
+    func testExternalLinkInAuthoredSeeAlso() throws {
+        let exampleDocumentation = Folder(name: "unit-test.docc", content: [
+            TextFile(name: "Root.md", utf8Content: """
+            # Root
+            
+            @Metadata {
+              @TechnologyRoot
+            }
+            
+            An external link in an authored SeeAlso section
+            
+            ## See Also
+            
+            - <doc://com.external.testbundle/something>
+            """),
+        ])
+        
+        let resolver = TestExternalReferenceResolver()
+        
+        let tempURL = try createTempFolder(content: [exampleDocumentation])
+        let (_, bundle, context) = try loadBundle(from: tempURL, externalResolvers: [resolver.bundleIdentifier: resolver])
+        
+        XCTAssert(context.problems.isEmpty, "Unexpected problems: \(context.problems.map(\.diagnostic.summary))")
+        
+        
+        // Check the curation on the root page
+        let reference = try XCTUnwrap(context.soleRootModuleReference)
+        let node = try context.entity(with: reference)
+        let converter = DocumentationNodeConverter(bundle: bundle, context: context)
+        let rendered = try converter.convert(node, at: nil)
+        
+        XCTAssertEqual(rendered.seeAlsoSections.count, 1, "The page should only have the authored See Also section.")
+        let seeAlso = try XCTUnwrap(rendered.seeAlsoSections.first)
+        
+        XCTAssertEqual(seeAlso.identifiers, [
+            "doc://com.external.testbundle/externally/resolved/path",
+        ])
+    }
 }


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://116540790

## Summary

Fix a bug where only links to external _symbols_ were included in the generated See Also sections. 

## Dependencies

None

## Testing


This can be tested using `bin/test-data-external-resolver` as an external resolver:

1. Set `DOCC_LINK_RESOLVER_EXECUTABLE` to the `test-data-external-resolver` path
2. Set `DOCC_HTML_DIR` to swift-docc-render-artifact checkout path (`/path/to/swift-docc-render-artifact/dist`)
3. In a documentation catalog that curates some local page somewhere, also curate an external link `<doc://com.test.bundle/something>` 


For example, with an Article.md file in Something.docc:
```md
# Article

An article.
```

and a Root.md file:
```md
# Root

@Metadata {
  @TechnologyRoot
}

Curate a local article and an external link

## Topics

- <doc:Article>
- <doc://com.test.bundle/something>
```

5. Build the documentation
```
swift run docc preview path/to/Something.docc
```

6.  Preview the curated page. It should display the external link in a generated See Also section

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
