### PR TITLE
[5.10] Support resolving links in `@DeprecationSummary` content (#784)

### DIFF
--- a/Sources/SwiftDocC/Semantics/ReferenceResolver.swift
+++ b/Sources/SwiftDocC/Semantics/ReferenceResolver.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -442,6 +442,9 @@ struct ReferenceResolver: SemanticVisitor {
             }
             return ParametersSection(parameters: parameters)
         }
+        let newDeprecatedSummaryVariants = symbol.deprecatedSummaryVariants.map {
+            return DeprecatedSection(content: $0.content.map { visitMarkup($0) })
+        }
         let newDictionaryKeysVariants = symbol.dictionaryKeysSectionVariants.map { dictionaryKeysSection -> DictionaryKeysSection in
             let keys = dictionaryKeysSection.dictionaryKeys.map {
                 DictionaryKey(name: $0.name, contents: $0.contents.map { visitMarkup($0) }, symbol: $0.symbol, required: $0.required)
@@ -485,7 +488,7 @@ struct ReferenceResolver: SemanticVisitor {
             externalIDVariants: symbol.externalIDVariants,
             accessLevelVariants: symbol.accessLevelVariants,
             availabilityVariants: symbol.availabilityVariants,
-            deprecatedSummaryVariants: symbol.deprecatedSummaryVariants,
+            deprecatedSummaryVariants: newDeprecatedSummaryVariants,
             mixinsVariants: symbol.mixinsVariants,
             declarationVariants: symbol.declarationVariants,
             defaultImplementationsVariants: symbol.defaultImplementationsVariants,

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -1982,6 +1982,68 @@ let expected = """
         
         XCTAssertEqual(unmatchedSidecarDiagnostic.summary, "No symbol matched 'MyKit/UnknownSymbol'. 'UnknownSymbol' doesn't exist at '/MyKit'.")
         XCTAssertEqual(unmatchedSidecarDiagnostic.severity, .warning)
+    }
+    
+    func testDeprecationSummaryWithLocalLink() throws {
+        let exampleDocumentation = Folder(name: "unit-test.docc", content: [
+            JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(
+                moduleName: "ModuleName",
+                symbols: ["Old", "New"].map {
+                    SymbolGraph.Symbol(
+                        identifier: .init(precise: "\($0.lowercased())-symbol-id", interfaceLanguage: "swift"),
+                        names: .init(title: "\($0)Symbol", navigator: nil, subHeading: nil, prose: nil),
+                        pathComponents: ["\($0)Symbol"],
+                        docComment: nil,
+                        accessLevel: .public,
+                        kind: .init(parsedIdentifier: .class, displayName: "Kind Display Name"),
+                        mixins: [:]
+                    )
+                }
+            )),
+            
+            TextFile(name: "Extension.md", utf8Content: """
+            # ``OldSymbol``
+            
+            @DeprecationSummary {
+              Use ``NewSymbol`` instead.
+            }
+            
+            Deprecate a symbol and link to its replacement in the deprecation message.
+            """),
+            
+            TextFile(name: "Article.md", utf8Content: """
+            # Article
+            
+            @DeprecationSummary {
+              Use ``NewSymbol`` instead.
+            }
+            
+            Link to external content in an article deprecation message.
+            """),
+        ])
+        
+        let tempURL = try createTempFolder(content: [exampleDocumentation])
+        let (_, bundle, context) = try loadBundle(from: tempURL)
+        
+        XCTAssert(context.problems.isEmpty, "Unexpected problems:\n\(context.problems.map(\.diagnostic.summary).joined(separator: "\n"))")
+        
+        do {
+            let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ModuleName/OldSymbol", sourceLanguage: .swift)
+            let node = try context.entity(with: reference)
+            
+            let deprecatedSection = try XCTUnwrap((node.semantic as? Symbol)?.deprecatedSummary)
+            XCTAssertEqual(deprecatedSection.content.count, 1)
+            XCTAssertEqual(deprecatedSection.content.first?.format().trimmingCharacters(in: .whitespaces), "Use ``doc://unit-test/documentation/ModuleName/NewSymbol`` instead.", "The link should have been resolved")
+        }
+        
+        do {
+            let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/unit-test/Article", sourceLanguage: .swift)
+            let node = try context.entity(with: reference)
+            
+            let deprecatedSection = try XCTUnwrap((node.semantic as? Article)?.deprecationSummary)
+            XCTAssertEqual(deprecatedSection.count, 1)
+            XCTAssertEqual(deprecatedSection.first?.format().trimmingCharacters(in: .whitespaces), "Use ``doc://unit-test/documentation/ModuleName/NewSymbol`` instead.", "The link should have been resolved")
+        }
     }
     
     func testUncuratedArticleDiagnostics() throws {


### PR DESCRIPTION
Cherrypick of #784 

**Explanation:** This adds support for resolving links in a symbol's `@DeprecationSummary` content.
**Scope:** Local and external links in content in inside symbol's optional `@DeprecationSummary` directive. 
**Issue:** rdar://120374614
**Risk:** Low.
**Testing:** Added tests and ran the existing automated tests.
**Reviewer:** @sofiaromorales  
