### PR TITLE
[5.10] Update allowed years in check-source script

### DIFF
--- a/bin/check-source
+++ b/bin/check-source
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
+# Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information
@@ -18,7 +18,7 @@ here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 function replace_acceptable_years() {
     # this needs to replace all acceptable forms with 'YEARS'
-    sed -e 's/20[12][7890123]-20[12][890123]/YEARS/' -e 's/20[12][890123]/YEARS/'
+    sed -e 's/20[12][78901234]-20[12][8901234]/YEARS/' -e 's/20[12][8901234]/YEARS/'
 }
 
 printf "=> Checking for unacceptable language… "


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

This updates the allowed years in `check-source` script to include 2024. 

Note that this _isn't_ a cherry-pick because this change was made in #778 which we didn't cherry-pick onto the 5.10 release.

## Dependencies

None.

## Testing

Run `check-source`, it shouldn't warn about the year in the check-source file itself.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- ~[ ] Added tests~
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
