### PR TITLE
[5.10] Fix link syntax issue in public documentation page (#787)

### DIFF
--- a/Sources/docc/DocCDocumentation.docc/DocC.symbols.json
+++ b/Sources/docc/DocCDocumentation.docc/DocC.symbols.json
@@ -609,7 +609,7 @@
             "text" : ""
           },
           {
-            "text" : "`@Available` is analagous to the `@available` attribute in Swift: It allows you to specify a"
+            "text" : "`@Available` is analogous to the `@available` attribute in Swift: It allows you to specify a"
           },
           {
             "text" : "platform version that the page relates to. To specify a platform and version, list the platform"
@@ -2953,6 +2953,9 @@
             "text" : "- ``PageImage``"
           },
           {
+            "text" : "- ``PageColor``"
+          },
+          {
             "text" : "- ``CallToAction``"
           },
           {
@@ -4732,7 +4735,7 @@
             "text" : ""
           },
           {
-            "text" : " To add a new tab to a ``TabNavigator``, add  a `@Tab` directive within the content of the `@TabNavigator` directive."
+            "text" : "To add a new tab to a ``TabNavigator``, add a `@Tab` directive within the content of the `@TabNavigator` directive."
           },
           {
             "text" : "- Parameters:"
@@ -4906,7 +4909,7 @@
             "text" : ""
           },
           {
-            "text" : "   @Tab(\"Excerise routines\") {"
+            "text" : "   @Tab(\"Exercise routines\") {"
           },
           {
             "text" : "      ![A sloth relaxing and enjoying a good book.](sloth-exercise)"

--- a/Sources/docc/DocCDocumentation.docc/documenting-a-swift-framework-or-package.md
+++ b/Sources/docc/DocCDocumentation.docc/documenting-a-swift-framework-or-package.md
@@ -28,8 +28,8 @@ To build documentation for your Swift framework or package, use the DocC command
 
 ![A screenshot showing the Sloth structure documentation in its rendered form.](1_sloth)
 
-> Tip: You can also use the Swift-DocC Plugin to 
-[build a documentation archive for a Swift package][plugin-docs].
+> Tip: You can also use the Swift-DocC Plugin to [build a documentation archive for a Swift package][plugin-docs].
+
 [plugin-docs]: https://apple.github.io/swift-docc-plugin/documentation/swiftdoccplugin/generating-documentation-for-hosting-online/
 
 DocC uses the comments you write in your source code as the content for the 
@@ -85,4 +85,4 @@ You can also use the DocC command-line interface, as described in <doc:distribut
 
 - <doc:writing-symbol-documentation-in-your-source-files>
 
-<!-- Copyright (c) 2021-2023 Apple Inc and the Swift Project authors. All Rights Reserved. -->
+<!-- Copyright (c) 2021-2024 Apple Inc and the Swift Project authors. All Rights Reserved. -->


### PR DESCRIPTION
Cherrypick of #787

**Explanation:** Fix link syntax issue so that the link displays as expected in the Tip aside on https://www.swift.org/documentation/docc/documenting-a-swift-framework-or-package
**Scope:** Hosted documentation
**Issue:** rdar://119959258
**Risk:** Low.
**Testing:** Locally previewed the DocC documentation
**Reviewer:** @daniel-grumberg 

