### PR TITLE
Implement a better cache key for resolved references

### DIFF
--- a/Sources/SwiftDocC/Model/Identifier.swift
+++ b/Sources/SwiftDocC/Model/Identifier.swift
@@ -141,10 +141,14 @@ extension TopicReferenceResolutionErrorInfo {
 /// > its data.
 public struct ResolvedTopicReference: Hashable, Codable, Equatable, CustomStringConvertible {
     typealias ReferenceBundleIdentifier = String
-    typealias ReferenceKey = String
+    private struct ReferenceKey: Hashable {
+        var path: String
+        var fragment: String?
+        var sourceLanguages: Set<SourceLanguage>
+    }
     
     /// A synchronized reference cache to store resolved references.
-    static var sharedPool = Synchronized([ReferenceBundleIdentifier: [ReferenceKey: ResolvedTopicReference]]())
+    private static var sharedPool = Synchronized([ReferenceBundleIdentifier: [ReferenceKey: ResolvedTopicReference]]())
     
     /// Clears cached references belonging to the bundle with the given identifier.
     /// - Parameter bundleIdentifier: The identifier of the bundle to which the method should clear belonging references.
@@ -219,11 +223,7 @@ public struct ResolvedTopicReference: Hashable, Codable, Equatable, CustomString
     private init(bundleIdentifier: String, urlReadablePath: String, urlReadableFragment: String? = nil, sourceLanguages: Set<SourceLanguage>) {
         precondition(!sourceLanguages.isEmpty, "ResolvedTopicReference.sourceLanguages cannot be empty")
         // Check for a cached instance of the reference
-        let key = Self.cacheKey(
-            urlReadablePath: urlReadablePath,
-            urlReadableFragment: urlReadableFragment,
-            sourceLanguages: sourceLanguages
-        )
+        let key = ReferenceKey(path: urlReadablePath, fragment: urlReadableFragment, sourceLanguages: sourceLanguages)
         let cached = Self.sharedPool.sync { $0[bundleIdentifier]?[key] }
         if let resolved = cached {
             self = resolved
@@ -241,20 +241,6 @@ public struct ResolvedTopicReference: Hashable, Codable, Equatable, CustomString
         Self.sharedPool.sync { sharedPool in
             // If we have a shared pool for this bundle identifier, cache the reference
             sharedPool[bundleIdentifier]?[key] = self
-        }
-    }
-    
-    private static func cacheKey(
-        urlReadablePath path: String,
-        urlReadableFragment fragment: String?,
-        sourceLanguages: Set<SourceLanguage>
-    ) -> String {
-        let sourceLanguagesString = sourceLanguages.map(\.id).sorted().joined(separator: "-")
-        
-        if let fragment = fragment {
-            return "\(path):\(fragment):\(sourceLanguagesString)"
-        } else {
-            return "\(path):\(sourceLanguagesString)"
         }
     }
     
@@ -495,22 +481,10 @@ public struct ResolvedTopicReference: Hashable, Codable, Equatable, CustomString
             self.absoluteString = self.url.absoluteString
         }
     }
-}
-
-typealias ResolvedTopicReferenceCacheKey = String
-
-extension ResolvedTopicReference {
-    /// Returns a unique cache ID for a pair of unresolved and parent references.
-    static func cacheIdentifier(_ reference: UnresolvedTopicReference, fromSymbolLink: Bool, in parent: ResolvedTopicReference?) -> ResolvedTopicReferenceCacheKey {
-        let isSymbolLink = fromSymbolLink ? ":symbol" : ""
-        if let parent = parent {
-            // Create a cache id in the parent context
-            return "\(reference.topicURL.absoluteString):\(parent.bundleIdentifier):\(parent.path):\(parent.sourceLanguage.id)\(isSymbolLink)"
-        } else {
-            // A cache ID for an external reference
-            assert(reference.topicURL.components.host != nil)
-            return reference.topicURL.absoluteString.appending(isSymbolLink)
-        }
+    
+    // For testing the caching
+    static func _numberOfCachedReferences(bundleID: ReferenceBundleIdentifier) -> Int? {
+        return Self.sharedPool.sync { $0[bundleID]?.count }
     }
 }
 

--- a/Tests/SwiftDocCTests/Converter/RenderNodeCodableTests.swift
+++ b/Tests/SwiftDocCTests/Converter/RenderNodeCodableTests.swift
@@ -146,21 +146,14 @@ class RenderNodeCodableTests: XCTestCase {
             subdirectory: "Test Resources"
         )!
         
-        let uniqueBundleIdentifier = #function
+        let bundleID = #function
         
-        let renderNodeWithUniqueBundleID = try String(
-            contentsOf: exampleRenderNodeJSON
-        )
-        .replacingOccurrences(
-            of: "org.swift.docc.example",
-            with: uniqueBundleIdentifier
-        )
+        let renderNodeWithUniqueBundleID = try String(contentsOf: exampleRenderNodeJSON)
+        .replacingOccurrences(of: "org.swift.docc.example", with: bundleID)
         
         _ = try JSONDecoder().decode(RenderNode.self, from: Data(renderNodeWithUniqueBundleID.utf8))
         
-        ResolvedTopicReference.sharedPool.sync { sharedPool in
-            XCTAssertNil(sharedPool[uniqueBundleIdentifier])
-        }
+        XCTAssertNil(ResolvedTopicReference._numberOfCachedReferences(bundleID: bundleID))
     }
     
     func testDecodeRenderNodeWithoutTopicSectionStyle() throws {

--- a/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
@@ -260,9 +260,7 @@ Root
             atomically: true
         )
         
-        ResolvedTopicReference.sharedPool.sync { sharedPool in
-            XCTAssertNil(sharedPool[uniqueTestBundleIdentifier])
-        }
+        XCTAssertNil(ResolvedTopicReference._numberOfCachedReferences(bundleID: uniqueTestBundleIdentifier))
     }
     
   

--- a/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
@@ -1769,9 +1769,7 @@ class ConvertActionTests: XCTestCase {
         
         _ = try action.perform(logHandle: .none)
         
-        ResolvedTopicReference.sharedPool.sync { sharedPool in
-            XCTAssertEqual(sharedPool[#function]?.count, 8)
-        }
+        XCTAssertEqual(ResolvedTopicReference._numberOfCachedReferences(bundleID: #function), 8)
     }
 
     func testIgnoresAnalyzerHintsByDefault() throws {


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

This implements a better key for the cache of `ResolvedTopicReference` storage. 

Using a concatenated `String` as a key in one of the examples from the [Understanding Swift Performance WWDC 16][1] video. The struct key in this PR still stores string values but it avoids creating a new string. The performance difference is only measurable in micro benchmarks but this has a small (~0.5%) measurable memory reduction when looking at a full `docc convert` call. 

[1]: https://developer.apple.com/videos/play/wwdc2016/416/

## Dependencies

None

## Testing

None. This change isn't user facing. 

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] ~Added~ Updated tests
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
