### PR TITLE
Fix Availability Selection in Symbol Graph Loader

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphLoader.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphLoader.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -232,14 +232,24 @@ struct SymbolGraphLoader {
                         newAvailabilityItems.append(macCatalystAvailability)
                     }
 
-                    // If a symbol doesn't have any availability annotation at all
-                    // for a given platform, create a new one just with the
-                    // introduced version so that it shows up in the sidebar.
+                    // If a symbol doesn't have any availability version
+                    // annotation at all for a given platform, create a new
+                    // one just with the introduced version so that it shows
+                    // up in the sidebar.
                     for defaultAvailability in defaultAvailabilities {
+                        // If the symbol does not exists for the given platform
+                        // don't add any default availability.
+                        guard newAvailabilityItems.contains(where: {
+                            $0.domain?.rawValue == defaultAvailability.platformName.rawValue
+                        }) else { continue }
+                        // If the symbol exists for the platform check if it also defines the availability
+                        // version information.
                         let hasAvailabilityForThisPlatform = newAvailabilityItems.contains {
-                            guard let domain = $0.domain else { return false }
-                            return PlatformName(operatingSystemName: domain.rawValue) == defaultAvailability.platformName
+                            // Safe to force unwrap below, we already checked that the domain does exists at this point.
+                            return PlatformName(operatingSystemName: $0.domain!.rawValue) == defaultAvailability.platformName
                         }
+                        // If the symbol exists in a given platform but does not defines version
+                        // information add the defualt one.
                         if !hasAvailabilityForThisPlatform {
                             // Safe to force unwrap below, the index contains all the avaialbility keys.
                             newAvailabilityItems.append(defaultAvailabilityIndex[defaultAvailability]!)

--- a/Sources/SwiftDocCTestUtilities/SymbolGraphCreation.swift
+++ b/Sources/SwiftDocCTestUtilities/SymbolGraphCreation.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -29,7 +29,7 @@ extension XCTestCase {
         )
     }
     
-    public func makeSymbolGraphString(moduleName: String, symbols: String = "", relationships: String = "") -> String {
+    public func makeSymbolGraphString(moduleName: String, symbols: String = "", relationships: String = "", platform: String = "") -> String {
         return """
         {
           "metadata": {
@@ -42,7 +42,7 @@ extension XCTestCase {
           },
           "module": {
               "name": "\(moduleName)",
-              "platform": { }
+              "platform": { \(platform) }
           },
           "relationships" : [
             \(relationships)

--- a/Tests/SwiftDocCTests/Infrastructure/SymbolGraph/SymbolGraphLoaderTests+Availability.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/SymbolGraph/SymbolGraphLoaderTests+Availability.swift
@@ -1,0 +1,206 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2024 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+import XCTest
+@testable import SymbolKit
+@testable import SwiftDocC
+import SwiftDocCTestUtilities
+
+class SymbolGraphLoaderTestsAvailability: XCTestCase {
+    
+    func testLoadSymbolPlatformAvailability() throws {
+        let tempURL = try createTemporaryDirectory()
+        try makeSymbolGraphString(
+            moduleName: "MyModule",
+            symbols: makeSymbol(title: "Foo", domain: "iOS", introducedVersion: (10, 0, 0)),
+            platform: makePlatform("iOS")
+        ).write(to: tempURL.appendingPathComponent("ios-swift.symbols.json"), atomically: true, encoding: .utf8)
+        try makeSymbolGraphString(
+            moduleName: "MyModule",
+            symbols: makeSymbol(title: "Foo", domain: "tvOS", introducedVersion: (8, 0, 0)),
+            platform: makePlatform("tvOS")
+        ).write(to: tempURL.appendingPathComponent("tvos-swift.symbols.json"), atomically: true, encoding: .utf8)
+        var loader = try makeSymbolGraphLoader(
+            symbolGraphURLs:[
+                tempURL.appendingPathComponent("ios-swift.symbols.json"),
+                tempURL.appendingPathComponent("tvos-swift.symbols.json")
+            ]
+        )
+        try loader.loadAll()
+        let expectedAvailabilitesInfo = ["tvOS":8, "iOS":10]
+        // Check that the availability matches the information from the symbolgraph.
+        XCTAssertEqual(expectedAvailabilitesInfo, extractSymbolAvailabilityInformation(loader))
+    }
+    
+    func testLoadSymbolPlatformAvailabilityWithDefaultAvailability() throws {
+        let tempURL = try createTemporaryDirectory()
+        let infoPlistInfo = makeInfoPlistFileWithDefaultAvailability(
+            availabilityInfo: [("iOS","1.0"), ("tvOS","1.0"), ("watchOS","1.0")]
+        )
+        let infoPlistWithAllFieldsData = Data(infoPlistInfo.utf8)
+        let documentationBundleInfo = try DocumentationBundle.Info(
+            from: infoPlistWithAllFieldsData
+        )
+        try makeSymbolGraphString(
+            moduleName: "MyModule",
+            symbols: makeSymbol(title: "Foo", domain: "iOS", introducedVersion: (10, 0, 0)),
+            platform: makePlatform("ios")
+        ).write(to: tempURL.appendingPathComponent("ios-swift.symbols.json"), atomically: true, encoding: .utf8)
+        try makeSymbolGraphString(
+            moduleName: "MyModule",
+            symbols: makeSymbol(title: "Foo", domain: "tvOS", introducedVersion: (8, 0, 0)),
+            platform: makePlatform("tvos")
+        ).write(to: tempURL.appendingPathComponent("tvos-swift.symbols.json"), atomically: true, encoding: .utf8)
+        try makeSymbolGraphString(
+            moduleName: "MyModule",
+            symbols: makeSymbol(title: "Foo", domain: "watchOS"),
+            platform: makePlatform("watchos")
+        ).write(to: tempURL.appendingPathComponent("watchos-swift.symbols.json"), atomically: true, encoding: .utf8)
+        
+        var loader = try makeSymbolGraphLoader(
+            symbolGraphURLs:[
+                tempURL.appendingPathComponent("ios-swift.symbols.json"),
+                tempURL.appendingPathComponent("tvos-swift.symbols.json"),
+                tempURL.appendingPathComponent("watchos-swift.symbols.json")
+            ],
+            bundleInfo: documentationBundleInfo
+        )
+        try loader.loadAll()
+        let expectedAvailabilitesInfo = ["tvOS":8, "iOS":10, "macCatalyst": 10, "watchOS": 1]
+        // Check that the availability contains the missing version information mathcing the
+        // Info.plist information.
+        XCTAssertEqual(expectedAvailabilitesInfo, extractSymbolAvailabilityInformation(loader))
+    }
+    
+    // MARK: - Helpers
+    
+    private func makeSymbolGraphLoader(
+        symbolGraphURLs: [URL],
+        configureSymbolGraph: ((inout SymbolGraph) -> ())? = nil,
+        bundleInfo: DocumentationBundle.Info? = nil
+    ) throws -> SymbolGraphLoader {
+        let workspace = DocumentationWorkspace()
+        let bundle = DocumentationBundle(
+            info: bundleInfo ?? DocumentationBundle.Info(
+                displayName: "Test",
+                identifier: "com.example.test",
+                version: "1.2.3"
+            ),
+            baseURL: URL(string: "https://example.com/example")!,
+            symbolGraphURLs: symbolGraphURLs,
+            markupURLs: [],
+            miscResourceURLs: []
+        )
+        try workspace.registerProvider(PrebuiltLocalFileSystemDataProvider(bundles: [bundle]))
+        
+        return SymbolGraphLoader(
+            bundle: bundle,
+            dataProvider: workspace,
+            configureSymbolGraph: configureSymbolGraph
+        )
+    }
+    
+    private func makeSymbol(
+        title: String,
+        domain: String,
+        introducedVersion: (major: Int, minor: Int, patch: Int)? = nil
+    ) -> String {
+        """
+        {
+            "kind": {
+                "identifier": "\(domain).property",
+                "displayName": "Instance Property"
+            },
+            "identifier": {
+                "precise": "c:@\(title)",
+                "interfaceLanguage": "\(domain)"
+            },
+            "pathComponents": [
+                "\(title)"
+            ],
+            "names": {
+                "title": "\(title)",
+            },
+            "accessLevel": "public",
+            "availability" : [
+                {
+                  "domain" : "\(domain)",
+                    \((introducedVersion != nil) 
+                    ? """
+                      "introduced" : {
+                        "major" : \(introducedVersion!.major),
+                        "minor" : \(introducedVersion!.minor),
+                        "patch" : \(introducedVersion!.patch),
+                      }
+                    """ : "")
+                  
+                }
+            ]
+        }
+        """
+    }
+    
+    private func makePlatform(_ platformName: String) -> String {
+        """
+        "architecture" : "arm64",
+        "operatingSystem" : {
+          "minimumVersion" : {
+            "major" : 12,
+            "minor" : 0,
+            "patch" : 0
+          },
+          "name" : "\(platformName)"
+        },
+        "vendor" : "apple"
+        """
+    }
+    
+    private func extractSymbolAvailabilityInformation(_ loader: SymbolGraphLoader) -> [String: Int] {
+        var availabilitiesInfo: [String:Int] = [:]
+        loader.symbolGraphs.forEach { (_, graph) in
+            graph.symbols.forEach { (_, symbol) in
+                if let availability = symbol.mixins[SymbolGraph.Symbol.Availability.mixinKey] as? SymbolGraph.Symbol.Availability {
+                    availability.availability.forEach {
+                        availabilitiesInfo[$0.domain!.rawValue] = $0.introducedVersion?.major
+                    }
+                }
+            }
+        }
+        return availabilitiesInfo
+    }
+    
+    private func makeInfoPlistFileWithDefaultAvailability(availabilityInfo: [(platformName: String, version: String)]) -> String {
+        """
+        <plist version="1.0">
+        <dict>
+            <key>CFBundleDisplayName</key>
+            <string>MyModule</string>
+            <key>CDAppleDefaultAvailability</key>
+            <dict>
+                <key>MyModule</key>
+                <array>
+                    \(availabilityInfo.map {
+                        """
+                        <dict>
+                            <key>name</key>
+                            <string>\($0.platformName)</string>
+                            <key>version</key>
+                            <string>\($0.version)</string>
+                        </dict>
+                        """
+                    }.joined(separator: "\n"))
+                </array>
+            </dict>
+        </dict>
+        </plist>
+        """
+    }
+}


### PR DESCRIPTION
<!--
If you're opening a PR to cherry-pick a change for a release branch, use this template instead:
https://github.com/apple/swift-docc/blob/main/.github/PULL_REQUEST_TEMPLATE/CHERRY_PICK.md
-->

Bug/issue #, if applicable:  rdar://118207413

## Summary

Currently, when the availability information comes from the SGFs and the Info.plist default availability section, the symbol graph loader fills each symbol with all the defined platforms in the Info.plist. This results in incorrect availability information being displayed in the subsequent documentation, as symbols are shown as available for platforms where they are not actually available, and, since DocC selects only one symbol from the unified symbol graph, the chosen symbol does not have the correct availability information for all its variants.

With this fix, each symbol will appear as available only in the platforms defined in the symbol SGF info. If there's default availability information defined in the Info.plist, we use it to fill any missing introduced version information, but only if the symbol exists in that platform.

-----

Before this fix, the symbol graph loading looked like this (from the availability perspective):

#### **Input:** 
tvOS-swift.symbols.json:
**A** -> { domain: tvOS }
watchOS-swift.symbols.json:
**A** -> { domain: watchOS, introduced: 8 }

Info.plist:
| tvOS | 3.0 |
| watchOS | 2.0 |
| iOS | 1.0 |

#### **Symbols after symbol graph loading:**
**A** -> { { domain: tvOS, introduced: 3 }, { domain: watchOS, introduced: 2.0 }, { domain: iOS, introduced: 1.0 } }
 **A** -> { { domain: tvOS, introduced: 3 }, { domain: watchOS, introduced: 8.0 }, { domain: iOS, introduced: 1.0 } }

#### **Resulting symbol availability in the docs:**
**A** -> { { domain: tvOS, introduced: 3 }, { domain: watchOS, introduced: 2.0 }, { domain: iOS, introduced: 1.0 } }

-----

Now it behaves like the following:

#### **Input:** 
tvOS-swift.symbols.json:
**A** -> { domain: tvOS }
watchOS-swift.symbols.json:
**A** -> { domain: watchOS, introduced: 8 }

Info.plist:
| tvOS | 3.0 |
| watchOS | 2.0 |
| iOS | 1.0 |

#### **Symbols after symbol graph loading:**
**A** -> { { domain: tvOS, introduced: 3 } }
**A** -> { { domain: watchOS, introduced: 8.0 } }

#### **Resulting symbol availability in the docs:**
**A** -> { { domain: tvOS, introduced: 3 }, { domain: watchOS, introduced: 8.0 } }

## Dependencies

N/A

## Testing

Steps:
1. Preview the attached documentation catalog with the provided SGFs
2. Assert that the symbol A: 
   - Is not available in VisionOS
   - Is available in watchOS from version 12 (availability defined in SGF)
   - Is available in tvOS from version 1.0 (availability defined in info.plist)

[Testing.zip](https://github.com/apple/swift-docc/files/13978679/Testing.zip)

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary
