### PR TITLE
R117883810 @redirected placement

### DIFF
--- a/Sources/SwiftDocC/Model/DocumentationMarkup.swift
+++ b/Sources/SwiftDocC/Model/DocumentationMarkup.swift
@@ -73,6 +73,14 @@ struct DocumentationMarkup {
         case end
     }
     
+    /// Directives which are removed from the markdown content after being parsed.
+    private static let directivesRemovedFromContent = [
+        Comment.directiveName,
+        Metadata.directiveName,
+        Options.directiveName,
+        Redirect.directiveName,
+    ]
+
     // MARK: - Parsed Data
     
     /// The documentation title, if found.
@@ -146,7 +154,7 @@ struct DocumentationMarkup {
                         // Found deprecation notice in the abstract.
                         deprecation = MarkupContainer(directive.children)
                         return
-                    } else if directive.name == Comment.directiveName || directive.name == Metadata.directiveName || directive.name == Options.directiveName {
+                    } else if Self.directivesRemovedFromContent.contains(directive.name) {
                         // These directives don't affect content so they shouldn't break us out of
                         // the automatic abstract section.
                         return

--- a/Sources/SwiftDocC/Semantics/Article/Article.swift
+++ b/Sources/SwiftDocC/Semantics/Article/Article.swift
@@ -121,7 +121,7 @@ public final class Article: Semantic, MarkupConvertible, Abstracted, Redirected,
         }
         
         var remainder: [Markup]
-        let redirects: [Redirect]
+        var redirects: [Redirect]
         (redirects, remainder) = markup.children.categorize { child -> Redirect? in
             guard let childDirective = child as? BlockDirective, childDirective.name == Redirect.directiveName else {
                 return nil
@@ -142,7 +142,13 @@ public final class Article: Semantic, MarkupConvertible, Abstracted, Redirected,
         }
         
         var optionalMetadata = metadata.first
-        
+
+        // Append any redirects found in the metadata to the redirects
+        // found in the main content.
+        if let redirectsFromMetadata = optionalMetadata?.redirects {
+            redirects.append(contentsOf: redirectsFromMetadata)
+        }
+
         let options: [Options]
         (options, remainder) = remainder.categorize { child -> Options? in
             guard let childDirective = child as? BlockDirective, childDirective.name == Options.directiveName else {

--- a/Sources/SwiftDocC/Semantics/Metadata/Metadata.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/Metadata.swift
@@ -74,7 +74,10 @@ public final class Metadata: Semantic, AutomaticDirectiveConvertible {
 
     @ChildDirective
     var titleHeading: TitleHeading? = nil
-    
+
+    @ChildDirective
+    var redirects: [Redirect]? = nil
+
     static var keyPaths: [String : AnyKeyPath] = [
         "documentationOptions"  : \Metadata._documentationOptions,
         "technologyRoot"        : \Metadata._technologyRoot,
@@ -87,6 +90,7 @@ public final class Metadata: Semantic, AutomaticDirectiveConvertible {
         "supportedLanguages"    : \Metadata._supportedLanguages,
         "_pageColor"            : \Metadata.__pageColor,
         "titleHeading"          : \Metadata._titleHeading,
+        "redirects"              : \Metadata._redirects,
     ]
     
     @available(*, deprecated, message: "Do not call directly. Required for 'AutomaticDirectiveConvertible'.")
@@ -96,7 +100,7 @@ public final class Metadata: Semantic, AutomaticDirectiveConvertible {
     
     func validate(source: URL?, for bundle: DocumentationBundle, in context: DocumentationContext, problems: inout [Problem]) -> Bool {
         // Check that something is configured in the metadata block
-        if documentationOptions == nil && technologyRoot == nil && displayName == nil && pageImages.isEmpty && customMetadata.isEmpty && callToAction == nil && availability.isEmpty && pageKind == nil && pageColor == nil && titleHeading == nil {
+        if documentationOptions == nil && technologyRoot == nil && displayName == nil && pageImages.isEmpty && customMetadata.isEmpty && callToAction == nil && availability.isEmpty && pageKind == nil && pageColor == nil && titleHeading == nil && redirects == nil {
             let diagnostic = Diagnostic(
                 source: source,
                 severity: .information,

--- a/Tests/SwiftDocCTests/Model/DocumentationMarkupTests.swift
+++ b/Tests/SwiftDocCTests/Model/DocumentationMarkupTests.swift
@@ -181,7 +181,108 @@ class DocumentationMarkupTests: XCTestCase {
             XCTAssertEqual(expected, model.abstractSection?.content.map{ $0.detachedFromParent.debugDescription() }.joined(separator: "\n"))
         }
     }
-    
+
+    func testCertainDirectivesAreRemovedFromContent() throws {
+
+        func checkSectionContent(expectedContent: String?, section: Section?) {
+            if let desc = section?.content.map({ $0.detachedFromParent.debugDescription() }).joined(separator: "\n") {
+                XCTAssertEqual(expectedContent, desc, "Found unexpected content: \n\(desc)")
+            }
+        }
+
+
+        func checkAbstractAndDiscussion(source: String, expectedAbstract: String, expectedDiscussion: String) {
+            let model = DocumentationMarkup(markup: Document(parsing: source, options: .parseBlockDirectives))
+            checkSectionContent(expectedContent: expectedAbstract, section: model.abstractSection)
+            checkSectionContent(expectedContent: expectedDiscussion, section: model.discussionSection)
+        }
+
+        func checkDirectiveIsRemoved(_ directiveSource: String) {
+            let expectedAbstract = """
+                                   Text "My abstract "
+                                   Strong
+                                   └─ Text "content"
+                                   Text "."
+                                   """
+
+            let expectedDiscussion = """
+                                     Paragraph
+                                     └─ Text "My discussion."
+                                     """
+
+            let sourceWithDirectiveBeforeAbstract = """
+                                    # Title
+                                    \(directiveSource)
+                                    My abstract __content__.
+
+                                    My discussion.
+                                    """
+            checkAbstractAndDiscussion(source: sourceWithDirectiveBeforeAbstract, expectedAbstract: expectedAbstract, expectedDiscussion: expectedDiscussion)
+
+            let sourceWithDirectiveAfterAbstract = """
+                                    # Title
+                                    My abstract __content__.
+                                    \(directiveSource)
+
+                                    My discussion.
+                                    """
+            checkAbstractAndDiscussion(source: sourceWithDirectiveAfterAbstract, expectedAbstract: expectedAbstract, expectedDiscussion: expectedDiscussion)
+        }
+
+        // @Comment, @Metadata, @Options and @Redirected should be removed from the content.
+        checkDirectiveIsRemoved("@Comment(\"this is a comment\")")
+        checkDirectiveIsRemoved("@Metadata { @DocumentationExtension(mergeBehavior: override) }")
+        checkDirectiveIsRemoved("@Options { @TopicsVisualStyle(hidden) }")
+        checkDirectiveIsRemoved("@Redirected(from: \"some/other/path\")")
+
+        // @Image should not be removed: abstract converted to discussion since images aren't
+        // allowed in abstracts.
+        let sourceWithImageBeforeAbstract = """
+                                            # Title
+                                            @Image(source: "some.png", alt: "Used in a unit test")
+                                            My abstract __content__.
+
+                                            My discussion.
+                                            """
+        var expectedAbstract = ""
+        var expectedDiscussion = """
+                                 BlockDirective name: "Image"
+                                 ├─ Argument text segments:
+                                 |    "source: \\"some.png\\", alt: \\"Used in a unit test\\""
+                                 Paragraph
+                                 ├─ Text "My abstract "
+                                 ├─ Strong
+                                 │  └─ Text "content"
+                                 └─ Text "."
+                                 Paragraph
+                                 └─ Text "My discussion."
+                                 """
+        checkAbstractAndDiscussion( source: sourceWithImageBeforeAbstract, expectedAbstract: expectedAbstract, expectedDiscussion: expectedDiscussion )
+
+        // @Image should not be removed; image falls through to discussion
+        let sourceWithImageAfterAbstract = """
+                                           # Title
+                                           My abstract __content__.
+                                           @Image(source: "some.png", alt: "Used in a unit test")
+
+                                           My discussion.
+                                           """
+        expectedAbstract = """
+                           Text "My abstract "
+                           Strong
+                           └─ Text "content"
+                           Text "."
+                           """
+        expectedDiscussion = """
+                             BlockDirective name: "Image"
+                             ├─ Argument text segments:
+                             |    "source: \\"some.png\\", alt: \\"Used in a unit test\\""
+                             Paragraph
+                             └─ Text "My discussion."
+                             """
+        checkAbstractAndDiscussion(source: sourceWithImageAfterAbstract, expectedAbstract: expectedAbstract, expectedDiscussion: expectedDiscussion)
+    }
+
     func testDeprecation() throws {
         // Deprecation before the abstract content.
         do {

--- a/Tests/SwiftDocCTests/Semantics/DirectiveInfrastructure/DirectiveMirrorTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/DirectiveInfrastructure/DirectiveMirrorTests.swift
@@ -52,7 +52,7 @@ class DirectiveMirrorTests: XCTestCase {
         XCTAssertFalse(reflectedDirective.allowsMarkup)
         XCTAssert(reflectedDirective.arguments.isEmpty)
         
-        XCTAssertEqual(reflectedDirective.childDirectives.count, 11)
+        XCTAssertEqual(reflectedDirective.childDirectives.count, 12)
         
         XCTAssertEqual(
             reflectedDirective.childDirectives["DocumentationExtension"]?.propertyLabel,

--- a/Tests/SwiftDocCTests/Semantics/MetadataTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/MetadataTests.swift
@@ -164,7 +164,23 @@ class MetadataTests: XCTestCase {
         XCTAssertEqual(metadata?.customMetadata.count, 2)
         XCTAssertEqual(problems.count, 0)
     }
-    
+
+    func testRedirectSupport() throws {
+        let source = """
+        @Metadata {
+           @Redirected(from: "some/other/path")
+        }
+        """
+        let document = Document(parsing: source, options: .parseBlockDirectives)
+        let directive = document.child(at: 0)! as! BlockDirective
+        let (bundle, context) = try testBundleAndContext(named: "TestBundle")
+        var problems = [Problem]()
+        let metadata = Metadata(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        XCTAssertNotNil(metadata)
+        XCTAssertEqual(0, problems.count)
+        XCTAssertEqual(metadata?.redirects?.first?.oldPath.relativePath, "some/other/path")
+    }
+
     // MARK: - Metadata Support
     
     func testArticleSupportsMetadata() throws {

--- a/Tests/SwiftDocCTests/Semantics/RedirectedTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/RedirectedTests.swift
@@ -296,9 +296,81 @@ class RedirectedTests: XCTestCase {
         
         @Redirected(from: /old/path/to/this/page)
         @Redirected(from: /another/old/path/to/this/page)
-           
+
         ## Section Name
-           
+
+        ![full width image](referenced-article-image.png)
+        """
+        let document = Document(parsing: source, options: .parseBlockDirectives)
+        let (bundle, context) = try testBundleAndContext(named: "TestBundle")
+        var problems = [Problem]()
+        let article = Article(from: document, source: nil, for: bundle, in: context, problems: &problems)
+        XCTAssertNotNil(article, "An Article value can be created with a Redirected child.")
+        XCTAssert(problems.isEmpty, "There shouldn't be any problems. Got:\n\(problems.map { $0.diagnostic.summary })")
+
+        var analyzer = SemanticAnalyzer(source: nil, context: context, bundle: bundle)
+        _ = analyzer.visit(document)
+        XCTAssert(analyzer.problems.isEmpty, "Expected no problems. Got \(DiagnosticConsoleWriter.formattedDescription(for:  analyzer.problems))")
+
+        let redirects = try XCTUnwrap(article?.redirects)
+        XCTAssertEqual(2, redirects.count)
+        let oldPaths = redirects.map{ $0.oldPath.relativePath }.sorted()
+        XCTAssertEqual([
+            "/another/old/path/to/this/page",
+            "/old/path/to/this/page",
+        ], oldPaths)
+    }
+
+    func testArticleSupportsRedirectInMetadata() throws {
+        let source = """
+        # Plain article
+
+        The abstract of this article
+
+        @Metadata {
+            @Redirected(from: /old/path/to/this/page)
+            @Redirected(from: /another/old/path/to/this/page)
+        }
+
+        ## Section Name
+
+        ![full width image](referenced-article-image.png)
+        """
+        let document = Document(parsing: source, options: .parseBlockDirectives)
+        let (bundle, context) = try testBundleAndContext(named: "TestBundle")
+        var problems = [Problem]()
+        let article = Article(from: document, source: nil, for: bundle, in: context, problems: &problems)
+        XCTAssertNotNil(article, "An Article value can be created with a Redirected child.")
+        XCTAssert(problems.isEmpty, "There shouldn't be any problems. Got:\n\(problems.map { $0.diagnostic.summary })")
+
+        var analyzer = SemanticAnalyzer(source: nil, context: context, bundle: bundle)
+        _ = analyzer.visit(document)
+        XCTAssert(analyzer.problems.isEmpty, "Expected no problems. Got \(DiagnosticConsoleWriter.formattedDescription(for:  analyzer.problems))")
+
+        let redirects = try XCTUnwrap(article?.redirects)
+        XCTAssertEqual(2, redirects.count)
+        let oldPaths = redirects.map{ $0.oldPath.relativePath }.sorted()
+        XCTAssertEqual([
+            "/another/old/path/to/this/page",
+            "/old/path/to/this/page",
+        ], oldPaths)
+    }
+
+    func testArticleSupportsBothRedirects() throws {
+        let source = """
+        # Plain article
+
+        The abstract of this article
+
+        @Metadata {
+            @Redirected(from: /old/path/to/this/page)
+            @Redirected(from: /another/old/path/to/this/page)
+        }
+
+        ## Section Name
+
+        @Redirected(from: /third/old/path/to/this/page)
+
         ![full width image](referenced-article-image.png)
         """
         let document = Document(parsing: source, options: .parseBlockDirectives)
@@ -311,6 +383,15 @@ class RedirectedTests: XCTestCase {
         var analyzer = SemanticAnalyzer(source: nil, context: context, bundle: bundle)
         _ = analyzer.visit(document)
         XCTAssert(analyzer.problems.isEmpty, "Expected no problems. Got \(DiagnosticConsoleWriter.formattedDescription(for:  analyzer.problems))")
+
+        let redirects = try XCTUnwrap(article?.redirects)
+        XCTAssertEqual(3, redirects.count)
+        let oldPaths = redirects.map{ $0.oldPath.relativePath }.sorted()
+        XCTAssertEqual([
+            "/another/old/path/to/this/page",
+            "/old/path/to/this/page",
+            "/third/old/path/to/this/page",
+        ], oldPaths)
     }
     
     func testIncorrectArgumentLabel() throws {


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://117883810

## Summary

Today DocC does not parse the `@Redirected` directive properly if it appears before the abstract in an article or documentation extension. If the directive appears before the abstract, the abstract's contents is set to the directive only and the actual abstract is instead considered to be part of the following discussion.

For example, compiling this article:

```
# Getting Started with Sloths

@Redirected(from: "some/path")

Create a sloth and assign personality traits and abilities.

## Overview

Sloths are complex creatures that require careful creation and a suitable habitat. After creating a sloth, you're responsible for feeding them, providing fulfilling activities, and giving them opportunities to exercise and rest.
```

...would produce this page:

![Screenshot 2024-01-18 at 2 55 17 PM](https://github.com/apple/swift-docc/assets/28140/c82a18eb-27e2-4019-b986-7b3a32c1bfce)

Note the abstract appears under "Overview", and that there are two "Overview" sections.

This fix removes any `@Redirected` directives from markdown content while parsing the title, abstract and discussion. Now DocC no longer considers `@Redirected` directives to be part of the markdown content at all, similar to how `@Comment`, `@Metadata` and `@Options` work. DocC saves the redirects' old path strings behind the scenes.

A related fix in this PR adds `@Redirected` as a child directive of `@Metadata`. This gives the author more flexibility to place `@Redirected` commands anywhere, including inside of the page's metadata which is the most logical place for it to appear.

## Dependencies

None.

## Testing

1. Create a new article which contains redirects after the title, but before the abstract as shown above in the Getting Started With Sloths page.
2. Compile and check the rendered article shows the abstract properly:

![Screenshot 2024-01-18 at 2 57 36 PM](https://github.com/apple/swift-docc/assets/28140/5e367a56-c75b-4997-a661-828962226ad8)

Repeat the same test, but move the `@Redirected` directive inside the `@Metadata` directives as a child. For example:

```
# Getting Started with Sloths

@Metadata {
    @Redirected(from: "some/path")
}

Create a sloth and assign personality traits and abilities.

## Overview

Sloths are complex creatures that require careful creation and a suitable habitat. After creating a sloth, you're responsible for feeding them, providing fulfilling activities, and giving them opportunities to exercise and rest. 
```

The page should render correctly again.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x ] Added tests
- [x ] Ran the `./bin/test` script and it succeeded
- [ ] ~~Updated documentation if necessary~~
