### PR TITLE
Record article mentions of symbols

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/Diffing/AnyRenderSection.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Diffing/AnyRenderSection.swift
@@ -54,7 +54,9 @@ struct AnyRenderSection: Equatable, Encodable, RenderJSONDiffable {
             return (value as! SampleDownloadSection).difference(from: (other.value as! SampleDownloadSection), at: path)
         case (.taskGroup, .taskGroup):
             return (value as! TaskGroupRenderSection).difference(from: (other.value as! TaskGroupRenderSection), at: path)
-            
+        case (.mentions, .mentions):
+            return (value as! MentionsRenderSection).difference(from: (other.value as! MentionsRenderSection), at: path)
+
         // MARK: Tutorial Sections
             
         case (.intro, .intro), (.hero, .hero):
@@ -119,7 +121,9 @@ struct AnyRenderSection: Equatable, Encodable, RenderJSONDiffable {
             return (lhs.value as! SampleDownloadSection) == (rhs.value as! SampleDownloadSection)
         case (.taskGroup, .taskGroup):
             return (lhs.value as! TaskGroupRenderSection) == (rhs.value as! TaskGroupRenderSection)
-            
+        case (.mentions, .mentions):
+            return (lhs.value as! MentionsRenderSection) == (rhs.value as! MentionsRenderSection)
+
         // MARK: Tutorial Sections
             
         case (.intro, .intro), (.hero, .hero):

--- a/Sources/SwiftDocC/Model/Rendering/RenderNode/CodableContentSection.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNode/CodableContentSection.swift
@@ -65,6 +65,8 @@ public struct CodableContentSection: Codable, Equatable {
                 section = try PlistDetailsRenderSection(from: decoder)
             case .possibleValues:
                 section = try PossibleValuesRenderSection(from: decoder)
+            case .mentions:
+                section = try MentionsRenderSection(from: decoder)
             default: fatalError()
         }
     }

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -1380,6 +1380,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
                     HTTPResponsesSectionTranslator(),
                     DictionaryKeysSectionTranslator(),
                     ReturnsSectionTranslator(),
+                    MentionsSectionTranslator(referencingSymbol: identifier),
                     DiscussionSectionTranslator(),
                 ]
             )

--- a/Sources/SwiftDocC/Model/Rendering/RenderSection.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderSection.swift
@@ -17,7 +17,7 @@ public enum RenderSectionKind: String, Codable {
     case hero, intro, tasks, assessments, volume, contentAndMedia, contentAndMediaGroup, callToAction, tile, articleBody, resources
     
     // Symbol render sections
-    case discussion, content, taskGroup, relationships, declarations, parameters, sampleDownload, row
+    case mentions, discussion, content, taskGroup, relationships, declarations, parameters, sampleDownload, row
 
     // Rest symbol sections
     case restParameters, restResponses, restBody, restEndpoint, properties

--- a/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/MentionsSectionTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/MentionsSectionTranslator.swift
@@ -1,0 +1,32 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2024 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+struct MentionsSectionTranslator: RenderSectionTranslator {
+    var symbolReference: ResolvedTopicReference
+    init(referencingSymbol symbolReference: ResolvedTopicReference) {
+        self.symbolReference = symbolReference
+    }
+
+    func translateSection(for symbol: Symbol, renderNode: inout RenderNode, renderNodeTranslator: inout RenderNodeTranslator) -> VariantCollection<CodableContentSection?>? {
+        guard FeatureFlags.current.isExperimentalMentionedInEnabled else {
+            return nil
+        }
+
+        let mentions = renderNodeTranslator.context.articleSymbolMentions.articlesMentioning(symbolReference)
+        guard !mentions.isEmpty else {
+            return nil
+        }
+
+        renderNodeTranslator.collectedTopicReferences.append(contentsOf: mentions)
+
+        let section = MentionsRenderSection(mentions: mentions.map { $0.url })
+        return VariantCollection(defaultValue: CodableContentSection(section))
+    }
+}

--- a/Sources/SwiftDocC/Model/Rendering/Symbol/MentionsRenderSection.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Symbol/MentionsRenderSection.swift
@@ -1,0 +1,47 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2024 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+
+public struct MentionsRenderSection: RenderSection, Codable, Equatable {
+    public var kind: RenderSectionKind = .mentions
+    public var mentions: [URL]
+
+    public init(mentions: [URL]) {
+        self.mentions = mentions
+    }
+}
+
+extension MentionsRenderSection: TextIndexing {
+    public var headings: [String] {
+        return []
+    }
+
+    public func rawIndexableTextContent(references: [String : RenderReference]) -> String {
+        return ""
+    }
+}
+
+// Diffable conformance
+extension MentionsRenderSection: RenderJSONDiffable {
+    /// Returns the differences between this MentionsRenderSection and the given one.
+    func difference(from other: MentionsRenderSection, at path: CodablePath) -> JSONPatchDifferences {
+        var diffBuilder = DifferenceBuilder(current: self, other: other, basePath: path)
+
+        diffBuilder.addDifferences(atKeyPath: \.mentions, forKey: CodingKeys.mentions)
+
+        return diffBuilder.differences
+    }
+
+    /// Returns if this DeclarationsRenderSection is similar enough to the given one.
+    func isSimilar(to other: MentionsRenderSection) -> Bool {
+        return self.mentions == other.mentions
+    }
+}

--- a/Sources/SwiftDocC/Semantics/Article/ArticleSymbolMentions.swift
+++ b/Sources/SwiftDocC/Semantics/Article/ArticleSymbolMentions.swift
@@ -1,0 +1,52 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2024 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Markdown
+
+/// An index that describes which articles mention symbols.
+///
+/// When an article mentions a symbol from a module registered with the
+/// documentation context, the mention is recorded in this data structure.
+/// This is ultimately used to render a "mentioned in" section in symbol documentation.
+///
+/// This type should only record article -> symbol links, as the "mentioned in" section
+/// is for directing readers to explanatory articles from the API reference.
+struct ArticleSymbolMentions {
+    /// A count of symbol mentions.
+    var mentions: [ResolvedTopicReference: [ResolvedTopicReference: Int]] = [:]
+
+    /// Record a symbol mention within an article.
+    mutating func article(_ article: ResolvedTopicReference, didMention symbol: ResolvedTopicReference, weight: Int) {
+        mentions[symbol, default: [:]][article, default: 0] += 1 * weight
+    }
+
+    /// The list of articles mentioning a symbol, from most frequent to least frequent.
+    func articlesMentioning(_ symbol: ResolvedTopicReference) -> [ResolvedTopicReference] {
+        // Mentions are sorted on demand based on the number of mentions.
+        // This could change in the future.
+        return mentions[symbol, default: [:]].sorted {
+            $0.value > $1.value
+        }
+        .map { $0.key }
+    }
+}
+
+struct SymbolLinkCollector: MarkupWalker {
+    var context: DocumentationContext
+    var article: ResolvedTopicReference
+    var baseWeight: Int
+
+    func visitSymbolLink(_ symbolLink: SymbolLink) {
+        if let destination = symbolLink.destination,
+           let symbol = context.referenceIndex[destination] {
+            context.articleSymbolMentions.article(article, didMention: symbol, weight: baseWeight)
+        }
+    }
+}

--- a/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderNode.spec.json
+++ b/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderNode.spec.json
@@ -2,7 +2,7 @@
     "openapi": "3.0.0",
     "info": {
         "description": "Render Node API",
-        "version": "0.3.0",
+        "version": "0.4.0",
         "title": "Render Node API"
     },
     "paths": { },
@@ -2443,6 +2443,9 @@
             "DocumentationPrimaryRenderSection": {
                 "oneOf": [
                     {
+                        "$ref": "#/components/schemas/MentionsRenderSection"
+                    },
+                    {
                         "$ref": "#/components/schemas/DeclarationsRenderSection"
                     },
                     {
@@ -2476,6 +2479,21 @@
                         "$ref": "#/components/schemas/PropertiesSection"
                     }
                 ]
+            },
+            "MentionsRenderSection": {
+                "required": [
+                    "kind",
+                    "mentions"
+                ],
+                "type": "object",
+                "properties": {
+                    "mentions": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
             },
             "DeclarationsRenderSection": {
                 "required": [

--- a/Sources/SwiftDocC/Utility/FeatureFlags.swift
+++ b/Sources/SwiftDocC/Utility/FeatureFlags.swift
@@ -27,6 +27,10 @@ public struct FeatureFlags: Codable {
     /// Whether or not experimental support for combining overloaded symbol pages is enabled.
     public var isExperimentalOverloadedSymbolPresentationEnabled = false
     
+    /// Whether experimental support for automatically rendering links on symbol documentation to articles
+    /// that mention that symbol.
+    public var isExperimentalMentionedInEnabled = false
+
     /// Creates a set of feature flags with the given values.
     ///
     /// - Parameters:

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/ActionExtensions/ConvertAction+CommandInitialization.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/ActionExtensions/ConvertAction+CommandInitialization.swift
@@ -23,7 +23,8 @@ extension ConvertAction {
         FeatureFlags.current.isExperimentalDeviceFrameSupportEnabled = convert.enableExperimentalDeviceFrameSupport
         FeatureFlags.current.isExperimentalLinkHierarchySerializationEnabled = convert.enableExperimentalLinkHierarchySerialization
         FeatureFlags.current.isExperimentalOverloadedSymbolPresentationEnabled = convert.enableExperimentalOverloadedSymbolPresentation
-        
+        FeatureFlags.current.isExperimentalMentionedInEnabled = convert.enableExperimentalMentionedIn
+
         // If the user-provided a URL for an external link resolver, attempt to
         // initialize an `OutOfProcessReferenceResolver` with the provided URL.
         if let linkResolverURL = convert.outOfProcessLinkResolverOption.linkResolverExecutableURL {

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Convert.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Convert.swift
@@ -539,6 +539,12 @@ extension Docc {
             )
             var enableExperimentalOverloadedSymbolPresentation = false
 
+            @Flag(
+                name: .customLong("enable-experimental-mentioned-in"),
+                help: ArgumentHelp("Render a section on symbol documentation which links to articles that mention that symbol")
+            )
+            var enableExperimentalMentionedIn = false
+
             @Flag(help: "Write additional metadata files to the output directory.")
             var emitDigest = false
         
@@ -626,6 +632,13 @@ extension Docc {
         public var enableExperimentalOverloadedSymbolPresentation: Bool {
             get { featureFlags.enableExperimentalOverloadedSymbolPresentation }
             set { featureFlags.enableExperimentalOverloadedSymbolPresentation = newValue }
+        }
+
+        /// A user-provided value that is true if the user enables experimental automatically generated "mentioned in"
+        /// links on symbols.
+        public var enableExperimentalMentionedIn: Bool {
+            get { featureFlags.enableExperimentalMentionedIn }
+            set { featureFlags.enableExperimentalMentionedIn = newValue }
         }
 
         /// A user-provided value that is true if additional metadata files should be produced.

--- a/Tests/SwiftDocCTests/Rendering/MentionsRenderSectionTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/MentionsRenderSectionTests.swift
@@ -1,0 +1,57 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2024 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+import XCTest
+@testable import SwiftDocC
+
+class MentionsRenderSectionTests: XCTestCase {
+    /// Verify that the Mentioned In section is present when a symbol is mentioned,
+    /// pointing to the correct article.
+    func testMentionedInSectionFull() throws {
+        enableFeatureFlag(\.isExperimentalMentionedInEnabled)
+        let (bundle, context) = try createMentionedInTestBundle()
+        let identifier = ResolvedTopicReference(
+            bundleIdentifier: bundle.identifier,
+            path: "/documentation/MentionedIn/MyClass",
+            sourceLanguage: .swift
+        )
+        let mentioningArticle = ResolvedTopicReference(
+            bundleIdentifier: bundle.identifier,
+            path: "/documentation/MentionedIn/ArticleMentioningSymbol",
+            sourceLanguage: .swift
+        )
+        let source = context.documentURL(for: identifier)
+        let node = try context.entity(with: identifier)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: source)
+        let renderNode = translator.visit(node.semantic) as! RenderNode
+        let mentionsSection = try XCTUnwrap(renderNode.primaryContentSections.mapFirst { $0 as? MentionsRenderSection })
+        XCTAssertEqual(1, mentionsSection.mentions.count)
+        let soleMention = try XCTUnwrap(mentionsSection.mentions.first)
+        XCTAssertEqual(mentioningArticle.url, soleMention)
+    }
+
+    /// If there are no qualifying mentions of a symbol, the Mentioned In section should not appear.
+    func testMentionedInSectionEmpty() throws {
+        enableFeatureFlag(\.isExperimentalMentionedInEnabled)
+        let (bundle, context) = try createMentionedInTestBundle()
+        let identifier = ResolvedTopicReference(
+            bundleIdentifier: bundle.identifier,
+            path: "/documentation/MentionedIn/MyClass/myFunction()",
+            sourceLanguage: .swift
+        )
+        let source = context.documentURL(for: identifier)
+        let node = try context.entity(with: identifier)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: source)
+        let renderNode = translator.visit(node.semantic) as! RenderNode
+        let mentionsSection = renderNode.primaryContentSections.mapFirst { $0 as? MentionsRenderSection }
+        XCTAssertNil(mentionsSection)
+    }
+}

--- a/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorSymbolVariantsTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorSymbolVariantsTests.swift
@@ -570,14 +570,7 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
     
     func testDiscussionSectionVariants() throws {
         func discussionSection(in renderNode: RenderNode) throws -> ContentRenderSection {
-            let discussionSectionIndex = 1
-            
-            guard renderNode.primaryContentSections.indices.contains(discussionSectionIndex) else {
-                XCTFail("Missing discussion section")
-                return ContentRenderSection(kind: .content, content: [], heading: nil)
-            }
-            
-            return try XCTUnwrap(renderNode.primaryContentSections[discussionSectionIndex] as? ContentRenderSection)
+            return try XCTUnwrap(renderNode.primaryContentSections.mapFirst { $0 as? ContentRenderSection })
         }
         
         try assertMultiVariantSymbol(

--- a/Tests/SwiftDocCTests/Semantics/ArticleSymbolMentionsTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/ArticleSymbolMentionsTests.swift
@@ -1,0 +1,77 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2024 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+@testable import SwiftDocC
+import Markdown
+import SwiftDocCTestUtilities
+import SymbolKit
+
+class ArticleSymbolMentionsTests: XCTestCase {
+    /// Test that the recording abstraction for ``ArticleSymbolMentions`` works as expected.
+    func testArticlesMentioningSymbol() throws {
+        let article = ResolvedTopicReference(
+            bundleIdentifier: "org.swift.anything",
+            path: "/article",
+            sourceLanguage: .swift
+        )
+        let symbol = ResolvedTopicReference(bundleIdentifier: "org.swift.anything", path: "/Thing", sourceLanguage: .swift)
+        var mentions = ArticleSymbolMentions()
+
+        XCTAssertTrue(mentions.articlesMentioning(symbol).isEmpty)
+
+        let weight = 99
+        mentions.article(article, didMention: symbol, weight: weight)
+        
+        let gottenArticles = mentions.articlesMentioning(symbol)
+        XCTAssertEqual(1, gottenArticles.count)
+        let gottenArticle = try XCTUnwrap(gottenArticles.first)
+        XCTAssertEqual(gottenArticle, article)
+    }
+
+    /// If the `--enable-mentioned-in` flag is passed, symbol mentions in the test bundle's
+    /// articles should be recorded.
+    func testSymbolLinkCollectorEnabled() throws {
+        enableFeatureFlag(\.isExperimentalMentionedInEnabled)
+        let (bundle, context) = try createMentionedInTestBundle()
+
+        // The test bundle currently only has one article with symbol mentions
+        // in the abstract/discussion.
+        XCTAssertEqual(1, context.articleSymbolMentions.mentions.count)
+
+        let mentioningArticle = ResolvedTopicReference(
+            bundleIdentifier: bundle.identifier,
+            path: "/documentation/MentionedIn/ArticleMentioningSymbol",
+            sourceLanguage: .swift)
+        let mentionedSymbol = ResolvedTopicReference(
+            bundleIdentifier: bundle.identifier,
+            path: "/documentation/MentionedIn/MyClass",
+            sourceLanguage: .swift)
+        
+        let mentions = context.articleSymbolMentions.articlesMentioning(mentionedSymbol)
+        XCTAssertEqual(1, mentions.count)
+        let gottenArticle = try XCTUnwrap(mentions.first)
+        XCTAssertEqual(mentioningArticle, gottenArticle)
+    }
+
+    /// If the `--enable-experimental-mentioned-in` flag is not passed, symbol mentions in the test bundle's
+    /// articles should not be recorded.
+    func testSymbolLinkCollectorDisabled() throws {
+        let (bundle, context) = try createMentionedInTestBundle()
+        XCTAssertTrue(context.articleSymbolMentions.mentions.isEmpty)
+
+        let mentionedSymbol = ResolvedTopicReference(
+            bundleIdentifier: bundle.identifier,
+            path: "/documentation/MentionedIn/MyClass",
+            sourceLanguage: .swift)
+
+        XCTAssertTrue(context.articleSymbolMentions.articlesMentioning(mentionedSymbol).isEmpty)
+    }
+}

--- a/Tests/SwiftDocCTests/Utility/XCTestCase+MentionedIn.swift
+++ b/Tests/SwiftDocCTests/Utility/XCTestCase+MentionedIn.swift
@@ -1,0 +1,79 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2024 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+@testable import SwiftDocC
+import XCTest
+import SwiftDocCTestUtilities
+import SymbolKit
+
+extension XCTestCase {
+    /// Creates a test bundle for testing "Mentioned In" features.
+    func createMentionedInTestBundle() throws -> (DocumentationBundle, DocumentationContext) {
+        let exampleDocumentation = Folder(name: "MentionedIn.docc", content: [
+            JSONFile(name: "MentionedIn.symbols.json", content: makeSymbolGraph(
+                moduleName: "MentionedIn",
+                symbols: [
+                    SymbolGraph.Symbol(
+                        identifier: .init(precise: "MyClass", interfaceLanguage: "swift"),
+                        names: .init(title: "MyClass", navigator: nil, subHeading: nil, prose: nil),
+                        pathComponents: ["MyClass"],
+                        docComment: nil,
+                        accessLevel: .public,
+                        kind: .init(parsedIdentifier: .class, displayName: "Class"),
+                        mixins: [:]
+                    ),
+                    SymbolGraph.Symbol(
+                        identifier: .init(precise: "myFunction()", interfaceLanguage: "swift"),
+                        names: .init(title: "myFunction()", navigator: nil, subHeading: nil, prose: nil),
+                        pathComponents: ["MyClass", "myFunction()"],
+                        docComment: nil,
+                        accessLevel: .public,
+                        kind: .init(parsedIdentifier: .func, displayName: "Function"),
+                        mixins: [:]
+                    )
+                ]
+            )),
+
+            TextFile(name: "ArticleMentioningSymbol.md", utf8Content: """
+                 # Article mentioning a symbol
+
+                 In the abstract, ``MyClass``.
+
+                 ## Other mentions
+
+                 Later, ``MyClass``.
+                 """),
+
+            TextFile(name: "APICollectionMentioningSybol.md", utf8Content: """
+                 # An API Collection
+
+                 In the abstract, ``MyClass``.
+
+                 ## Other mentions
+
+                 Later, ``MyClass``.
+
+                 This API Collection should not count as an article mention.
+
+                 ## Topics
+
+                 ### Things that don't count as mentions
+
+                 Curation does not count as a significant "mention".
+
+                 - ``MyClass``
+                 """),
+        ])
+
+        let tempURL = try createTempFolder(content: [exampleDocumentation])
+        let (_, bundle, context) = try loadBundle(from: tempURL)
+        return (bundle, context)
+    }
+}


### PR DESCRIPTION
Adds an optional, new section to symbol documentation pages called "Mentioned In", containing up to five links to articles that mention the symbol in the abstract or discussion, scored by mention count (abstract mentions are worth more). The purpose of this section is to highlight explanatory and conceptual content in which the symbol plays an important or central role.

This functionality is currently hidden by the `--enable-experimental-mentioned-in` flag.

rdar://121899474