### PR TITLE
Avoid debug assertions bout adding the same symbol to the path hierarchy twice

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2022-2023 Apple Inc. and the Swift project authors
+ Copyright (c) 2022-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -120,7 +120,8 @@ struct PathHierarchy {
                 }
             }
             
-            var topLevelCandidates = nodes
+            // If there are multiple symbol graphs (for example for different source languages or platforms) then the nodes may have already been added to the hierarchy.
+            var topLevelCandidates = nodes.filter { _, node in node.parent == nil }
             for relationship in graph.relationships where relationship.kind.formsHierarchy {
                 guard let sourceNode = nodes[relationship.source], let expectedContainerName = sourceNode.symbol?.pathComponents.dropLast().last else {
                     continue
@@ -180,7 +181,14 @@ struct PathHierarchy {
                 moduleNode.add(symbolChild: topLevelNode)
             }
             
-            for node in topLevelCandidates.values where node.symbol!.pathComponents.count > 1 {
+            assert(
+                topLevelCandidates.values.filter({ $0.symbol!.pathComponents.count > 1 }).allSatisfy({ $0.parent == nil }), """
+                Top-level candidates shouldn't already exist in the hierarchy. \
+                This wasn't true for \(topLevelCandidates.filter({ $0.value.symbol!.pathComponents.count > 1 && $0.value.parent != nil }).map(\.key).sorted())
+                """
+            )
+            
+            for node in topLevelCandidates.values where node.symbol!.pathComponents.count > 1 && node.parent == nil {
                 var parent = moduleNode
                 var components = { (symbol: SymbolGraph.Symbol) -> [String] in
                     let original = symbol.pathComponents

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchyBasedLinkResolver.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchyBasedLinkResolver.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2022-2023 Apple Inc. and the Swift project authors
+ Copyright (c) 2022-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -14,7 +14,7 @@ import SymbolKit
 /// A type that encapsulates resolving links by searching a hierarchy of path components.
 final class PathHierarchyBasedLinkResolver {
     /// A hierarchy of path components used to resolve links in the documentation.
-    private(set) var pathHierarchy: PathHierarchy!
+    private(set) var pathHierarchy: PathHierarchy
     
     /// Map between resolved identifiers and resolved topic references.
     private(set) var resolvedReferenceMap = BidirectionalMap<ResolvedIdentifier, ResolvedTopicReference>()

--- a/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
@@ -18,7 +18,7 @@ class PathHierarchyTests: XCTestCase {
     
     func testFindingUnambiguousAbsolutePaths() throws {
         let (_, context) = try testBundleAndContext(named: "MixedLanguageFrameworkWithLanguageRefinements")
-        let tree = try XCTUnwrap(context.linkResolver.localResolver?.pathHierarchy)
+        let tree = context.linkResolver.localResolver.pathHierarchy
         
         try assertFindsPath("/MixedFramework", in: tree, asSymbolID: "MixedFramework")
         
@@ -288,7 +288,7 @@ class PathHierarchyTests: XCTestCase {
         }
         
         let (_, context) = try testBundleAndContext(named: "MixedLanguageFrameworkWithLanguageRefinements")
-        let tree = try XCTUnwrap(context.linkResolver.localResolver?.pathHierarchy)
+        let tree = context.linkResolver.localResolver.pathHierarchy
         
         // Symbol name not found. Suggestions only include module names (search is not relative to a known page)
         try assertPathRaisesErrorMessage("/MixFramework", in: tree, context: context, expectedErrorMessage: """
@@ -574,7 +574,7 @@ class PathHierarchyTests: XCTestCase {
     
     func testRedundantKindDisambiguation() throws {
         let (_, context) = try testBundleAndContext(named: "MixedLanguageFrameworkWithLanguageRefinements")
-        let tree = try XCTUnwrap(context.linkResolver.localResolver?.pathHierarchy)
+        let tree = context.linkResolver.localResolver.pathHierarchy
         
         try assertFindsPath("/MixedFramework-module", in: tree, asSymbolID: "MixedFramework")
         
@@ -626,7 +626,7 @@ class PathHierarchyTests: XCTestCase {
     
     func testBothRedundantDisambiguations() throws {
         let (_, context) = try testBundleAndContext(named: "MixedLanguageFrameworkWithLanguageRefinements")
-        let tree = try XCTUnwrap(context.linkResolver.localResolver?.pathHierarchy)
+        let tree = context.linkResolver.localResolver.pathHierarchy
         
         try assertFindsPath("/MixedFramework-module-9r7pl", in: tree, asSymbolID: "MixedFramework")
         
@@ -690,7 +690,7 @@ class PathHierarchyTests: XCTestCase {
         // @_exported import Inner
         // public typealias Something = Inner.Something
         let (_, context) = try testBundleAndContext(named: "DefaultImplementationsWithExportedImport")
-        let tree = try XCTUnwrap(context.linkResolver.localResolver?.pathHierarchy)
+        let tree = context.linkResolver.localResolver.pathHierarchy
         
         // The @_export imported protocol can be found
         try assertFindsPath("/DefaultImplementationsWithExportedImport/Something-protocol", in: tree, asSymbolID: "s:5Inner9SomethingP")
@@ -712,7 +712,7 @@ class PathHierarchyTests: XCTestCase {
     
     func testDisambiguatedPaths() throws {
         let (_, context) = try testBundleAndContext(named: "MixedLanguageFrameworkWithLanguageRefinements")
-        let tree = try XCTUnwrap(context.linkResolver.localResolver?.pathHierarchy)
+        let tree = context.linkResolver.localResolver.pathHierarchy
         
         let paths = tree.caseInsensitiveDisambiguatedPaths()
         // @objc public enum MyEnum: Int {
@@ -833,7 +833,7 @@ class PathHierarchyTests: XCTestCase {
     
     func testDisambiguatedOperatorPaths() throws {
         let (_, context) = try testBundleAndContext(named: "InheritedOperators")
-        let tree = try XCTUnwrap(context.linkResolver.localResolver?.pathHierarchy)
+        let tree = context.linkResolver.localResolver.pathHierarchy
         
         let paths = tree.caseInsensitiveDisambiguatedPaths()
         
@@ -889,7 +889,7 @@ class PathHierarchyTests: XCTestCase {
     
     func testFindingRelativePaths() throws {
         let (_, context) = try testBundleAndContext(named: "MixedLanguageFrameworkWithLanguageRefinements")
-        let tree = try XCTUnwrap(context.linkResolver.localResolver?.pathHierarchy)
+        let tree = context.linkResolver.localResolver.pathHierarchy
         
         let moduleID = try tree.find(path: "/MixedFramework", onlyFindSymbols: true)
         
@@ -1042,7 +1042,7 @@ class PathHierarchyTests: XCTestCase {
     
     func testPathWithDocumentationPrefix() throws {
         let (_, context) = try testBundleAndContext(named: "MixedLanguageFrameworkWithLanguageRefinements")
-        let tree = try XCTUnwrap(context.linkResolver.localResolver?.pathHierarchy)
+        let tree = context.linkResolver.localResolver.pathHierarchy
         
         let moduleID = try tree.find(path: "/MixedFramework", onlyFindSymbols: true)
         
@@ -1115,7 +1115,7 @@ class PathHierarchyTests: XCTestCase {
     
     func testMixedLanguageFramework() throws {
         let (_, context) = try testBundleAndContext(named: "MixedLanguageFramework")
-        let tree = try XCTUnwrap(context.linkResolver.localResolver?.pathHierarchy)
+        let tree = context.linkResolver.localResolver.pathHierarchy
         
         try assertFindsPath("MixedLanguageFramework/Bar/myStringFunction(_:)", in: tree, asSymbolID: "c:objc(cs)Bar(cm)myStringFunction:error:")
         try assertFindsPath("MixedLanguageFramework/Bar/myStringFunction:error:", in: tree, asSymbolID: "c:objc(cs)Bar(cm)myStringFunction:error:")
@@ -1175,7 +1175,7 @@ class PathHierarchyTests: XCTestCase {
             This article has the same path as a symbol
             """.write(to: url.appendingPathComponent("Bar.md"), atomically: true, encoding: .utf8)
         }
-        let tree = try XCTUnwrap(context.linkResolver.localResolver?.pathHierarchy)
+        let tree = context.linkResolver.localResolver.pathHierarchy
         
         // The added article above has the same path as an existing symbol in the this module.
         let symbolNode = try tree.findNode(path: "/MixedLanguageFramework/Bar", onlyFindSymbols: true)
@@ -1198,7 +1198,7 @@ class PathHierarchyTests: XCTestCase {
             """.write(to: url.appendingPathComponent("ArticleWithHeading.md"), atomically: true, encoding: .utf8)
         }
 
-        let tree = try XCTUnwrap(context.linkResolver.localResolver?.pathHierarchy)
+        let tree = context.linkResolver.localResolver.pathHierarchy
         let articleNode = try tree.findNode(path: "/MixedLanguageFramework/ArticleWithHeading", onlyFindSymbols: false)
 
         let linkNode = try tree.find(path: "TestTargetHeading", parent: articleNode.identifier, onlyFindSymbols: false)
@@ -1209,7 +1209,7 @@ class PathHierarchyTests: XCTestCase {
 
     func testOverloadedSymbols() throws {
         let (_, context) = try testBundleAndContext(named: "OverloadedSymbols")
-        let tree = try XCTUnwrap(context.linkResolver.localResolver?.pathHierarchy)
+        let tree = context.linkResolver.localResolver.pathHierarchy
         
         let paths = tree.caseInsensitiveDisambiguatedPaths()
         
@@ -1242,7 +1242,7 @@ class PathHierarchyTests: XCTestCase {
     
     func testSymbolsWithSameNameAsModule() throws {
         let (_, context) = try testBundleAndContext(named: "SymbolsWithSameNameAsModule")
-        let tree = try XCTUnwrap(context.linkResolver.localResolver?.pathHierarchy)
+        let tree = context.linkResolver.localResolver.pathHierarchy
         
         // /* in a module named "Something "*/
         // public struct Something {
@@ -1303,7 +1303,7 @@ class PathHierarchyTests: XCTestCase {
         //     func something() {}
         // }
         let (_, context) = try testBundleAndContext(named: "ShadowExtendedModuleWithLocalSymbol")
-        let tree = try XCTUnwrap(context.linkResolver.localResolver?.pathHierarchy)
+        let tree = context.linkResolver.localResolver.pathHierarchy
 
         try assertPathCollision("Outer/Inner", in: tree, collisions: [
             ("s:m:s:e:s:5Inner0A5ClassC5OuterE9somethingyyF", "module.extension"),
@@ -1332,7 +1332,7 @@ class PathHierarchyTests: XCTestCase {
     
     func testSnippets() throws {
         let (_, context) = try testBundleAndContext(named: "Snippets")
-        let tree = try XCTUnwrap(context.linkResolver.localResolver?.pathHierarchy)
+        let tree = context.linkResolver.localResolver.pathHierarchy
         
         try assertFindsPath("/Snippets/Snippets/MySnippet", in: tree, asSymbolID: "$snippet__Test.Snippets.MySnippet")
         
@@ -1357,7 +1357,7 @@ class PathHierarchyTests: XCTestCase {
     
     func testInheritedOperators() throws {
         let (_, context) = try testBundleAndContext(named: "InheritedOperators")
-        let tree = try XCTUnwrap(context.linkResolver.localResolver?.pathHierarchy)
+        let tree = context.linkResolver.localResolver.pathHierarchy
         
         // public struct MyNumber: SignedNumeric, Comparable, Equatable, Hashable {
         //    public static func / (lhs: MyNumber, rhs: MyNumber) -> MyNumber { ... }
@@ -1434,7 +1434,7 @@ class PathHierarchyTests: XCTestCase {
     
     func testSameNameForSymbolAndContainer() throws {
         let (_, context) = try testBundleAndContext(named: "BundleWithSameNameForSymbolAndContainer")
-        let tree = try XCTUnwrap(context.linkResolver.localResolver?.pathHierarchy)
+        let tree = context.linkResolver.localResolver.pathHierarchy
         
         // public struct Something {
         //     public struct Something {
@@ -1478,7 +1478,7 @@ class PathHierarchyTests: XCTestCase {
             // Also change the display name so that the article container has the same name as the module.
             try InfoPlist(displayName: "Something", identifier: "com.example.Something").write(inside: url)
         }
-        let tree = try XCTUnwrap(context.linkResolver.localResolver?.pathHierarchy)
+        let tree = context.linkResolver.localResolver.pathHierarchy
         
         do {
             // Links to non-symbols can use only the file name, without specifying the module or catalog name.
@@ -1508,7 +1508,7 @@ class PathHierarchyTests: XCTestCase {
 
         do {
             let (_, _, context) = try loadBundle(from: bundleURL)
-            let tree = try XCTUnwrap(context.linkResolver.localResolver?.pathHierarchy)
+            let tree = context.linkResolver.localResolver.pathHierarchy
             
             try assertFindsPath("/MyKit/MyClass/myFunction()", in: tree, asSymbolID: "s:5MyKit0A5ClassC10myFunctionyyF")
             try assertPathNotFound("/MyKit/MyClass-swift.class/myFunction()", in: tree)
@@ -1527,7 +1527,7 @@ class PathHierarchyTests: XCTestCase {
                     "s:5MyKit0A5ClassC10myFunctionyyF": ["MyClass-swift.class", "myFunction()"]
                 ]
             }
-            let tree = try XCTUnwrap(context.linkResolver.localResolver?.pathHierarchy)
+            let tree = context.linkResolver.localResolver.pathHierarchy
             
             try assertFindsPath("/MyKit/MyClass-swift.class/myFunction()", in: tree, asSymbolID: "s:5MyKit0A5ClassC10myFunctionyyF")
             try assertPathNotFound("/MyKit/MyClass", in: tree)
@@ -1546,7 +1546,7 @@ class PathHierarchyTests: XCTestCase {
                     "s:5MyKit0A5ClassC10myFunctionyyF": ["MyClass-swift.class-hash", "myFunction()"]
                 ]
             }
-            let tree = try XCTUnwrap(context.linkResolver.localResolver?.pathHierarchy)
+            let tree = context.linkResolver.localResolver.pathHierarchy
             
             try assertFindsPath("/MyKit/MyClass-swift.class-hash/myFunction()", in: tree, asSymbolID: "s:5MyKit0A5ClassC10myFunctionyyF")
             try assertPathNotFound("/MyKit/MyClass", in: tree)
@@ -1589,7 +1589,7 @@ class PathHierarchyTests: XCTestCase {
             let (_, _, context) = try loadBundle(from: bundleURL)
             XCTAssert(context.problems.isEmpty, "Unexpected problems: \(context.problems.map { DiagnosticConsoleWriter.formattedDescription(for: $0) })")
             
-            let tree = try XCTUnwrap(context.linkResolver.localResolver?.pathHierarchy)
+            let tree = context.linkResolver.localResolver.pathHierarchy
             
             let baseKitID = try tree.find(path: "/BaseKit", onlyFindSymbols: true)
             
@@ -1619,7 +1619,7 @@ class PathHierarchyTests: XCTestCase {
         let bundleURL = try exampleDocumentation.write(inside: tempURL)
         
         let (_, _, context) = try loadBundle(from: bundleURL)
-        let tree = try XCTUnwrap(context.linkResolver.localResolver?.pathHierarchy)
+        let tree = context.linkResolver.localResolver.pathHierarchy
         
         try assertPathNotFound("/Module/A", in: tree)
         try assertPathNotFound("/Module/A/B", in: tree)
@@ -1676,7 +1676,7 @@ class PathHierarchyTests: XCTestCase {
         
         let tempURL = try createTempFolder(content: [exampleDocumentation])
         let (_, _, context) = try loadBundle(from: tempURL)
-        let tree = try XCTUnwrap(context.linkResolver.localResolver?.pathHierarchy)
+        let tree = context.linkResolver.localResolver.pathHierarchy
         
         let paths = tree.caseInsensitiveDisambiguatedPaths()
         XCTAssertEqual(paths[containerID], "/ModuleName/ContainerName")
@@ -1719,7 +1719,7 @@ class PathHierarchyTests: XCTestCase {
         
         let tempURL = try createTempFolder(content: [exampleDocumentation])
         let (_, _, context) = try loadBundle(from: tempURL)
-        let tree = try XCTUnwrap(context.linkResolver.localResolver?.pathHierarchy)
+        let tree = context.linkResolver.localResolver.pathHierarchy
         
         let paths = tree.caseInsensitiveDisambiguatedPaths()
         XCTAssertEqual(paths[containerID], "/ModuleName/SwiftContainerName")
@@ -1747,7 +1747,7 @@ class PathHierarchyTests: XCTestCase {
         
         let tempURL = try createTempFolder(content: [exampleDocumentation])
         let (_, _, context) = try loadBundle(from: tempURL)
-        let tree = try XCTUnwrap(context.linkResolver.localResolver?.pathHierarchy)
+        let tree = context.linkResolver.localResolver.pathHierarchy
         
         let paths = tree.caseInsensitiveDisambiguatedPaths(includeDisambiguationForUnambiguousChildren: true)
         XCTAssertEqual(paths[otherID], "/ModuleName/ContainerName-2vaqf")
@@ -1780,7 +1780,7 @@ class PathHierarchyTests: XCTestCase {
         
         let tempURL = try createTempFolder(content: [exampleDocumentation])
         let (_, _, context) = try loadBundle(from: tempURL)
-        let tree = try XCTUnwrap(context.linkResolver.localResolver?.pathHierarchy)
+        let tree = context.linkResolver.localResolver.pathHierarchy
         
         let paths = tree.caseInsensitiveDisambiguatedPaths(includeDisambiguationForUnambiguousChildren: true)
         XCTAssertEqual(paths[symbolID], "/ModuleName/SymbolName")
@@ -1813,7 +1813,7 @@ class PathHierarchyTests: XCTestCase {
         ])
         
         let (_, _, context) = try loadBundle(from: createTempFolder(content: [multiPlatform]))
-        let tree = try XCTUnwrap(context.linkResolver.localResolver?.pathHierarchy)
+        let tree = context.linkResolver.localResolver.pathHierarchy
         
         let paths = tree.caseInsensitiveDisambiguatedPaths()
         XCTAssertEqual(paths[protocolRequirementID], "/ModuleName/SomeProtocolName/someProtocolRequirement()-8lcpm")
@@ -1831,7 +1831,7 @@ class PathHierarchyTests: XCTestCase {
     
     func testMultiPlatformModuleWithExtension() throws {
         let (_, context) = try testBundleAndContext(named: "MultiPlatformModuleWithExtension")
-        let tree = try XCTUnwrap(context.linkResolver.localResolver?.pathHierarchy)
+        let tree = context.linkResolver.localResolver.pathHierarchy
         
         try assertFindsPath("/MainModule/TopLevelProtocol/extensionMember(_:)", in: tree, asSymbolID: "extensionMember1")
         try assertFindsPath("/MainModule/TopLevelProtocol/InnerStruct/extensionMember(_:)", in: tree, asSymbolID: "extensionMember2")


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://122034140

## Summary

This avoids the processing symbols that are potential "top level candidates" in the `PathHierarchy` if those symbols have already been processes for another platforms or source languages.

I also found that the existing tests were doing an unnecessary `XCTUwrap` so I removed that.

## Dependencies

None.

## Testing

- Create a Swift project with a public protocol with some requirement and provide a default implementation for that protocol requirement
- Extract symbol graphs for at least two platforms for that project. 
- Run `swift run docc convert --additional-symbol-graph-dir` and pass both platform's symbol graph files to DocC.
- The above performs a debug build but shouldn't hit any of the assertions that verify the internal path hierarchy in DocC.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
