### PR TITLE
add type subscripts to overloadable symbol kinds

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Extensions/KindIdentifier+Overloads.swift
+++ b/Sources/SwiftDocC/Infrastructure/Extensions/KindIdentifier+Overloads.swift
@@ -20,6 +20,7 @@ extension SymbolGraph.Symbol.KindIdentifier {
              .`init`,
              .macro,
              .subscript,
+             .typeSubscript,
              .`operator`:
             return true
         default:


### PR DESCRIPTION
Bug/issue #, if applicable: None

## Summary

This PR adds static/type subscripts as an overloadable symbol kind, per discussion in #740.

## Dependencies

None

## Testing

The following code demonstrates overloaded type subscripts:

```swift
public class MyClass {
    public class subscript(_ idx: Int) -> Int {
        get {
            return idx
        }
    }

    public class subscript(_ idx: String) -> String {
        get {
            return idx
        }
    }
}
```

A documentation catalog containing a symbol graph with these symbols is available here: [asdf.docc.zip](https://github.com/apple/swift-docc/files/14247680/asdf.docc.zip)

1. Ensure that a recent main-branch Swift-DocC-Render (or swift-docc-render-artifact) is available in `$DOCC_HTML_DIR`.
2. `swift run docc preview --enable-experimental-overloaded-symbol-presentation asdf.docc`
3. Navigate to either of `MyClass`'s type subscripts and ensure that they display the overloaded-symbol UI for selecting other overloads.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ n/a ] Added tests (Overloaded symbols are automatically tested in `DocumentationContextTests.testContextRecognizesOverloads`)
- [x] Ran the `./bin/test` script and it succeeded
- [ n/a ] Updated documentation if necessary
