### PR TITLE
Make it easier to support other link disambiguation in the future

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+Error.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+Error.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2023 Apple Inc. and the Swift project authors
+ Copyright (c) 2023-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -169,7 +169,7 @@ extension PathHierarchy.Error {
             // Use the authored disambiguation to try and reduce the possible near misses. For example, if the link was disambiguated with `-struct` we should
             // only make suggestions for similarly spelled structs.
             let filteredNearMisses = nearMisses.filter { name in
-                (try? partialResult.node.children[name]?.find(nextPathComponent.kind.map(String.init), nextPathComponent.hash.map(String.init))) != nil
+                (try? partialResult.node.children[name]?.find(nextPathComponent.disambiguation)) != nil
             }
 
             let pathPrefix = partialResult.pathPrefix

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+PathComponent.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+PathComponent.swift
@@ -14,16 +14,16 @@ import SymbolKit
 ///
 /// This is used to identify parsed path components as kind information.
 private let knownSymbolKinds: Set<String> = {
-    // There's nowhere else that registers these extended symbol kinds and we need to know them in this list.
-    SymbolGraph.Symbol.KindIdentifier.register(
+    // We don't want to register these extended symbol kinds because that makes them available for decoding from symbol graphs which is unexpected.
+    let knownKinds = SymbolGraph.Symbol.KindIdentifier.allCases + [
         .extendedProtocol,
         .extendedStructure,
         .extendedClass,
         .extendedEnumeration,
         .unknownExtendedType,
         .extendedModule
-    )
-    return Set(SymbolGraph.Symbol.KindIdentifier.allCases.map(\.identifier))
+    ]
+    return Set(knownKinds.map(\.identifier))
 }()
 
 /// All known source language identifiers.

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+PathComponent.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+PathComponent.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2023 Apple Inc. and the Swift project authors
+ Copyright (c) 2023-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -38,10 +38,13 @@ extension PathHierarchy {
         let full: String
         /// The parsed entity name
         let name: Substring
-        /// The parsed entity kind, if any.
-        var kind: Substring?
-        /// The parsed entity hash, if any.
-        var hash: Substring?
+        /// The parsed disambiguation information, if any.
+        var disambiguation: Disambiguation?
+        
+        enum Disambiguation {
+            /// This path component uses a combination of kind and hash disambiguation
+            case kindAndHash(kind: Substring?, hash: Substring?)
+        }
     }
     
     enum PathParser {
@@ -65,13 +68,14 @@ extension PathHierarchy.PathParser {
     static func parse(pathComponent original: Substring) -> PathComponent {
         let full = String(original)
         guard let dashIndex = original.lastIndex(of: "-") else {
-            return PathComponent(full: full, name: full[...], kind: nil, hash: nil)
+            return PathComponent(full: full, name: full[...], disambiguation: nil)
         }
         
         let hash = original[dashIndex...].dropFirst()
         let name = original[..<dashIndex]
         
         func isValidHash(_ hash: Substring) -> Bool {
+            // Checks if a string looks like a truncated, lowercase FNV-1 hash string.
             var index: UInt8 = 0
             for char in hash.utf8 {
                 guard index <= 5, (48...57).contains(char) || (97...122).contains(char) else { return false }
@@ -82,28 +86,28 @@ extension PathHierarchy.PathParser {
         
         if knownSymbolKinds.contains(String(hash)) {
             // The parsed hash value is a symbol kind
-            return PathComponent(full: full, name: name, kind: hash, hash: nil)
+            return PathComponent(full: full, name: name, disambiguation: .kindAndHash(kind: hash, hash: nil))
         }
         if let languagePrefix = knownLanguagePrefixes.first(where: { hash.starts(with: $0) }) {
             // The hash is actually a symbol kind with a language prefix
-            return PathComponent(full: full, name: name, kind: hash.dropFirst(languagePrefix.count), hash: nil)
+            return PathComponent(full: full, name: name, disambiguation: .kindAndHash(kind: hash.dropFirst(languagePrefix.count), hash: nil))
         }
         if !isValidHash(hash) {
             // The parsed hash is neither a symbol not a valid hash. It's probably a hyphen-separated name.
-            return PathComponent(full: full, name: full[...], kind: nil, hash: nil)
+            return PathComponent(full: full, name: full[...], disambiguation: nil)
         }
         
         if let dashIndex = name.lastIndex(of: "-") {
             let kind = name[dashIndex...].dropFirst()
             let name = name[..<dashIndex]
             if knownSymbolKinds.contains(String(kind)) {
-                return PathComponent(full: full, name: name, kind: kind, hash: hash)
+                return PathComponent(full: full, name: name, disambiguation: .kindAndHash(kind: kind, hash: hash))
             } else if let languagePrefix = knownLanguagePrefixes.first(where: { kind.starts(with: $0) }) {
                 let kindWithoutLanguage = kind.dropFirst(languagePrefix.count)
-                return PathComponent(full: full, name: name, kind: kindWithoutLanguage, hash: hash)
+                return PathComponent(full: full, name: name, disambiguation: .kindAndHash(kind: kindWithoutLanguage, hash: hash))
             }
         }
-        return PathComponent(full: full, name: name, kind: nil, hash: hash)
+        return PathComponent(full: full, name: name, disambiguation: .kindAndHash(kind: nil, hash: hash))
     }
     
     static func split(_ path: String) -> (componentSubstrings: [Substring], isAbsolute: Bool) {

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
@@ -198,7 +198,7 @@ struct PathHierarchy {
                         return original
                     }
                 }(node.symbol!)[...].dropLast()
-                while !components.isEmpty, let child = try? parent.children[components.first!]?.find(nil, nil) {
+                while !components.isEmpty, let child = try? parent.children[components.first!]?.find(nil) {
                     parent = child
                     components = components.dropFirst()
                 }
@@ -210,7 +210,12 @@ struct PathHierarchy {
                     let component = PathParser.parse(pathComponent: component[...])
                     let nodeWithoutSymbol = Node(name: String(component.name))
                     nodeWithoutSymbol.isDisfavoredInCollision = true
-                    parent.add(child: nodeWithoutSymbol, kind: component.kind.map(String.init), hash: component.hash.map(String.init))
+                    switch component.disambiguation {
+                    case .kindAndHash(kind: let kind, hash: let hash):
+                        parent.add(child: nodeWithoutSymbol, kind: kind.map(String.init), hash: hash.map(String.init))
+                    case nil:
+                        parent.add(child: nodeWithoutSymbol, kind: nil, hash: nil)
+                    }
                     parent = nodeWithoutSymbol
                 }
                 parent.add(symbolChild: node)
@@ -425,7 +430,7 @@ extension PathHierarchy {
         fileprivate func add(child: Node, kind: String?, hash: String?) {
             guard child.parent !== self else { 
                 assert(
-                    (try? children[child.name]?.find(kind, hash)) === child,
+                    (try? children[child.name]?.find(.kindAndHash(kind: kind?[...], hash: hash?[...]))) === child,
                     "If the new child node already has this node as its parent it should already exist among this node's children."
                 )
                 return

--- a/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
@@ -1051,8 +1051,8 @@ class PathHierarchyTests: XCTestCase {
         XCTAssertEqual(try tree.findSymbol(path: "documentation/MixedFramework/MyEnum", parent: moduleID).identifier.precise, "c:@M@MixedFramework@E@MyEnum")
         XCTAssertEqual(try tree.findSymbol(path: "/documentation/MixedFramework/MyEnum", parent: moduleID).identifier.precise, "c:@M@MixedFramework@E@MyEnum")
         
-        assertParsedPathComponents("documentation/MixedFramework/MyEnum", [("documentation", nil, nil), ("MixedFramework", nil, nil), ("MyEnum", nil, nil)])
-        assertParsedPathComponents("/documentation/MixedFramework/MyEnum", [("documentation", nil, nil), ("MixedFramework", nil, nil), ("MyEnum", nil, nil)])
+        assertParsedPathComponents("documentation/MixedFramework/MyEnum", [("documentation", nil), ("MixedFramework", nil), ("MyEnum", nil)])
+        assertParsedPathComponents("/documentation/MixedFramework/MyEnum", [("documentation", nil), ("MixedFramework", nil), ("MyEnum", nil)])
     }
     
     func testTestBundle() throws {
@@ -1841,46 +1841,46 @@ class PathHierarchyTests: XCTestCase {
         // Check path components without disambiguation
         assertParsedPathComponents("", [])
         assertParsedPathComponents("/", [])
-        assertParsedPathComponents("/first", [("first", nil, nil)])
-        assertParsedPathComponents("first", [("first", nil, nil)])
-        assertParsedPathComponents("first/", [("first", nil, nil)])
-        assertParsedPathComponents("first/second/third", [("first", nil, nil), ("second", nil, nil), ("third", nil, nil)])
-        assertParsedPathComponents("/first/second/third", [("first", nil, nil), ("second", nil, nil), ("third", nil, nil)])
-        assertParsedPathComponents("first/", [("first", nil, nil)])
-        assertParsedPathComponents("first//second", [("first", nil, nil), ("/second", nil, nil)])
-        assertParsedPathComponents("first/second#third", [("first", nil, nil), ("second", nil, nil), ("third", nil, nil)])
-        assertParsedPathComponents("#first", [("first", nil, nil)])
+        assertParsedPathComponents("/first", [("first", nil)])
+        assertParsedPathComponents("first", [("first", nil)])
+        assertParsedPathComponents("first/", [("first", nil)])
+        assertParsedPathComponents("first/second/third", [("first", nil), ("second", nil), ("third", nil)])
+        assertParsedPathComponents("/first/second/third", [("first", nil), ("second", nil), ("third", nil)])
+        assertParsedPathComponents("first/", [("first",  nil)])
+        assertParsedPathComponents("first//second", [("first", nil), ("/second", nil)])
+        assertParsedPathComponents("first/second#third", [("first", nil), ("second", nil), ("third", nil)])
+        assertParsedPathComponents("#first", [("first", nil)])
 
         // Check disambiguation
-        assertParsedPathComponents("path-hash", [("path", nil, "hash")])
-        assertParsedPathComponents("path-struct", [("path", "struct", nil)])
-        assertParsedPathComponents("path-struct-hash", [("path", "struct", "hash")])
+        assertParsedPathComponents("path-hash", [("path", .kindAndHash(kind: nil, hash: "hash"))])
+        assertParsedPathComponents("path-struct", [("path", .kindAndHash(kind: "struct", hash: nil))])
+        assertParsedPathComponents("path-struct-hash", [("path", .kindAndHash(kind: "struct", hash: "hash"))])
         
-        assertParsedPathComponents("path-swift.something", [("path", "something", nil)])
-        assertParsedPathComponents("path-c.something", [("path", "something", nil)])
+        assertParsedPathComponents("path-swift.something", [("path", .kindAndHash(kind: "something", hash: nil))])
+        assertParsedPathComponents("path-c.something", [("path", .kindAndHash(kind: "something", hash: nil))])
         
-        assertParsedPathComponents("path-swift.something-hash", [("path", "something", "hash")])
-        assertParsedPathComponents("path-c.something-hash", [("path", "something", "hash")])
+        assertParsedPathComponents("path-swift.something-hash", [("path", .kindAndHash(kind: "something", hash: "hash"))])
+        assertParsedPathComponents("path-c.something-hash", [("path", .kindAndHash(kind: "something", hash: "hash"))])
         
-        assertParsedPathComponents("path-type.property-hash", [("path", "type.property", "hash")])
-        assertParsedPathComponents("path-swift.type.property-hash", [("path", "type.property", "hash")])
-        assertParsedPathComponents("path-type.property", [("path", "type.property", nil)])
-        assertParsedPathComponents("path-swift.type.property", [("path", "type.property", nil)])
+        assertParsedPathComponents("path-type.property-hash", [("path", .kindAndHash(kind: "type.property", hash: "hash"))])
+        assertParsedPathComponents("path-swift.type.property-hash", [("path", .kindAndHash(kind: "type.property", hash: "hash"))])
+        assertParsedPathComponents("path-type.property", [("path", .kindAndHash(kind: "type.property", hash: nil))])
+        assertParsedPathComponents("path-swift.type.property", [("path", .kindAndHash(kind: "type.property", hash: nil))])
         
-        assertParsedPathComponents("-(_:_:)-hash", [("-(_:_:)", nil, "hash")])
-        assertParsedPathComponents("/=(_:_:)", [("/=(_:_:)", nil, nil)])
-        assertParsedPathComponents("/(_:_:)-func.op", [("/(_:_:)", "func.op", nil)])
-        assertParsedPathComponents("//(_:_:)-hash", [("//(_:_:)", nil, "hash")])
-        assertParsedPathComponents("+/-(_:_:)", [("+/-(_:_:)", nil, nil)])
-        assertParsedPathComponents("+/-(_:_:)-hash", [("+/-(_:_:)", nil, "hash")])
-        assertParsedPathComponents("+/-(_:_:)-func.op", [("+/-(_:_:)", "func.op", nil)])
-        assertParsedPathComponents("+/-(_:_:)-func.op-hash", [("+/-(_:_:)", "func.op", "hash")])
-        assertParsedPathComponents("+/-(_:_:)/+/-(_:_:)/+/-(_:_:)/+/-(_:_:)", [("+/-(_:_:)", nil, nil), ("+/-(_:_:)", nil, nil), ("+/-(_:_:)", nil, nil), ("+/-(_:_:)", nil, nil)])
-        assertParsedPathComponents("+/-(_:_:)-hash/+/-(_:_:)-func.op/+/-(_:_:)-func.op-hash/+/-(_:_:)", [("+/-(_:_:)", nil, "hash"), ("+/-(_:_:)", "func.op", nil), ("+/-(_:_:)", "func.op", "hash"), ("+/-(_:_:)", nil, nil)])
+        assertParsedPathComponents("-(_:_:)-hash", [("-(_:_:)", .kindAndHash(kind: nil, hash: "hash"))])
+        assertParsedPathComponents("/=(_:_:)", [("/=(_:_:)", nil)])
+        assertParsedPathComponents("/(_:_:)-func.op", [("/(_:_:)", .kindAndHash(kind: "func.op", hash: nil))])
+        assertParsedPathComponents("//(_:_:)-hash", [("//(_:_:)", .kindAndHash(kind: nil, hash: "hash"))])
+        assertParsedPathComponents("+/-(_:_:)", [("+/-(_:_:)", nil)])
+        assertParsedPathComponents("+/-(_:_:)-hash", [("+/-(_:_:)", .kindAndHash(kind: nil, hash: "hash"))])
+        assertParsedPathComponents("+/-(_:_:)-func.op", [("+/-(_:_:)", .kindAndHash(kind: "func.op", hash: nil))])
+        assertParsedPathComponents("+/-(_:_:)-func.op-hash", [("+/-(_:_:)", .kindAndHash(kind: "func.op", hash: "hash"))])
+        assertParsedPathComponents("+/-(_:_:)/+/-(_:_:)/+/-(_:_:)/+/-(_:_:)", [("+/-(_:_:)", nil), ("+/-(_:_:)", nil), ("+/-(_:_:)", nil), ("+/-(_:_:)", nil)])
+        assertParsedPathComponents("+/-(_:_:)-hash/+/-(_:_:)-func.op/+/-(_:_:)-func.op-hash/+/-(_:_:)", [("+/-(_:_:)", .kindAndHash(kind: nil, hash: "hash")), ("+/-(_:_:)", .kindAndHash(kind: "func.op", hash: nil)), ("+/-(_:_:)", .kindAndHash(kind: "func.op", hash: "hash")), ("+/-(_:_:)", nil)])
         
-        assertParsedPathComponents("MyNumber//=(_:_:)", [("MyNumber", nil, nil), ("/=(_:_:)", nil, nil)])
-        assertParsedPathComponents("MyNumber////=(_:_:)", [("MyNumber", nil, nil), ("///=(_:_:)", nil, nil)])
-        assertParsedPathComponents("MyNumber/+/-(_:_:)", [("MyNumber", nil, nil), ("+/-(_:_:)", nil, nil)])
+        assertParsedPathComponents("MyNumber//=(_:_:)", [("MyNumber", nil), ("/=(_:_:)", nil)])
+        assertParsedPathComponents("MyNumber////=(_:_:)", [("MyNumber", nil), ("///=(_:_:)", nil)])
+        assertParsedPathComponents("MyNumber/+/-(_:_:)", [("MyNumber", nil), ("+/-(_:_:)", nil)])
     }
     
     // MARK: Test helpers
@@ -1970,13 +1970,20 @@ class PathHierarchyTests: XCTestCase {
         }
     }
     
-    private func assertParsedPathComponents(_ path: String, _ expected: [(String, String?, String?)], file: StaticString = #file, line: UInt = #line) {
+    private func assertParsedPathComponents(_ path: String, _ expected: [(String, PathHierarchy.PathComponent.Disambiguation?)], file: StaticString = #file, line: UInt = #line) {
         let (actual, _) = PathHierarchy.PathParser.parse(path: path)
         XCTAssertEqual(actual.count, expected.count, file: file, line: line)
         for (actualComponents, expectedComponents) in zip(actual, expected) {
             XCTAssertEqual(String(actualComponents.name), expectedComponents.0, "Incorrect path component", file: file, line: line)
-            XCTAssertEqual(actualComponents.kind.map(String.init), expectedComponents.1, "Incorrect kind disambiguation", file: file, line: line)
-            XCTAssertEqual(actualComponents.hash.map(String.init), expectedComponents.2, "Incorrect hash disambiguation", file: file, line: line)
+            switch (actualComponents.disambiguation, expectedComponents.1) {
+            case (.kindAndHash(let actualKind, let actualHash), .kindAndHash(let expectedKind, let expectedHash)):
+                XCTAssertEqual(actualKind, expectedKind, "Incorrect kind disambiguation", file: file, line: line)
+                XCTAssertEqual(actualHash, expectedHash, "Incorrect hash disambiguation", file: file, line: line)
+            case (nil, nil):
+                continue
+            default:
+                XCTFail("Incorrect type of disambiguation", file: file, line: line)
+            }
         }
     }
 }


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

This handpicks some of the changes from #643 to make it easier to support other types of link disambiguation without adding any new link disambiguation. 

Specifically, this wraps the path component disambiguation as its own type instead of storing the values directly on the path component. This means that in the future, if we added a new type of link disambiguation—like in #643—then all the places that process path component disambiguation would already be switching over the type of disambiguation.

A follow up PR will handpick some more changes from #643 to change how the path hierarchy internally stores its disambiguated elements.

## Dependencies

None

## Testing

Nothing in particular. 

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] ~Added~ Updated tests
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
