### PR TITLE
Add a new generated page to group symbol overloads together

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -2369,8 +2369,17 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
             topicGraph.addNode(overloadGroupTopicGraphNode)
             
             // Create the new overload group symbol
-            let overloadGroupSymbol = firstOverloadSymbol
-            
+            // This needs to be a clone because otherwise the declaration simplifications below will
+            // also modify the original overload symbol
+            let overloadGroupSymbol = Symbol(cloning: firstOverloadSymbol)
+
+            if let subHeading = overloadGroupSymbol.subHeadingVariants[.swift] {
+                overloadGroupSymbol.subHeadingVariants[.swift] = subHeading.simplifyForOverloads()
+            }
+            if let navigator = overloadGroupSymbol.navigatorVariants[.swift] {
+                overloadGroupSymbol.navigatorVariants[.swift] = navigator.simplifyForOverloads()
+            }
+
             // Create the new overload group documentation node
             let overloadGroupNode = DocumentationNode(
                 reference: overloadGroupReference,

--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -2330,6 +2330,15 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
                 return
             }
 
+            // Create the overload group topic reference without a disambiguating hash at the end.
+            guard let indexOfHash = firstOverloadReference.path.lastIndex(of: "-") else { return }
+            let overloadGroupPath = String(firstOverloadReference.path[..<indexOfHash])
+            let overloadGroupReference = ResolvedTopicReference(
+                bundleIdentifier: firstOverloadTopicNode.reference.bundleIdentifier,
+                path: overloadGroupPath,
+                sourceLanguages: firstOverloadTopicNode.reference.sourceLanguages
+            )
+
             // Tell each symbol what other symbols overload it.
             for (index, symbolReference) in overloadedSymbolReferences.indexed() {
                 let documentationNode = try entity(with: symbolReference)
@@ -2347,18 +2356,13 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
 
                 var otherOverloadedSymbolReferences = overloadedSymbolReferences
                 otherOverloadedSymbolReferences.remove(at: index)
-                let overloads = Symbol.Overloads(references: otherOverloadedSymbolReferences, displayIndex: index)
+                let overloads = Symbol.Overloads(
+                    references: otherOverloadedSymbolReferences,
+                    overloadGroup: overloadGroupReference,
+                    displayIndex: index
+                )
                 symbol.overloadsVariants = .init(swiftVariant: overloads)
             }
-            
-            // Create the overload group topic reference without a disambiguating hash at the end.
-            guard let indexOfHash = firstOverloadReference.path.lastIndex(of: "-") else { return }
-            let overloadGroupPath = String(firstOverloadReference.path[..<indexOfHash])
-            let overloadGroupReference = ResolvedTopicReference(
-                bundleIdentifier: firstOverloadTopicNode.reference.bundleIdentifier,
-                path: overloadGroupPath,
-                sourceLanguages: firstOverloadTopicNode.reference.sourceLanguages
-            )
             
             // Add the topic graph node
             let overloadGroupTopicGraphNode = TopicGraph.Node(reference: overloadGroupReference,

--- a/Sources/SwiftDocC/Infrastructure/Extensions/DeclarationFragments+Simplify.swift
+++ b/Sources/SwiftDocC/Infrastructure/Extensions/DeclarationFragments+Simplify.swift
@@ -1,0 +1,78 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2024 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import SymbolKit
+
+fileprivate typealias Fragment = SymbolKit.SymbolGraph.Symbol.DeclarationFragments.Fragment
+
+extension [Fragment] {
+    /// Simplifies a declaration into its overloaded representation by removing type idenfiers.
+    ///
+    /// Consider the following Swift code:
+    ///
+    /// ```swift
+    /// class MyClass {
+    ///     func myFunc(param: Int) -> Int {}
+    ///     func myFunc(param: String) -> String {}
+    /// }
+    /// ```
+    ///
+    /// These two methods can both be referred to as `myFunc(param:)`, regardless of their
+    /// parameter and return types. However, when generating an overload group's landing page, we
+    /// copy the symbol information from one of these methods, including the type names in the
+    /// sub-heading and navigator titles. Ideally, we would want to be able to display
+    /// `func myFunc(param:)` in curation and navigation to prevent any confusion.
+    ///
+    /// The idea behind this function is that any overload will have the same basic display
+    /// fragments other than any type names, and that (in Swift) these type names (and only these
+    /// type names) are all rendered as `typeIdentifier` fragments. Therefore, we can strip out
+    /// these references and get a unified representation.
+    ///
+    /// However, doing this by itself will return `func myFunc(param: ) -> ` as the result. After
+    /// stripping out any `typeIdentifier` fragments, this method then cleans up any visual
+    /// oddities like the space in the parameters list and the trailing return-type arrow.
+    func simplifyForOverloads() -> Self {
+        var output = [Fragment]()
+
+        for var nextFragment in self where nextFragment.kind != .typeIdentifier {
+            // If this fragment is the text fragment with the return-type arrow, drop the arrow
+            if nextFragment.kind == .text, nextFragment.spelling.hasSuffix(" -> ") {
+                nextFragment.spelling = String(nextFragment.spelling.prefix(nextFragment.spelling.count - 4))
+            }
+
+            // We want to concatenate text fragments together, so bail here if that's not the situation we're in
+            guard var lastFragment = output.last,
+                    nextFragment.kind == .text,
+                    lastFragment.kind == .text else {
+                output.append(nextFragment)
+                continue
+            }
+            output.removeLast()
+
+            // If this is the last argument label before the closing parenthesis, trim the space out before concatenating
+            if lastFragment.spelling.hasSuffix(" "), nextFragment.spelling.hasPrefix(")") {
+                lastFragment.spelling = lastFragment.spelling.removingTrailingWhitespace()
+            }
+
+            // If we're between argument labels, drop the ", " and trim the interleaving whitespace
+            if lastFragment.spelling.hasSuffix(": "), nextFragment.spelling == ", " {
+                nextFragment.spelling = ""
+                lastFragment.spelling = lastFragment.spelling.removingTrailingWhitespace()
+            }
+
+            // Now that we've cleaned up the text fragments, we can concatenate them together and
+            // add the resulting fragment back to the output
+            lastFragment.spelling += nextFragment.spelling
+            output.append(lastFragment)
+        }
+
+        return output
+    }
+}

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+Find.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+Find.swift
@@ -421,6 +421,8 @@ extension PathHierarchy.DisambiguationContainer {
                 return subtree[hash]
             } else if subtree.count == 1 {
                 return subtree.values.first
+            } else if let overloadGroupNode = subtree["overloadGroup"] {
+                return overloadGroupNode
             } else {
                 // Subtree contains more than one match.
                 throw Error.lookupCollision(subtree.map { ($0.value, $0.key) })
@@ -431,6 +433,8 @@ extension PathHierarchy.DisambiguationContainer {
                 return subtree[hash]
             } else if subtree.count == 1 {
                 return subtree.values.first
+            } else if let overloadGroupNode = subtree["overloadGroup"] {
+                return overloadGroupNode
             } else {
                 // Subtree contains more than one match.
                 throw Error.lookupCollision(subtree.map { ($0.value, $0.key) })
@@ -442,6 +446,8 @@ extension PathHierarchy.DisambiguationContainer {
                 return nil
             } else if kinds.count == 1 {
                 return kinds.first!.value[hash]
+            } else if hash == "overloadGroup" {
+                return kinds.first!.value["overloadGroup"]
             } else {
                 // Subtree contains more than one match
                 throw Error.lookupCollision(kinds.map { ($0.value[hash]!, $0.key) })

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchyBasedLinkResolver.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchyBasedLinkResolver.swift
@@ -59,9 +59,10 @@ final class PathHierarchyBasedLinkResolver {
     }
     
     /// Traverse all symbols of the same kind that have collisions.
-    func traverseOverloadedSymbols(_ observe: (_ overloadedSymbols: [ResolvedTopicReference]) throws -> Void) rethrows {
-        try pathHierarchy.traverseOverloadedSymbolGroups() { overloadedSymbols in
-            try observe(overloadedSymbols.map { resolvedReferenceMap[$0]! })
+    func traverseOverloadedSymbols(_ observe: (_ parent: ResolvedTopicReference, _ overloadedSymbols: [ResolvedTopicReference]) throws -> Void) rethrows {
+        try pathHierarchy.traverseOverloadedSymbolGroups() { id, overloadedSymbols in
+            guard let parent = resolvedReferenceMap[id] else { return }
+            try observe(parent, overloadedSymbols.map { resolvedReferenceMap[$0]! })
         }
     }
     
@@ -195,6 +196,14 @@ final class PathHierarchyBasedLinkResolver {
         let parentID = resolvedReferenceMap[parent]!
         let taskGroupID = pathHierarchy.addNonSymbolChild(parent: parentID, name: urlReadableFragment(name), kind: "taskGroup")
         resolvedReferenceMap[taskGroupID] = reference
+    }
+    
+    /// Adds an overload group on a given page to the documentation hierarchy.
+    func addOverloadGroup(named name: String, reference: ResolvedTopicReference, kind: String,
+                          symbol: SymbolKit.SymbolGraph.Symbol?, to parent: ResolvedTopicReference) {
+        let parentID = resolvedReferenceMap[parent]!
+        let overloadGroupID = pathHierarchy.addOverloadGroupChild(parent: parentID, name: urlReadablePath(name), kind: kind, symbol: symbol)
+        resolvedReferenceMap[overloadGroupID] = reference
     }
     
     // MARK: Reference resolving

--- a/Sources/SwiftDocC/Semantics/Symbol/Symbol.swift
+++ b/Sources/SwiftDocC/Semantics/Symbol/Symbol.swift
@@ -237,10 +237,12 @@ public final class Symbol: Semantic, Abstracted, Redirected, AutomaticTaskGroups
     var automaticTaskGroupsVariants: DocumentationDataVariants<[AutomaticTaskGroupSection]>
     
     struct Overloads {
-         /// References to other symbols that overload this one.
-         let references: [ResolvedTopicReference]
-         /// The index where this symbol's should be displayed (inserted) among the overloads declarations.
-         let displayIndex: Int
+        /// References to other symbols that overload this one.
+        let references: [ResolvedTopicReference]
+        /// Reference to the "overload group" page, which points to the first declaration.
+        let overloadGroup: ResolvedTopicReference
+        /// The index where this symbol's should be displayed (inserted) among the overloads declarations.
+        let displayIndex: Int
     }
     
     /// References to other symbols that overload this one.

--- a/Sources/SwiftDocC/Semantics/Symbol/Symbol.swift
+++ b/Sources/SwiftDocC/Semantics/Symbol/Symbol.swift
@@ -344,7 +344,44 @@ public final class Symbol: Semantic, Abstracted, Redirected, AutomaticTaskGroups
         self.automaticTaskGroupsVariants = automaticTaskGroupsVariants
         self.overloadsVariants = overloadsVariants
     }
-    
+
+    internal convenience init(cloning other: Symbol) {
+        self.init(
+            kindVariants: other.kindVariants,
+            titleVariants: other.titleVariants,
+            subHeadingVariants: other.subHeadingVariants,
+            navigatorVariants: other.navigatorVariants,
+            roleHeadingVariants: other.roleHeadingVariants,
+            platformNameVariants: other.platformNameVariants,
+            moduleReference: other.moduleReference,
+            requiredVariants: other.isRequiredVariants,
+            externalIDVariants: other.externalIDVariants,
+            accessLevelVariants: other.accessLevelVariants,
+            availabilityVariants: other.availabilityVariants,
+            deprecatedSummaryVariants: other.deprecatedSummaryVariants,
+            mixinsVariants: other.mixinsVariants,
+            declarationVariants: other.declarationVariants,
+            defaultImplementationsVariants: other.defaultImplementationsVariants,
+            relationshipsVariants: other.relationshipsVariants,
+            abstractSectionVariants: other.abstractSectionVariants,
+            discussionVariants: other.discussionVariants,
+            topicsVariants: other.topicsVariants,
+            seeAlsoVariants: other.seeAlsoVariants,
+            returnsSectionVariants: other.returnsSectionVariants,
+            parametersSectionVariants: other.parametersSectionVariants,
+            dictionaryKeysSectionVariants: other.dictionaryKeysSectionVariants,
+            httpEndpointSectionVariants: other.httpEndpointSectionVariants,
+            httpBodySectionVariants: other.httpBodySectionVariants,
+            httpParametersSectionVariants: other.httpParametersSectionVariants,
+            httpResponsesSectionVariants: other.httpResponsesSectionVariants,
+            redirectsVariants: other.redirectsVariants,
+            crossImportOverlayModule: other.crossImportOverlayModule,
+            originVariants: other.originVariants,
+            automaticTaskGroupsVariants: other.automaticTaskGroupsVariants,
+            overloadsVariants: other.overloadsVariants
+        )
+    }
+
     public override func accept<V: SemanticVisitor>(_ visitor: inout V) -> V.Result {
         return visitor.visitSymbol(self)
     }


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://116550528

## Summary

In an effort to simplify symbol overloads, this PR creates a new generated "overload group" page for each group of overloads it encounters. This page has a simplified page subheading based on the first overload's information, and links to the first overload's declaration. This page's path is the same as the first overload's path, without a disambiguating hash.

## Dependencies

None

## Testing

Steps:
1. With a recent `main` branch Swift-DocC-Render built in `$DOCC_HTML_DIR`, run `swift run docc preview --enable-experimental-overloaded-symbol-presentation Tests/SwiftDocCTests/Test\ Bundles/OverloadedSymbols.docc`
2. Navigate to the `OverloadedEnum` symbol.
3. Ensure that a separate `firstTestMemberName(_:)` page is added to the automatic curation alongside the specific overloads.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ n/a ] Updated documentation if necessary
