### PR TITLE
Resolve dependency symbol reference in declarations and relationships

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/ExternalPathHierarchyResolver.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/ExternalPathHierarchyResolver.swift
@@ -78,11 +78,9 @@ final class ExternalPathHierarchyResolver {
     }
 
     /// Returns the external entity for a symbol's unique identifier or `nil` if that symbol isn't known in this external context.
-    func entity(symbolID usr: String) -> LinkResolver.ExternalEntity? {
-        // TODO: Resolve external symbols by USR (rdar://116085974) (There is nothing calling this function)
-        // This function has an optional return value since it's not easy to check what module a symbol belongs to based on its identifier.
+    func symbolReferenceAndEntity(symbolID usr: String) -> (ResolvedTopicReference, LinkResolver.ExternalEntity)? {
         guard let reference = symbols[usr] else { return nil }
-        return entity(reference)
+        return (reference, entity(reference))
     }
     
     /// Returns the external entity for a reference that was successfully resolved by this external resolver.
@@ -163,14 +161,14 @@ final class ExternalPathHierarchyResolver {
         }
     }
     
-    convenience init(dependencyArchive: URL) throws {
+    convenience init(dependencyArchive: URL, fileManager: FileManagerProtocol) throws {
         // ???: Should it be the callers responsibility to pass both these URLs?
         let linkHierarchyFile = dependencyArchive.appendingPathComponent("link-hierarchy.json")
         let entityURL = dependencyArchive.appendingPathComponent("linkable-entities.json")
         
         self.init(
-            linkInformation: try JSONDecoder().decode(SerializableLinkResolutionInformation.self, from: Data(contentsOf: linkHierarchyFile)),
-            entityInformation: try JSONDecoder().decode([LinkDestinationSummary].self, from: Data(contentsOf: entityURL))
+            linkInformation: try JSONDecoder().decode(SerializableLinkResolutionInformation.self, from: fileManager.contents(of: linkHierarchyFile)),
+            entityInformation: try JSONDecoder().decode([LinkDestinationSummary].self, from: fileManager.contents(of: entityURL))
         )
     }
 }

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/ExternalPathHierarchyResolver.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/ExternalPathHierarchyResolver.swift
@@ -207,7 +207,7 @@ private extension LinkDestinationSummary {
             identifier: .init(referenceURL.absoluteString),
             titleVariants: titleVariants,
             abstractVariants: abstractVariants,
-            url: referenceURL.absoluteString,
+            url: relativePresentationURL.absoluteString,
             kind: kind,
             required: false,
             role: role,

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/LinkResolver.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/LinkResolver.swift
@@ -85,22 +85,16 @@ public class LinkResolver {
     ///   - context: The documentation context to resolve the link in.
     /// - Returns: The result of resolving the reference.
     func resolve(_ unresolvedReference: UnresolvedTopicReference, in parent: ResolvedTopicReference, fromSymbolLink isCurrentlyResolvingSymbolLink: Bool, context: DocumentationContext) -> TopicReferenceResolutionResult {
-        // Check if the unresolved reference is external
-        if let bundleID = unresolvedReference.bundleIdentifier,
-           !context.registeredBundles.contains(where: { bundle in
-               bundle.identifier == bundleID || urlReadablePath(bundle.displayName) == bundleID
-           }) {
-            if context.externalDocumentationSources[bundleID] != nil,
-               let resolvedExternalReference = context.externallyResolvedLinks[unresolvedReference.topicURL] {
-                // Return the successful or failed externally resolved reference.
-                return resolvedExternalReference
-            } else if !context.registeredBundles.contains(where: { $0.identifier == bundleID }) {
-                return .failure(unresolvedReference, TopicReferenceResolutionErrorInfo("No external resolver registered for \(bundleID.singleQuoted)."))
-            }
+        // Check if this is an external link that has previously been resolved, either successfully or not.
+        if let previousExternalResult = contextExternalLinksLock.sync({ context.externallyResolvedLinks[unresolvedReference.topicURL] }) {
+            return previousExternalResult
         }
         
-        if let previousExternalResult = context.externallyResolvedLinks[unresolvedReference.topicURL] {
-            return previousExternalResult
+        // Check if this is a link to an external documentation source that should have previously been resolved in `DocumentationContext.preResolveExternalLinks(...)`
+        if let bundleID = unresolvedReference.bundleIdentifier,
+           !context.registeredBundles.contains(where: { $0.identifier == bundleID || urlReadablePath($0.displayName) == bundleID })
+        {
+            return .failure(unresolvedReference, TopicReferenceResolutionErrorInfo("No external resolver registered for \(bundleID.singleQuoted)."))
         }
         
         do {
@@ -109,9 +103,11 @@ public class LinkResolver {
             // Check if there's a known external resolver for this module.
             if case .moduleNotFound(_, let remainingPathComponents, _) = error, let resolver = externalResolvers[remainingPathComponents.first!.full] {
                 let result = resolver.resolve(unresolvedReference, fromSymbolLink: isCurrentlyResolvingSymbolLink)
-                context.externallyResolvedLinks[unresolvedReference.topicURL] = result
-                if case .success(let resolved) = result {
-                    context.externalCache[resolved] = resolver.entity(resolved)
+                contextExternalLinksLock.sync {
+                    context.externallyResolvedLinks[unresolvedReference.topicURL] = result
+                    if case .success(let resolved) = result {
+                        context.externalCache[resolved] = resolver.entity(resolved)
+                    }
                 }
                 return result
             }
@@ -126,6 +122,15 @@ public class LinkResolver {
             fatalError("Only SymbolPathTree.Error errors are raised from the symbol link resolution code above.")
         }
     }
+    
+    /// The context resolves links concurrently for different pages.
+    ///
+    /// Since the link resolver may both read and write to the context to cache externally resolved references, it needs to synchronize those accesses to avoid data races.
+    ///
+    /// > Note:
+    /// > We don't generally want to require a lock around these properties because the context will also render pages in parallel and during rendering the external content
+    /// > is only read, so requiring synchronization would add unnecessary overhead during rendering.
+    private var contextExternalLinksLock = Lock()
 }
 
 // MARK: Fallback resolver

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/LinkResolver.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/LinkResolver.swift
@@ -17,6 +17,7 @@ public class LinkResolver {
     @_spi(ExternalLinks) // This needs to be public SPI so that the ConvertAction can set it.
     public var dependencyArchives: [URL] = []
     
+    var fileManager: FileManagerProtocol = FileManager.default
     /// The link resolver to use to resolve links in the local bundle
     var localResolver: PathHierarchyBasedLinkResolver!
     /// A fallback resolver to use when the local resolver fails to resolve a link.
@@ -29,7 +30,7 @@ public class LinkResolver {
     /// Create link resolvers for all documentation archive dependencies.
     func loadExternalResolvers() throws {
         let resolvers = try dependencyArchives.compactMap {
-            try ExternalPathHierarchyResolver(dependencyArchive: $0)
+            try ExternalPathHierarchyResolver(dependencyArchive: $0, fileManager: fileManager)
         }
         for resolver in resolvers {
             for moduleNode in resolver.pathHierarchy.modules {

--- a/Sources/SwiftDocC/Utility/FileManagerProtocol.swift
+++ b/Sources/SwiftDocC/Utility/FileManagerProtocol.swift
@@ -63,6 +63,17 @@ public protocol FileManagerProtocol {
     /// - Throws: If the file couldn't be created with the specified contents.
     func createFile(at: URL, contents: Data) throws
     
+    /// Returns the data content of a file at the given URL.
+    ///
+    /// - Parameters:
+    ///   - url: The location to create the file
+    ///
+    /// - Note: This method doesn't exist on ``FileManager``.
+    ///         There is a similar looking method but it doesn't provide information about potential errors.
+    ///
+    /// - Throws: If the file couldn't be read.
+    func contents(of url: URL) throws -> Data
+    
     /// Creates a file with the given contents at the given url with the specified
     /// writing options.
     ///
@@ -88,6 +99,10 @@ extension FileManagerProtocol {
 /// most of the methods are already implemented in Foundation.
 @_spi(FileManagerProtocol)
 extension FileManager: FileManagerProtocol {
+    // This method doesn't exist on `FileManager`. There is a similar looking method but it doesn't provide information about potential errors.
+    public func contents(of url: URL) throws -> Data {
+        return try Data(contentsOf: url)
+    }
     
     // This method doesn't exist on `FileManager`. There is a similar looking method but it doesn't provide information about potential errors.
     public func createFile(at location: URL, contents: Data) throws {

--- a/Sources/SwiftDocCTestUtilities/FilesAndFolders.swift
+++ b/Sources/SwiftDocCTestUtilities/FilesAndFolders.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -93,7 +93,7 @@ public struct InfoPlist: File, DataRepresentable {
     /// The information that the Into.plist file contains.
     public let content: Content
 
-    public init(displayName: String, identifier: String? = nil, versionString: String = "1.0") {
+    public init(displayName: String? = nil, identifier: String? = nil, versionString: String = "1.0") {
         self.content = Content(
             displayName: displayName,
             identifier: identifier,
@@ -102,11 +102,11 @@ public struct InfoPlist: File, DataRepresentable {
     }
 
     public struct Content: Codable, Equatable {
-        public let displayName: String
+        public let displayName: String?
         public let identifier: String?
         public let versionString: String?
 
-        fileprivate init(displayName: String, identifier: String?, versionString: String) {
+        fileprivate init(displayName: String?, identifier: String?, versionString: String) {
             self.displayName = displayName
             self.identifier = identifier
             self.versionString = versionString

--- a/Sources/SwiftDocCTestUtilities/TestFileSystem.swift
+++ b/Sources/SwiftDocCTestUtilities/TestFileSystem.swift
@@ -121,9 +121,13 @@ public class TestFileSystem: FileManagerProtocol, DocumentationWorkspaceDataProv
         defer { filesLock.unlock() }
 
         guard let file = files[url.path] else {
-            throw Errors.invalidPath(url.path)
+            throw CocoaError.error(.fileReadNoSuchFile)
         }
         return file
+    }
+    
+    public func contents(of url: URL) throws -> Data {
+        try contentsOfURL(url)
     }
     
     func filesIn(folder: Folder, at: URL) throws -> [String: Data] {
@@ -223,7 +227,7 @@ public class TestFileSystem: FileManagerProtocol, DocumentationWorkspaceDataProv
             // If it's not the root folder, check if parents exist
             if createIntermediates == false {
                 guard files.keys.contains(parent.path) else {
-                    throw Errors.invalidPath(path)
+                    throw CocoaError.error(.fileReadNoSuchFile)
                 }
             } else {
                 // Create missing parent directories
@@ -322,16 +326,6 @@ public class TestFileSystem: FileManagerProtocol, DocumentationWorkspaceDataProv
         }
 
         return output
-    }
-
-    
-    enum Errors: DescribedError {
-        case invalidPath(String)
-        var errorDescription: String {
-            switch self { 
-                case .invalidPath(let path): return "Invalid path \(path.singleQuoted)"
-            }
-        }
     }
     
     func dump() -> String {

--- a/Sources/SwiftDocCUtilities/Action/Actions/Action+MoveOutput.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Action+MoveOutput.swift
@@ -24,6 +24,8 @@ extension Action {
         
         if let template = template {
             // If a template directory has been provided, create the temporary build folder with its contents
+            // Ensure that the container exists
+            try? fileManager.createDirectory(at: targetURL.deletingLastPathComponent(), withIntermediateDirectories: false, attributes: nil)
             try fileManager.copyItem(at: template, to: targetURL)
         } else {
             // Otherwise, create an empty directory

--- a/Tests/SwiftDocCTests/Infrastructure/ExternalPathHierarchyResolverTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/ExternalPathHierarchyResolverTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2023 Apple Inc. and the Swift project authors
+ Copyright (c) 2023-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -10,7 +10,9 @@
 
 import XCTest
 import Markdown
-@testable import SwiftDocC
+import SymbolKit
+@testable @_spi(ExternalLinks) import SwiftDocC
+import SwiftDocCTestUtilities
 
 class ExternalPathHierarchyResolverTests: XCTestCase {
     
@@ -18,14 +20,7 @@ class ExternalPathHierarchyResolverTests: XCTestCase {
     
     override func setUp() {
         super.setUp()
-        originalFeatureFlagsState = FeatureFlags.current
-        FeatureFlags.current.isExperimentalLinkHierarchySerializationEnabled = true
-    }
-    
-    override func tearDown() {
-        FeatureFlags.current = originalFeatureFlagsState
-        originalFeatureFlagsState = nil
-        super.tearDown()
+        enableFeatureFlag(\.isExperimentalLinkHierarchySerializationEnabled)
     }
     
     // These tests resolve absolute symbol links in both a local and external context to verify that external links work the same local links.
@@ -638,6 +633,171 @@ class ExternalPathHierarchyResolverTests: XCTestCase {
             authoredLink: "/MixedFramework-module-9r7pl/myTopLevelVariable-var-520ez",
             to: "doc://org.swift.MixedFramework/documentation/MixedFramework/myTopLevelVariable"
         )
+    }
+    
+    func testSymbolLinksInDeclarationsAndRelationships() throws {
+        // Build documentation for the dependency first
+        let symbols = [("First", .class), ("Second", .protocol), ("Third", .struct), ("Fourth", .enum)].map { (name: String, kind: SymbolGraph.Symbol.KindIdentifier) in
+            return SymbolGraph.Symbol(
+                identifier: .init(precise: "dependency-\(name.lowercased())-symbol-id", interfaceLanguage: SourceLanguage.swift.id),
+                names: .init(title: name, navigator: nil, subHeading: nil, prose: nil),
+                pathComponents: [name],
+                docComment: nil,
+                accessLevel: .public,
+                kind: .init(parsedIdentifier: kind, displayName: "Kind Display Name"),
+                mixins: [:]
+            )
+        }
+        
+        let (dependencyBundle, dependencyContext) = try loadBundle(
+            catalog: Folder(name: "Dependency.docc", content: [
+                InfoPlist(identifier: "com.example.dependency"), // This isn't necessary but makes it easier to distinguish the identifier from the module name in the external references.
+                JSONFile(name: "Dependency.symbols.json", content: makeSymbolGraph(moduleName: "Dependency", symbols: symbols))
+            ])
+        )
+        
+        // Retrieve the link information from the dependency, as if '--enable-experimental-external-link-support' was passed to DocC
+        let dependencyConverter = DocumentationContextConverter(bundle: dependencyBundle, context: dependencyContext, renderContext: .init(documentationContext: dependencyContext, bundle: dependencyBundle))
+        
+        let linkSummaries: [LinkDestinationSummary] = try dependencyContext.knownPages.flatMap { reference in
+            let entity = try dependencyContext.entity(with: reference)
+            let renderNode = try XCTUnwrap(dependencyConverter.renderNode(for: entity, at: nil))
+            
+            return entity.externallyLinkableElementSummaries(context: dependencyContext, renderNode: renderNode, includeTaskGroups: false)
+        }
+        let linkResolutionInformation = try dependencyContext.linkResolver.localResolver.prepareForSerialization(bundleID: dependencyBundle.identifier)
+        
+        XCTAssertEqual(linkResolutionInformation.pathHierarchy.nodes.count - linkResolutionInformation.nonSymbolPaths.count, 5 /* 4 symbols & 1 module */)
+        XCTAssertEqual(linkSummaries.count, 5 /* 4 symbols & 1 module */)
+        
+        // After building the dependency,
+        let (mainBundle, mainContext) = try loadBundle(
+            catalog: Folder(name: "Main.docc", content: [
+                JSONFile(name: "Main.symbols.json", content: makeSymbolGraph(
+                    moduleName: "Main",
+                    symbols: [
+                        // import Dependency
+                        //
+                        // public class SomeClass: Dependency.First, Dependency.Second {
+                        //     public func someFunction(parameter: Dependency.Third) -> Dependency.Fourth {}
+                        // }
+                        SymbolGraph.Symbol(
+                            identifier: .init(precise: "main-container-symbol-id", interfaceLanguage: SourceLanguage.swift.id),
+                            names: .init(title: "SomeClass", navigator: nil, subHeading: nil, prose: nil),
+                            pathComponents: ["SomeClass"],
+                            docComment: nil,
+                            accessLevel: .public,
+                            kind: .init(parsedIdentifier: .class, displayName: "Kind Display Name"),
+                            mixins: [
+                                // "class SomeClass"
+                                SymbolGraph.Symbol.DeclarationFragments.mixinKey: SymbolGraph.Symbol.DeclarationFragments(declarationFragments: [
+                                    .init(kind: .keyword, spelling: "class", preciseIdentifier: nil),
+                                    .init(kind: .text, spelling: " ", preciseIdentifier: nil),
+                                    .init(kind: .identifier, spelling: "SomeClass", preciseIdentifier: nil),
+                                ])
+                            ]
+                        ),
+                        SymbolGraph.Symbol(
+                            identifier: .init(precise: "main-member-symbol-id", interfaceLanguage: SourceLanguage.swift.id),
+                            names: .init(title: "someFunction(parameter:)", navigator: nil, subHeading: nil, prose: nil),
+                            pathComponents: ["SomeClass", "someFunction(parameter:)"],
+                            docComment: nil,
+                            accessLevel: .public,
+                            kind: .init(parsedIdentifier: .func, displayName: "Kind Display Name"),
+                            mixins: [
+                                // "func someFunction(parameter: Third) -> Fourth"
+                                SymbolGraph.Symbol.DeclarationFragments.mixinKey: SymbolGraph.Symbol.DeclarationFragments(declarationFragments: [
+                                    .init(kind: .keyword, spelling: "func", preciseIdentifier: nil),
+                                    .init(kind: .text, spelling: " ", preciseIdentifier: nil),
+                                    .init(kind: .identifier, spelling: "someFunction", preciseIdentifier: nil),
+                                    .init(kind: .text, spelling: "(", preciseIdentifier: nil),
+                                    .init(kind: .externalParameter, spelling: "paramater", preciseIdentifier: nil),
+                                    .init(kind: .text, spelling: ": ", preciseIdentifier: nil),
+                                    .init(kind: .typeIdentifier, spelling: "Third", preciseIdentifier: "dependency-third-symbol-id"),
+                                    .init(kind: .text, spelling: ") -> ", preciseIdentifier: nil),
+                                    .init(kind: .typeIdentifier, spelling: "Fourth", preciseIdentifier: "dependency-fourth-symbol-id"),
+                                ])
+                            ]
+                        ),
+                    ],
+                    relationships: [
+                        // 'someFunction(parameter:)' is a member of 'SomeClass'
+                        .init(source: "main-member-symbol-id", target: "main-container-symbol-id", kind: .memberOf, targetFallback: nil),
+                        // 'SomeClass' inherits from 'Dependency.First'
+                        .init(source: "main-container-symbol-id", target: "dependency-first-symbol-id", kind: .inheritsFrom, targetFallback: "Dependency.First"),
+                        // 'SomeClass' conforms to 'Dependency.Second'
+                        .init(source: "main-container-symbol-id", target: "dependency-second-symbol-id", kind: .conformsTo, targetFallback: "Dependency.Second"),
+                    ]
+                ))
+            ]),
+            otherFileSystemDirectories: [
+                Folder(name: "Dependency.doccarchive", content: [
+                    JSONFile(name: "linkable-entities.json", content: linkSummaries),
+                    JSONFile(name: "link-hierarchy.json", content: linkResolutionInformation),
+                ])
+            ],
+            configureContext: {
+                $0.linkResolver.dependencyArchives = [URL(fileURLWithPath: "/Dependency.doccarchive")]
+            }
+        )
+        
+        XCTAssertEqual(mainContext.knownPages.count, 3 /* 2 symbols & 1 module*/)
+        
+        let mainConverter = DocumentationContextConverter(bundle: mainBundle, context: mainContext, renderContext: .init(documentationContext: mainContext, bundle: mainBundle))
+        
+        // Check the relationships of 'SomeClass'
+        do {
+            let reference = ResolvedTopicReference(bundleIdentifier: mainBundle.identifier, path: "/documentation/Main/SomeClass", sourceLanguage: .swift)
+            let entity = try mainContext.entity(with: reference)
+            let renderNode = try XCTUnwrap(mainConverter.renderNode(for: entity, at: nil))
+            
+            XCTAssertEqual(renderNode.relationshipSections.count, 2)
+            let inheritsFromSection = try XCTUnwrap(renderNode.relationshipSections.first)
+            XCTAssertEqual(inheritsFromSection.title, "Inherits From")
+            XCTAssertEqual(inheritsFromSection.identifiers, ["doc://com.example.dependency/documentation/Dependency/First"])
+            
+            let conformsToSection = try XCTUnwrap(renderNode.relationshipSections.last)
+            XCTAssertEqual(conformsToSection.title, "Conforms To")
+            XCTAssertEqual(conformsToSection.identifiers, ["doc://com.example.dependency/documentation/Dependency/Second"])
+            
+            let firstReference = try XCTUnwrap(renderNode.references["doc://com.example.dependency/documentation/Dependency/First"] as? TopicRenderReference)
+            XCTAssertEqual(firstReference.title, "First")
+            XCTAssertEqual(firstReference.role, RenderMetadata.Role.symbol.rawValue)
+            
+            let secondReference = try XCTUnwrap(renderNode.references["doc://com.example.dependency/documentation/Dependency/Second"] as? TopicRenderReference)
+            XCTAssertEqual(secondReference.title, "Second")
+            XCTAssertEqual(secondReference.role, RenderMetadata.Role.symbol.rawValue)
+        }
+        
+        // Check the declaration of 'someFunction'
+        do {
+            let reference = ResolvedTopicReference(bundleIdentifier: mainBundle.identifier, path: "/documentation/Main/SomeClass/someFunction(parameter:)", sourceLanguage: .swift)
+            let entity = try mainContext.entity(with: reference)
+            let renderNode = try XCTUnwrap(mainConverter.renderNode(for: entity, at: nil))
+            
+            XCTAssertEqual(renderNode.primaryContentSections.count, 1)
+            let declarationSection = try XCTUnwrap(renderNode.primaryContentSections.first as? DeclarationsRenderSection)
+            XCTAssertEqual(declarationSection.declarations.count, 1)
+            XCTAssertEqual(declarationSection.declarations.first?.tokens, [
+                .init(text: "func", kind: .keyword),
+                .init(text: " ", kind: .text),
+                .init(text: "someFunction", kind: .identifier),
+                .init(text: "(", kind: .text),
+                .init(text: "paramater", kind: .externalParam),
+                .init(text: ": ", kind: .text),
+                .init(text: "Third", kind: .typeIdentifier, identifier: "doc://com.example.dependency/documentation/Dependency/Third", preciseIdentifier: "dependency-third-symbol-id"),
+                .init(text: ") -> ", kind: .text),
+                .init(text: "Fourth", kind: .typeIdentifier, identifier: "doc://com.example.dependency/documentation/Dependency/Fourth", preciseIdentifier: "dependency-fourth-symbol-id"),
+            ])
+            
+            let thirdReference = try XCTUnwrap(renderNode.references["doc://com.example.dependency/documentation/Dependency/Third"] as? TopicRenderReference)
+            XCTAssertEqual(thirdReference.title, "Third")
+            XCTAssertEqual(thirdReference.role, RenderMetadata.Role.symbol.rawValue)
+            
+            let fourthReference = try XCTUnwrap(renderNode.references["doc://com.example.dependency/documentation/Dependency/Fourth"] as? TopicRenderReference)
+            XCTAssertEqual(fourthReference.title, "Fourth")
+            XCTAssertEqual(fourthReference.role, RenderMetadata.Role.symbol.rawValue)
+        }
     }
     
     // MARK: Test helpers

--- a/Tests/SwiftDocCTests/Infrastructure/ExternalReferenceResolverTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/ExternalReferenceResolverTests.swift
@@ -97,13 +97,6 @@ class ExternalReferenceResolverTests: XCTestCase {
         
         let expectedURL = URL(string: "doc://com.external.testbundle/externally/resolved/path")
         XCTAssertEqual(expectedURL, resolved.url)
-        
-        try workspace.unregisterProvider(dataProvider)
-        context.externalDocumentationSources = [:]
-        guard case .failure = context.resolve(.unresolved(unresolved), in: parent) else {
-            XCTFail("Unexpectedly resolved \(unresolved.topicURL) despite removing a data provider for it")
-            return
-        }
     }
     
     // Asserts that an external reference from a source language not locally included


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://116085974

## Summary

This improves the support for external documentation dependencies by resolving symbol references found in declarations and relationships in the local symbol graph files.

> [!IMPORTANT]
> There is more work needed to support this end-to-end. If you run this now you'll notice that the external links are 404s in the browser unless you host both archives on the same server.

## Dependencies

None

## Testing

To test this you need a project with two documentable targets. 

- Build documentation for one of the targets and pass `--enable-experimental-external-link-support` to enable linking to this documentation.

- Check that the output directory contains a "linkable-entities.json" file and a "link-hierarchy.json" file. (This hasn't changed since #710 but can help verify that the first target is configured correctly)

- In the other target, refer to symbols in the first target in the source code. For example:
  - Make a public subclass of a class from the first target
  - Conform a public type to a protocol from the first target
  - Make a public protocol that extends a protocol from the first target
  - Use a type from the first target as the type of a public property in the other target, `public var someProperty: First.Something`
  - Use a type from the first target as a parameter in the other target, `public func doSomething(with value: First.Something)`
  - Use a type from the first target as a return value in the other target, `public func doSomething() -⁠> First.Something`

- Build documentation for the other target and pass `--dependency /path/to/first-target.doccarchive`.

- Preview the other target's documentation and navigate to the pages that reference types from the first target.

  - Tokens that refer to types in the first target should display as links in the declarations and should be clickable.
    > Note: Unless the local server hosts both archives the link will be a 404 when clicked.
 
  - Types from the first target that are mentioned in "Inherits From", "Conforms To" and other relationship sections should display as links in the declarations and should be clickable.
    > Note: Unless the local server hosts both archives the link will be a 404 when clicked.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary
