### PR TITLE
[5.10] @Redirected placement

### DIFF
--- a/Sources/SwiftDocC/Model/DocumentationMarkup.swift
+++ b/Sources/SwiftDocC/Model/DocumentationMarkup.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -73,6 +73,14 @@ struct DocumentationMarkup {
         case end
     }
     
+    /// Directives which are removed from the markdown content after being parsed.
+    private static let directivesRemovedFromContent = [
+        Comment.directiveName,
+        Metadata.directiveName,
+        Options.directiveName,
+        Redirect.directiveName,
+    ]
+
     // MARK: - Parsed Data
     
     /// The documentation title, if found.
@@ -146,7 +154,7 @@ struct DocumentationMarkup {
                         // Found deprecation notice in the abstract.
                         deprecation = MarkupContainer(directive.children)
                         return
-                    } else if directive.name == Comment.directiveName || directive.name == Metadata.directiveName || directive.name == Options.directiveName {
+                    } else if Self.directivesRemovedFromContent.contains(directive.name) {
                         // These directives don't affect content so they shouldn't break us out of
                         // the automatic abstract section.
                         return

--- a/Sources/SwiftDocC/Semantics/Article/Article.swift
+++ b/Sources/SwiftDocC/Semantics/Article/Article.swift
@@ -121,7 +121,7 @@ public final class Article: Semantic, MarkupConvertible, Abstracted, Redirected,
         }
         
         var remainder: [Markup]
-        let redirects: [Redirect]
+        var redirects: [Redirect]
         (redirects, remainder) = markup.children.categorize { child -> Redirect? in
             guard let childDirective = child as? BlockDirective, childDirective.name == Redirect.directiveName else {
                 return nil
@@ -142,7 +142,13 @@ public final class Article: Semantic, MarkupConvertible, Abstracted, Redirected,
         }
         
         var optionalMetadata = metadata.first
-        
+
+        // Append any redirects found in the metadata to the redirects
+        // found in the main content.
+        if let redirectsFromMetadata = optionalMetadata?.redirects {
+            redirects.append(contentsOf: redirectsFromMetadata)
+        }
+
         let options: [Options]
         (options, remainder) = remainder.categorize { child -> Options? in
             guard let childDirective = child as? BlockDirective, childDirective.name == Options.directiveName else {

--- a/Sources/SwiftDocC/Semantics/Metadata/Metadata.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/Metadata.swift
@@ -72,7 +72,10 @@ public final class Metadata: Semantic, AutomaticDirectiveConvertible {
 
     @ChildDirective
     var titleHeading: TitleHeading? = nil
-    
+
+    @ChildDirective
+    var redirects: [Redirect]? = nil
+
     static var keyPaths: [String : AnyKeyPath] = [
         "documentationOptions"  : \Metadata._documentationOptions,
         "technologyRoot"        : \Metadata._technologyRoot,
@@ -85,6 +88,7 @@ public final class Metadata: Semantic, AutomaticDirectiveConvertible {
         "supportedLanguages"    : \Metadata._supportedLanguages,
         "_pageColor"            : \Metadata.__pageColor,
         "titleHeading"          : \Metadata._titleHeading,
+        "redirects"             : \Metadata._redirects,
     ]
     
     @available(*, deprecated, message: "Do not call directly. Required for 'AutomaticDirectiveConvertible'.")
@@ -94,7 +98,7 @@ public final class Metadata: Semantic, AutomaticDirectiveConvertible {
     
     func validate(source: URL?, for bundle: DocumentationBundle, in context: DocumentationContext, problems: inout [Problem]) -> Bool {
         // Check that something is configured in the metadata block
-        if documentationOptions == nil && technologyRoot == nil && displayName == nil && pageImages.isEmpty && customMetadata.isEmpty && callToAction == nil && availability.isEmpty && pageKind == nil && pageColor == nil && titleHeading == nil {
+        if documentationOptions == nil && technologyRoot == nil && displayName == nil && pageImages.isEmpty && customMetadata.isEmpty && callToAction == nil && availability.isEmpty && pageKind == nil && pageColor == nil && titleHeading == nil && redirects == nil {
             let diagnostic = Diagnostic(
                 source: source,
                 severity: .information,

--- a/Sources/SwiftDocC/Semantics/Redirect.swift
+++ b/Sources/SwiftDocC/Semantics/Redirect.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -18,6 +18,10 @@ import Markdown
 /// For example, if you host the compiled documentation on a web server,
 /// that server can read this data and set an HTTP "301 Moved Permanently" redirect from
 /// the declared URL to the page's current URL and avoid breaking any existing links to the content.
+///
+/// > Note: Starting with version 5.10, @Redirected is supported as a child directive of @Metadata. In
+/// previous versions, @Redirected must be used as a top level directive.
+///
 public final class Redirect: Semantic, AutomaticDirectiveConvertible {
     public static let directiveName = "Redirected"
     public let originalMarkup: BlockDirective
@@ -30,7 +34,7 @@ public final class Redirect: Semantic, AutomaticDirectiveConvertible {
         "oldPath" : \Redirect._oldPath,
     ]
     
-    static var hiddenFromDocumentation = true
+    static var hiddenFromDocumentation = false
     
     init(originalMarkup: BlockDirective, oldPath: URL) {
         self.originalMarkup = originalMarkup

--- a/Sources/docc/DocCDocumentation.docc/DocC.symbols.json
+++ b/Sources/docc/DocCDocumentation.docc/DocC.symbols.json
@@ -2953,9 +2953,6 @@
             "text" : "- ``PageImage``"
           },
           {
-            "text" : "- ``PageColor``"
-          },
-          {
             "text" : "- ``CallToAction``"
           },
           {
@@ -3481,7 +3478,7 @@
             "text" : "For example, use the page image directive to customize the icon used to represent this page in the navigation sidebar,"
           },
           {
-            "text" : "or the card image used to represent this page when using the ``Links`` directive and the ``Links\/detailedGrid``"
+            "text" : "or the card image used to represent this page when using the ``Links`` directive and the ``Links\/VisualStyle\/detailedGrid``"
           },
           {
             "text" : "visual style."
@@ -3761,6 +3758,137 @@
       },
       "pathComponents" : [
         "PageKind"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "Redirected"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "("
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "from"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "URL"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ")"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "text" : "A directive that specifies an additional URL for the page where the directive appears."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "Use this directive to declare a URL where a piece of content was previously located."
+          },
+          {
+            "text" : "For example, if you host the compiled documentation on a web server,"
+          },
+          {
+            "text" : "that server can read this data and set an HTTP \"301 Moved Permanently\" redirect from"
+          },
+          {
+            "text" : "the declared URL to the page's current URL and avoid breaking any existing links to the content."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "> Note: Starting with version 5.10, @Redirected is supported as a child directive of @Metadata. In"
+          },
+          {
+            "text" : "previous versions, @Redirected must be used as a top level directive."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "- Parameters:"
+          },
+          {
+            "text" : "  - from: The URL that redirects to the page associated with the directive."
+          },
+          {
+            "text" : "     **(required)**"
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$Redirected"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$Redirected",
+            "spelling" : "Redirected"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "Redirected"
+          },
+          {
+            "kind" : "text",
+            "spelling" : "("
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "from"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "spelling" : "URL"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ")"
+          }
+        ],
+        "title" : "Redirected"
+      },
+      "pathComponents" : [
+        "Redirected"
       ]
     },
     {
@@ -5115,7 +5243,7 @@
             "text" : ""
           },
           {
-            "text" : "@TitleHeading accepts an unnamed parameter containing containing the page's title heading."
+            "text" : "The `@TitleHeading` directive accepts an unnamed parameter containing containing the page's title heading."
           },
           {
             "text" : ""

--- a/Sources/docc/DocCDocumentation.docc/Reference Syntax/API Reference Syntax/Metadata.md
+++ b/Sources/docc/DocCDocumentation.docc/Reference Syntax/API Reference Syntax/Metadata.md
@@ -40,6 +40,20 @@ Use the `Metadata` directive with the ``TitleHeading`` directive to configure th
 }
 ```
 
+Starting with version 5.10, use the `Metadata` directive with one or more ``Redirected`` directives
+to add additional URLs for a page.
+```
+# ``SlothCreator``
+
+@Metadata {
+    @Redirected(from: "old/path/to/page")
+    @Redirected(from: "another/old/path/to/page")
+}
+```
+
+> Note: Starting with version 5.10, @Redirected is supported as a child directive of @Metadata. In
+previous versions, @Redirected must be used as a top level directive.
+
 ## Topics
 
 ### Extending or Overriding Source Documentation
@@ -66,5 +80,12 @@ Use the `Metadata` directive with the ``TitleHeading`` directive to configure th
 ### Customizing the Availability Information of a Page
 
 - ``Available``
+
+### Specifying an Additional URL of a Page
+
+- ``Redirected``
+
+> Note: Starting with version 5.10, @Redirected is supported as a child directive of @Metadata. In
+previous versions, @Redirected must be used as a top level directive.
 
 <!-- Copyright (c) 2021-2023 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Sources/docc/DocCDocumentation.docc/Reference Syntax/API Reference Syntax/api-reference-syntax.md
+++ b/Sources/docc/DocCDocumentation.docc/Reference Syntax/API Reference Syntax/api-reference-syntax.md
@@ -15,6 +15,7 @@ Use documentation markup, a custom variant of Markdown, to add in-source documen
 - ``Options``
 - ``Metadata``
 - ``TechnologyRoot``
+- ``Redirected``
 
 ### Creating Custom Page Layouts
 

--- a/Tests/SwiftDocCTests/Semantics/DirectiveInfrastructure/DirectiveMirrorTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/DirectiveInfrastructure/DirectiveMirrorTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2022-2023 Apple Inc. and the Swift project authors
+ Copyright (c) 2022-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -52,7 +52,7 @@ class DirectiveMirrorTests: XCTestCase {
         XCTAssertFalse(reflectedDirective.allowsMarkup)
         XCTAssert(reflectedDirective.arguments.isEmpty)
         
-        XCTAssertEqual(reflectedDirective.childDirectives.count, 11)
+        XCTAssertEqual(reflectedDirective.childDirectives.count, 12)
         
         XCTAssertEqual(
             reflectedDirective.childDirectives["DocumentationExtension"]?.propertyLabel,

--- a/Tests/SwiftDocCTests/Semantics/MetadataTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/MetadataTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -164,7 +164,23 @@ class MetadataTests: XCTestCase {
         XCTAssertEqual(metadata?.customMetadata.count, 2)
         XCTAssertEqual(problems.count, 0)
     }
-    
+
+    func testRedirectSupport() throws {
+        let source = """
+        @Metadata {
+           @Redirected(from: "some/other/path")
+        }
+        """
+        let document = Document(parsing: source, options: .parseBlockDirectives)
+        let directive = document.child(at: 0)! as! BlockDirective
+        let (bundle, context) = try testBundleAndContext(named: "TestBundle")
+        var problems = [Problem]()
+        let metadata = Metadata(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        XCTAssertNotNil(metadata)
+        XCTAssertEqual(0, problems.count)
+        XCTAssertEqual(metadata?.redirects?.first?.oldPath.relativePath, "some/other/path")
+    }
+
     // MARK: - Metadata Support
     
     func testArticleSupportsMetadata() throws {


### PR DESCRIPTION
- **Explanation**:

Today DocC does not parse the `@Redirected` directive properly if it appears before the abstract in an article or documentation extension. If the directive appears before the abstract, the abstract's contents is set to the directive only and the actual abstract is instead considered to be part of the following discussion.

For example, compiling this article:

```
# Getting Started with Sloths

@Redirected(from: "some/path")

Create a sloth and assign personality traits and abilities.

## Overview

Sloths are complex creatures that require careful creation and a suitable habitat. After creating a sloth, you're responsible for feeding them, providing fulfilling activities, and giving them opportunities to exercise and rest.
```

...would produce this page:

![Screenshot 2024-01-18 at 2 55 17 PM](https://github.com/apple/swift-docc/assets/28140/c82a18eb-27e2-4019-b986-7b3a32c1bfce)

Note the abstract appears under "Overview", and that there are two "Overview" sections.

This fix removes any `@Redirected` directives from markdown content while parsing the title, abstract and discussion. Now DocC no longer considers `@Redirected` directives to be part of the markdown content at all, similar to how `@Comment`, `@Metadata` and `@Options` work. DocC saves the redirects' old path strings behind the scenes.

A related fix in this PR adds `@Redirected` as a child directive of `@Metadata`. This gives the author more flexibility to place `@Redirected` commands anywhere, including inside of the page's metadata which is the most logical place for it to appear.


- **Scope**: This is an important fix that will restore missing abstracts on a number of existing documentation pages. It is not source-breaking; the `@Redirected` directive will continue to work the same way, although after this is merged the directive can be placed inside of `@Metadata` if preferred.


- **GitHub Issue**: n/a


- **Risk**: Low. This changes the way DocC parses and handles `@Redirected` directives in a minor, but important way.


- **Testing**: 

1. Create a new article which contains redirects after the title, but before the abstract as shown above in the Getting Started With Sloths page.
2. Compile and check the rendered article shows the abstract properly:

![Screenshot 2024-01-18 at 2 57 36 PM](https://github.com/apple/swift-docc/assets/28140/5e367a56-c75b-4997-a661-828962226ad8)

Repeat the same test, but move the `@Redirected` directive inside the `@Metadata` directives as a child. For example:

```
# Getting Started with Sloths

@Metadata {
    @Redirected(from: "some/path")
}

Create a sloth and assign personality traits and abilities.

## Overview

Sloths are complex creatures that require careful creation and a suitable habitat. After creating a sloth, you're responsible for feeding them, providing fulfilling activities, and giving them opportunities to exercise and rest. 
```

The page should render correctly again.


- **Reviewer**: @d-ronnqvist 

