### PR TITLE
Make it easier to store other types of link disambiguating information in the path hierarchy 

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+Dump.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+Dump.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2023 Apple Inc. and the Swift project authors
+ Copyright (c) 2023-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -23,17 +23,17 @@ private extension PathHierarchy.Node {
         // Each node is printed as 3-layer hierarchy with the child names, their kind disambiguation, and their hash disambiguation.
         return DumpableNode(
             name: symbol.map { "{ \($0.identifier.precise) : \($0.identifier.interfaceLanguage).\($0.kind.identifier.identifier) }" } ?? "[ \(name) ]",
-            children:
-                children.sorted(by: \.key).map { (key, disambiguationTree) -> DumpableNode in
-                DumpableNode(
+            children: children.sorted(by: \.key).map { (key, disambiguationTree) -> DumpableNode in
+                let grouped = [String: [PathHierarchy.DisambiguationContainer.Element]](grouping: disambiguationTree.storage, by: { $0.kind ?? "_" })
+                return DumpableNode(
                     name: key,
-                    children: disambiguationTree.storage.sorted(by: \.key).map { (kind, kindTree) -> DumpableNode in
+                    children: grouped.sorted(by: \.key).map { (kind, kindTree) -> DumpableNode in
                         DumpableNode(
                             name: kind,
-                            children: kindTree.sorted(by: \.key).map { (usr, node) -> DumpableNode in
+                            children: kindTree.sorted(by: { lhs, rhs in (lhs.hash ?? "_") < (rhs.hash ?? "_") }).map { (element) -> DumpableNode in
                                 DumpableNode(
-                                    name: usr,
-                                    children: [node.dumpableNode()]
+                                    name: element.hash ?? "_",
+                                    children: [element.node.dumpableNode()]
                                 )
                             }
                         )

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+Find.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+Find.swift
@@ -410,49 +410,33 @@ extension PathHierarchy.DisambiguationContainer {
     ///  - Exactly one match is found; indicated by a non-nil return value.
     ///  - More than one match is found; indicated by a raised error listing the matches and their missing disambiguation.
     func find(_ disambiguation: PathHierarchy.PathComponent.Disambiguation?) throws -> PathHierarchy.Node? {
-        var kind: String?
-        var hash: String?
-        switch disambiguation {
-        case .kindAndHash(kind: let maybeKind, hash: let maybeHash):
-            kind = maybeKind.map(String.init)
-            hash = maybeHash.map(String.init)
-        case nil:
-            kind = nil
-            hash = nil
+        if storage.count <= 1, disambiguation == nil {
+            return storage.first?.node
         }
         
-        if let kind = kind {
-            // Need to match the provided kind
-            guard let subtree = storage[kind] else { return nil }
-            if let hash = hash {
-                return subtree[hash]
-            } else if subtree.count == 1 {
-                return subtree.values.first
-            } else {
-                // Subtree contains more than one match.
-                throw Error.lookupCollision(subtree.map { ($0.value, $0.key) })
+        switch disambiguation {
+        case .kindAndHash(let kind, let hash):
+            switch (kind, hash) {
+            case (let kind?, let hash?):
+                return storage.first(where: { $0.kind == kind && $0.hash == hash })?.node
+            case (let kind?, nil):
+                let matches = storage.filter({ $0.kind == kind })
+                guard matches.count <= 1 else {
+                    // Suggest not only hash disambiguation, but also type signature disambiguation.
+                    throw Error.lookupCollision(Self.disambiguatedValues(for: matches).map { ($0.value, $0.disambiguation.value()) })
+                }
+                return matches.first?.node
+            case (nil, let hash?):
+                let matches = storage.filter({ $0.hash == hash })
+                guard matches.count <= 1 else {
+                    throw Error.lookupCollision(matches.map { ($0.node, $0.kind!) }) // An element wouldn't match if it didn't have kind disambiguation.
+                }
+                return matches.first?.node
+            case (nil, nil):
+                break
             }
-        } else if storage.count == 1, let subtree = storage.values.first {
-            // Tree only contains one kind subtree
-            if let hash = hash {
-                return subtree[hash]
-            } else if subtree.count == 1 {
-                return subtree.values.first
-            } else {
-                // Subtree contains more than one match.
-                throw Error.lookupCollision(subtree.map { ($0.value, $0.key) })
-            }
-        } else if let hash = hash {
-            // Need to match the provided hash
-            let kinds = storage.filter { $0.value.keys.contains(hash) }
-            if kinds.isEmpty {
-                return nil
-            } else if kinds.count == 1 {
-                return kinds.first!.value[hash]
-            } else {
-                // Subtree contains more than one match
-                throw Error.lookupCollision(kinds.map { ($0.value[hash]!, $0.key) })
-            }
+        case nil:
+            break
         }
         // Disambiguate by a mix of kinds and USRs
         throw Error.lookupCollision(self.disambiguatedValues().map { ($0.value, $0.disambiguation.value()) })
@@ -460,6 +444,12 @@ extension PathHierarchy.DisambiguationContainer {
 }
 
 // MARK: Private helper extensions
+
+// Allow optional substrings to be compared to non-optional strings
+private func == <S1: StringProtocol, S2: StringProtocol>(lhs: S1?, rhs: S2) -> Bool {
+     guard let lhs = lhs else { return false }
+     return lhs == rhs
+ }
 
 private extension Sequence {
     /// Returns the only element of the sequence that satisfies the given predicate.

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+Serialization.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+Serialization.swift
@@ -45,11 +45,9 @@ extension PathHierarchy.FileRepresentation {
                         isDisfavoredInCollision: node.isDisfavoredInCollision,
                         children: node.children.values.flatMap({ tree in
                             var disambiguations = [Node.Disambiguation]()
-                            for (kind, kindTree) in tree.storage {
-                                for (hash, childNode) in kindTree where childNode.identifier != nil { // nodes without identifiers can't be found in the tree
-                                    disambiguations.append(.init(kind: kind, hash: hash, nodeID: identifierMap[childNode.identifier]!))
+                            for element in tree.storage where element.node.identifier != nil { // nodes without identifiers can't be found in the tree
+                                disambiguations.append(.init(kind: element.kind, hash: element.hash, nodeID: identifierMap[element.node.identifier]!))
                                 }
-                            }
                             return disambiguations
                         }),
                         symbolID: node.symbol?.identifier
@@ -101,7 +99,7 @@ extension PathHierarchy {
         /// The container of tutorial overview pages.
         var tutorialOverviewContainer: Int
         
-        /// A node in the
+        /// A node in the hierarchy.
         struct Node: Codable {
             var name: String
             var isDisfavoredInCollision: Bool = false

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
@@ -209,6 +209,7 @@ struct PathHierarchy {
                     )
                     guard knownDisambiguatedPathComponents != nil else {
                         let nodeWithoutSymbol = Node(name: component)
+                        nodeWithoutSymbol.isDisfavoredInCollision = true
                         parent.add(child: nodeWithoutSymbol, kind: nil, hash: nil)
                         parent = nodeWithoutSymbol
                         continue

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
@@ -207,9 +207,17 @@ struct PathHierarchy {
                         parent.children[components.first!] == nil,
                         "Shouldn't create a new sparse node when symbol node already exist. This is an indication that a symbol is missing a relationship."
                     )
+                    guard knownDisambiguatedPathComponents != nil else {
+                        let nodeWithoutSymbol = Node(name: component)
+                        parent.add(child: nodeWithoutSymbol, kind: nil, hash: nil)
+                        parent = nodeWithoutSymbol
+                        continue
+                    }
+                    // If the path hierarchy was passed any known disambiguated path components, then it may need to parse the disambiguation when creating sparse nodes.
                     let component = PathParser.parse(pathComponent: component[...])
                     let nodeWithoutSymbol = Node(name: String(component.name))
                     nodeWithoutSymbol.isDisfavoredInCollision = true
+                    // If 'known disambiguated path components' was provided, then
                     switch component.disambiguation {
                     case .kindAndHash(kind: let kind, hash: let hash):
                         parent.add(child: nodeWithoutSymbol, kind: kind.map(String.init), hash: hash.map(String.init))
@@ -253,23 +261,21 @@ struct PathHierarchy {
                 lookup[node.identifier] = node
             }
             for tree in node.children.values {
-                for (_, subtree) in tree.storage {
-                    for (_, childNode) in subtree {
-                        assert(childNode.parent === node, {
-                            func describe(_ node: Node?) -> String {
-                                guard let node = node else { return "<nil>" }
-                                guard let identifier = node.symbol?.identifier else { return node.name }
-                                return "\(identifier.precise) (\(identifier.interfaceLanguage))"
-                            }
-                            return """
+                for element in tree.storage {
+                    assert(element.node.parent === node, {
+                        func describe(_ node: Node?) -> String {
+                            guard let node = node else { return "<nil>" }
+                            guard let identifier = node.symbol?.identifier else { return node.name }
+                            return "\(identifier.precise) (\(identifier.interfaceLanguage))"
+                        }
+                        return """
                             Every child node should point back to its parent so that the tree can be traversed both up and down without any dead-ends. \
-                            This wasn't true for '\(describe(childNode))' which pointed to '\(describe(childNode.parent))' but should have pointed to '\(describe(node))'.
+                            This wasn't true for '\(describe(element.node))' which pointed to '\(describe(element.node.parent))' but should have pointed to '\(describe(node))'.
                             """ }()
-                        )
-                        // In release builds we close off any dead-ends in the tree as a precaution for what shouldn't happen.
-                        childNode.parent = node
-                        descend(childNode)
-                    }
+                    )
+                    // In release builds we close off any dead-ends in the tree as a precaution for what shouldn't happen.
+                    element.node.parent = node
+                    descend(element.node)
                 }
             }
         }
@@ -437,7 +443,7 @@ extension PathHierarchy {
             }
             // If the name was passed explicitly, then the node could have spaces in its name
             child.parent = self
-            children[child.name, default: .init()].add(kind ?? "_", hash ?? "_", child)
+            children[child.name, default: .init()].add(child, kind: kind, hash: hash)
             
             assert(child.parent === self, "Potentially merging nodes shouldn't break the child node's reference to its parent.")
         }
@@ -448,10 +454,8 @@ extension PathHierarchy {
             self.children = self.children.merging(other.children, uniquingKeysWith: { $0.merge(with: $1) })
             
             for (_, tree) in self.children {
-                for subtree in tree.storage.values {
-                    for node in subtree.values {
-                        node.parent = self
-                    }
+                for element in tree.storage {
+                    element.node.parent = self
                 }
             }
         }
@@ -467,10 +471,8 @@ extension PathHierarchy {
         // Roots represent modules and only have direct symbol descendants.
         for root in modules {
             for (_, tree) in root.children {
-                for subtree in tree.storage.values {
-                    for node in subtree.values where node.symbol != nil {
-                        result.insert(node.identifier)
-                    }
+                for element in tree.storage where element.node.symbol != nil {
+                    result.insert(element.node.identifier)
                 }
             }
         }
@@ -480,10 +482,15 @@ extension PathHierarchy {
     func traverseOverloadedSymbolGroups(observe: (_ overloadedSymbols: [ResolvedIdentifier]) throws -> Void) rethrows {
         for node in lookup.values where node.symbol != nil {
             for disambiguation in node.children.values {
-                for (kind, innerStorage) in disambiguation.storage where innerStorage.count > 1 && SymbolGraph.Symbol.KindIdentifier(identifier: kind).isOverloadableKind {
-                    assert(innerStorage.values.allSatisfy { $0.symbol != nil }, "Only symbols should have symbol kind identifiers (\(kind))")
-
-                    try observe(innerStorage.values.map(\.identifier))
+                var overloadGroups = [SymbolGraph.Symbol.KindIdentifier: [ResolvedIdentifier]]()
+                for element in disambiguation.storage {
+                    guard let kind = element.node.symbol?.kind.identifier, kind.isOverloadableKind else {
+                        continue
+                    }
+                    overloadGroups[kind, default: []].append(element.node.identifier)
+                }
+                for overloads in overloadGroups.values where overloads.count > 1 {
+                    try observe(overloads)
                 }
             }
         }
@@ -510,46 +517,62 @@ extension PathHierarchy {
 // MARK: Disambiguation container
 
 extension PathHierarchy {
-    /// A fixed-depth tree that stores disambiguation information and finds values based on partial disambiguation.
+    /// A container that stores values and their disambiguation information and find values based on partial disambiguation.
     struct DisambiguationContainer {
-        // Each disambiguation tree is fixed at two levels and stores a limited number of values.
-        // In practice, almost all trees store either 1, 2, or 3 elements with 1 being the most common.
+        // Each disambiguation container stores its elements in a flat list, which is very short in practice.
+        //
+        // Almost all containers store either 1, 2, or 3 elements with 1 being the most common case.
         // It's very rare to have more than 10 values and 20+ values is extremely rare.
         //
-        // Given this expected amount of data, a nested dictionary implementation performs well.
-        private(set) var storage: [String: [String: PathHierarchy.Node]] = [:]
+        // Given this expected amount of data, linear searches through an array performs well.
+        private(set) var storage = ContiguousArray<Element>()
     }
 }
 
 extension PathHierarchy.DisambiguationContainer {
+    struct Element {
+        let node: PathHierarchy.Node
+        let kind: String?
+        let hash: String?
+        
+        func matches(kind: String?, hash: String?) -> Bool {
+            // The 'hash' is more unique than the 'kind', so compare the 'hash' first.
+            self.hash == hash && self.kind == kind
+        }
+        var isPlaceholderValue: Bool {
+            // Only symbols have 'hash' disambiguation, so check the 'kind' first.
+            kind == nil && hash == nil
+        }
+    }
+    
     /// Add a new value to the tree for a given pair of kind and hash disambiguations.
     /// - Parameters:
+    ///   - value: The new value
     ///   - kind: The kind disambiguation for this value.
     ///   - hash: The hash disambiguation for this value.
-    ///   - value: The new value
     /// - Returns: If a value already exist with the same pair of kind and hash disambiguations.
-    mutating func add(_ kind: String, _ hash: String, _ value: PathHierarchy.Node) {
-        if let existing = storage[kind]?[hash] {
-            existing.merge(with: value)
-        } else if storage.count == 1, let existing = storage["_"]?["_"] {
-            // It is possible for articles and other non-symbols to collide with unfindable symbol placeholder nodes.
+    mutating func add(_ value: PathHierarchy.Node, kind: String?, hash: String?) {
+        // When adding new elements to the container, it's sufficient to check if the hash and kind match.
+        if let existing = storage.first(where: { $0.matches(kind: kind, hash: hash) }) {
+            existing.node.merge(with: value)
+        } else if storage.count == 1, storage.first!.isPlaceholderValue {
+            // It is possible for articles and other non-symbols to collide with "unfindable" symbol placeholder nodes.
             // When this happens, remove the placeholder node and move its children to the real (non-symbol) node.
-            value.merge(with: existing)
-            storage = [kind: [hash: value]]
+            let existing = storage.removeFirst()
+            value.merge(with: existing.node)
+            storage = [Element(node: value, kind: kind, hash: hash)]
         } else {
-            storage[kind, default: [:]][hash] = value
+            storage.append(Element(node: value, kind: kind, hash: hash))
         }
     }
     
     /// Combines the data from this tree with another tree to form a new, merged disambiguation tree.
     func merge(with other: Self) -> Self {
-        return .init(storage: self.storage.merging(other.storage, uniquingKeysWith: { lhs, rhs in
-            lhs.merging(rhs, uniquingKeysWith: {
-                lhsValue, rhsValue in
-                assert(lhsValue.symbol!.identifier.precise == rhsValue.symbol!.identifier.precise)
-                return lhsValue
-            })
-        }))
+        var newStorage = storage
+        for element in other.storage where !storage.contains(where: { $0.matches(kind: element.kind, hash: element.hash )}) {
+            newStorage.append(element)
+        }
+        return .init(storage: newStorage)
     }
 }
 


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

This is a small refactor to change how the path hierarchy internally stores its disambiguated elements, changing the implementation from nested dictionaries per name collision per node to small lists per name collision per node. 

The benefit of a small list is that new disambiguating information can be added without increasing the depth of the nested dictionaries at each node.

## Dependencies

None.

## Testing

Nothing in particular.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- ~[ ] Added tests~
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
