### PR TITLE
Relax rules for decoding JSON for asides with custom styles 

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/Content/RenderBlockContent.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Content/RenderBlockContent.swift
@@ -711,7 +711,7 @@ extension RenderBlockContent: Codable {
             self = try .paragraph(.init(inlineContent: container.decode([RenderInlineContent].self, forKey: .inlineContent)))
         case .aside:
             var style = try container.decode(AsideStyle.self, forKey: .style)
-            if style.renderKind == "note", let displayName = try container.decodeIfPresent(String.self, forKey: .name) {
+            if let displayName = try container.decodeIfPresent(String.self, forKey: .name) {
                 style = AsideStyle(displayName: displayName)
             }
             self = try .aside(.init(style: style, content: container.decode([RenderBlockContent].self, forKey: .content)))

--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
@@ -2987,6 +2987,10 @@ Document
               "name": "Custom Title"
             }
             """)
+            
+        for style in Aside.Kind.allCases.map({ RenderBlockContent.AsideStyle(asideKind: $0) }) + [.init(displayName: "Custom Title")] {
+            try assertRoundTripCoding(RenderBlockContent.aside(.init(style: style, content: [.paragraph(.init(inlineContent: [.text("This is a custom title...")]))])))
+        }
     }
 
     /// Tests links to symbols that have deprecation summary in markdown appear deprecated.

--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
@@ -2956,8 +2956,36 @@ Document
             {"type":"aside", "style":"note", "name":"See Also",
                 "content": [{"type":"paragraph", "inlineContent":[{"type":"text", "text":"And this other thing."}]}]},
             {"type":"aside", "style":"note", "name":"Throws",
-                "content": [{"type":"paragraph", "inlineContent":[{"type":"text", "text":"A serious error."}]}]}
+                "content": [{"type":"paragraph", "inlineContent":[{"type":"text", "text":"A serious error."}]}]},
             ]
+            """)
+
+        // While decoding, overwrite the style with the name, if both are specified. We expect the style's raw value
+        // to be "Custom Title", not "important" in this example.
+        try assertJSONRepresentation(
+            RenderBlockContent.aside(
+                .init(
+                    style: .init(rawValue: "Custom Title"),
+                    content: [.paragraph(.init(inlineContent: [.text("This is a custom title...")]))]
+                )
+            ),
+            """
+            {
+              "type": "aside",
+              "content": [
+                {
+                  "type": "paragraph",
+                  "inlineContent": [
+                    {
+                      "type": "text",
+                      "text": "This is a custom title..."
+                    }
+                  ]
+                }
+              ],
+              "style": "important",
+              "name": "Custom Title"
+            }
             """)
     }
 


### PR DESCRIPTION
Bug/issue #, if applicable: 

rdar://117158675

## Summary

Today DocC normally encodes aside block content as JSON like this:

```json
 {
  "type": "aside",
  "content": [

  ],
  "style": "important"
}
```

...for a set of standard styles ("tip", "important", "experiment", etc.). These styles are defined in the [Swift Markdown package](https://github.com/apple/swift-markdown/blob/main/Sources/Markdown/Interpretive%20Nodes/Aside.swift#L25).

Aside blocks can also use a custom style that is not defined in Swift Markdown, in which case DocC will encode the aside as JSON by setting style="note" and then appending an optional name attribute:


```json
 {
  "type": "aside",
  "content": [

  ],
  "style": "note",
  "name": "Some Custom Title"
}
```

When decoding asides, DocC uses the opposite logic: If both style="note" and a name attribute is present, then set the style to the given name. Otherwise, directly save the style.

However, this makes it impossible to parse JSON containing asides that might be generated by other tools which do not follow the rule about style="note". The code change in this PR allows `RenderBlockContent#init(from decoder:)` to be a bit more flexible when decoding JSON. After merging this change, DocC will always save the value of the name attribute as the style if it is present, regardless of what style is set to.

For example, while parsing this JSON:

```json
 {
  "type": "aside",
  "content": [

  ],
  "style": "important",
  "name": "Some Custom Title"
}
```

... DocC will discard "important" and instead set style="Some Custom Title".

## Dependencies

None.

## Testing

Create an aside in some documentation with a custom style, for example like this:

```
## Overview

> Custom Title: this is an important note.
```

Then compile the content, find the Render JSON file representing this page, and find the encoded version of this aside. For example:

```
jq < .docc-build/data/documentation/testasides.json '.primaryContentSections[0].content[1]'
{
  "name": "Custom Title",
  "style": "note",
  "type": "aside",
  "content": [
    {
      "type": "paragraph",
      "inlineContent": [
        {
          "type": "text",
          "text": "this is an important note."
        }
      ]
    }
  ]
}
```

Manually edit the JSON and set the style attribute to some other value, such as "important:"

```
jq < .docc-build/data/documentation/testasides.json '.primaryContentSections[0].content[1]' 
{
  "name": "Custom Title",
  "style": "important",
  "type": "aside",
  "content": [
    {
      "type": "paragraph",
      "inlineContent": [
        {
          "type": "text",
          "text": "this is an important note."
        }
      ]
    }
  ]
}
```

Now write a small Swift program that parses this modified JSON file and displays the custom title of this aside:

```
let path = "file:///path/to/testasides.json"
if let url = URL(string: path) {
    let data = try Data(contentsOf: url)
    let renderNode = try JSONDecoder().decode(RenderNode.self, from: data)
    let sec = renderNode.primaryContentSections[0] as! ContentRenderSection
    if case let .aside(aside) = sec.content[1] {
        print("Custom Aside Title: \(aside.style.displayName)")
    }
}
```

It should display the custom title, and not "important:"

```
Custom Aside Title: Custom Title
```

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x ] Ran the `./bin/test` script and it succeeded
~~- [ ] Updated documentation if necessary``
