### PR TITLE
Update the DocC documentation script so that it works with the changes to the merge command

### DIFF
--- a/Sources/SwiftDocCUtilities/Action/Actions/MergeAction.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/MergeAction.swift
@@ -40,18 +40,15 @@ struct MergeAction: Action {
         }
         var combinedJSONIndex = try JSONDecoder().decode(RenderIndex.self, from: jsonIndexData)
         
+        // Ensure that the destination has a data directory in case the first archive didn't have any pages.
+        try? fileManager.createDirectory(at: targetURL.appendingPathComponent("data", isDirectory: true), withIntermediateDirectories: false, attributes: nil)
+        
         for archive in archives.dropFirst() {
             for directoryToCopy in ["data/documentation", "data/tutorials", "documentation", "tutorials", "images", "videos", "downloads"] {
                 let fromDirectory = archive.appendingPathComponent(directoryToCopy, isDirectory: true)
                 let toDirectory = targetURL.appendingPathComponent(directoryToCopy, isDirectory: true)
 
-                var mkdir_p = false
                 for from in (try? fileManager.contentsOfDirectory(at: fromDirectory, includingPropertiesForKeys: nil, options: .skipsHiddenFiles)) ?? [] {
-                    // Create the full path to the destination directory if necessary, once for each directory to copy
-                    if !mkdir_p {
-                        try fileManager.createDirectory(at: toDirectory, withIntermediateDirectories: true, attributes: nil)
-                        mkdir_p = true
-                    }
                     // Copy each file or subdirectory
                     try fileManager.copyItem(at: from, to: toDirectory.appendingPathComponent(from.lastPathComponent))
                 }

--- a/Sources/SwiftDocCUtilities/Action/Actions/MergeAction.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/MergeAction.swift
@@ -171,7 +171,9 @@ struct MergeAction: Action {
                 || fileManager.directoryExists(atPath: $0.appendingPathComponent("tutorials").path)
         }
         
-        guard archivesWithStaticHostingSupport.count == nonEmptyArchives.count else {
+        guard archivesWithStaticHostingSupport.count == nonEmptyArchives.count // All archives support static hosting
+           || archivesWithStaticHostingSupport.count == 0 // No archives support static hosting
+        else {
             struct DifferentStaticHostingSupportError: DescribedError {
                 var withSupport: Set<String>
                 var withoutSupport: Set<String>

--- a/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
@@ -96,7 +96,7 @@ class ConvertActionTests: XCTestCase {
             currentPlatforms: nil,
             dataProvider: testDataProvider,
             fileManager: testDataProvider,
-            temporaryDirectory: createTemporaryDirectory())
+            temporaryDirectory: testDataProvider.uniqueTemporaryDirectory())
         let result = try action.perform(logHandle: .none)
         
         // Verify that the following files and folder exist at the output location
@@ -145,7 +145,7 @@ class ConvertActionTests: XCTestCase {
             currentPlatforms: nil,
             dataProvider: testDataProvider,
             fileManager: testDataProvider,
-            temporaryDirectory: createTemporaryDirectory())
+            temporaryDirectory: testDataProvider.uniqueTemporaryDirectory())
         let result = try action.perform(logHandle: .none)
         
         // Verify that the following files and folder exist at the output location
@@ -206,7 +206,7 @@ class ConvertActionTests: XCTestCase {
             currentPlatforms: nil,
             dataProvider: testDataProvider,
             fileManager: testDataProvider,
-            temporaryDirectory: createTemporaryDirectory())
+            temporaryDirectory: testDataProvider.uniqueTemporaryDirectory())
         let result = try action.perform(logHandle: .none)
         
         // Verify that the following files and folder exist at the output location
@@ -242,7 +242,7 @@ class ConvertActionTests: XCTestCase {
             currentPlatforms: nil,
             dataProvider: testDataProvider,
             fileManager: testDataProvider,
-            temporaryDirectory: createTemporaryDirectory())
+            temporaryDirectory: testDataProvider.uniqueTemporaryDirectory())
         let result = try action.perform(logHandle: .none)
         
         // Verify that the following files and folder exist at the output location
@@ -275,7 +275,7 @@ class ConvertActionTests: XCTestCase {
             currentPlatforms: nil,
             dataProvider: testDataProvider,
             fileManager: testDataProvider,
-            temporaryDirectory: createTemporaryDirectory())
+            temporaryDirectory: testDataProvider.uniqueTemporaryDirectory())
         let result = try action.perform(logHandle: .none)
         XCTAssertEqual(result.problems.count, 0)
     }
@@ -308,7 +308,7 @@ class ConvertActionTests: XCTestCase {
             emitDigest: false,
             currentPlatforms: nil,
             fileManager: testDataProvider,
-            temporaryDirectory: createTemporaryDirectory(),
+            temporaryDirectory: testDataProvider.uniqueTemporaryDirectory(),
             bundleDiscoveryOptions: BundleDiscoveryOptions(
                 infoPlistFallbacks: infoPlistFallbacks,
                 additionalSymbolGraphFiles: [URL(fileURLWithPath: "/Not-a-doc-bundle/MyKit.symbols.json")]
@@ -373,7 +373,7 @@ class ConvertActionTests: XCTestCase {
             currentPlatforms: nil,
             dataProvider: testDataProvider,
             fileManager: testDataProvider,
-            temporaryDirectory: createTemporaryDirectory())
+            temporaryDirectory: testDataProvider.uniqueTemporaryDirectory())
         
         let targetURL = target.absoluteURL.appendingPathComponent("output")
         
@@ -410,7 +410,7 @@ class ConvertActionTests: XCTestCase {
             currentPlatforms: nil,
             dataProvider: testDataProvider,
             fileManager: testDataProvider,
-            temporaryDirectory: createTemporaryDirectory())
+            temporaryDirectory: testDataProvider.uniqueTemporaryDirectory())
         
         let targetURL = target.absoluteURL.appendingPathComponent("target").appendingPathComponent("output")
         
@@ -439,7 +439,7 @@ class ConvertActionTests: XCTestCase {
             currentPlatforms: nil,
             dataProvider: testDataProvider,
             fileManager: testDataProvider,
-            temporaryDirectory: createTemporaryDirectory())
+            temporaryDirectory: testDataProvider.uniqueTemporaryDirectory())
         let result = try action.perform(logHandle: .none)
         
         // Verify that the following files and folder exist at the output location
@@ -482,7 +482,7 @@ class ConvertActionTests: XCTestCase {
             currentPlatforms: nil,
             dataProvider: testDataProvider,
             fileManager: testDataProvider,
-            temporaryDirectory: createTemporaryDirectory())
+            temporaryDirectory: testDataProvider.uniqueTemporaryDirectory())
         let result = try action.perform(logHandle: .none)
         
         // Construct the URLs for the produced render json:
@@ -552,7 +552,7 @@ class ConvertActionTests: XCTestCase {
             currentPlatforms: nil,
             dataProvider: testDataProvider,
             fileManager: testDataProvider,
-            temporaryDirectory: createTemporaryDirectory())
+            temporaryDirectory: testDataProvider.uniqueTemporaryDirectory())
         let result = try action.perform(logHandle: .none)
         
         // Construct the URLs for the produced render json:
@@ -640,7 +640,7 @@ class ConvertActionTests: XCTestCase {
             currentPlatforms: nil,
             dataProvider: testDataProvider,
             fileManager: testDataProvider,
-            temporaryDirectory: createTemporaryDirectory())
+            temporaryDirectory: testDataProvider.uniqueTemporaryDirectory())
         let result = try action.perform(logHandle: .none)
 
         // Verify that the following files and folder exist at the output location
@@ -700,7 +700,7 @@ class ConvertActionTests: XCTestCase {
             currentPlatforms: nil,
             dataProvider: testDataProvider,
             fileManager: testDataProvider,
-            temporaryDirectory: createTemporaryDirectory(),
+            temporaryDirectory: testDataProvider.uniqueTemporaryDirectory(),
             diagnosticLevel: "hint") // report all errors during the test
         let result = try action.perform(logHandle: .none)
 
@@ -781,7 +781,7 @@ class ConvertActionTests: XCTestCase {
             currentPlatforms: nil,
             dataProvider: testDataProvider,
             fileManager: testDataProvider,
-            temporaryDirectory: createTemporaryDirectory(),
+            temporaryDirectory: testDataProvider.uniqueTemporaryDirectory(),
             diagnosticLevel: "hint") // report all errors during the test
         let result = try action.perform(logHandle: .none)
 
@@ -867,7 +867,7 @@ class ConvertActionTests: XCTestCase {
                 currentPlatforms: nil,
                 dataProvider: testDataProvider,
                 fileManager: testDataProvider,
-                temporaryDirectory: createTemporaryDirectory())
+                temporaryDirectory: testDataProvider.uniqueTemporaryDirectory())
             let result = try action.perform(logHandle: .none)
             
             XCTAssertFalse(
@@ -897,7 +897,7 @@ class ConvertActionTests: XCTestCase {
                 currentPlatforms: nil,
                 dataProvider: testDataProvider,
                 fileManager: testDataProvider,
-                temporaryDirectory: createTemporaryDirectory())
+                temporaryDirectory: testDataProvider.uniqueTemporaryDirectory())
             let result = try action.perform(logHandle: .none)
 
             XCTAssert(
@@ -936,7 +936,7 @@ class ConvertActionTests: XCTestCase {
             currentPlatforms: nil,
             dataProvider: testDataProvider,
             fileManager: testDataProvider,
-            temporaryDirectory: createTemporaryDirectory())
+            temporaryDirectory: testDataProvider.uniqueTemporaryDirectory())
         let result = try action.perform(logHandle: .none)
 
         // Verify that the following files and folder exist at the output location
@@ -1039,7 +1039,7 @@ class ConvertActionTests: XCTestCase {
             currentPlatforms: nil,
             dataProvider: testDataProvider,
             fileManager: testDataProvider,
-            temporaryDirectory: createTemporaryDirectory())
+            temporaryDirectory: testDataProvider.uniqueTemporaryDirectory())
         let result = try action.perform(logHandle: .none)
 
         // Because the page order isn't deterministic, we create the indexing records and linkable entities in the same order as the pages.
@@ -1310,7 +1310,8 @@ class ConvertActionTests: XCTestCase {
             currentPlatforms: nil,
             dataProvider: testDataProvider,
             fileManager: testDataProvider,
-            temporaryDirectory: createTemporaryDirectory())
+            temporaryDirectory: testDataProvider.uniqueTemporaryDirectory()
+        )
         let result = try action.perform(logHandle: .none)
 
         func contentsOfJSONFile<Result: Decodable>(url: URL) -> Result? {
@@ -1400,7 +1401,8 @@ class ConvertActionTests: XCTestCase {
             currentPlatforms: nil,
             dataProvider: testDataProvider,
             fileManager: testDataProvider,
-            temporaryDirectory: createTemporaryDirectory())
+            temporaryDirectory: testDataProvider.uniqueTemporaryDirectory()
+        )
         let result = try action.perform(logHandle: .none)
         
         // Because the page order isn't deterministic, we create the indexing records and linkable entities in the same order as the pages.
@@ -1562,7 +1564,8 @@ class ConvertActionTests: XCTestCase {
                 currentPlatforms: nil,
                 dataProvider: testDataProvider,
                 fileManager: testDataProvider,
-                temporaryDirectory: createTemporaryDirectory())
+                temporaryDirectory: testDataProvider.uniqueTemporaryDirectory()
+            )
             let result = try action.perform(logHandle: .none)
             
             XCTAssertTrue(testDataProvider.fileExists(atPath: result.outputs[0].appendingPathComponent("assets.json").path))
@@ -1587,7 +1590,8 @@ class ConvertActionTests: XCTestCase {
                 currentPlatforms: nil,
                 dataProvider: testDataProvider,
                 fileManager: testDataProvider,
-                temporaryDirectory: createTemporaryDirectory())
+                temporaryDirectory: testDataProvider.uniqueTemporaryDirectory()
+            )
             let result = try action.perform(logHandle: .none)
             
             XCTAssertFalse(testDataProvider.fileExists(atPath: result.outputs[0].appendingPathComponent("assets.json").path))
@@ -1651,7 +1655,7 @@ class ConvertActionTests: XCTestCase {
                 currentPlatforms: nil,
                 dataProvider: testDataProvider,
                 fileManager: testDataProvider,
-                temporaryDirectory: createTemporaryDirectory(),
+                temporaryDirectory: testDataProvider.uniqueTemporaryDirectory(),
                 documentationCoverageOptions: .noCoverage)
             let result = try action.perform(logHandle: .none)
 
@@ -1678,7 +1682,7 @@ class ConvertActionTests: XCTestCase {
                 currentPlatforms: nil,
                 dataProvider: testDataProvider,
                 fileManager: testDataProvider,
-                temporaryDirectory: createTemporaryDirectory(),
+                temporaryDirectory: testDataProvider.uniqueTemporaryDirectory(),
                 documentationCoverageOptions: DocumentationCoverageOptions(level: .brief))
             let result = try action.perform(logHandle: .none)
 
@@ -1706,7 +1710,7 @@ class ConvertActionTests: XCTestCase {
                 currentPlatforms: nil,
                 dataProvider: testDataProvider,
                 fileManager: testDataProvider,
-                temporaryDirectory: createTemporaryDirectory(),
+                temporaryDirectory: testDataProvider.uniqueTemporaryDirectory(),
                 documentationCoverageOptions: DocumentationCoverageOptions(level: .detailed))
             let result = try action.perform(logHandle: .none)
 
@@ -1747,7 +1751,8 @@ class ConvertActionTests: XCTestCase {
             ],
             dataProvider: testDataProvider,
             fileManager: testDataProvider,
-            temporaryDirectory: createTemporaryDirectory())
+            temporaryDirectory: testDataProvider.uniqueTemporaryDirectory()
+        )
         
         XCTAssertEqual(action.context.externalMetadata.currentPlatforms, [
             "platform1" : PlatformVersion(.init(10, 11, 12), beta: false),
@@ -1778,7 +1783,8 @@ class ConvertActionTests: XCTestCase {
             currentPlatforms: [:],
             dataProvider: testDataProvider,
             fileManager: testDataProvider,
-            temporaryDirectory: createTemporaryDirectory())
+            temporaryDirectory: testDataProvider.uniqueTemporaryDirectory()
+        )
         
         _ = try action.perform(logHandle: .none)
         
@@ -1807,7 +1813,7 @@ class ConvertActionTests: XCTestCase {
                 currentPlatforms: nil,
                 dataProvider: testDataProvider,
                 fileManager: testDataProvider,
-                temporaryDirectory: createTemporaryDirectory(),
+                temporaryDirectory: testDataProvider.uniqueTemporaryDirectory(),
                 diagnosticEngine: engine)
             let result = try action.perform(logHandle: .none)
             XCTAssertFalse(result.didEncounterError)
@@ -1858,7 +1864,8 @@ class ConvertActionTests: XCTestCase {
                 currentPlatforms: nil,
                 dataProvider: testDataProvider,
                 fileManager: testDataProvider,
-                temporaryDirectory: createTemporaryDirectory())
+                temporaryDirectory: testDataProvider.uniqueTemporaryDirectory()
+            )
             
             action.converter.batchNodeCount = batchSize
             
@@ -1938,7 +1945,7 @@ class ConvertActionTests: XCTestCase {
                 currentPlatforms: nil,
                 dataProvider: testFileSystem,
                 fileManager: testFileSystem,
-                temporaryDirectory: createTemporaryDirectory()
+                temporaryDirectory: testFileSystem.uniqueTemporaryDirectory()
             )
             action.diagnosticEngine.consumers.sync { $0.removeAll() } 
             
@@ -2275,7 +2282,7 @@ class ConvertActionTests: XCTestCase {
             currentPlatforms: nil,
             dataProvider: testDataProvider,
             fileManager: testDataProvider,
-            temporaryDirectory: createTemporaryDirectory(),
+            temporaryDirectory: testDataProvider.uniqueTemporaryDirectory(),
             diagnosticLevel: "error",
             diagnosticEngine: engine
         )
@@ -2313,7 +2320,7 @@ class ConvertActionTests: XCTestCase {
             currentPlatforms: nil,
             dataProvider: testDataProvider,
             fileManager: testDataProvider,
-            temporaryDirectory: createTemporaryDirectory(),
+            temporaryDirectory: testDataProvider.uniqueTemporaryDirectory(),
             diagnosticLevel: "error",
             diagnosticEngine: engine
         )
@@ -2352,7 +2359,7 @@ class ConvertActionTests: XCTestCase {
             currentPlatforms: nil,
             dataProvider: testDataProvider,
             fileManager: testDataProvider,
-            temporaryDirectory: createTemporaryDirectory(),
+            temporaryDirectory: testDataProvider.uniqueTemporaryDirectory(),
             diagnosticLevel: "error"
         )
         XCTAssertThrowsError(try action.performAndHandleResult(logHandle: .none)) { error in
@@ -2377,6 +2384,7 @@ class ConvertActionTests: XCTestCase {
         let targetDirectory = URL(fileURLWithPath: testDataProvider.currentDirectoryPath)
             .appendingPathComponent("target", isDirectory: true)
 
+        // TODO: Support TestFileSystem in DiagnosticFileWriter
         let diagnosticFile = try createTemporaryDirectory().appendingPathComponent("test-diagnostics.json")
         
         var action = try ConvertAction(
@@ -2389,11 +2397,12 @@ class ConvertActionTests: XCTestCase {
             currentPlatforms: nil,
             dataProvider: testDataProvider,
             fileManager: testDataProvider,
-            temporaryDirectory: createTemporaryDirectory(),
+            temporaryDirectory: testDataProvider.uniqueTemporaryDirectory(),
             diagnosticLevel: "error",
             diagnosticFilePath: diagnosticFile
         )
         
+        // TODO: Support TestFileSystem in DiagnosticFileWriter
         XCTAssertFalse(FileManager.default.fileExists(atPath: diagnosticFile.path), "Diagnostic file doesn't exist before")
         XCTAssertThrowsError(try action.performAndHandleResult(logHandle: .none)) { error in
             XCTAssert(error is ErrorsEncountered, "Unexpected error type thrown by \(ConvertAction.self)")
@@ -2424,7 +2433,7 @@ class ConvertActionTests: XCTestCase {
                 currentPlatforms: nil,
                 dataProvider: testDataProvider,
                 fileManager: testDataProvider,
-                temporaryDirectory: createTemporaryDirectory(),
+                temporaryDirectory: testDataProvider.uniqueTemporaryDirectory(),
                 inheritDocs: flag)
             XCTAssertEqual(action.context.externalMetadata.inheritDocs, flag)
         }
@@ -2440,7 +2449,7 @@ class ConvertActionTests: XCTestCase {
             currentPlatforms: nil,
             dataProvider: testDataProvider,
             fileManager: testDataProvider,
-            temporaryDirectory: createTemporaryDirectory())
+            temporaryDirectory: testDataProvider.uniqueTemporaryDirectory())
         XCTAssertEqual(action.context.externalMetadata.inheritDocs, false)
     }
     
@@ -2467,7 +2476,7 @@ class ConvertActionTests: XCTestCase {
             currentPlatforms: nil,
             dataProvider: testDataProvider,
             fileManager: testDataProvider,
-            temporaryDirectory: createTemporaryDirectory()
+            temporaryDirectory: testDataProvider.uniqueTemporaryDirectory()
         )
         
         XCTAssertThrowsError(try action.performAndHandleResult(logHandle: .none), "The test bundle should have thrown an error about an incomplete symbol graph file")
@@ -2536,7 +2545,7 @@ class ConvertActionTests: XCTestCase {
             currentPlatforms: nil,
             dataProvider: testDataProvider,
             fileManager: testDataProvider,
-            temporaryDirectory: createTemporaryDirectory()
+            temporaryDirectory: testDataProvider.uniqueTemporaryDirectory()
         )
         let result = try action.perform(logHandle: .none)
         
@@ -2887,7 +2896,7 @@ class ConvertActionTests: XCTestCase {
                 currentPlatforms: nil,
                 dataProvider: testDataProvider,
                 fileManager: testDataProvider,
-                temporaryDirectory: createTemporaryDirectory(),
+                temporaryDirectory: testDataProvider.uniqueTemporaryDirectory(),
                 diagnosticEngine: engine
             )
             let result = try action.perform(logHandle: .none)
@@ -2909,7 +2918,7 @@ class ConvertActionTests: XCTestCase {
                 currentPlatforms: nil,
                 dataProvider: testDataProvider,
                 fileManager: testDataProvider,
-                temporaryDirectory: createTemporaryDirectory(),
+                temporaryDirectory: testDataProvider.uniqueTemporaryDirectory(),
                 diagnosticEngine: engine
             )
             let result = try action.perform(logHandle: .none)
@@ -2928,7 +2937,7 @@ class ConvertActionTests: XCTestCase {
                 currentPlatforms: nil,
                 dataProvider: testDataProvider,
                 fileManager: testDataProvider,
-                temporaryDirectory: createTemporaryDirectory(),
+                temporaryDirectory: testDataProvider.uniqueTemporaryDirectory(),
                 diagnosticEngine: nil,
                 treatWarningsAsErrors: true
             )
@@ -2960,7 +2969,7 @@ class ConvertActionTests: XCTestCase {
             emitDigest: false,
             currentPlatforms: nil,
             fileManager: testDataProvider,
-                temporaryDirectory: createTemporaryDirectory(),
+            temporaryDirectory: testDataProvider.uniqueTemporaryDirectory(),
             bundleDiscoveryOptions: BundleDiscoveryOptions(
                 additionalSymbolGraphFiles: [URL(fileURLWithPath: "/Not-a-doc-bundle/MyKit.symbols.json")]
             )
@@ -3007,7 +3016,7 @@ class ConvertActionTests: XCTestCase {
             emitDigest: false,
             currentPlatforms: nil,
             fileManager: testDataProvider,
-                temporaryDirectory: createTemporaryDirectory(),
+            temporaryDirectory: testDataProvider.uniqueTemporaryDirectory(),
             bundleDiscoveryOptions: BundleDiscoveryOptions(
                 infoPlistFallbacks: infoPlistFallbacks,
                 additionalSymbolGraphFiles: [
@@ -3176,7 +3185,7 @@ class ConvertActionTests: XCTestCase {
             currentPlatforms: nil,
             dataProvider: testDataProvider,
             fileManager: testDataProvider,
-            temporaryDirectory: createTemporaryDirectory(),
+            temporaryDirectory: testDataProvider.uniqueTemporaryDirectory(),
             diagnosticEngine: engine
         )
         

--- a/Tests/SwiftDocCUtilitiesTests/Utility/TestFileSystemTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/Utility/TestFileSystemTests.swift
@@ -20,7 +20,7 @@ class TestFileSystemTests: XCTestCase {
         XCTAssertTrue(try fs.bundles().isEmpty)
         var isDirectory = ObjCBool(false)
         XCTAssertTrue(fs.fileExists(atPath: "/", isDirectory: &isDirectory))
-        XCTAssertEqual(fs.files.keys.sorted(), ["/"], "The root (/) should be the only existing path.")
+        XCTAssertEqual(fs.files.keys.sorted(), ["/", "/tmp"], "The root (/) should be the only existing path.")
         XCTAssertTrue(isDirectory.boolValue)
         XCTAssertFalse(fs.disableWriting)
     }
@@ -50,9 +50,10 @@ class TestFileSystemTests: XCTestCase {
         XCTAssertEqual(fs.dump(), """
         /
         ├─ additional/
-        ╰─ main/
-           ╰─ nested/
-              ╰─ myfile.txt
+        ├─ main/
+        │  ╰─ nested/
+        │     ╰─ myfile.txt
+        ╰─ tmp/
         """)
     }
 
@@ -68,10 +69,11 @@ class TestFileSystemTests: XCTestCase {
         
         XCTAssertEqual(fs.dump(), """
         /
-        ╰─ main/
-           ╰─ nested/
-              ├─ myfile1.txt
-              ╰─ myfile2.txt
+        ├─ main/
+        │  ╰─ nested/
+        │     ├─ myfile1.txt
+        │     ╰─ myfile2.txt
+        ╰─ tmp/
         """)
 
         return fs
@@ -81,10 +83,11 @@ class TestFileSystemTests: XCTestCase {
         let fs = try makeTestFS()
         XCTAssertEqual(fs.dump(), """
         /
-        ╰─ main/
-           ╰─ nested/
-              ├─ myfile1.txt
-              ╰─ myfile2.txt
+        ├─ main/
+        │  ╰─ nested/
+        │     ├─ myfile1.txt
+        │     ╰─ myfile2.txt
+        ╰─ tmp/
         """)
         
         XCTAssertEqual(fs.dump(subHierarchyFrom: "/main"), """
@@ -107,11 +110,12 @@ class TestFileSystemTests: XCTestCase {
         try fs.copyItem(at: URL(string: "/main/nested/myfile1.txt")!, to: URL(string: "/main/myfile1.txt")!)
         XCTAssertEqual(fs.dump(), """
         /
-        ╰─ main/
-           ├─ myfile1.txt
-           ╰─ nested/
-              ├─ myfile1.txt
-              ╰─ myfile2.txt
+        ├─ main/
+        │  ├─ myfile1.txt
+        │  ╰─ nested/
+        │     ├─ myfile1.txt
+        │     ╰─ myfile2.txt
+        ╰─ tmp/
         """)
     }
 
@@ -124,10 +128,11 @@ class TestFileSystemTests: XCTestCase {
         ├─ copy/
         │  ├─ myfile1.txt
         │  ╰─ myfile2.txt
-        ╰─ main/
-           ╰─ nested/
-              ├─ myfile1.txt
-              ╰─ myfile2.txt
+        ├─ main/
+        │  ╰─ nested/
+        │     ├─ myfile1.txt
+        │     ╰─ myfile2.txt
+        ╰─ tmp/
         """)
     }
 
@@ -138,10 +143,11 @@ class TestFileSystemTests: XCTestCase {
         try fs.moveItem(at: URL(string: "/main/nested/myfile1.txt")!, to: URL(string: "/main/myfile1.txt")!)
         XCTAssertEqual(fs.dump(), """
         /
-        ╰─ main/
-           ├─ myfile1.txt
-           ╰─ nested/
-              ╰─ myfile2.txt
+        ├─ main/
+        │  ├─ myfile1.txt
+        │  ╰─ nested/
+        │     ╰─ myfile2.txt
+        ╰─ tmp/
         """)
     }
 
@@ -151,10 +157,11 @@ class TestFileSystemTests: XCTestCase {
         try fs.moveItem(at: URL(string: "/main/nested")!, to: URL(string: "/main/new")!)
         XCTAssertEqual(fs.dump(), """
         /
-        ╰─ main/
-           ╰─ new/
-              ├─ myfile1.txt
-              ╰─ myfile2.txt
+        ├─ main/
+        │  ╰─ new/
+        │     ├─ myfile1.txt
+        │     ╰─ myfile2.txt
+        ╰─ tmp/
         """)
     }
     
@@ -164,9 +171,10 @@ class TestFileSystemTests: XCTestCase {
         try fs.removeItem(at: URL(string: "/main/nested/myfile1.txt")!)
         XCTAssertEqual(fs.dump(), """
         /
-        ╰─ main/
-           ╰─ nested/
-              ╰─ myfile2.txt
+        ├─ main/
+        │  ╰─ nested/
+        │     ╰─ myfile2.txt
+        ╰─ tmp/
         """)
     }
 
@@ -176,7 +184,8 @@ class TestFileSystemTests: XCTestCase {
         try fs.removeItem(at: URL(string: "/main/nested")!)
         XCTAssertEqual(fs.dump(), """
         /
-        ╰─ main/
+        ├─ main/
+        ╰─ tmp/
         """)
     }
 
@@ -194,22 +203,24 @@ class TestFileSystemTests: XCTestCase {
         try fs.createDirectory(at: URL(string: "/main/nested/inner")!, withIntermediateDirectories: false)
         XCTAssertEqual(fs.dump(), """
         /
-        ╰─ main/
-           ╰─ nested/
-              ├─ inner/
-              ├─ myfile1.txt
-              ╰─ myfile2.txt
+        ├─ main/
+        │  ╰─ nested/
+        │     ├─ inner/
+        │     ├─ myfile1.txt
+        │     ╰─ myfile2.txt
+        ╰─ tmp/
         """)
 
         try fs.createDirectory(at: URL(string: "/main/nested/inner2")!, withIntermediateDirectories: true)
         XCTAssertEqual(fs.dump(), """
         /
-        ╰─ main/
-           ╰─ nested/
-              ├─ inner/
-              ├─ inner2/
-              ├─ myfile1.txt
-              ╰─ myfile2.txt
+        ├─ main/
+        │  ╰─ nested/
+        │     ├─ inner/
+        │     ├─ inner2/
+        │     ├─ myfile1.txt
+        │     ╰─ myfile2.txt
+        ╰─ tmp/
         """)
 
         // Test it throws when parent folder is missing
@@ -219,14 +230,15 @@ class TestFileSystemTests: XCTestCase {
         try fs.createDirectory(at: URL(string: "/main/nested/missing/inner4")!, withIntermediateDirectories: true)
         XCTAssertEqual(fs.dump(), """
         /
-        ╰─ main/
-           ╰─ nested/
-              ├─ inner/
-              ├─ inner2/
-              ├─ missing/
-              │  ╰─ inner4/
-              ├─ myfile1.txt
-              ╰─ myfile2.txt
+        ├─ main/
+        │  ╰─ nested/
+        │     ├─ inner/
+        │     ├─ inner2/
+        │     ├─ missing/
+        │     │  ╰─ inner4/
+        │     ├─ myfile1.txt
+        │     ╰─ myfile2.txt
+        ╰─ tmp/
         """)
     }
     
@@ -238,12 +250,13 @@ class TestFileSystemTests: XCTestCase {
         
         XCTAssertEqual(fs.dump(), """
         /
-        ╰─ one/
-           ╰─ two/
-              ╰─ three/
-                 ╰─ four/
-                    ╰─ five/
-                       ╰─ six/
+        ├─ one/
+        │  ╰─ two/
+        │     ╰─ three/
+        │        ╰─ four/
+        │           ╰─ five/
+        │              ╰─ six/
+        ╰─ tmp/
         """)
     }
     

--- a/bin/update-gh-pages-documentation-site
+++ b/bin/update-gh-pages-documentation-site
@@ -76,6 +76,9 @@ swift package \
 
 echo -e "\033[34;1m Merging docs \033q[0m"
 
+# Remove the output directory so that the merge command can output there
+rm -rf "$SWIFT_DOCC_ROOT/gh-pages/docs"
+
 # Merge the SwiftDocCUtilities docs into the primary SwiftDocC docs
 swift run docc merge \
     "$DOCC_OUTPUT_DIR" \


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://124270602

## Summary

This small follow up PR to #821 updates the script that DocC uses to build and host its contributor documentation to work the the latest changes to the merge command and moves some directory creation code out of a loop.

## Dependencies

None

## Testing

Nothing in particular

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
