### PR TITLE
Update year in footer for hosted documentation to 2024

### DIFF
--- a/Sources/docc/DocCDocumentation.docc/footer.html
+++ b/Sources/docc/DocCDocumentation.docc/footer.html
@@ -1,7 +1,7 @@
 <!--
   This source file is part of the Swift.org open source project
 
-  Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
+  Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
   Licensed under Apache License v2.0 with Runtime Library Exception
 
   See https://swift.org/LICENSE.txt for license information
@@ -11,7 +11,7 @@
 <footer id="footer" role="contentinfo" hidden>
   <div class="container">
     <div>
-      <p class="copyright">Copyright © 2023 Apple Inc. All rights reserved.</p>
+      <p class="copyright">Copyright © 2024 Apple Inc. All rights reserved.</p>
       <p class="trademark">Swift and the Swift logo are trademarks of Apple Inc.</p>
       <p class="privacy">
         <a href="//www.apple.com/privacy/privacy-policy/">Privacy Policy</a>


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://123145742

## Summary

This updates the year in the custom footer that DocC uses in its hosted documentation on Swift.org

## Dependencies

None

## Testing

Build DocC documentation with custom templates enabled
```sh
xcrun docc preview Sources/docc/DocCDocumentation.docc --experimental-enable-custom-templates
```

Inspect the year in the footer

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- ~[ ] Added tests~
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
