### PR TITLE
Use the asset's per module file path in the render JSON

### DIFF
--- a/Sources/SwiftDocCUtilities/Action/Actions/Convert/JSONEncodingRenderNodeWriter.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Convert/JSONEncodingRenderNodeWriter.swift
@@ -78,8 +78,6 @@ class JSONEncodingRenderNodeWriter {
             }
         }
         
-        let encoder = RenderJSONEncoder.makeEncoder()
-        
         let data = try renderNode.encodeToJSON(with: encoder, renderReferenceCache: renderReferenceCache)
         try fileManager.createFile(at: renderNodeTargetFileURL, contents: data, options: nil)
         


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://123145729

## Summary

Fix a bug where images and other assets didn't encode the correct path because the configured encoder passed as an argument wasn't used.

Images still worked in the integrated preview server but didn't work in hosted environments, for example https://www.swift.org/documentation/docc/

## Dependencies

None.

## Testing

Build DocC's documentation 
```
swift run docc convert Sources/docc/DocCDocumentation.docc --output-dir /path/to/DocC.doccarchive
```

Preview the build documentation using a static hosting web server, not the `docc preview` command.

The image on the main DocC page should display.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
