### PR TITLE
Standardize platform name variances during Symbol Graph loading.

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphLoader.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphLoader.swift
@@ -362,30 +362,35 @@ extension SymbolGraph.Symbol.Availability.AvailabilityItem {
         guard let domain = self.domain else {
             return self
         }
+        
+        var newValue = self
+        // To ensure the uniformity of platform availability names derived from SGFs,
+        // we replace the original domain value with a value from the platform's name
+        // since the platform name maps aliases to the canonical name.
+        let platformName = PlatformName(operatingSystemName: domain.rawValue)
+        newValue.domain = SymbolGraph.Symbol.Availability.Domain(rawValue: platformName.rawValue)
 
         // If a symbol is unconditionally unavailable for a given domain,
         // don't add an introduced version here as it may cause it to
         // incorrectly display availability information
         guard !isUnconditionallyUnavailable else {
-            return self
+            return newValue
         }
 
         // If this had an explicit introduced version from source, don't replace it.
         guard introducedVersion == nil else {
-            return self
+            return newValue
         }
 
-        let platformName = PlatformName(operatingSystemName: domain.rawValue)
         let fallbackPlatformName = fallbackPlatform.map(PlatformName.init(operatingSystemName:))
         
         // Try to find a default version string for this availability
         // item's platform (a.k.a. domain)
         guard let platformVersion = defaults[platformName] ??
             fallbackPlatformName.flatMap({ defaults[$0] }) else {
-            return self
+            return newValue
         }
 
-        var newValue = self
         newValue.introducedVersion = platformVersion
         return newValue
     }

--- a/Sources/SwiftDocCTestUtilities/SymbolGraphCreation.swift
+++ b/Sources/SwiftDocCTestUtilities/SymbolGraphCreation.swift
@@ -29,7 +29,7 @@ extension XCTestCase {
         )
     }
     
-    public func makeSymbolGraphString(moduleName: String, symbols: String = "", relationships: String = "") -> String {
+    public func makeSymbolGraphString(moduleName: String, symbols: String = "", relationships: String = "", patform: String = "") -> String {
         return """
         {
           "metadata": {
@@ -42,7 +42,7 @@ extension XCTestCase {
           },
           "module": {
               "name": "\(moduleName)",
-              "platform": { }
+              "platform": { \(patform) }
           },
           "relationships" : [
             \(relationships)


### PR DESCRIPTION
<!--
If you're opening a PR to cherry-pick a change for a release branch, use this template instead:
https://github.com/apple/swift-docc/blob/main/.github/PULL_REQUEST_TEMPLATE/CHERRY_PICK.md
-->

Bug/issue #, if applicable:  rdar://116399438

## Summary

Fix a bug causing DocC to display repeated platforms due to variations in platform names between multiple SGFs and the Info.plist. This change unifies platform name variations into their canonical form during symbol graph loading.

## Dependencies

N/A

## Testing

Steps:
1. Preview the attached docs.
2. Assert that the symbol `A` only shows one tag for the platform 'Mac Catalyst'.

[116399438.docc.zip](https://github.com/apple/swift-docc/files/14330750/116399438.docc.zip)

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary (N/A)
