### PR TITLE
Clarify that links to tutorials don't need a /tutorials/ prefix

### DIFF
--- a/Sources/docc/DocCDocumentation.docc/linking-to-symbols-and-other-content.md
+++ b/Sources/docc/DocCDocumentation.docc/linking-to-symbols-and-other-content.md
@@ -180,14 +180,11 @@ text. Links to tutorials follow the same format.
 <doc:SlothCreator>
 ```
 
-If you have an article file and a tutorial file with the same base name you can add a leading `documentation` or `tutorials` component to the path, with or without a leading slash: 
+If you have an article file and a tutorial file with the same base name, DocC will resolve the `<doc:BaseName>` link to the article. To refer to the tutorial instead you can add a leading `tutorials` component to the path, with or without a leading slash: 
 
 ```markdown
-<doc:documentation/SlothCreator>
-<doc:tutorials/SlothCreator>
-
-<doc:/documentation/SlothCreator>
-<doc:/tutorials/SlothCreator>
+<doc:tutorials/BaseName>
+<doc:/tutorials/BaseName>
 ```
 
 > Tip: You can also link to symbols using the `<doc:>` syntax. Just insert the 

--- a/Sources/docc/DocCDocumentation.docc/linking-to-symbols-and-other-content.md
+++ b/Sources/docc/DocCDocumentation.docc/linking-to-symbols-and-other-content.md
@@ -166,18 +166,27 @@ path in either source language.
 ### Navigate to an Article
 
 To add a link to an article, use the less-than symbol (`<`), the `doc` keyword, 
-a colon (`:`), the name of the article, and a greater-than symbol 
-(`>`). Don't include the article's file extension in the name. 
+a colon (`:`), the article's file name without file extension, and a greater-than symbol 
+(`>`).  
 
-```
+```markdown
 <doc:GettingStarted>
 ```
 
 When DocC resolves the link, it uses the article's page title as the link's 
-text, and the article's filename as the link's URL. Links to tutorials follow 
-the same format, except you must add the `/tutorials/` prefix to the path: 
+text. Links to tutorials follow the same format. 
 
+```markdown
+<doc:SlothCreator>
 ```
+
+If you have an article file and a tutorial file with the same base name you can add a leading `documentation` or `tutorials` component to the path, with or without a leading slash: 
+
+```markdown
+<doc:documentation/SlothCreator>
+<doc:tutorials/SlothCreator>
+
+<doc:/documentation/SlothCreator>
 <doc:/tutorials/SlothCreator>
 ```
 
@@ -196,4 +205,4 @@ add the link's URL within the parentheses.
 [Apple](https://www.apple.com)
 ```
 
-<!-- Copyright (c) 2023 Apple Inc and the Swift Project authors. All Rights Reserved. -->
+<!-- Copyright (c) 2023-2024 Apple Inc and the Swift Project authors. All Rights Reserved. -->


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://124124417

## Summary

Clarify that links to tutorials don't _need_ a `/tutorials/` prefix. 

Also, document that it's possible to add a `/documentation/` prefix and give an example of when this could be useful.  

## Dependencies

None.

## Testing

None. This only changes documentation.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- ~[ ] Added tests~
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
