### PR TITLE
Avoid ambiguous `FileManager.temporaryDirectory` definition in tests on Swift CI

### DIFF
--- a/Sources/SwiftDocC/Utility/FileManagerProtocol.swift
+++ b/Sources/SwiftDocC/Utility/FileManagerProtocol.swift
@@ -50,9 +50,11 @@ public protocol FileManagerProtocol {
     /// Returns a list of items in a directory
     func contentsOfDirectory(atPath path: String) throws -> [String]
     func contentsOfDirectory(at url: URL, includingPropertiesForKeys keys: [URLResourceKey]?, options mask: FileManager.DirectoryEnumerationOptions) throws -> [URL]
-
-    /// The temporary directory for the current user.
-    var temporaryDirectory: URL { get }
+    
+    /// Returns a unique temporary directory.
+    ///
+    /// Each call to this function will return a new temporary directory.
+    func uniqueTemporaryDirectory() -> URL // Because we shadow 'FileManager.temporaryDirectory' in our tests, we can't also use 'temporaryDirectory' in FileManagerProtocol
     
     /// Creates a file with the specified `contents` at the specified location.
     ///
@@ -103,5 +105,10 @@ extension FileManager: FileManagerProtocol {
         } else {
             try contents.write(to: location)
         }
+    }
+    
+    // Because we shadow 'FileManager.temporaryDirectory' in our tests, we can't also use 'temporaryDirectory' in FileManagerProtocol/
+    public func uniqueTemporaryDirectory() -> URL {
+        temporaryDirectory.appendingPathComponent(ProcessInfo.processInfo.globallyUniqueString, isDirectory: true)
     }
 }

--- a/Sources/SwiftDocCTestUtilities/TestFileSystem.swift
+++ b/Sources/SwiftDocCTestUtilities/TestFileSystem.swift
@@ -42,7 +42,6 @@ import XCTest
 /// - Warning: Use this type for unit testing.
 @_spi(FileManagerProtocol) // This needs to be SPI because it conforms to an SPI protocol
 public class TestFileSystem: FileManagerProtocol, DocumentationWorkspaceDataProvider {
-    public let temporaryDirectory = URL(fileURLWithPath: "/tmp")
     public let currentDirectoryPath = "/"
     
     public var identifier: String = UUID().uuidString
@@ -325,6 +324,9 @@ public class TestFileSystem: FileManagerProtocol, DocumentationWorkspaceDataProv
         return output
     }
 
+    public func uniqueTemporaryDirectory() -> URL {
+        URL(fileURLWithPath: "/tmp/\(ProcessInfo.processInfo.globallyUniqueString)", isDirectory: true)
+    }
     
     enum Errors: DescribedError {
         case invalidPath(String)

--- a/Sources/SwiftDocCUtilities/Action/Actions/MergeAction.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/MergeAction.swift
@@ -27,7 +27,7 @@ struct MergeAction: Action {
         try validateThatOutputIsEmpty()
         try validateThatArchivesHaveDisjointData()
         
-        let targetURL = try Self.createUniqueDirectory(inside: fileManager.temporaryDirectory, template: firstArchive, fileManager: fileManager)
+        let targetURL = try Self.createUniqueDirectory(inside: fileManager.uniqueTemporaryDirectory(), template: firstArchive, fileManager: fileManager)
         defer {
             try? fileManager.removeItem(at: targetURL)
         }

--- a/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
@@ -3226,7 +3226,7 @@ class ConvertActionTests: XCTestCase {
             currentPlatforms: nil,
             dataProvider: fileSystem,
             fileManager: fileSystem,
-            temporaryDirectory: fileSystem.temporaryDirectory
+            temporaryDirectory: fileSystem.uniqueTemporaryDirectory()
         )
         
         let result = try action.perform(logHandle: .none)


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://123281955

## Summary

This avoids a Swift compiler crash in the latest 5.11 toolchain on Linux
```
1.	Swift version 5.11-dev (LLVM f74ee64f7c77089, Swift 53e268bf5bf88cb)
2.	Compiling with the current language version
3.	While evaluating request ExecuteSILPipelineRequest(Run pipelines { PrepareOptimizationPasses, EarlyModulePasses, HighLevel,Function+EarlyLoopOpt, HighLevel,Module+StackPromote, MidLevel,Function, ClosureSpecialize, LowLevel,Function, LateLoopOpt, SIL Debug Info Generator } on SIL for SwiftDocCUtilitiesTests)
4.	While running pass #15197 SILModuleTransform "PerformanceSILLinker".
5.	While deserializing SIL function "$s10Foundation11FileManagerC9SwiftDocC0bC8ProtocolA2dEP18temporaryDirectoryAA3URLVvgTW"
6.	*** DESERIALIZATION FAILURE ***
*** If any module named here was modified in the SDK, please delete the ***
*** new swiftmodule files from the SDK and keep only swiftinterfaces.   ***
module 'SwiftDocC', builder version '5.11(5.11)/Swift version 5.11-dev (LLVM f74ee64f7c77089, Swift 53e268bf5bf88cb)', built from source, non-resilient, loaded from '/home/build-user/build/buildbot_linux/unified-swiftpm-build-linux-x86_64/x86_64-unknown-linux-gnu/release/Modules/SwiftDocC.swiftmodule'
result is ambiguous (_)
Cross-reference to module 'Foundation'
... FileManager
... temporaryDirectory
... with type URL
... (getter)
```

## Dependencies

None.

## Testing

- Pull and build the `swiftlang/swift:nightly-jammy` Docker image.

- Run that image and run `swift test -c release`. 
  - The build and the tests should pass

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- ~[ ] Added tests~
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
