### PR TITLE
Fix crash when emitted diagnostics have incorrect source ranges

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Diagnostics/ANSIAnnotation.swift
+++ b/Sources/SwiftDocC/Infrastructure/Diagnostics/ANSIAnnotation.swift
@@ -38,8 +38,11 @@ struct ANSIAnnotation {
         self.trait = trait
     }
     
-    func applied(to message: String) -> String {
-        "\(code)\(message)\(ANSIAnnotation.normal.code)"
+    func applied<S: StringProtocol>(to message: S) -> String {
+        guard !message.isEmpty else {
+            return ""
+        }
+        return "\(code)\(message)\(ANSIAnnotation.normal.code)"
     }
     
     static var normal: ANSIAnnotation {

--- a/Tests/SwiftDocCTests/Diagnostics/DiagnosticConsoleWriterDefaultFormattingTest.swift
+++ b/Tests/SwiftDocCTests/Diagnostics/DiagnosticConsoleWriterDefaultFormattingTest.swift
@@ -270,7 +270,7 @@ class DiagnosticConsoleWriterDefaultFormattingTest: XCTestCase {
         let bundle = try XCTUnwrap(fs.bundles().first)
         let baseURL = bundle.baseURL
         let source = try XCTUnwrap(bundle.markupURLs.first)
-        let range = SourceLocation(line: 3, column: 18, source: source)..<SourceLocation(line: 3, column: 32, source: source)
+        let range = SourceLocation(line: 3, column: 18, source: source)..<SourceLocation(line: 3, column: 36, source: source)
 
         let logStorage = LogHandle.LogStorage()
         let consumer = DiagnosticConsoleWriter(LogHandle.memory(logStorage), baseURL: baseURL, highlight: true, fileManager: fs)
@@ -282,10 +282,10 @@ class DiagnosticConsoleWriterDefaultFormattingTest: XCTestCase {
         XCTAssertEqual(logStorage.text, """
         \u{001B}[1;33mwarning: \(summary)\u{001B}[0;0m
         \(explanation)
-         --> Something.docc/Nested folder/Article.md:3:18-3:32
+         --> Something.docc/Nested folder/Article.md:3:18-3:36
         1 | # Title
         2 |
-        3 + A short abstract \u{001B}[1;32mwith emoji \u{001B}[0;0m💻 in it.
+        3 + A short abstract \u{001B}[1;32mwith emoji 💻 in\u{001B}[0;0m it.
         4 |
         5 | @Metadata {
         """)


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://122345738

## Summary

This updates the default diagnostics formatter to skip highlighting the line if the diagnostic range is incorrect. 

Currently the default diagnostics formatter assumes that all the diagnostic ranges are correct and crashes—instead of printing any diagnostics—if they are not.

With these changes we'll also assert in debug builds if the diagnostic range is incorrect with extra information for us to investigate where the diagnostic with incorrect ranges originated from to help us fix the root cause of the incorrect diagnostic range. 

Because of this assertion we can't add a test that the diagnostic isn't highlighted when the range is incorrect. I feel that the assertion—helping us find and fix the root cause of these issues—is more valuable than that test.

## Dependencies

None.

## Testing

This issue currently reproduces with the main branch of the Swift Programming Language documentation catalog.

- Clone `git@github.com:apple/swift-book.git`
- Run `swift run docc convert /path/to/swift-book/TSPL.docc`
  This should fail with an assertion, since it's a debug build.
- Run `swift run --configuration release docc convert /path/to/swift-book/TSPL.docc`
  This should succeed and print a few diagnostics, where not all of the diagnostics will highlight the range in the displayed lines of markup. 

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [ ] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary
