### PR TITLE
Populate the "Attributes" section based on OAS data

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -1379,6 +1379,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
                     HTTPBodySectionTranslator(),
                     HTTPResponsesSectionTranslator(),
                     DictionaryKeysSectionTranslator(),
+                    AttributesSectionTranslator(),
                     ReturnsSectionTranslator(),
                     MentionsSectionTranslator(referencingSymbol: identifier),
                     DiscussionSectionTranslator(),

--- a/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/AttributesSectionTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/AttributesSectionTranslator.swift
@@ -60,13 +60,7 @@ struct AttributesSectionTranslator: RenderSectionTranslator {
                     case (.default, let value as SymbolGraph.AnyScalar):
                         return RenderAttribute.default(String(value))
                     case (.allowedTypes, let types as [SymbolGraph.Symbol.TypeDetail]):
-                        let tokens = types.compactMap {
-                            if let fragments = $0.fragments {
-                                return translateFragments(fragments)
-                            } else {
-                                return nil
-                            }
-                        }
+                        let tokens = types.compactMap { $0.fragments.map(translateFragments) }
                         return RenderAttribute.allowedTypes(tokens)
                     case (.allowedValues, let values as [SymbolGraph.AnyScalar]):
                         let stringValues = values.map { String($0) }

--- a/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/AttributesSectionTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/AttributesSectionTranslator.swift
@@ -1,0 +1,84 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2024 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+import SymbolKit
+
+/// Translates a symbol's constraints and details into a render node's Attributes section.
+struct AttributesSectionTranslator: RenderSectionTranslator {
+    func translateSection(
+        for symbol: Symbol,
+        renderNode: inout RenderNode,
+        renderNodeTranslator: inout RenderNodeTranslator
+    ) -> VariantCollection<CodableContentSection?>? {
+        translateSectionToVariantCollection(
+            documentationDataVariants: symbol.attributesVariants
+        ) { _, attributes in
+            guard !attributes.isEmpty else { return nil }
+            
+            func translateFragments(_ fragments: [SymbolGraph.Symbol.DeclarationFragments.Fragment]) -> [DeclarationRenderSection.Token] {
+                return fragments.map { fragment in
+                    let reference: ResolvedTopicReference?
+                    if let preciseIdentifier = fragment.preciseIdentifier,
+                       let resolved = renderNodeTranslator.context.localOrExternalReference(symbolID: preciseIdentifier)
+                    {
+                        reference = resolved
+                        renderNodeTranslator.collectedTopicReferences.append(resolved)
+                    } else {
+                        reference = nil
+                    }
+
+                    // Add the declaration token
+                    return DeclarationRenderSection.Token(fragment: fragment, identifier: reference?.absoluteString)
+                }
+            }
+            
+            return AttributesRenderSection(
+                title: "Attributes",
+                attributes: attributes.compactMap { kind, attribute in
+                    
+                    switch (kind, attribute) {
+                    case (.minimum, let value as SymbolGraph.AnyNumber):
+                        return RenderAttribute.minimum(String(value))
+                    case (.maximum, let value as SymbolGraph.AnyNumber):
+                        return RenderAttribute.maximum(String(value))
+                    case (.minimumExclusive, let value as SymbolGraph.AnyNumber):
+                        return RenderAttribute.minimumExclusive(String(value))
+                    case (.maximumExclusive, let value as SymbolGraph.AnyNumber):
+                        return RenderAttribute.maximumExclusive(String(value))
+                    case (.minimumLength, let value as Int):
+                        return RenderAttribute.minimumLength(String(value))
+                    case (.maximumLength, let value as Int):
+                        return RenderAttribute.maximumLength(String(value))
+                    case (.default, let value as SymbolGraph.AnyScalar):
+                        return RenderAttribute.default(String(value))
+                    case (.allowedTypes, let types as [SymbolGraph.Symbol.TypeDetail]):
+                        let tokens = types.compactMap {
+                            if let fragments = $0.fragments {
+                                return translateFragments(fragments)
+                            } else {
+                                return nil
+                            }
+                        }
+                        return RenderAttribute.allowedTypes(tokens)
+                    case (.allowedValues, let values as [SymbolGraph.AnyScalar]):
+                        let stringValues = values.map { String($0) }
+                        return RenderAttribute.allowedValues(stringValues)
+                    default:
+                        return nil
+                    }
+                    
+                }.sorted { $0.title < $1.title }
+            )
+        }
+    }
+    
+    
+}

--- a/Sources/SwiftDocC/Semantics/Symbol/Symbol.swift
+++ b/Sources/SwiftDocC/Semantics/Symbol/Symbol.swift
@@ -36,7 +36,6 @@ import SymbolKit
 /// - ``accessLevelVariants``
 /// - ``deprecatedSummaryVariants``
 /// - ``declarationVariants``
-/// - ``possibleValuesVariants``
 /// - ``attributesVariants``
 /// - ``locationVariants``
 /// - ``constraintsVariants``
@@ -150,9 +149,6 @@ public final class Symbol: Semantic, Abstracted, Redirected, AutomaticTaskGroups
     /// The symbol's alternate declarations in each language variant the symbol is available in.
     public var alternateDeclarationVariants = DocumentationDataVariants<[[PlatformName?]: [SymbolGraph.Symbol.DeclarationFragments]]>()
 
-    /// The symbol's possible values in each language variant the symbol is available in.
-    public var possibleValuesVariants = DocumentationDataVariants<[SymbolGraph.AnyScalar]>()
-    
     /// The symbol's possible values in each language variant the symbol is available in.
     public var attributesVariants = DocumentationDataVariants<[RenderAttribute.Kind: Any]>()
     

--- a/Sources/SwiftDocC/Semantics/Symbol/Symbol.swift
+++ b/Sources/SwiftDocC/Semantics/Symbol/Symbol.swift
@@ -308,7 +308,7 @@ public final class Symbol: Semantic, Abstracted, Redirected, AutomaticTaskGroups
         self.mixinsVariants = mixinsVariants
         
         for (trait, variant) in mixinsVariants.allValues {
-            var attributesVariants: [RenderAttribute.Kind: Any] = [:]
+            var attributes: [RenderAttribute.Kind: Any] = [:]
             for item in variant.values {
                 switch item {
                 case let declaration as SymbolGraph.Symbol.DeclarationFragments:
@@ -324,29 +324,32 @@ public final class Symbol: Semantic, Abstracted, Redirected, AutomaticTaskGroups
                     self.alternateDeclarationVariants[trait] = [[platformNameVariants[trait]]: alternateDeclarations.declarations]
                 
                 case let attribute as SymbolGraph.Symbol.Minimum:
-                    attributesVariants[.minimum] = attribute.value
+                    attributes[.minimum] = attribute.value
                 case let attribute as SymbolGraph.Symbol.Maximum:
-                    attributesVariants[.maximum] = attribute.value
+                    attributes[.maximum] = attribute.value
                 case let attribute as SymbolGraph.Symbol.MinimumExclusive:
-                    attributesVariants[.minimumExclusive] = attribute.value
+                    attributes[.minimumExclusive] = attribute.value
                 case let attribute as SymbolGraph.Symbol.MaximumExclusive:
-                    attributesVariants[.maximumExclusive] = attribute.value
+                    attributes[.maximumExclusive] = attribute.value
                 case let attribute as SymbolGraph.Symbol.MinimumLength:
-                    attributesVariants[.minimumLength] = attribute.value
+                    attributes[.minimumLength] = attribute.value
                 case let attribute as SymbolGraph.Symbol.MaximumLength:
-                    attributesVariants[.maximumLength] = attribute.value
+                    attributes[.maximumLength] = attribute.value
                 case let attribute as SymbolGraph.Symbol.DefaultValue:
-                    attributesVariants[.default] = attribute.value
+                    attributes[.default] = attribute.value
                 
                 case let attribute as SymbolGraph.Symbol.TypeDetails:
-                    attributesVariants[.allowedTypes] = attribute.value
+                    attributes[.allowedTypes] = attribute.value
                 case let attribute as SymbolGraph.Symbol.AllowedValues:
-                    attributesVariants[.allowedValues] = attribute.value
+                    // Allowed values are part of a symbol's attributes and listed among the rest,
+                    // but individual values can be optionally documented within a Possible Values section.
+                    self.possibleValuesVariants[trait] = attribute.value
+                    attributes[.allowedValues] = attribute.value
                 default: break;
                 }
             }
-            if attributesVariants.count > 0 {
-                self.attributesVariants[trait] = attributesVariants
+            if !attributes.isEmpty {
+                self.attributesVariants[trait] = attributes
             }
 
         }
@@ -563,12 +566,6 @@ extension Symbol {
     public var declaration: [[PlatformName?]: SymbolGraph.Symbol.DeclarationFragments] {
         get { declarationVariants.firstValue! }
         set { declarationVariants.firstValue = newValue }
-    }
-    
-    /// The first variant of the symbol's attributes.
-    public var attributes: [RenderAttribute.Kind: Any]? {
-        get { attributesVariants.firstValue! }
-        set { attributesVariants.firstValue = newValue }
     }
     
     /// The place where the first variant of the symbol was originally declared in a source file.

--- a/Sources/SwiftDocC/Semantics/Symbol/Symbol.swift
+++ b/Sources/SwiftDocC/Semantics/Symbol/Symbol.swift
@@ -36,6 +36,7 @@ import SymbolKit
 /// - ``accessLevelVariants``
 /// - ``deprecatedSummaryVariants``
 /// - ``declarationVariants``
+/// - ``possibleValuesVariants``
 /// - ``attributesVariants``
 /// - ``locationVariants``
 /// - ``constraintsVariants``
@@ -149,6 +150,9 @@ public final class Symbol: Semantic, Abstracted, Redirected, AutomaticTaskGroups
     /// The symbol's alternate declarations in each language variant the symbol is available in.
     public var alternateDeclarationVariants = DocumentationDataVariants<[[PlatformName?]: [SymbolGraph.Symbol.DeclarationFragments]]>()
 
+    /// The symbol's possible values in each language variant the symbol is available in.
+    public var possibleValuesVariants = DocumentationDataVariants<[SymbolGraph.AnyScalar]>()
+    
     /// The symbol's possible values in each language variant the symbol is available in.
     public var attributesVariants = DocumentationDataVariants<[RenderAttribute.Kind: Any]>()
     
@@ -341,9 +345,6 @@ public final class Symbol: Semantic, Abstracted, Redirected, AutomaticTaskGroups
                 case let attribute as SymbolGraph.Symbol.TypeDetails:
                     attributes[.allowedTypes] = attribute.value
                 case let attribute as SymbolGraph.Symbol.AllowedValues:
-                    // Allowed values are part of a symbol's attributes and listed among the rest,
-                    // but individual values can be optionally documented within a Possible Values section.
-                    self.possibleValuesVariants[trait] = attribute.value
                     attributes[.allowedValues] = attribute.value
                 default: break;
                 }

--- a/Sources/SwiftDocC/Semantics/Symbol/Symbol.swift
+++ b/Sources/SwiftDocC/Semantics/Symbol/Symbol.swift
@@ -36,6 +36,7 @@ import SymbolKit
 /// - ``accessLevelVariants``
 /// - ``deprecatedSummaryVariants``
 /// - ``declarationVariants``
+/// - ``attributesVariants``
 /// - ``locationVariants``
 /// - ``constraintsVariants``
 /// - ``originVariants``
@@ -145,9 +146,12 @@ public final class Symbol: Semantic, Abstracted, Redirected, AutomaticTaskGroups
         defaultVariantValue: [:]
     )
 
-    /// The symbols alternate declarations in each language variant the symbol is available in.
+    /// The symbol's alternate declarations in each language variant the symbol is available in.
     public var alternateDeclarationVariants = DocumentationDataVariants<[[PlatformName?]: [SymbolGraph.Symbol.DeclarationFragments]]>()
 
+    /// The symbol's possible values in each language variant the symbol is available in.
+    public var attributesVariants = DocumentationDataVariants<[RenderAttribute.Kind: Any]>()
+    
     public var locationVariants = DocumentationDataVariants<SymbolGraph.Symbol.Location>()
 
     /// The symbol's availability or conformance constraints, in each language variant the symbol is available in.
@@ -304,6 +308,7 @@ public final class Symbol: Semantic, Abstracted, Redirected, AutomaticTaskGroups
         self.mixinsVariants = mixinsVariants
         
         for (trait, variant) in mixinsVariants.allValues {
+            var attributesVariants: [RenderAttribute.Kind: Any] = [:]
             for item in variant.values {
                 switch item {
                 case let declaration as SymbolGraph.Symbol.DeclarationFragments:
@@ -317,9 +322,33 @@ public final class Symbol: Semantic, Abstracted, Redirected, AutomaticTaskGroups
                     self.isSPIVariants[trait] = spi.isSPI
                 case let alternateDeclarations as SymbolGraph.Symbol.AlternateDeclarations:
                     self.alternateDeclarationVariants[trait] = [[platformNameVariants[trait]]: alternateDeclarations.declarations]
+                
+                case let attribute as SymbolGraph.Symbol.Minimum:
+                    attributesVariants[.minimum] = attribute.value
+                case let attribute as SymbolGraph.Symbol.Maximum:
+                    attributesVariants[.maximum] = attribute.value
+                case let attribute as SymbolGraph.Symbol.MinimumExclusive:
+                    attributesVariants[.minimumExclusive] = attribute.value
+                case let attribute as SymbolGraph.Symbol.MaximumExclusive:
+                    attributesVariants[.maximumExclusive] = attribute.value
+                case let attribute as SymbolGraph.Symbol.MinimumLength:
+                    attributesVariants[.minimumLength] = attribute.value
+                case let attribute as SymbolGraph.Symbol.MaximumLength:
+                    attributesVariants[.maximumLength] = attribute.value
+                case let attribute as SymbolGraph.Symbol.DefaultValue:
+                    attributesVariants[.default] = attribute.value
+                
+                case let attribute as SymbolGraph.Symbol.TypeDetails:
+                    attributesVariants[.allowedTypes] = attribute.value
+                case let attribute as SymbolGraph.Symbol.AllowedValues:
+                    attributesVariants[.allowedValues] = attribute.value
                 default: break;
                 }
             }
+            if attributesVariants.count > 0 {
+                self.attributesVariants[trait] = attributesVariants
+            }
+
         }
         
         if !relationshipsVariants.isEmpty {
@@ -534,6 +563,12 @@ extension Symbol {
     public var declaration: [[PlatformName?]: SymbolGraph.Symbol.DeclarationFragments] {
         get { declarationVariants.firstValue! }
         set { declarationVariants.firstValue = newValue }
+    }
+    
+    /// The first variant of the symbol's attributes.
+    public var attributes: [RenderAttribute.Kind: Any]? {
+        get { attributesVariants.firstValue! }
+        set { attributesVariants.firstValue = newValue }
     }
     
     /// The place where the first variant of the symbol was originally declared in a source file.

--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeDictionaryDataTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeDictionaryDataTests.swift
@@ -224,7 +224,9 @@ class SemaToRenderNodeDictionaryDataTests: XCTestCase {
         let outputConsumer = try renderNodeConsumer(for: "DictionaryData")
         let genreRenderNode = try outputConsumer.renderNode(withIdentifier: "data:test:Genre")
         
-        print(genreRenderNode)
+        let type1 = DeclarationRenderSection.Token(fragment: SymbolGraph.Symbol.DeclarationFragments.Fragment(kind: .text, spelling: "string", preciseIdentifier: nil), identifier: nil)
+        let type2 = DeclarationRenderSection.Token(fragment: SymbolGraph.Symbol.DeclarationFragments.Fragment(kind: .text, spelling: "GENCODE", preciseIdentifier: nil), identifier: nil)
+        
         assertExpectedContent(
             genreRenderNode,
             sourceLanguage: "data",
@@ -232,6 +234,7 @@ class SemaToRenderNodeDictionaryDataTests: XCTestCase {
             title: "Genre",
             navigatorTitle: nil,
             abstract: nil,
+            attributes: [.maximumLength("40"), .allowedTypes([[type1], [type2]]), .allowedValues(["Classic Rock", "Folk", "null"])],
             declarationTokens: [
                 "string ",
                 "Genre"

--- a/Tests/SwiftDocCTests/Test Bundles/DictionaryData.docc/dictionary.symbols.json
+++ b/Tests/SwiftDocCTests/Test Bundles/DictionaryData.docc/dictionary.symbols.json
@@ -239,6 +239,32 @@
     },
     {
       "accessLevel": "public",
+      "allowedValues": [
+        "Classic Rock",
+        "Folk",
+        null
+      ],
+      "maximumLength": 40,
+      "typeDetails" : [
+        {
+          "baseType" : "string",
+          "fragments" : [
+            {
+              "kind" : "text",
+              "spelling" : "string"
+            }
+          ]
+        },
+        {
+          "baseType" : "string",
+          "fragments" : [
+            {
+              "kind" : "text",
+              "spelling" : "GENCODE"
+            }
+          ]
+        }
+      ],
       "declarationFragments": [
         {
           "kind": "text",

--- a/Tests/SwiftDocCTests/Test Bundles/DictionaryData.docc/dictionary.symbols.json
+++ b/Tests/SwiftDocCTests/Test Bundles/DictionaryData.docc/dictionary.symbols.json
@@ -245,26 +245,6 @@
         null
       ],
       "maximumLength": 40,
-      "typeDetails" : [
-        {
-          "baseType" : "string",
-          "fragments" : [
-            {
-              "kind" : "text",
-              "spelling" : "string"
-            }
-          ]
-        },
-        {
-          "baseType" : "string",
-          "fragments" : [
-            {
-              "kind" : "text",
-              "spelling" : "GENCODE"
-            }
-          ]
-        }
-      ],
       "declarationFragments": [
         {
           "kind": "text",
@@ -302,6 +282,21 @@
       "typeDetails": [
         {
           "baseType": "string",
+          "fragments": [
+            {
+              "kind": "text",
+              "spelling": "string"
+            }
+          ]
+        },
+        {
+          "baseType": "string",
+          "fragments": [
+            {
+              "kind": "text",
+              "spelling": "GENCODE"
+            }
+          ]
         }
       ]
     },

--- a/Tests/SwiftDocCTests/XCTestCase+AssertingTestData.swift
+++ b/Tests/SwiftDocCTests/XCTestCase+AssertingTestData.swift
@@ -23,6 +23,7 @@ extension XCTestCase {
         title expectedTitle: String,
         navigatorTitle expectedNavigatorTitle: String?,
         abstract expectedAbstract: String?,
+        attributes expectedAttributes: [RenderAttribute]? = nil,
         declarationTokens expectedDeclarationTokens: [String]?,
         endpointTokens expectedEndpointTokens: [String]? = nil,
         httpParameters expectedHTTPParameters: [String]? = nil,
@@ -58,6 +59,15 @@ extension XCTestCase {
             renderNode.identifier.sourceLanguage.id,
             expectedSourceLanguage,
             failureMessageForField("source language id"),
+            file: file,
+            line: line
+        )
+        
+        let attributesSection = renderNode.primaryContentSections.compactMap { $0 as? AttributesRenderSection }.first
+        XCTAssertEqual(
+            attributesSection?.attributes,
+            expectedAttributes,
+            failureMessageForField("attributes"),
             file: file,
             line: line
         )


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://121475839&121224338

## Summary

Important details recorded in symbol graphs about the allowed values of a data type, such as minimum and maximum values, default values, and enumerated values, were not getting used to generate an `AttributeRenderSection` on a symbol's page. That data now gets passed through to the render JSON.

## Dependencies

None.

## Testing

Add one of the value constraint fields to a data type in a symbol graph (eg, `"minimum": 12`) and compile the documentation. The render JSON for the data type should include an "attributes" primary content section with the attribute value.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary (N/A)
