### PR TITLE
Support linking to authored task groups / topic sections

### DIFF
--- a/Sources/SwiftDocC/Model/DocumentationNode.swift
+++ b/Sources/SwiftDocC/Model/DocumentationNode.swift
@@ -110,9 +110,12 @@ public struct DocumentationNode {
             discussionSections = []
         }
         
+        anchorSections.removeAll()
         var seenAnchorTitles = Set<String>()
         
         func addAnchorSection(title: String) {
+            // To preserve the order of headings and task groups in the content, we use *both* a `Set` and
+            // an `Array` to ensure unique titles and to accumulate the linkable anchor section elements.
             guard !title.isEmpty, !seenAnchorTitles.contains(title) else { return }
             seenAnchorTitles.insert(title)
             anchorSections.append(
@@ -122,9 +125,6 @@ public struct DocumentationNode {
         
         for discussion in discussionSections {
             for child in discussion.content {
-                // For any non-H1 Heading sections found in the topic's discussion
-                // create an `AnchorSection` and add it to `anchorSections`
-                // so we can index all anchors found in the bundle for link resolution.
                 if let heading = child as? Heading, heading.level > 1 {
                     addAnchorSection(title: heading.plainText)
                 }

--- a/Sources/docc/DocCDocumentation.docc/linking-to-symbols-and-other-content.md
+++ b/Sources/docc/DocCDocumentation.docc/linking-to-symbols-and-other-content.md
@@ -173,6 +173,13 @@ a colon (`:`), the name of the article, and a greater-than symbol
 <doc:GettingStarted>
 ```
 
+If the article's file name contains whitespace characters, replace each consecutive sequence of whitespace characters with a dash. 
+For example, the link to an article with a file name "Getting Started.md" is
+
+```
+<doc:Getting-Started>
+```
+
 When DocC resolves the link, it uses the article's page title as the link's 
 text, and the article's filename as the link's URL. Links to tutorials follow 
 the same format, except you must add the `/tutorials/` prefix to the path: 
@@ -185,6 +192,41 @@ the same format, except you must add the `/tutorials/` prefix to the path:
 symbol's path between the colon (`:`) and the terminating greater-than 
 symbol (`>`).
 `<doc:Sloth/init(name:color:power:)>`
+
+### Navigate to a Heading or Task Group
+
+To add a link to heading or task group on another page, use a `<doc:>` link to the page and end the link with a hash (`#`) followed by the name of the heading. 
+If the heading text contains whitespace or punctuation characters, replace each consecutive sequence of whitespace characters with a dash and optionally remove the punctuation characters. 
+
+For example, consider this level 3 heading with a handful of punctuation characters:
+
+```
+### (1) "Example": Sloth's diet.
+```
+
+A link to this heading can either include all the punctuation characters from the heading text or remove some or all of the punctuation characters.
+
+```
+<doc:OtherPage#(1)-"Example":-Sloth's-diet.>
+<doc:OtherPage#1-Example-Sloths-diet>
+```
+
+> Note:
+> Links to headings or task groups on symbol pages use `<doc:>` syntax. 
+
+To add a link to heading or task group on the current page, use a `<doc:>` link that starts with the name of the heading. If you prefer you can include the hash (`#`) prefix before the heading name. For example, both these links resolve to a heading named "Some heading title" on the current page:
+
+```
+<doc:#Some-heading-title>
+<doc:Some-heading-title>
+```
+
+If a task group is empty or none of its links resolve successfully, it's not possible to link to that task group because it will be omitted from the rendered page. Linking to generated per-symbol-kind task groups is not supported.
+
+> Earlier Versions:
+> Before Swift-DocC 6.0, links to task groups isn't supported. The syntax above only works for links to general headings.
+>
+> Before Swift-DocC 5.9, links to same-page headings don't support a leading hash (`#`) character.
 
 ### Include web links
 

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -12,7 +12,7 @@ import XCTest
 import SymbolKit
 @testable import SwiftDocC
 import Markdown
-import SwiftDocCTestUtilities
+@_spi(FileManagerProtocol) import SwiftDocCTestUtilities
 
 func diffDescription(lhs: String, rhs: String) -> String {
     let leftLines = lhs.components(separatedBy: .newlines)
@@ -2986,7 +2986,7 @@ let expected = """
         XCTAssertEqual(taskGroup.links.count, 16)
         
         XCTAssertEqual(node.anchorSections.first?.title, "Overview")
-        for (index, anchor) in node.anchorSections.dropFirst().enumerated() {
+        for (index, anchor) in node.anchorSections.dropFirst().dropLast().enumerated() {
             XCTAssertEqual(taskGroup.links.dropFirst(index * 2 + 0).first?.destination, anchor.reference.absoluteString)
             XCTAssertEqual(taskGroup.links.dropFirst(index * 2 + 1).first?.destination, anchor.reference.absoluteString)
         }
@@ -2995,11 +2995,141 @@ let expected = """
         XCTAssertEqual(node.anchorSections.dropFirst(2).first?.reference.absoluteString, "doc://com.test.docc/documentation/article#Apostrophe-firsts-second")
         XCTAssertEqual(node.anchorSections.dropFirst(3).first?.reference.absoluteString, "doc://com.test.docc/documentation/article#Prime-firsts-second")
         
-        XCTAssertEqual(node.anchorSections.dropLast(2).last?.reference.absoluteString, "doc://com.test.docc/documentation/article#Em-dash-first-second")
-        XCTAssertEqual(node.anchorSections.dropLast().last?.reference.absoluteString, "doc://com.test.docc/documentation/article#Triple-hyphen-first-second")
-        XCTAssertEqual(node.anchorSections.last?.reference.absoluteString, "doc://com.test.docc/documentation/article#Emoji-%F0%9F%92%BB")
+        XCTAssertEqual(node.anchorSections.dropLast(3).last?.reference.absoluteString, "doc://com.test.docc/documentation/article#Em-dash-first-second")
+        XCTAssertEqual(node.anchorSections.dropLast(2).last?.reference.absoluteString, "doc://com.test.docc/documentation/article#Triple-hyphen-first-second")
+        XCTAssertEqual(node.anchorSections.dropLast().last?.reference.absoluteString, "doc://com.test.docc/documentation/article#Emoji-%F0%9F%92%BB")
     }
 
+    func testResolvingLinksToTopicSections() throws {
+        let fileSystem = try TestFileSystem(folders: [
+            Folder(name: "unit-test.docc", content: [
+                JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(moduleName: "ModuleName")),
+                
+                TextFile(name: "ModuleName.md", utf8Content: """
+                # ``ModuleName``
+                
+                A symbol with two topic section
+                
+                ## Topics
+                
+                ### One
+                
+                - <doc:First>
+                
+                ### Two
+                
+                - <doc:Second>
+                """),
+                
+                TextFile(name: "First.md", utf8Content: """
+                # The first article
+                
+                An article with a top-level topic section
+                
+                ## Topics
+                
+                - <doc:Third>
+                """),
+                
+                TextFile(name: "Second.md", utf8Content: """
+                # The second article
+                
+                An article with a named topic section
+                
+                ## Topics
+                
+                ### Some topic section
+                
+                - <doc:Third>
+                """),
+                
+                TextFile(name: "Third.md", utf8Content: """
+                # The third article
+                
+                An article that links to the various topic sections
+                
+                - <doc:ModuleName#One>
+                - <doc:ModuleName#Two>
+                - <doc:First#Topics>
+                - <doc:Second#Some-topic-section>
+                - <doc:Third#Another-topic-section>
+                - <doc:#Another-topic-section>
+                
+                ## Topics
+                
+                ### Another topic section
+                
+                - <doc:Fourth>
+                """),
+                
+                TextFile(name: "Fourth.md", utf8Content: """
+                # The fourth article
+                
+                An article that only exists to be linked to
+                """),
+            ])
+        ])
+        
+        let workspace = DocumentationWorkspace()
+        let context = try DocumentationContext(dataProvider: workspace)
+        try workspace.registerProvider(fileSystem)
+        
+        XCTAssert(context.problems.isEmpty, "Unexpected problems: \(context.problems.map(\.diagnostic.summary).sorted())")
+        
+        let reference = try XCTUnwrap(context.knownPages.first(where: { $0.lastPathComponent == "Third" }))
+        let entity = try context.entity(with: reference)
+        
+        struct LinkAggregator: MarkupWalker {
+            var destinations: [String] = []
+            
+            mutating func visitLink(_ link: Link) -> () {
+                if let destination = link.destination {
+                    destinations.append(destination)
+                }
+            }
+            mutating func visitSymbolLink(_ symbolLink: SymbolLink) -> () {
+                if let destination = symbolLink.destination {
+                    destinations.append(destination)
+                }
+            }
+        }
+        
+        // Verify that the links are resolved in the in-memory model
+        
+        var linkAggregator = LinkAggregator()
+        let list = try XCTUnwrap((entity.semantic as? Article)?.discussion?.content.first as? UnorderedList)
+        linkAggregator.visit(list)
+        
+        XCTAssertEqual(linkAggregator.destinations, [
+            "doc://unit-test/documentation/ModuleName#One",
+            "doc://unit-test/documentation/ModuleName#Two",
+            "doc://unit-test/documentation/unit-test/First#Topics",
+            "doc://unit-test/documentation/unit-test/Second#Some-topic-section",
+            "doc://unit-test/documentation/unit-test/Third#Another-topic-section",
+            "doc://unit-test/documentation/unit-test/Third#Another-topic-section",
+        ])
+        
+        // Verify that the links are resolved in the render model.
+        let bundle = try XCTUnwrap(context.registeredBundles.first)
+        let converter = DocumentationNodeConverter(bundle: bundle, context: context)
+        let renderNode = try converter.convert(entity, at: nil)
+        
+        let overviewSection = try XCTUnwrap(renderNode.primaryContentSections.first as? ContentRenderSection)
+        guard case .unorderedList(let unorderedList) = overviewSection.content.dropFirst().first else {
+            XCTFail("The first element of the Overview section (after the heading) should be an unordered list")
+            return
+        }
+        
+        XCTAssertEqual(unorderedList.items.map(\.content.firstParagraph.first), [
+            .reference(identifier: RenderReferenceIdentifier("doc://unit-test/documentation/ModuleName#One"), isActive: true, overridingTitle: nil, overridingTitleInlineContent: nil),
+            .reference(identifier: RenderReferenceIdentifier("doc://unit-test/documentation/ModuleName#Two"), isActive: true, overridingTitle: nil, overridingTitleInlineContent: nil),
+            .reference(identifier: RenderReferenceIdentifier("doc://unit-test/documentation/unit-test/First#Topics"), isActive: true, overridingTitle: nil, overridingTitleInlineContent: nil),
+            .reference(identifier: RenderReferenceIdentifier("doc://unit-test/documentation/unit-test/Second#Some-topic-section"), isActive: true, overridingTitle: nil, overridingTitleInlineContent: nil),
+            .reference(identifier: RenderReferenceIdentifier("doc://unit-test/documentation/unit-test/Third#Another-topic-section"), isActive: true, overridingTitle: nil, overridingTitleInlineContent: nil),
+            .reference(identifier: RenderReferenceIdentifier("doc://unit-test/documentation/unit-test/Third#Another-topic-section"), isActive: true, overridingTitle: nil, overridingTitleInlineContent: nil),
+        ])
+    }
+    
     func testWarnOnMultipleMarkdownExtensions() throws {
         let fileContent = """
         # ``MyKit/MyClass/myFunction()``

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -905,7 +905,7 @@ class DocumentationContextTests: XCTestCase {
         XCTAssertEqual(myProtocolSymbol.topics?.taskGroups.first?.heading?.detachedFromParent.debugDescription(),
                         """
                         Heading level: 3
-                        └─ Text "Task Group Excercising Symbol Links"
+                        └─ Text "Task Group Exercising Symbol Links"
                         """)
         XCTAssertEqual(myProtocolSymbol.topics?.taskGroups.first?.links.count, 3)
         XCTAssertEqual(myProtocolSymbol.topics?.taskGroups.first?.links[0].destination, "doc://com.example.documentation/documentation/MyKit/MyClass")

--- a/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
@@ -1116,9 +1116,9 @@ class PathHierarchyTests: XCTestCase {
         XCTAssertNil(tree.lookup[modulePageTaskGroupID]!.symbol)
         XCTAssertEqual(tree.lookup[modulePageTaskGroupID]!.name, "Extensions-to-other-frameworks")
         
-        let symbolPageTaskGroupID = try tree.find(path: "/MyKit/MyProtocol#Task-Group-Excercising-Symbol-Links", onlyFindSymbols: false)
+        let symbolPageTaskGroupID = try tree.find(path: "/MyKit/MyProtocol#Task-Group-Exercising-Symbol-Links", onlyFindSymbols: false)
         XCTAssertNil(tree.lookup[symbolPageTaskGroupID]!.symbol)
-        XCTAssertEqual(tree.lookup[symbolPageTaskGroupID]!.name, "Task-Group-Excercising-Symbol-Links")
+        XCTAssertEqual(tree.lookup[symbolPageTaskGroupID]!.name, "Task-Group-Exercising-Symbol-Links")
     }
     
     func testMixedLanguageFramework() throws {

--- a/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
@@ -1111,6 +1111,14 @@ class PathHierarchyTests: XCTestCase {
         let articleID = try tree.find(path: "/Test-Bundle/Default-Code-Listing-Syntax", onlyFindSymbols: false)
         XCTAssertNil(tree.lookup[articleID]!.symbol)
         XCTAssertEqual(tree.lookup[articleID]!.name, "Default-Code-Listing-Syntax")
+        
+        let modulePageTaskGroupID = try tree.find(path: "/MyKit#Extensions-to-other-frameworks", onlyFindSymbols: false)
+        XCTAssertNil(tree.lookup[modulePageTaskGroupID]!.symbol)
+        XCTAssertEqual(tree.lookup[modulePageTaskGroupID]!.name, "Extensions-to-other-frameworks")
+        
+        let symbolPageTaskGroupID = try tree.find(path: "/MyKit/MyProtocol#Task-Group-Excercising-Symbol-Links", onlyFindSymbols: false)
+        XCTAssertNil(tree.lookup[symbolPageTaskGroupID]!.symbol)
+        XCTAssertEqual(tree.lookup[symbolPageTaskGroupID]!.name, "Task-Group-Excercising-Symbol-Links")
     }
     
     func testMixedLanguageFramework() throws {
@@ -1753,6 +1761,105 @@ class PathHierarchyTests: XCTestCase {
         XCTAssertEqual(paths[otherID], "/ModuleName/ContainerName-2vaqf")
         XCTAssertEqual(paths[containerID], "/ModuleName/ContainerName-qwwf")
         XCTAssertEqual(paths[memberID], "/ModuleName/ContainerName-qwwf/MemberName1")
+    }
+    
+    func testLinkToTopicSection() throws {
+        let exampleDocumentation = Folder(name: "unit-test.docc", content: [
+            JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(
+                moduleName: "ModuleName",
+                symbols: [
+                    ("some-symbol-id", .swift, ["SymbolName"]),
+                ],
+                relationships: []
+            )),
+            
+            TextFile(name: "ModuleName.md", utf8Content: """
+            # ``ModuleName``
+            
+            A module with some named topic sections
+            
+            ## Other level 2 heading
+            
+            Some content
+            
+            ### Other level 3 heading
+            
+            Some more content
+            
+            ## Topics
+            
+            ### My classes
+            
+            - ``SymbolName``
+            
+            ### My articles
+            
+            - <doc:Article>
+            """),
+            
+            TextFile(name: "Article.md", utf8Content: """
+            # Some Article
+            
+            An article with a top-level topic section
+            
+            ## Topics
+            
+            - ``SymbolName``
+            """)
+        ])
+        
+        let tempURL = try createTempFolder(content: [exampleDocumentation])
+        let (_, _, context) = try loadBundle(from: tempURL)
+        let tree = context.linkResolver.localResolver.pathHierarchy
+        
+        print(tree.dump())
+        
+        let moduleID = try tree.find(path: "/ModuleName", onlyFindSymbols: true)
+        // Relative link from the module to a topic section
+        do {
+            let topicSectionID = try tree.find(path: "#My-classes", parent: moduleID, onlyFindSymbols: false)
+            let node = try XCTUnwrap(tree.lookup[topicSectionID])
+            XCTAssertNil(node.symbol)
+            XCTAssertEqual(node.name, "My-classes")
+        }
+        
+        // Absolute link to a topic section on the module page
+        do {
+            let topicSectionID = try tree.find(path: "/ModuleName#My-classes", parent: nil, onlyFindSymbols: false)
+            let node = try XCTUnwrap(tree.lookup[topicSectionID])
+            XCTAssertNil(node.symbol)
+            XCTAssertEqual(node.name, "My-classes")
+        }
+        
+        // Absolute link to a heading on the module page
+        do {
+            let headingID = try tree.find(path: "/ModuleName#Other-level-2-heading", parent: nil, onlyFindSymbols: false)
+            let node = try XCTUnwrap(tree.lookup[headingID])
+            XCTAssertNil(node.symbol)
+            XCTAssertEqual(node.name, "Other-level-2-heading")
+        }
+        
+        // Relative link to a heading on the module page
+        do {
+            let headingID = try tree.find(path: "#Other-level-3-heading", parent: moduleID, onlyFindSymbols: false)
+            let node = try XCTUnwrap(tree.lookup[headingID])
+            XCTAssertNil(node.symbol)
+            XCTAssertEqual(node.name, "Other-level-3-heading")
+        }
+        
+        // Relative link to a top-level topic section on another page
+        do {
+            let topicSectionID = try tree.find(path: "Article#Topics", parent: moduleID, onlyFindSymbols: false)
+            let node = try XCTUnwrap(tree.lookup[topicSectionID])
+            XCTAssertNil(node.symbol)
+            XCTAssertEqual(node.name, "Topics")
+        }
+        
+        let paths = tree.caseInsensitiveDisambiguatedPaths(includeDisambiguationForUnambiguousChildren: true)
+        XCTAssertEqual(paths.values.sorted(), [
+            "/ModuleName",
+            "/ModuleName/SymbolName",
+        ], "The hierarchy only computes paths for symbols, not for headings or topic sections")
     }
     
     func testModuleAndCollidingTechnologyRootHasPathsForItsSymbols() throws {

--- a/Tests/SwiftDocCTests/LinkTargets/LinkDestinationSummaryTests.swift
+++ b/Tests/SwiftDocCTests/LinkTargets/LinkDestinationSummaryTests.swift
@@ -217,7 +217,7 @@ class ExternalLinkableTests: XCTestCase {
             XCTAssertEqual(summary.abstract, [.text("An abstract of a protocol using a "), .codeVoice(code: "String"), .text(" id value.")])
             XCTAssertEqual(summary.taskGroups, [
                 .init(
-                    title: "Task Group Excercising Symbol Links",
+                    title: "Task Group Exercising Symbol Links",
                     identifiers: [
                         // MyClass is curated 3 times using different syntax.
                         summary.referenceURL.deletingLastPathComponent().appendingPathComponent("MyClass").absoluteString,

--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
@@ -1050,7 +1050,7 @@ class SemaToRenderNodeTests: XCTestCase {
         }
 
         // Test all identifiers have been resolved to the ``MyClass`` symbol
-        XCTAssertEqual(renderNode.topicSections[0].title, "Task Group Excercising Symbol Links")
+        XCTAssertEqual(renderNode.topicSections[0].title, "Task Group Exercising Symbol Links")
         XCTAssertEqual(renderNode.topicSections[0].abstract?.map{ RenderBlockContent.paragraph(.init(inlineContent: [$0])) }.paragraphText.joined(), "Task Group abstract text.")
         
         guard let discussion = renderNode.topicSections[0].discussion as? ContentRenderSection else {
@@ -1062,7 +1062,7 @@ class SemaToRenderNodeTests: XCTestCase {
         // Test childrenRelationships are handled correctly
         let children = renderNode.childrenRelationship()
         XCTAssertEqual(children.count, renderNode.topicSections.count)
-        XCTAssertEqual(children.first?.name, "Task Group Excercising Symbol Links")
+        XCTAssertEqual(children.first?.name, "Task Group Exercising Symbol Links")
         XCTAssertEqual(children.first?.references.count, 3)
         
         let groupDiscussionParagraphPrefixes = discussion.content.paragraphText

--- a/Tests/SwiftDocCTests/Semantics/SymbolTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/SymbolTests.swift
@@ -571,7 +571,7 @@ class SymbolTests: XCTestCase {
 
             ## Topics
 
-            ### Unresolvable curation
+            ### Curation that won't resolve
 
             - ``UnresolvableClassInMyClassTopicCuration``
             - ``MyClass/unresolvablePropertyInMyClassTopicCuration``
@@ -641,7 +641,7 @@ class SymbolTests: XCTestCase {
 
         ## Topics
 
-        ### Unresolvable curation
+        ### Curation that won't resolve
 
         - ``UnresolvableClassInMyClassTopicCuration``
         - ``MyClass/unresolvablePropertyInMyClassTopicCuration``
@@ -689,7 +689,7 @@ class SymbolTests: XCTestCase {
 
         ## Topics
 
-        ### Unresolvable curation
+        ### Curation that won't resolve
 
         - ``UnresolvableClassInMyClassTopicCuration``
         - ``MyClass/unresolvablePropertyInMyClassTopicCuration``
@@ -737,7 +737,7 @@ class SymbolTests: XCTestCase {
 
         ## Topics
 
-        ### Unresolvable curation
+        ### Curation that won't resolve
 
         - ``UnresolvableClassInMyClassTopicCuration``
         - ``MyClass/unresolvablePropertyInMyClassTopicCuration``
@@ -782,7 +782,7 @@ class SymbolTests: XCTestCase {
 
         ## Topics
 
-        ### Unresolvable curation
+        ### Curation that won't resolve
 
         - ``UnresolvableClassInMyClassTopicCuration``
         - ``MyClass/unresolvablePropertyInMyClassTopicCuration``
@@ -829,7 +829,7 @@ class SymbolTests: XCTestCase {
 
         ## Topics
 
-        ### Unresolvable curation
+        ### Curation that won't resolve
 
         - ``UnresolvableClassInMyClassTopicCuration``
         - ``MyClass/unresolvablePropertyInMyClassTopicCuration``
@@ -876,7 +876,7 @@ class SymbolTests: XCTestCase {
 
         ## Topics
 
-        ### Unresolvable curation
+        ### Curation that won't resolve
 
         - ``UnresolvableClassInMyClassTopicCuration``
         - ``MyClass/unresolvablePropertyInMyClassTopicCuration``
@@ -923,7 +923,7 @@ class SymbolTests: XCTestCase {
 
         ## Topics
 
-        ### Unresolvable curation
+        ### Curation that won't resolve
 
         - ``UnresolvableClassInMyClassTopicCuration``
         - ``MyClass/unresolvablePropertyInMyClassTopicCuration``

--- a/Tests/SwiftDocCTests/Test Bundles/TestBundle.docc/documentation/myprotocol.md
+++ b/Tests/SwiftDocCTests/Test Bundles/TestBundle.docc/documentation/myprotocol.md
@@ -32,7 +32,7 @@ Exercise external references: <doc://com.test.external/ExternalPage>
 
 ## Topics
 
-### Task Group Excercising Symbol Links
+### Task Group Exercising Symbol Links
 
 Task Group abstract text.
 

--- a/Tests/SwiftDocCTests/Test Resources/TestBundle-RenderIndex.json
+++ b/Tests/SwiftDocCTests/Test Resources/TestBundle-RenderIndex.json
@@ -50,7 +50,7 @@
       {
         "children" : [
           {
-            "title" : "Task Group Excercising Symbol Links",
+            "title" : "Task Group Exercising Symbol Links",
             "type" : "groupMarker"
           },
           {

--- a/Tests/SwiftDocCTests/Test Resources/testNavigatorIndexGeneration.txt
+++ b/Tests/SwiftDocCTests/Test Resources/testNavigatorIndexGeneration.txt
@@ -11,7 +11,7 @@
 ┣╸MyKit
 ┃ ┣╸Basics
 ┃ ┣╸MyProtocol
-┃ ┃ ┣╸Task Group Excercising Symbol Links
+┃ ┃ ┣╸Task Group Exercising Symbol Links
 ┃ ┃ ┣╸MyClass
 ┃ ┃ ┃ ┣╸MyClass members (relative)
 ┃ ┃ ┃ ┣╸init()

--- a/Tests/SwiftDocCTests/Test Resources/testNavigatorIndexGenerationTechnologies.txt
+++ b/Tests/SwiftDocCTests/Test Resources/testNavigatorIndexGenerationTechnologies.txt
@@ -7,7 +7,7 @@
 ┃ ┃ ┃ ┗╸Chapter 1
 ┃ ┃ ┣╸Basics
 ┃ ┃ ┣╸MyProtocol
-┃ ┃ ┃ ┣╸Task Group Excercising Symbol Links
+┃ ┃ ┃ ┣╸Task Group Exercising Symbol Links
 ┃ ┃ ┃ ┣╸MyClass
 ┃ ┃ ┃ ┃ ┣╸MyClass members (relative)
 ┃ ┃ ┃ ┃ ┣╸init()

--- a/Tests/SwiftDocCTests/Test Resources/testNavigatorIndexGenerationWithLanguageGrouping.txt
+++ b/Tests/SwiftDocCTests/Test Resources/testNavigatorIndexGenerationWithLanguageGrouping.txt
@@ -12,7 +12,7 @@
   ┣╸MyKit
   ┃ ┣╸Basics
   ┃ ┣╸MyProtocol
-  ┃ ┃ ┣╸Task Group Excercising Symbol Links
+  ┃ ┃ ┣╸Task Group Exercising Symbol Links
   ┃ ┃ ┣╸MyClass
   ┃ ┃ ┃ ┣╸MyClass members (relative)
   ┃ ┃ ┃ ┣╸init()

--- a/Tests/SwiftDocCTests/Test Resources/testNavigatorIndexPageTitleGeneration.txt
+++ b/Tests/SwiftDocCTests/Test Resources/testNavigatorIndexPageTitleGeneration.txt
@@ -11,7 +11,7 @@
 ┣╸MyKit
 ┃ ┣╸Basics
 ┃ ┣╸MyProtocol
-┃ ┃ ┣╸Task Group Excercising Symbol Links
+┃ ┃ ┣╸Task Group Exercising Symbol Links
 ┃ ┃ ┣╸MyClass
 ┃ ┃ ┃ ┣╸MyClass members (relative)
 ┃ ┃ ┃ ┣╸init()

--- a/Tests/SwiftDocCUtilitiesTests/Test Bundles/TestBundle.docc/documentation/myprotocol.md
+++ b/Tests/SwiftDocCUtilitiesTests/Test Bundles/TestBundle.docc/documentation/myprotocol.md
@@ -26,7 +26,7 @@ Excercise known unresolvable symbols: know unresolvable ``NSCodable``.
 
 ## Topics
 
-### Task Group Excercising Symbol Links
+### Task Group Exercising Symbol Links
 
 Task Group abstract text.
 


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://78908451

## Summary

This extends the existing, but undocumented, support for linking to headers to also include linking to task groups / topic sections.

I had initially thought that including all the task groups in the anchor sections would be too slow or increase memory usage too much but in my local benchmarking the difference is too small to measure. 

## Dependencies

None.

## Testing

Follow the added documentation to write links to headings or task groups, both on the current page and on other pages

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
