### PR TITLE
Add visionOS support

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "33a20e650c33f6d72d822d558333f2085effa3dc",
-        "version" : "2.5.0"
+        "revision" : "60f13f60c4d093691934dc6cfdf5f508ada1f894",
+        "version" : "2.6.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -138,7 +138,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(url: "https://github.com/apple/swift-lmdb.git", branch: "main"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.2"),
         .package(url: "https://github.com/apple/swift-docc-symbolkit", branch: "main"),
-        .package(url: "https://github.com/apple/swift-crypto.git", from: "2.5.0"),
+        .package(url: "https://github.com/apple/swift-crypto.git", from: "2.6.0"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.2.0"),
     ]
 } else {

--- a/Sources/SwiftDocC/Benchmark/Benchmark.swift
+++ b/Sources/SwiftDocC/Benchmark/Benchmark.swift
@@ -42,6 +42,8 @@ public class Benchmark: Encodable {
     public let platform = "macOS"
     #elseif os(iOS)
     public let platform = "iOS"
+    #elseif os(visionOS)
+    public let platform = "visionOS"
     #elseif os(Linux)
     public let platform = "Linux"
     #elseif os(Android)

--- a/Sources/SwiftDocC/Benchmark/Metrics/PeakMemory.swift
+++ b/Sources/SwiftDocC/Benchmark/Metrics/PeakMemory.swift
@@ -26,7 +26,7 @@ extension Benchmark {
             memoryPeak = Self.peakMemory()
         }
         
-        #if os(macOS) || os(iOS)
+        #if os(macOS) || os(iOS) || os(visionOS)
         private static func peakMemory() -> Int64? {
             // On macOS we use the Kernel framework to read a pretty accurate
             // memory footprint for the current task. The value reported here

--- a/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphLoader.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphLoader.swift
@@ -109,7 +109,7 @@ struct SymbolGraphLoader {
         // load and decode each one on a separate thread.
         // This strategy benchmarks better when we have multiple
         // "larger" symbol graphs.
-        #if os(macOS) || os(iOS)
+        #if os(macOS) || os(iOS) || os(visionOS)
         if bundle.symbolGraphURLs.filter({ !$0.lastPathComponent.contains("@") }).count > 1 {
             // There are multiple main symbol graphs, better parallelize all files decoding.
             decodingStrategy = .concurrentlyAllFiles

--- a/Sources/SwiftDocC/Model/Rendering/RenderContext.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderContext.swift
@@ -61,7 +61,7 @@ public struct RenderContext {
             )
         }
         
-        #if os(macOS) || os(iOS) || os(Android) || os(Windows)
+        #if os(macOS) || os(iOS) || os(visionOS) || os(Android) || os(Windows)
         // Concurrently render content on macOS/iOS, Windows & Android
         let results: [(reference: ResolvedTopicReference, content: RenderReferenceStore.TopicContent)] = references.concurrentPerform { reference, results in
             results.append((reference, renderContentFor(reference)))

--- a/Sources/SwiftDocC/Utility/Collection+ConcurrentPerform.swift
+++ b/Sources/SwiftDocC/Utility/Collection+ConcurrentPerform.swift
@@ -14,7 +14,7 @@ import Foundation
 // concurrency in the Collection extensions in this file and have tests expect
 // them to work serially on Linux. rdar://75794062
 
-#if os(macOS) || os(iOS)
+#if os(macOS) || os(iOS) || os(visionOS)
 private let useConcurrentCollectionExtensions = true
 #else
 private let useConcurrentCollectionExtensions = false

--- a/Sources/SwiftDocC/Utility/LMDB/LMDB.swift
+++ b/Sources/SwiftDocC/Utility/LMDB/LMDB.swift
@@ -101,7 +101,7 @@ extension String: LMDBData {
 // This is required for macOS, for Linux the default implementation works as expected.
 extension Array: LMDBData where Element: FixedWidthInteger {
     
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if os(macOS) || os(iOS) || os(visionOS) || os(tvOS) || os(watchOS)
     public init?(data: UnsafeRawBufferPointer) {
         var array = Array<Element>(repeating: 0, count: data.count / MemoryLayout<Element>.stride)
         _ = array.withUnsafeMutableBytes { data.copyBytes(to: $0) }

--- a/Sources/SwiftDocC/Utility/Synchronization.swift
+++ b/Sources/SwiftDocC/Utility/Synchronization.swift
@@ -28,7 +28,7 @@ public class Synchronized<Value> {
     /// A value that requires synchronized access.
     private var value: Value
     
-    #if os(macOS) || os(iOS)
+    #if os(macOS) || os(iOS) || os(visionOS)
     /// A lock type appropriate for the current platform.
     /// > Note: To avoid access race reports we manage the memory manually.
     var lock: UnsafeMutablePointer<os_unfair_lock>
@@ -46,7 +46,7 @@ public class Synchronized<Value> {
     public init(_ value: Value) {
         self.value = value
 
-        #if os(macOS) || os(iOS)
+        #if os(macOS) || os(iOS) || os(visionOS)
         lock = UnsafeMutablePointer<os_unfair_lock>.allocate(capacity: 1)
         lock.initialize(to: os_unfair_lock())
         #elseif os(Linux) || os(Android)
@@ -71,7 +71,7 @@ public class Synchronized<Value> {
     /// - Returns: Returns the returned value of `block`, if any.
     @discardableResult
     public func sync<Result>(_ block: (inout Value) throws -> Result) rethrows -> Result {
-        #if os(macOS) || os(iOS)
+        #if os(macOS) || os(iOS) || os(visionOS)
         os_unfair_lock_lock(lock)
         defer { os_unfair_lock_unlock(lock) }
         #elseif os(Linux) || os(Android)
@@ -107,7 +107,7 @@ public extension Lock {
     
     @discardableResult
     func sync<Result>(_ block: () throws -> Result) rethrows -> Result {
-        #if os(macOS) || os(iOS)
+        #if os(macOS) || os(iOS) || os(visionOS)
         os_unfair_lock_lock(lock)
         defer { os_unfair_lock_unlock(lock) }
         #elseif os(Linux) || os(Android)

--- a/Tests/SwiftDocCTests/Infrastructure/SymbolGraph/SymbolGraphLoaderTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/SymbolGraph/SymbolGraphLoaderTests.swift
@@ -281,7 +281,7 @@ class SymbolGraphLoaderTests: XCTestCase {
             var loader = try makeSymbolGraphLoader(symbolGraphURLs: [symbolGraphURL, extraSymbolGraphFile])
             try loader.loadAll()
             
-            #if os(macOS) || os(iOS)
+            #if os(macOS) || os(iOS) || os(visionOS)
             XCTAssertEqual(loader.decodingStrategy, .concurrentlyAllFiles)
             #else
             XCTAssertEqual(loader.decodingStrategy, .concurrentlyEachFileInBatches)
@@ -323,7 +323,7 @@ class SymbolGraphLoaderTests: XCTestCase {
         var loader = try makeSymbolGraphLoader(symbolGraphURLs: symbolGraphURLs)
         try loader.loadAll()
 
-        #if os(macOS) || os(iOS)
+        #if os(macOS) || os(iOS) || os(visionOS)
         XCTAssertEqual(loader.decodingStrategy, .concurrentlyAllFiles)
         #else
         XCTAssertEqual(loader.decodingStrategy, .concurrentlyEachFileInBatches)

--- a/Tests/SwiftDocCTests/Utility/Collection+ConcurrentPerformTests.swift
+++ b/Tests/SwiftDocCTests/Utility/Collection+ConcurrentPerformTests.swift
@@ -76,7 +76,7 @@ class CollectionConcurrentPerformTests: XCTestCase {
                 return next.start < result.end
             })
 
-        #if os(macOS) || os(iOS)
+        #if os(macOS) || os(iOS) || os(visionOS)
         // Expect all blocks ran concurrently on supported platforms.
         XCTAssertTrue(didBlocksExecuteConcurrently, "Blocks didn't run concurrently")
         #else
@@ -122,7 +122,7 @@ class CollectionConcurrentPerformTests: XCTestCase {
                 return next.start < result.end
             })
         
-        #if os(macOS) || os(iOS)
+        #if os(macOS) || os(iOS) || os(visionOS)
         // Expect all blocks ran concurrently on supported platforms.
         XCTAssertTrue(didBlocksExecuteConcurrently, "Blocks didn't run concurrently")
         #else

--- a/Tests/SwiftDocCTests/Utility/SynchronizationTests.swift
+++ b/Tests/SwiftDocCTests/Utility/SynchronizationTests.swift
@@ -15,7 +15,7 @@ import func WinSDK.TryAcquireSRWLockExclusive
 #endif
 
 private func XCTAssertLockIsUnlocked<T>(_ synced: Synchronized<T>) {
-    #if os(macOS) || os(iOS)
+    #if os(macOS) || os(iOS) || os(visionOS)
     XCTAssertTrue(os_unfair_lock_trylock(synced.lock))
     #elseif os(Windows)
     XCTAssertNotEqual(TryAcquireSRWLockExclusive(synced.lock), 0)
@@ -25,7 +25,7 @@ private func XCTAssertLockIsUnlocked<T>(_ synced: Synchronized<T>) {
 }
 
 private func XCTAssertLockIsLocked<T>(_ synced: Synchronized<T>) {
-    #if os(macOS) || os(iOS)
+    #if os(macOS) || os(iOS) || os(visionOS)
     XCTAssertFalse(os_unfair_lock_trylock(synced.lock))
     #elseif os(Windows)
     XCTAssertEqual(TryAcquireSRWLockExclusive(synced.lock), 0)

--- a/bin/benchmark/Sources/benchmark/Diff/DiffAnalysis.swift
+++ b/bin/benchmark/Sources/benchmark/Diff/DiffAnalysis.swift
@@ -169,7 +169,7 @@ extension BenchmarkResultSeries.MetricSeries.ValueSeries {
             case .duration(let value):
                 let average = value.mean()
             
-                #if os(macOS) || os(iOS)
+                #if os(macOS) || os(iOS) || os(visionOS)
                 return durationFormatter.string(from: Measurement(value: average, unit: UnitDuration.seconds))
                 #else
                 return durationFormatter.string(from: NSNumber(value: average))! + " sec"
@@ -189,7 +189,7 @@ extension BenchmarkResultSeries.MetricSeries.ValueSeries {
     }
 }
 
-#if os(macOS) || os(iOS)
+#if os(macOS) || os(iOS) || os(visionOS)
 private let durationFormatter: MeasurementFormatter = {
     let fmt = MeasurementFormatter()
     fmt.unitStyle = .medium


### PR DESCRIPTION
## Summary

Adds support for running DocC on visionOS by extending platform checks.

## Dependencies

Upgrades Swift Crypto to [v2.6.0](https://github.com/apple/swift-crypto/releases/tag/2.6.0), which removed specific os conditions.

## Testing

Run `SwiftDocCTests` and `SwiftDocCUtilitiesTests` with a visionOS simulator target.
No platform-specific tests added.
I don't think there's a public way to run the benchmark for a target other than host.
