### PR TITLE
Collect external links from _symbol_ deprecation summary content

### DIFF
--- a/Sources/SwiftDocC/Semantics/ExternalLinks/ExternalReferenceWalker.swift
+++ b/Sources/SwiftDocC/Semantics/ExternalLinks/ExternalReferenceWalker.swift
@@ -181,6 +181,7 @@ struct ExternalReferenceWalker: SemanticVisitor {
         symbol.topics.unwrap { $0.content.forEach { visitMarkup($0) }}
         symbol.seeAlso.unwrap { $0.content.forEach { visitMarkup($0) }}
         symbol.returnsSection.unwrap { $0.content.forEach { visitMarkup($0) }}
+        symbol.deprecatedSummary.unwrap { $0.content.forEach { visitMarkup($0) }}
         
         symbol.parametersSection.unwrap {
             $0.parameters.forEach {

--- a/Tests/SwiftDocCTests/Infrastructure/ExternalReferenceResolverTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/ExternalReferenceResolverTests.swift
@@ -998,7 +998,7 @@ class ExternalReferenceResolverTests: XCTestCase {
             # Article
             
             @DeprecationSummary {
-              Use <doc://com.external.testbundle/something> instead.
+              Use <doc://com.external.testbundle/something-else> instead.
             }
             
             Link to external content in an article deprecation message.


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://120374614

## Summary

This fixes a bug where external links in a symbol's deprecation summary content didn't resolve unless that external link was also used anywhere else in the project's content.

## Dependencies

None.

## Testing

This can be tested using `bin/test-data-external-resolver` as an external resolver:

1. Set `DOCC_LINK_RESOLVER_EXECUTABLE` to the `test-data-external-resolver` path
2. Set `DOCC_HTML_DIR` to swift-docc-render-artifact checkout path (`/path/to/swift-docc-render-artifact/dist`)
3. In a documentation catalog with some some deprecated symbols, add a documentation extension file for the deprecated symbols and add an external link in a `@DeprecationSummary` directive. For example:

```md
# ``SymbolName``

@DeprecationSummary {
  Use <doc://com.test.bundle/something> instead.
}

Link to external content in a symbol deprecation message.
```

4. Build the documentation
```
swift run docc preview path/to/Something.docc
```

5.  Preview the deprecated symbol's page. The deprecation information should display the resolved external link

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
