### PR TITLE
Don't resolve ConvertService fallback links unless bundle ID matches

### DIFF
--- a/Sources/SwiftDocC/DocumentationService/Convert/Fallback Link Resolution/ConvertServiceFallbackResolver.swift
+++ b/Sources/SwiftDocC/DocumentationService/Convert/Fallback Link Resolution/ConvertServiceFallbackResolver.swift
@@ -23,6 +23,11 @@ import Foundation
 /// "external" content, even if it represents pages that would be "local" if the full project was built together.
 protocol ConvertServiceFallbackResolver {
     
+    /// The bundle identifier for the fallback resolver.
+    ///
+    /// The fallback resolver will only resolve links with this bundle identifier.
+    var bundleIdentifier: String { get }
+    
     // MARK: References
     
     /// Attempts to resolve an unresolved reference for a page that couldn't be resolved locally.

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/LinkResolver.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/LinkResolver.swift
@@ -170,7 +170,8 @@ private final class FallbackResolverBasedLinkResolver {
         // Check if a fallback reference resolver should resolve this
         let referenceBundleIdentifier = unresolvedReference.bundleIdentifier ?? parent.bundleIdentifier
         guard let fallbackResolver = context.convertServiceFallbackResolver,
-              let knownBundleIdentifier = context.registeredBundles.first(where: { $0.identifier == referenceBundleIdentifier || urlReadablePath($0.displayName) == referenceBundleIdentifier })?.identifier
+              let knownBundleIdentifier = context.registeredBundles.first(where: { $0.identifier == referenceBundleIdentifier || urlReadablePath($0.displayName) == referenceBundleIdentifier })?.identifier,
+              fallbackResolver.bundleIdentifier == knownBundleIdentifier
         else {
             return nil
         }

--- a/Tests/SwiftDocCTests/DocumentationService/ConvertService/ConvertServiceTests.swift
+++ b/Tests/SwiftDocCTests/DocumentationService/ConvertService/ConvertServiceTests.swift
@@ -2324,6 +2324,45 @@ class ConvertServiceTests: XCTestCase {
         }
     }
     
+    func testDoesNotResolveLinksUnlessBundleIDMatches() throws {
+        let tempURL = try createTempFolder(content: [
+            Folder(name: "unit-test.docc", content: [
+                TextFile(name: "SomeExtension.md", utf8Content: """
+                # ``/ModuleName/SymbolName``
+                
+                Some documentation extension
+                """),
+                
+                // This catalog doesn't have any symbol graph files
+                
+                InfoPlist(identifier: "com.example.something")
+            ])
+        ])
+        let bundleURL = tempURL.appendingPathComponent("unit-test.docc")
+        
+        let requestWithDifferentBundleID = ConvertRequest(
+            bundleInfo: DocumentationBundle.Info(displayName: "DisplayName", identifier: "com.example.something-else"),
+            externalIDsToConvert: [],
+            bundleLocation: bundleURL,
+            symbolGraphs: [],
+            markupFiles: [],
+            miscResourceURLs: []
+        )
+        XCTAssertEqual(try linkResolutionRequestsForConvertRequest(requestWithDifferentBundleID), [], "Shouldn't make any link resolution requests because the bundle IDs are different.")
+        
+        let requestWithSameBundleID = ConvertRequest(
+            bundleInfo: DocumentationBundle.Info(displayName: "DisplayName", identifier: "com.example.something"),
+            externalIDsToConvert: [],
+            bundleLocation: bundleURL,
+            symbolGraphs: [],
+            markupFiles: [],
+            miscResourceURLs: []
+        )
+        let linkResolutionRequests = try linkResolutionRequestsForConvertRequest(requestWithSameBundleID)
+        XCTAssertFalse(linkResolutionRequests.isEmpty, "Should have made some link resolution requests to try to match the extension file")
+        XCTAssert(linkResolutionRequests.allSatisfy { $0.hasSuffix("/SymbolName") }, "Should have made some link resolution requests to try to match the extension file")
+    }
+    
     func testReturnsErrorWhenConversionHasProblems() throws {
         let request = ConvertRequest(
             bundleInfo: testBundleInfo,

--- a/Tests/SwiftDocCTests/Infrastructure/ExternalReferenceResolverTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/ExternalReferenceResolverTests.swift
@@ -192,6 +192,12 @@ class ExternalReferenceResolverTests: XCTestCase {
         
         do {
             class TestFallbackResolver: ConvertServiceFallbackResolver {
+                init(bundleIdentifier: String) {
+                    resolver.bundleIdentifier = bundleIdentifier
+                }
+                var bundleIdentifier: String {
+                    resolver.bundleIdentifier
+                }
                 private var resolver = TestExternalReferenceResolver()
                 func resolve(_ reference: SwiftDocC.TopicReference) -> TopicReferenceResolutionResult {
                     TestExternalReferenceResolver().resolve(reference)
@@ -205,7 +211,7 @@ class ExternalReferenceResolverTests: XCTestCase {
             }
             
             context.externalDocumentationSources = [:]
-            context.convertServiceFallbackResolver = TestFallbackResolver()
+            context.convertServiceFallbackResolver = TestFallbackResolver(bundleIdentifier: "org.swift.docc.example")
             
             guard case let .success(resolved) = context.resolve(.unresolved(unresolved), in: parent) else {
                 XCTFail("The reference was unexpectedly unresolved.")


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://122964958

## Summary

This fixes a regression where the convert service fallback resolver was asked to resolve _all_ unresolved links, not just the unresolved links to local content.

## Dependencies

None

## Testing

It's rather cumbersome to test this end-to-end since it requires another project to use `SwiftDocC` as a framework dependency and create a `ConvertService` and send requests for certain content. You'd more or less reimplement `testDoesNotResolveLinksUnlessBundleIDMatches()` but in a new project.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
