### PR TITLE
Remove two print statements in tests

### DIFF
--- a/Tests/SwiftDocCTests/DocumentationService/ConvertService/ConvertServiceTests.swift
+++ b/Tests/SwiftDocCTests/DocumentationService/ConvertService/ConvertServiceTests.swift
@@ -919,7 +919,6 @@ class ConvertServiceTests: XCTestCase {
                     )
                     
                 case .asset(let assetReference):
-                    print(assetReference)
                     switch (assetReference.assetName, assetReference.bundleIdentifier) {
                     case (let assetName, "identifier") where ["before.swift", "after.swift"].contains(assetName):
                         var asset = DataAsset()

--- a/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
@@ -1812,8 +1812,6 @@ class PathHierarchyTests: XCTestCase {
         let (_, _, context) = try loadBundle(from: tempURL)
         let tree = context.linkResolver.localResolver.pathHierarchy
         
-        print(tree.dump())
-        
         let moduleID = try tree.find(path: "/ModuleName", onlyFindSymbols: true)
         // Relative link from the module to a topic section
         do {


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

This removes two print-statements in test code.

## Dependencies

None.

## Testing

Run these two tests. They shouldn't print anything.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] ~Added~ Updated tests
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
