### PR TITLE
Fix incorrect key name in ThemeSettings spec JSON

### DIFF
--- a/Sources/SwiftDocC/SwiftDocC.docc/Resources/ThemeSettings.spec.json
+++ b/Sources/SwiftDocC/SwiftDocC.docc/Resources/ThemeSettings.spec.json
@@ -73,7 +73,7 @@
                                     }
                                 }
                             },
-                            "colors": {
+                            "color": {
                                 "type": "object",
                                 "description": "An object where each key represents the name of a color variable referenced in the renderer. A CSS property in the form `--color-[key]` will either be created or overwritten with the value associated with it.",
                                 "properties": {


### PR DESCRIPTION
<!--
If you're opening a PR to cherry-pick a change for a release branch, use this template instead:
https://github.com/apple/swift-docc/blob/main/.github/PULL_REQUEST_TEMPLATE/CHERRY_PICK.md
-->

## Summary

The `ThemeSettings.spec.json` file specifies that the key under `theme` for the dictionary of colors is `colors`. However, when used in practice, the correct key is `color`; `colors` does not work. This corrects the spec to match the implementation.

(In truth, it seems like `colors` would be both more accurate and more consistent, but changing the implementation to match the spec would be _considerably_ wider-ranging and have significant compatibility implications.)

## Testing

N/A, documentation-only change

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] ~~Added tests~~ N/A, documentation-only change
- [ ] ~~Ran the `./bin/test` script and it succeeded~~ N/A, documentation-only change
- [x] Updated documentation if necessary
