### PR TITLE
Explicitly load unaligned data in test

### DIFF
--- a/Tests/SwiftDocCTests/Utility/LMDBTests.swift
+++ b/Tests/SwiftDocCTests/Utility/LMDBTests.swift
@@ -313,13 +313,13 @@ struct RawStub: LMDBData, Equatable, Codable {
         
         var cursor: Int = 0
         let length = MemoryLayout<Int64>.stride
-        let id = d[cursor..<cursor + length].withUnsafeBytes { $0.load(as: Int64.self) }
+        let id = d[cursor..<cursor + length].withUnsafeBytes { $0.loadUnaligned(as: Int64.self) }
         cursor += length
         
-        let titleLength = d[cursor..<cursor + length].withUnsafeBytes{ $0.load(as: Int64.self) }
+        let titleLength = d[cursor..<cursor + length].withUnsafeBytes{ $0.loadUnaligned(as: Int64.self) }
         cursor += length
         
-        let typeLength = d[cursor..<cursor + length].withUnsafeBytes { $0.load(as: Int64.self) }
+        let typeLength = d[cursor..<cursor + length].withUnsafeBytes { $0.loadUnaligned(as: Int64.self) }
         cursor += length
         
         let titleData = d[cursor..<cursor + Int(titleLength)]


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://125770540 

## Summary

This fixes the Linux CI crashing due to unaligned read from buffer in a LMDB test. For example:
https://ci.swift.org/job/pr-swift-docc-linux/1243/

## Dependencies

None

## Testing

Verify that the Linux CI passes. 

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] ~Added~ Updated tests
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~ Not applicable
