### PR TITLE
[6.0] Unaligned buffer load in test

### DIFF
--- a/Tests/SwiftDocCTests/Utility/LMDBTests.swift
+++ b/Tests/SwiftDocCTests/Utility/LMDBTests.swift
@@ -313,13 +313,13 @@ struct RawStub: LMDBData, Equatable, Codable {
         
         var cursor: Int = 0
         let length = MemoryLayout<Int64>.stride
-        let id = d[cursor..<cursor + length].withUnsafeBytes { $0.load(as: Int64.self) }
+        let id = d[cursor..<cursor + length].withUnsafeBytes { $0.loadUnaligned(as: Int64.self) }
         cursor += length
         
-        let titleLength = d[cursor..<cursor + length].withUnsafeBytes{ $0.load(as: Int64.self) }
+        let titleLength = d[cursor..<cursor + length].withUnsafeBytes{ $0.loadUnaligned(as: Int64.self) }
         cursor += length
         
-        let typeLength = d[cursor..<cursor + length].withUnsafeBytes { $0.load(as: Int64.self) }
+        let typeLength = d[cursor..<cursor + length].withUnsafeBytes { $0.loadUnaligned(as: Int64.self) }
         cursor += length
         
         let titleData = d[cursor..<cursor + Int(titleLength)]


### PR DESCRIPTION
- **Explanation**:  This fixes a crash in the Linux CI due to unaligned reads from a buffer in a test type.
- **Scope**: CI failure 
- **Issue**: rdar://125770540
- **Original PR**: #875 
- **Risk**: Low. Test-only change.
- **Testing**: Linux CI passes with these changes.
- **Reviewer**: @daniel-grumberg 