### PR TITLE
Use package access level (SE-0386) instead of SPI for FileManagerProtocol

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Diagnostics/DiagnosticConsoleWriter.swift
+++ b/Sources/SwiftDocC/Infrastructure/Diagnostics/DiagnosticConsoleWriter.swift
@@ -36,8 +36,7 @@ public final class DiagnosticConsoleWriter: DiagnosticFormattingConsumer {
         self.init(stream, formattingOptions: options, baseURL: baseURL, highlight: highlight, fileManager: FileManager.default)
     }
     
-    @_spi(FileManagerProtocol)
-    public init(
+    package init(
         _ stream: TextOutputStream = LogHandle.standardError,
         formattingOptions options: DiagnosticFormattingOptions = [],
         baseURL: URL? = nil,
@@ -101,16 +100,14 @@ extension DiagnosticConsoleWriter {
     public static func formattedDescription(for problems: some Sequence<Problem>, options: DiagnosticFormattingOptions = []) -> String {
         formattedDescription(for: problems, options: options, fileManager: FileManager.default)
     }
-    @_spi(FileManagerProtocol)
-    public static func formattedDescription(for problems: some Sequence<Problem>, options: DiagnosticFormattingOptions = [], fileManager: FileManagerProtocol) -> String {
+    package static func formattedDescription(for problems: some Sequence<Problem>, options: DiagnosticFormattingOptions = [], fileManager: FileManagerProtocol) -> String {
         return problems.map { formattedDescription(for: $0, options: options, fileManager: fileManager) }.joined(separator: "\n")
     }
     
     public static func formattedDescription(for problem: Problem, options: DiagnosticFormattingOptions = []) -> String {
         formattedDescription(for: problem, options: options, fileManager: FileManager.default)
     }
-    @_spi(FileManagerProtocol)
-    public static func formattedDescription(for problem: Problem, options: DiagnosticFormattingOptions = [], fileManager: FileManagerProtocol = FileManager.default) -> String {
+    package static func formattedDescription(for problem: Problem, options: DiagnosticFormattingOptions = [], fileManager: FileManagerProtocol = FileManager.default) -> String {
         let diagnosticFormatter = makeDiagnosticFormatter(options, baseURL: nil, highlight: TerminalHelper.isConnectedToTerminal, fileManager: fileManager)
         return diagnosticFormatter.formattedDescription(for: problem)
     }
@@ -118,8 +115,7 @@ extension DiagnosticConsoleWriter {
     public static func formattedDescription(for diagnostic: Diagnostic, options: DiagnosticFormattingOptions = []) -> String {
         formattedDescription(for: diagnostic, options: options, fileManager: FileManager.default)
     }
-    @_spi(FileManagerProtocol)
-    public static func formattedDescription(for diagnostic: Diagnostic, options: DiagnosticFormattingOptions = [], fileManager: FileManagerProtocol) -> String {
+    package static func formattedDescription(for diagnostic: Diagnostic, options: DiagnosticFormattingOptions = [], fileManager: FileManagerProtocol) -> String {
         let diagnosticFormatter = makeDiagnosticFormatter(options, baseURL: nil, highlight: TerminalHelper.isConnectedToTerminal, fileManager: fileManager)
         return diagnosticFormatter.formattedDescription(for: diagnostic)
     }

--- a/Sources/SwiftDocC/Utility/FileManagerProtocol.swift
+++ b/Sources/SwiftDocC/Utility/FileManagerProtocol.swift
@@ -22,8 +22,7 @@ import Foundation
 /// Should you need a file system with a different storage, create your own
 /// protocol implementations to manage files in memory,
 /// on a network, in a database, or elsewhere.
-@_spi(FileManagerProtocol)
-public protocol FileManagerProtocol {
+package protocol FileManagerProtocol {
     
     /// Returns the data content of a file at the given path, if it exists.
     func contents(atPath: String) -> Data?
@@ -90,10 +89,9 @@ public protocol FileManagerProtocol {
     func createFile(at location: URL, contents: Data, options writingOptions: NSData.WritingOptions?) throws
 }
 
-@_spi(FileManagerProtocol)
 extension FileManagerProtocol {
     /// Returns a Boolean value that indicates whether a directory exists at a specified path.
-    public func directoryExists(atPath path: String) -> Bool {
+    package func directoryExists(atPath path: String) -> Bool {
         var isDirectory = ObjCBool(booleanLiteral: false)
         let fileExistsAtPath = fileExists(atPath: path, isDirectory: &isDirectory)
         return fileExistsAtPath && isDirectory.boolValue
@@ -102,19 +100,18 @@ extension FileManagerProtocol {
 
 /// Add compliance to `FileManagerProtocol` to `FileManager`,
 /// most of the methods are already implemented in Foundation.
-@_spi(FileManagerProtocol)
 extension FileManager: FileManagerProtocol {
     // This method doesn't exist on `FileManager`. There is a similar looking method but it doesn't provide information about potential errors.
-    public func contents(of url: URL) throws -> Data {
+    package func contents(of url: URL) throws -> Data {
         return try Data(contentsOf: url)
     }
     
     // This method doesn't exist on `FileManager`. There is a similar looking method but it doesn't provide information about potential errors.
-    public func createFile(at location: URL, contents: Data) throws {
+    package func createFile(at location: URL, contents: Data) throws {
         try contents.write(to: location, options: .atomic)
     }
     
-    public func createFile(at location: URL, contents: Data, options writingOptions: NSData.WritingOptions?) throws {
+    package func createFile(at location: URL, contents: Data, options writingOptions: NSData.WritingOptions?) throws {
         if let writingOptions {
             try contents.write(to: location, options: writingOptions)
         } else {
@@ -123,7 +120,7 @@ extension FileManager: FileManagerProtocol {
     }
     
     // Because we shadow 'FileManager.temporaryDirectory' in our tests, we can't also use 'temporaryDirectory' in FileManagerProtocol/
-    public func uniqueTemporaryDirectory() -> URL {
+    package func uniqueTemporaryDirectory() -> URL {
         temporaryDirectory.appendingPathComponent(ProcessInfo.processInfo.globallyUniqueString, isDirectory: true)
     }
 }

--- a/Sources/SwiftDocCTestUtilities/TestFileSystem.swift
+++ b/Sources/SwiftDocCTestUtilities/TestFileSystem.swift
@@ -10,7 +10,7 @@
 
 import Foundation
 import XCTest
-@testable @_spi(FileManagerProtocol) import SwiftDocC
+@testable import SwiftDocC
 
 /// A Data provider and file manager that accepts pre-built documentation bundles with files on the local filesystem.
 ///
@@ -40,14 +40,13 @@ import XCTest
 ///
 /// - Note: This class is thread-safe by using a naive locking for each access to the files dictionary.
 /// - Warning: Use this type for unit testing.
-@_spi(FileManagerProtocol) // This needs to be SPI because it conforms to an SPI protocol
-public class TestFileSystem: FileManagerProtocol, DocumentationWorkspaceDataProvider {
-    public let currentDirectoryPath = "/"
+package class TestFileSystem: FileManagerProtocol, DocumentationWorkspaceDataProvider {
+    package let currentDirectoryPath = "/"
     
-    public var identifier: String = UUID().uuidString
+    package var identifier: String = UUID().uuidString
     
     private var _bundles = [DocumentationBundle]()
-    public func bundles(options: BundleDiscoveryOptions) throws -> [DocumentationBundle] {
+    package func bundles(options: BundleDiscoveryOptions) throws -> [DocumentationBundle] {
         // Ignore the bundle discovery options, these test bundles are already built.
         return _bundles
     }
@@ -65,7 +64,7 @@ public class TestFileSystem: FileManagerProtocol, DocumentationWorkspaceDataProv
     /// A data fixture to use in the `files` index to mark folders.
     static let folderFixtureData = "Folder".data(using: .utf8)!
     
-    public convenience init(folders: [Folder]) throws {
+    package convenience init(folders: [Folder]) throws {
         self.init()
         
         // Default system paths
@@ -117,7 +116,7 @@ public class TestFileSystem: FileManagerProtocol, DocumentationWorkspaceDataProv
         }
     }
 
-    public func contentsOfURL(_ url: URL) throws -> Data {
+    package func contentsOfURL(_ url: URL) throws -> Data {
         filesLock.lock()
         defer { filesLock.unlock() }
 
@@ -127,7 +126,7 @@ public class TestFileSystem: FileManagerProtocol, DocumentationWorkspaceDataProv
         return file
     }
     
-    public func contents(of url: URL) throws -> Data {
+    package func contents(of url: URL) throws -> Data {
         try contentsOfURL(url)
     }
     
@@ -166,7 +165,7 @@ public class TestFileSystem: FileManagerProtocol, DocumentationWorkspaceDataProv
         return Array(fileList.keys)
     }
     
-    public func fileExists(atPath path: String, isDirectory: UnsafeMutablePointer<ObjCBool>?) -> Bool {
+    package func fileExists(atPath path: String, isDirectory: UnsafeMutablePointer<ObjCBool>?) -> Bool {
         filesLock.lock()
         defer { filesLock.unlock() }
         
@@ -179,14 +178,14 @@ public class TestFileSystem: FileManagerProtocol, DocumentationWorkspaceDataProv
         return true
     }
     
-    public func fileExists(atPath path: String) -> Bool {
+    package func fileExists(atPath path: String) -> Bool {
         filesLock.lock()
         defer { filesLock.unlock() }
 
         return files.keys.contains(path)
     }
     
-    public func copyItem(at srcURL: URL, to dstURL: URL) throws {
+    package func copyItem(at srcURL: URL, to dstURL: URL) throws {
         guard !disableWriting else { return }
         
         filesLock.lock()
@@ -203,7 +202,7 @@ public class TestFileSystem: FileManagerProtocol, DocumentationWorkspaceDataProv
         }
     }
     
-    public func moveItem(at srcURL: URL, to dstURL: URL) throws {
+    package func moveItem(at srcURL: URL, to dstURL: URL) throws {
         guard !disableWriting else { return }
         
         filesLock.lock()
@@ -240,7 +239,7 @@ public class TestFileSystem: FileManagerProtocol, DocumentationWorkspaceDataProv
         files[path] = Self.folderFixtureData
     }
     
-    public func createDirectory(at url: URL, withIntermediateDirectories createIntermediates: Bool, attributes: [FileAttributeKey : Any]? = nil) throws {
+    package func createDirectory(at url: URL, withIntermediateDirectories createIntermediates: Bool, attributes: [FileAttributeKey : Any]? = nil) throws {
         guard !disableWriting else { return }
         
         filesLock.lock()
@@ -249,14 +248,14 @@ public class TestFileSystem: FileManagerProtocol, DocumentationWorkspaceDataProv
         try createDirectory(atPath: url.path, withIntermediateDirectories: createIntermediates)
     }
     
-    public func contentsEqual(atPath path1: String, andPath path2: String) -> Bool {
+    package func contentsEqual(atPath path1: String, andPath path2: String) -> Bool {
         filesLock.lock()
         defer { filesLock.unlock() }
 
         return files[path1] == files[path2]
     }
     
-    public func removeItem(at: URL) throws {
+    package func removeItem(at: URL) throws {
         guard !disableWriting else { return }
         
         filesLock.lock()
@@ -268,7 +267,7 @@ public class TestFileSystem: FileManagerProtocol, DocumentationWorkspaceDataProv
         }
     }
     
-    public func createFile(at url: URL, contents: Data) throws {
+    package func createFile(at url: URL, contents: Data) throws {
         filesLock.lock()
         defer { filesLock.unlock() }
 
@@ -279,18 +278,18 @@ public class TestFileSystem: FileManagerProtocol, DocumentationWorkspaceDataProv
         }
     }
     
-    public func createFile(at url: URL, contents: Data, options: NSData.WritingOptions?) throws {
+    package func createFile(at url: URL, contents: Data, options: NSData.WritingOptions?) throws {
         try createFile(at: url, contents: contents)
     }
     
-    public func contents(atPath: String) -> Data? {
+    package func contents(atPath: String) -> Data? {
         filesLock.lock()
         defer { filesLock.unlock() }
 
         return files[atPath]
     }
     
-    public func contentsOfDirectory(atPath path: String) throws -> [String] {
+    package func contentsOfDirectory(atPath path: String) throws -> [String] {
         filesLock.lock()
         defer { filesLock.unlock() }
         
@@ -309,7 +308,7 @@ public class TestFileSystem: FileManagerProtocol, DocumentationWorkspaceDataProv
         return Array(results)
     }
 
-    public func contentsOfDirectory(at url: URL, includingPropertiesForKeys keys: [URLResourceKey]?, options mask: FileManager.DirectoryEnumerationOptions) throws -> [URL] {
+    package func contentsOfDirectory(at url: URL, includingPropertiesForKeys keys: [URLResourceKey]?, options mask: FileManager.DirectoryEnumerationOptions) throws -> [URL] {
 
         if let keys {
             XCTAssertTrue(keys.isEmpty, "includingPropertiesForKeys is not implemented in contentsOfDirectory in TestFileSystem")
@@ -328,7 +327,7 @@ public class TestFileSystem: FileManagerProtocol, DocumentationWorkspaceDataProv
         return output
     }
 
-    public func uniqueTemporaryDirectory() -> URL {
+    package func uniqueTemporaryDirectory() -> URL {
         URL(fileURLWithPath: "/tmp/\(ProcessInfo.processInfo.globallyUniqueString)", isDirectory: true)
     }
     
@@ -345,7 +344,7 @@ public class TestFileSystem: FileManagerProtocol, DocumentationWorkspaceDataProv
     ///
     /// - Parameter path: The path to the sub hierarchy to dump to a string representation.
     /// - Returns: A stable string representation that can be checked in tests.
-    public func dump(subHierarchyFrom path: String = "/") -> String {
+    package func dump(subHierarchyFrom path: String = "/") -> String {
         filesLock.lock()
         defer { filesLock.unlock() }
         
@@ -368,7 +367,7 @@ public class TestFileSystem: FileManagerProtocol, DocumentationWorkspaceDataProv
     }
     
     // This is a convenience utility for testing, not FileManagerProtocol API
-    public func recursiveContentsOfDirectory(atPath path: String) throws -> [String] {
+    package func recursiveContentsOfDirectory(atPath path: String) throws -> [String] {
         var allSubpaths = try contentsOfDirectory(atPath: path)
         
         for subpath in allSubpaths { // This is iterating over a copy

--- a/Sources/SwiftDocCUtilities/Action/Actions/Action+MoveOutput.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Action+MoveOutput.swift
@@ -9,7 +9,7 @@
 */
 
 import Foundation
-@_spi(FileManagerProtocol) import SwiftDocC
+import SwiftDocC
 
 extension Action {
     

--- a/Sources/SwiftDocCUtilities/Action/Actions/Convert/ConvertAction.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Convert/ConvertAction.swift
@@ -11,7 +11,6 @@
 import Foundation
 
 @_spi(ExternalLinks) // SPI to set `context.linkResolver.dependencyArchives`
-@_spi(FileManagerProtocol) // SPI to initialize `DiagnosticConsoleWriter` with a `FileManagerProtocol`
 import SwiftDocC
 
 /// An action that converts a source bundle into compiled documentation.

--- a/Sources/SwiftDocCUtilities/Action/Actions/Convert/ConvertFileWritingConsumer.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Convert/ConvertFileWritingConsumer.swift
@@ -9,7 +9,7 @@
 */
 
 import Foundation
-@_spi(FileManagerProtocol) import SwiftDocC
+import SwiftDocC
 
 struct ConvertFileWritingConsumer: ConvertOutputConsumer {
     var targetFolder: URL

--- a/Sources/SwiftDocCUtilities/Action/Actions/Convert/CoverageDataEntry+generateSummary.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Convert/CoverageDataEntry+generateSummary.swift
@@ -9,7 +9,7 @@
 */
 
 import Foundation
-@_spi(FileManagerProtocol) import SwiftDocC
+import SwiftDocC
 
 extension CoverageDataEntry {
     /// Outputs a short table summarizing the coverage statistics for a list of data entries in a file at the given URL.

--- a/Sources/SwiftDocCUtilities/Action/Actions/Convert/JSONEncodingRenderNodeWriter.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Convert/JSONEncodingRenderNodeWriter.swift
@@ -9,7 +9,7 @@
 */
 
 import Foundation
-@_spi(FileManagerProtocol) import SwiftDocC
+import SwiftDocC
 
 /// An object that writes render nodes, as JSON files, into a target folder.
 ///

--- a/Sources/SwiftDocCUtilities/Action/Actions/CoverageAction.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/CoverageAction.swift
@@ -9,7 +9,7 @@
 */
 
 import Foundation
-@_spi(FileManagerProtocol) import SwiftDocC
+import SwiftDocC
 
 /// An action that creates documentation coverage info for a documentation bundle.
 public struct CoverageAction: Action {

--- a/Sources/SwiftDocCUtilities/Action/Actions/EmitGeneratedCurationAction.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/EmitGeneratedCurationAction.swift
@@ -9,7 +9,7 @@
 */
 
 import Foundation
-@_spi(FileManagerProtocol) import SwiftDocC
+import SwiftDocC
 
 /// An action that emits documentation extension files that reflect the auto-generated curation.
 struct EmitGeneratedCurationAction: Action {

--- a/Sources/SwiftDocCUtilities/Action/Actions/Init/InitAction.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Init/InitAction.swift
@@ -9,7 +9,7 @@
 */
 
 import Foundation
-@_spi(FileManagerProtocol) import SwiftDocC
+import SwiftDocC
 
 /// An action that generates a documentation catalog from a template seed.
 public struct InitAction: Action {

--- a/Sources/SwiftDocCUtilities/Action/Actions/MergeAction.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/MergeAction.swift
@@ -9,7 +9,7 @@
 */
 
 import Foundation
-@_spi(FileManagerProtocol) import SwiftDocC
+import SwiftDocC
 
 /// An action that merges a list of documentation archives into a combined archive.
 struct MergeAction: Action {

--- a/Sources/SwiftDocCUtilities/Action/Actions/TransformForStaticHostingAction.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/TransformForStaticHostingAction.swift
@@ -9,7 +9,7 @@
 */
 
 import Foundation
-@_spi(FileManagerProtocol) import SwiftDocC
+import SwiftDocC
 
 /// An action that emits a static hostable website from a DocC Archive.
 struct TransformForStaticHostingAction: Action {

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Merge.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Merge.swift
@@ -9,7 +9,7 @@
 */
 
 import ArgumentParser
-@_spi(FileManagerProtocol) import SwiftDocC
+import SwiftDocC
 import Foundation
 
 extension Docc {

--- a/Sources/SwiftDocCUtilities/Transformers/StaticHostableTransformer.swift
+++ b/Sources/SwiftDocCUtilities/Transformers/StaticHostableTransformer.swift
@@ -9,7 +9,7 @@
 */
 
 import Foundation
-@_spi(FileManagerProtocol) import SwiftDocC
+import SwiftDocC
 
 enum HTMLTemplate: String {
     case templateFileName = "index-template.html"

--- a/Sources/SwiftDocCUtilities/Utility/DirectoryMonitor.swift
+++ b/Sources/SwiftDocCUtilities/Utility/DirectoryMonitor.swift
@@ -9,7 +9,7 @@
 */
 
 import Foundation
-@_spi(FileManagerProtocol) import SwiftDocC
+import SwiftDocC
 
 #if !os(Linux) && !os(Android) && !os(Windows)
 import Darwin

--- a/Tests/SwiftDocCTests/Diagnostics/DiagnosticConsoleWriterDefaultFormattingTest.swift
+++ b/Tests/SwiftDocCTests/Diagnostics/DiagnosticConsoleWriterDefaultFormattingTest.swift
@@ -10,8 +10,8 @@
 
 import XCTest
 import Markdown
-@testable @_spi(FileManagerProtocol) import SwiftDocC
-@_spi(FileManagerProtocol) import SwiftDocCTestUtilities
+@testable import SwiftDocC
+import SwiftDocCTestUtilities
 
 class DiagnosticConsoleWriterDefaultFormattingTest: XCTestCase {
 

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -12,7 +12,7 @@ import XCTest
 import SymbolKit
 @testable import SwiftDocC
 import Markdown
-@_spi(FileManagerProtocol) import SwiftDocCTestUtilities
+import SwiftDocCTestUtilities
 
 func diffDescription(lhs: String, rhs: String) -> String {
     let leftLines = lhs.components(separatedBy: .newlines)

--- a/Tests/SwiftDocCTests/Model/ParametersAndReturnValidatorTests.swift
+++ b/Tests/SwiftDocCTests/Model/ParametersAndReturnValidatorTests.swift
@@ -12,8 +12,8 @@ import Foundation
 import XCTest
 import Markdown
 @testable import SymbolKit
-@testable @_spi(FileManagerProtocol) import SwiftDocC
-@_spi(FileManagerProtocol) import SwiftDocCTestUtilities
+@testable import SwiftDocC
+import SwiftDocCTestUtilities
 
 class ParametersAndReturnValidatorTests: XCTestCase {
     

--- a/Tests/SwiftDocCTests/XCTestCase+LoadingTestData.swift
+++ b/Tests/SwiftDocCTests/XCTestCase+LoadingTestData.swift
@@ -12,7 +12,7 @@ import Foundation
 import XCTest
 @testable import SwiftDocC
 import Markdown
-@_spi(FileManagerProtocol) import SwiftDocCTestUtilities
+import SwiftDocCTestUtilities
 
 extension XCTestCase {
     

--- a/Tests/SwiftDocCUtilitiesTests/ArgumentParsing/MergeSubcommandTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ArgumentParsing/MergeSubcommandTests.swift
@@ -12,7 +12,7 @@ import XCTest
 import ArgumentParser
 @testable import SwiftDocCUtilities
 @testable import SwiftDocC
-@_spi(FileManagerProtocol) import SwiftDocCTestUtilities
+import SwiftDocCTestUtilities
 
 class MergeSubcommandTests: XCTestCase {
     func testCommandLineArgumentValidation() throws {

--- a/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
@@ -10,11 +10,11 @@
 
 import XCTest
 import Foundation
-@testable @_spi(FileManagerProtocol) @_spi(ExternalLinks) import SwiftDocC
+@testable @_spi(ExternalLinks) import SwiftDocC
 @testable import SwiftDocCUtilities
 import SymbolKit
 import Markdown
-@testable @_spi(FileManagerProtocol) import SwiftDocCTestUtilities
+@testable import SwiftDocCTestUtilities
 
 class ConvertActionTests: XCTestCase {
     #if !os(iOS)

--- a/Tests/SwiftDocCUtilitiesTests/EmitGeneratedCurationsActionTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/EmitGeneratedCurationsActionTests.swift
@@ -11,7 +11,7 @@
 import XCTest
 import Foundation
 @testable import SwiftDocCUtilities
-@_spi(FileManagerProtocol) import SwiftDocCTestUtilities
+import SwiftDocCTestUtilities
 
 class EmitGeneratedCurationsActionTests: XCTestCase {
     

--- a/Tests/SwiftDocCUtilitiesTests/FolderStructure.swift
+++ b/Tests/SwiftDocCUtilitiesTests/FolderStructure.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-@testable @_spi(FileManagerProtocol) import SwiftDocC
+@testable import SwiftDocC
 @testable import SwiftDocCUtilities
 import XCTest
 import SwiftDocCTestUtilities

--- a/Tests/SwiftDocCUtilitiesTests/Init/InitActionTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/Init/InitActionTests.swift
@@ -10,7 +10,7 @@
 
 import XCTest
 import Foundation
-@_spi(FileManagerProtocol) import SwiftDocCTestUtilities
+import SwiftDocCTestUtilities
 @testable import SwiftDocCUtilities
 
 final class InitActionTests: XCTestCase {

--- a/Tests/SwiftDocCUtilitiesTests/MergeActionTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/MergeActionTests.swift
@@ -11,7 +11,7 @@
 import XCTest
 @testable import SwiftDocC
 @testable import SwiftDocCUtilities
-@_spi(FileManagerProtocol) import SwiftDocCTestUtilities
+import SwiftDocCTestUtilities
 
 class MergeActionTests: XCTestCase {
     

--- a/Tests/SwiftDocCUtilitiesTests/StaticHostableTransformerTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/StaticHostableTransformerTests.swift
@@ -10,7 +10,7 @@
 
 import XCTest
 import Foundation
-@testable @_spi(FileManagerProtocol) import SwiftDocC
+@testable import SwiftDocC
 @testable import SwiftDocCUtilities
 import SwiftDocCTestUtilities
 

--- a/Tests/SwiftDocCUtilitiesTests/Utility/TestFileSystemTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/Utility/TestFileSystemTests.swift
@@ -9,7 +9,7 @@
 */
 
 import XCTest
-@testable @_spi(FileManagerProtocol) import SwiftDocCTestUtilities
+@testable import SwiftDocCTestUtilities
 
 class TestFileSystemTests: XCTestCase {
     


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://125785105

## Summary

This follows up on #861 to add back the temporarily reverted commit to use package access level (SE-0386, available from Swift 5.9) instead of SPI for FileManagerProtocol.

## Dependencies

None

## Testing

Nothing in particular. This isn't a use facing change.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- ~[ ] Added tests~
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
