### PR TITLE
Add an anchor to TaskGroupRenderSection

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -996,7 +996,8 @@ public struct RenderNodeTranslator: SemanticVisitor {
                 abstract: nil,
                 discussion: nil,
                 identifiers: group.references.map(\.url.absoluteString),
-                generated: true
+                generated: true,
+                anchor: urlReadableFragment(group.title)
             )
         }
     }
@@ -1148,7 +1149,8 @@ public struct RenderNodeTranslator: SemanticVisitor {
                     default: break
                     }
                     return nil
-                }
+                },
+                anchor: group.heading.map { urlReadableFragment($0.plainText) } ?? "Topics"
             )
             
             // rdar://74617294 If a task group doesn't have any symbol or external links it shouldn't be rendered
@@ -1608,7 +1610,8 @@ public struct RenderNodeTranslator: SemanticVisitor {
                     title: group.heading,
                     abstract: nil,
                     discussion: nil,
-                    identifiers: group.references.map({ $0.url!.absoluteString })
+                    identifiers: group.references.map({ $0.url!.absoluteString }),
+                    anchor: urlReadableFragment(group.heading)
                 )
             }
         } ?? .init(defaultValue: [])

--- a/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderNode.spec.json
+++ b/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderNode.spec.json
@@ -2,7 +2,7 @@
     "openapi": "3.0.0",
     "info": {
         "description": "Render Node API",
-        "version": "0.4.1",
+        "version": "0.4.2",
         "title": "Render Node API"
     },
     "paths": { },
@@ -2704,6 +2704,9 @@
                     },
                     "generated": {
                         "type": "boolean"
+                    },
+                    "anchor": {
+                        "type": "string"
                     }
                 }
             },

--- a/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
@@ -776,7 +776,8 @@ Root
                                                           abstract: section.abstract,
                                                           discussion: section.discussion,
                                                           identifiers: identifiers,
-                                                          generated: section.generated)
+                                                          generated: section.generated,
+                                                          anchor: section.title.map(urlReadableFragment))
                         }
                         return section
                     }

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -3100,7 +3100,7 @@ let expected = """
                 
                 ## Topics
                 
-                ### Some topic section
+                ### Some, topic - section!
                 
                 - <doc:Third>
                 """),
@@ -3175,6 +3175,22 @@ let expected = """
         let bundle = try XCTUnwrap(context.registeredBundles.first)
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
         let renderNode = try converter.convert(entity, at: nil)
+        
+        XCTAssertEqual(renderNode.topicSections.map(\.anchor), [
+            "Another-topic-section"
+        ])
+        
+        let firstReference = try XCTUnwrap(context.knownPages.first(where: { $0.lastPathComponent == "First" }))
+        let firstRenderNode = try converter.convert(context.entity(with: firstReference), at: nil)
+        XCTAssertEqual(firstRenderNode.topicSections.map(\.anchor), [
+            "Topics"
+        ])
+        
+        let secondReference = try XCTUnwrap(context.knownPages.first(where: { $0.lastPathComponent == "Second" }))
+        let secondRenderNode = try converter.convert(context.entity(with: secondReference), at: nil)
+        XCTAssertEqual(secondRenderNode.topicSections.map(\.anchor), [
+            "Some-topic-section"
+        ])
         
         let overviewSection = try XCTUnwrap(renderNode.primaryContentSections.first as? ContentRenderSection)
         guard case .unorderedList(let unorderedList) = overviewSection.content.dropFirst().first else {

--- a/Tests/SwiftDocCTests/Model/RenderNodeDiffingBundleTests.swift
+++ b/Tests/SwiftDocCTests/Model/RenderNodeDiffingBundleTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2023 Apple Inc. and the Swift project authors
+ Copyright (c) 2023-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -69,7 +69,8 @@ class RenderNodeDiffingBundleTests: XCTestCase {
                                                                                            discussion: nil,
                                                                                            identifiers: ["doc://org.swift.docc.example/tutorials/Test-Bundle/TestTutorial",
                                                                                                 "doc://org.swift.docc.example/tutorials/Test-Bundle/TestTutorial2"],
-                                                                                           generated: false)))
+                                                                                           generated: false,
+                                                                                           anchor: "Tutorials")))
         assertDifferences(differences,
                           contains: expectedDiff,
                           valueType: TaskGroupRenderSection.self)


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://125967110

## Summary

This adds an anchor to `TaskGroupRenderSection` so that links to task groups scroll to that section (after the corresponding DocC Render change (rdar://124536381) is implemented).

## Dependencies

None.

## Testing

- Build documentation for any project with manual or automatic curation. 
- Inspect the JSON files in the output. 
- The entries in the "topicSections" array should have an "anchor"

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
