### PR TITLE
Fix JSON typo

### DIFF
--- a/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderNode.spec.json
+++ b/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderNode.spec.json
@@ -701,7 +701,7 @@
             "ThematicBreak": {
                 "type": "object",
                 "required": [
-                    "type",
+                    "type"
                 ],
                 "properties": {
                     "type": {


### PR DESCRIPTION
## Summary

The JSON schema for RenderNode is invalid, as it includes an extra comma at the final element of an array (that is only valid in JavaScript, and not JSON).

I also checked the other JSON Schemas to make sure there were no other invalid syntaxes.

## Dependencies

None

## Testing

Parse the JSON in any conforming implementation

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [ ] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary
