### PR TITLE
Add logic to look for overload groups when emitting warnings

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+Error.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+Error.swift
@@ -150,17 +150,10 @@ extension PathHierarchy.Error {
             let solutions: [Solution] = candidates
                 .sorted(by: collisionIsBefore)
                 .map { (node: PathHierarchy.Node, disambiguation: String) -> Solution in
-                    // Suggest removing the disambiguation hash entirely
-                    if disambiguation.isEmpty {
-                        return Solution(summary: "\(Self.replacementOperationDescription(from: disambiguations, to: disambiguation)) for\n\(node.name.singleQuoted)", replacements: [
-                            Replacement(range: replacementRange, replacement: "")
-                        ])
-                    // Suggest replacing the disambiguation hash with the correct value
-                    } else {
-                        return Solution(summary: "\(Self.replacementOperationDescription(from: disambiguations.dropFirst(), to: disambiguation)) for\n\(fullNameOfNode(node).singleQuoted)", replacements: [
-                            Replacement(range: replacementRange, replacement: "-" + disambiguation)
-                        ])
-                    }
+                    let from = disambiguation.isEmpty ? disambiguations : disambiguations.dropFirst()
+                    return Solution(summary: "\(Self.replacementOperationDescription(from: from, to: disambiguation.dropFirst())) for\n\(fullNameOfNode(node).singleQuoted)", replacements: [
+                        Replacement(range: replacementRange, replacement: disambiguation)
+                    ])
                 }
             
             return TopicReferenceResolutionErrorInfo("""

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+Error.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+Error.swift
@@ -150,8 +150,7 @@ extension PathHierarchy.Error {
             let solutions: [Solution] = candidates
                 .sorted(by: collisionIsBefore)
                 .map { (node: PathHierarchy.Node, disambiguation: String) -> Solution in
-                    let from = disambiguation.isEmpty ? disambiguations : disambiguations.dropFirst()
-                    return Solution(summary: "\(Self.replacementOperationDescription(from: from, to: disambiguation.dropFirst())) for\n\(fullNameOfNode(node).singleQuoted)", replacements: [
+                    return Solution(summary: "\(Self.replacementOperationDescription(from: disambiguations, to: disambiguation)) for\n\(fullNameOfNode(node).singleQuoted)", replacements: [
                         Replacement(range: replacementRange, replacement: disambiguation)
                     ])
                 }

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+Find.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+Find.swift
@@ -475,7 +475,7 @@ private func == (lhs: (some StringProtocol)?, rhs: some StringProtocol) -> Bool 
      return lhs == rhs
  }
 
-package extension Sequence {
+internal extension Sequence {
     /// Returns the only element of the sequence that satisfies the given predicate.
     /// - Parameters:
     ///   - predicate: A closure that takes an element of the sequence as its argument and returns a Boolean value indicating whether the element is a match.

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+Find.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+Find.swift
@@ -371,7 +371,7 @@ extension PathHierarchy {
         // suffix entirely.
         let candidates = disambiguationTree.disambiguatedValues()
         let favoredSuffix = favoredSuffix(from: candidates)
-        let suffixes = candidates.map { suffix(for: $0.disambiguation) }
+        let suffixes = candidates.map { $0.disambiguation.makeSuffix() }
         let candidatesAndSuffixes = zip(candidates, suffixes).map { (candidate, suffix) in
             if suffix == favoredSuffix {
                 return (node: candidate.value, disambiguation: "")
@@ -396,20 +396,10 @@ extension PathHierarchy {
     /// - Returns: An optional string set to the disambiguation suffix string, without the hyphen separator e.g. "abc123",
     ///            or nil if there is no preferred symbol.
     private func favoredSuffix(from candidates: [(value: PathHierarchy.Node, disambiguation: PathHierarchy.DisambiguationContainer.Disambiguation)]) -> String? {
-        guard let favored = candidates.singleMatch({
+        return candidates.singleMatch({
             !$0.value.specialBehaviors.contains(PathHierarchy.Node.SpecialBehaviors.disfavorInLinkCollision)
-        }) else { return nil }
-        return suffix(for: favored.disambiguation)
+        })?.disambiguation.makeSuffix()
     }
-
-    /// Return the suffix string "abc123" for the given disambiguation, without the hyphen separator
-    /// - Parameters:
-    ///   - from: A PathHierarchy disambiguation structure
-    /// - Returns: The corresponding disambiguation suffix string, without the hyphen separator e.g. "abc123"
-    private func suffix(for disambiguation: PathHierarchy.DisambiguationContainer.Disambiguation) -> String {
-        return String(disambiguation.makeSuffix().dropFirst())
-    }
-
 
     private func pathForError(
         of rawPath: String,

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+Find.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+Find.swift
@@ -355,29 +355,62 @@ extension PathHierarchy {
         remaining: ArraySlice<PathComponent>,
         rawPathForError: String
     ) -> Error {
-        if let disambiguationTree = node.children[String(remaining.first!.name)] {
-            return Error.unknownDisambiguation(
+        guard let disambiguationTree = node.children[String(remaining.first!.name)] else {
+            return Error.unknownName(
                 partialResult: (
                     node,
                     pathForError(of: rawPathForError, droppingLast: remaining.count)
                 ),
                 remaining: Array(remaining),
-                candidates: disambiguationTree.disambiguatedValues().map {
-                    (node: $0.value, disambiguation: String($0.disambiguation.makeSuffix().dropFirst()))
-                }
+                availableChildren: Set(node.children.keys)
             )
         }
-        
-        return Error.unknownName(
+
+        // Use a empty disambiguation suffix for the preferred symbol, if there
+        // is one, which will trigger the warning to suggest removing the
+        // suffix entirely.
+        let candidates = disambiguationTree.disambiguatedValues()
+        let favoredSuffix = favoredSuffix(from: candidates)
+        let suffixes = candidates.map { suffix(for: $0.disambiguation) }
+        let candidatesAndSuffixes = zip(candidates, suffixes).map { (candidate, suffix) in
+            if suffix == favoredSuffix {
+                return (node: candidate.value, disambiguation: "")
+            } else {
+                return (node: candidate.value, disambiguation: suffix)
+            }
+        }
+        return Error.unknownDisambiguation(
             partialResult: (
                 node,
                 pathForError(of: rawPathForError, droppingLast: remaining.count)
             ),
             remaining: Array(remaining),
-            availableChildren: Set(node.children.keys)
+            candidates: candidatesAndSuffixes
         )
     }
-    
+
+    /// Check if exactly one of the given candidate symbols is preferred, because it is not disfavored
+    /// for link resolution and all the other symbols are.
+    /// - Parameters:
+    ///   - from: An array of candidate node and disambiguation tuples.
+    /// - Returns: An optional string set to the disambiguation suffix string, without the hyphen separator e.g. "abc123",
+    ///            or nil if there is no preferred symbol.
+    private func favoredSuffix(from candidates: [(value: PathHierarchy.Node, disambiguation: PathHierarchy.DisambiguationContainer.Disambiguation)]) -> String? {
+        guard let favored = candidates.singleMatch({
+            !$0.value.specialBehaviors.contains(PathHierarchy.Node.SpecialBehaviors.disfavorInLinkCollision)
+        }) else { return nil }
+        return suffix(for: favored.disambiguation)
+    }
+
+    /// Return the suffix string "abc123" for the given disambiguation, without the hyphen separator
+    /// - Parameters:
+    ///   - from: A PathHierarchy disambiguation structure
+    /// - Returns: The corresponding disambiguation suffix string, without the hyphen separator e.g. "abc123"
+    private func suffix(for disambiguation: PathHierarchy.DisambiguationContainer.Disambiguation) -> String {
+        return String(disambiguation.makeSuffix().dropFirst())
+    }
+
+
     private func pathForError(
         of rawPath: String,
         droppingLast trailingComponentsToDrop: Int
@@ -475,7 +508,7 @@ private func == (lhs: (some StringProtocol)?, rhs: some StringProtocol) -> Bool 
      return lhs == rhs
  }
 
-internal extension Sequence {
+private extension Sequence {
     /// Returns the only element of the sequence that satisfies the given predicate.
     /// - Parameters:
     ///   - predicate: A closure that takes an element of the sequence as its argument and returns a Boolean value indicating whether the element is a match.

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+Find.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+Find.swift
@@ -475,7 +475,7 @@ private func == (lhs: (some StringProtocol)?, rhs: some StringProtocol) -> Bool 
      return lhs == rhs
  }
 
-private extension Sequence {
+package extension Sequence {
     /// Returns the only element of the sequence that satisfies the given predicate.
     /// - Parameters:
     ///   - predicate: A closure that takes an element of the sequence as its argument and returns a Boolean value indicating whether the element is a match.

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchyBasedLinkResolver.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchyBasedLinkResolver.swift
@@ -251,7 +251,8 @@ final class PathHierarchyBasedLinkResolver {
     func fullName(of node: PathHierarchy.Node, in context: DocumentationContext) -> String {
         guard let identifier = node.identifier else { return node.name }
         if let symbol = node.symbol {
-            if let fragments = symbol.declarationFragments {
+            // Use the simple title for overload group symbols to avoid showing detailed type info
+            if !symbol.isOverloadGroup, let fragments = symbol.declarationFragments {
                 return fragments.map(\.spelling).joined().split(whereSeparator: { $0.isWhitespace || $0.isNewline }).joined(separator: " ")
             }
             return symbol.names.title

--- a/Tests/SwiftDocCTests/Infrastructure/ExternalPathHierarchyResolverTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/ExternalPathHierarchyResolverTests.swift
@@ -379,8 +379,8 @@ class ExternalPathHierarchyResolverTests: XCTestCase {
             authoredLink: "/MixedFramework/CollisionsWithDifferentKinds/something-class",
             errorMessage: "'class' isn't a disambiguation for 'something' at '/MixedFramework/CollisionsWithDifferentKinds'",
             solutions: [
-                .init(summary: "Replace 'class' with 'enum.case' for\n'case something'", replacement: ("-enum.case", 54, 60)),
-                .init(summary: "Replace 'class' with 'property' for\n'var something: String { get }'", replacement: ("-property", 54, 60)),
+                .init(summary: "Replace '-class' with '-enum.case' for\n'case something'", replacement: ("-enum.case", 54, 60)),
+                .init(summary: "Replace '-class' with '-property' for\n'var something: String { get }'", replacement: ("-property", 54, 60)),
             ]
         )
  
@@ -407,9 +407,9 @@ class ExternalPathHierarchyResolverTests: XCTestCase {
             authoredLink: "/MixedFramework/CollisionsWithEscapedKeywords/init()-abc123",
             errorMessage: "'abc123' isn't a disambiguation for 'init()' at '/MixedFramework/CollisionsWithEscapedKeywords'",
             solutions: [
-                .init(summary: "Replace 'abc123' with 'method' for\n'func `init`()'", replacement: ("-method", 52, 59)),
-                .init(summary: "Replace 'abc123' with 'init' for\n'init()'", replacement: ("-init", 52, 59)),
-                .init(summary: "Replace 'abc123' with 'type.method' for\n'static func `init`()'", replacement: ("-type.method", 52, 59)),
+                .init(summary: "Replace '-abc123' with '-method' for\n'func `init`()'", replacement: ("-method", 52, 59)),
+                .init(summary: "Replace '-abc123' with '-init' for\n'init()'", replacement: ("-init", 52, 59)),
+                .init(summary: "Replace '-abc123' with '-type.method' for\n'static func `init`()'", replacement: ("-type.method", 52, 59)),
             ]
         )
         // Providing disambiguation will narrow down the suggestions. Note that `()` is missing in the last path component
@@ -469,8 +469,8 @@ class ExternalPathHierarchyResolverTests: XCTestCase {
             authoredLink: "/MixedFramework/CollisionsWithDifferentFunctionArguments/something(argument:)-abc123",
             errorMessage: "'abc123' isn't a disambiguation for 'something(argument:)' at '/MixedFramework/CollisionsWithDifferentFunctionArguments'",
             solutions: [
-                .init(summary: "Replace 'abc123' with '1cyvp' for\n'func something(argument: Int) -> Int'", replacement: ("-1cyvp", 77, 84)),
-                .init(summary: "Replace 'abc123' with '2vke2' for\n'func something(argument: String) -> Int'", replacement: ("-2vke2", 77, 84)),
+                .init(summary: "Replace '-abc123' with '-1cyvp' for\n'func something(argument: Int) -> Int'", replacement: ("-1cyvp", 77, 84)),
+                .init(summary: "Replace '-abc123' with '-2vke2' for\n'func something(argument: String) -> Int'", replacement: ("-2vke2", 77, 84)),
             ]
         )
         // Providing disambiguation will narrow down the suggestions. Note that `argument` label is missing in the last path component

--- a/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
@@ -1329,7 +1329,7 @@ class PathHierarchyTests: XCTestCase {
         'abc123' isn't a disambiguation for 'fourthTestMemberName(test:)' at '/ShapeKit/OverloadedProtocol'
         """) { error in
             XCTAssertEqual(error.solutions, [
-                .init(summary: "Remove '-abc123' to select preferred symbol\n'func fourthTestMemberName(test: String) -> Double\'", replacements: [("", 56, 63)]),
+                .init(summary: "Remove '-abc123' for\n'fourthTestMemberName(test:)'", replacements: [("", 56, 63)]),
                 .init(summary: "Replace 'abc123' with '8iuz7' for\n'func fourthTestMemberName(test: String) -> Double\'", replacements: [("-8iuz7", 56, 63)]),
                 .init(summary: "Replace 'abc123' with '1h173' for\n'func fourthTestMemberName(test: String) -> Float\'", replacements: [("-1h173", 56, 63)]),
                 .init(summary: "Replace 'abc123' with '91hxs' for\n'func fourthTestMemberName(test: String) -> Int\'", replacements: [("-91hxs", 56, 63)]),

--- a/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
@@ -327,8 +327,8 @@ class PathHierarchyTests: XCTestCase {
         'class' isn't a disambiguation for 'something' at '/MixedFramework/CollisionsWithDifferentKinds'
         """) { error in
             XCTAssertEqual(error.solutions, [
-                .init(summary: "Replace 'class' with 'enum.case' for\n'case something'", replacements: [("-enum.case", 54, 60)]),
-                .init(summary: "Replace 'class' with 'property' for\n'var something: String { get }'", replacements: [("-property", 54, 60)]),
+                .init(summary: "Replace '-class' with '-enum.case' for\n'case something'", replacements: [("-enum.case", 54, 60)]),
+                .init(summary: "Replace '-class' with '-property' for\n'var something: String { get }'", replacements: [("-property", 54, 60)]),
             ])
         }
         
@@ -350,9 +350,9 @@ class PathHierarchyTests: XCTestCase {
         'abc123' isn't a disambiguation for 'init()' at '/MixedFramework/CollisionsWithEscapedKeywords'
         """) { error in
             XCTAssertEqual(error.solutions, [
-                .init(summary: "Replace 'abc123' with 'method' for\n'func `init`()'", replacements: [("-method", 52, 59)]),
-                .init(summary: "Replace 'abc123' with 'init' for\n'init()'", replacements: [("-init", 52, 59)]),
-                .init(summary: "Replace 'abc123' with 'type.method' for\n'static func `init`()'", replacements: [("-type.method", 52, 59)]),
+                .init(summary: "Replace '-abc123' with '-method' for\n'func `init`()'", replacements: [("-method", 52, 59)]),
+                .init(summary: "Replace '-abc123' with '-init' for\n'init()'", replacements: [("-init", 52, 59)]),
+                .init(summary: "Replace '-abc123' with '-type.method' for\n'static func `init`()'", replacements: [("-type.method", 52, 59)]),
             ])
         }
         try assertPathRaisesErrorMessage("/MixedFramework/CollisionsWithEscapedKeywords/init()", in: tree, context: context, expectedErrorMessage: """
@@ -431,8 +431,8 @@ class PathHierarchyTests: XCTestCase {
         'abc123' isn't a disambiguation for 'something(argument:)' at '/MixedFramework/CollisionsWithDifferentFunctionArguments'
         """) { error in
             XCTAssertEqual(error.solutions, [
-                .init(summary: "Replace 'abc123' with '1cyvp' for\n'func something(argument: Int) -> Int'", replacements: [("-1cyvp", 77, 84)]),
-                .init(summary: "Replace 'abc123' with '2vke2' for\n'func something(argument: String) -> Int'", replacements: [("-2vke2", 77, 84)]),
+                .init(summary: "Replace '-abc123' with '-1cyvp' for\n'func something(argument: Int) -> Int'", replacements: [("-1cyvp", 77, 84)]),
+                .init(summary: "Replace '-abc123' with '-2vke2' for\n'func something(argument: String) -> Int'", replacements: [("-2vke2", 77, 84)]),
             ])
         }
         // Providing disambiguation will narrow down the suggestions. Note that `argument` label is missing in the last path component
@@ -1330,10 +1330,10 @@ class PathHierarchyTests: XCTestCase {
         """) { error in
             XCTAssertEqual(error.solutions, [
                 .init(summary: "Remove '-abc123' for\n'fourthTestMemberName(test:)'", replacements: [("", 56, 63)]),
-                .init(summary: "Replace 'abc123' with '8iuz7' for\n'func fourthTestMemberName(test: String) -> Double\'", replacements: [("-8iuz7", 56, 63)]),
-                .init(summary: "Replace 'abc123' with '1h173' for\n'func fourthTestMemberName(test: String) -> Float\'", replacements: [("-1h173", 56, 63)]),
-                .init(summary: "Replace 'abc123' with '91hxs' for\n'func fourthTestMemberName(test: String) -> Int\'", replacements: [("-91hxs", 56, 63)]),
-                .init(summary: "Replace 'abc123' with '961zx' for\n'func fourthTestMemberName(test: String) -> String\'", replacements: [("-961zx", 56, 63)]),
+                .init(summary: "Replace '-abc123' with '-8iuz7' for\n'func fourthTestMemberName(test: String) -> Double\'", replacements: [("-8iuz7", 56, 63)]),
+                .init(summary: "Replace '-abc123' with '-1h173' for\n'func fourthTestMemberName(test: String) -> Float\'", replacements: [("-1h173", 56, 63)]),
+                .init(summary: "Replace '-abc123' with '-91hxs' for\n'func fourthTestMemberName(test: String) -> Int\'", replacements: [("-91hxs", 56, 63)]),
+                .init(summary: "Replace '-abc123' with '-961zx' for\n'func fourthTestMemberName(test: String) -> String\'", replacements: [("-961zx", 56, 63)]),
             ])
         }
     }

--- a/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
@@ -1329,7 +1329,11 @@ class PathHierarchyTests: XCTestCase {
         'abc123' isn't a disambiguation for 'fourthTestMemberName(test:)' at '/ShapeKit/OverloadedProtocol'
         """) { error in
             XCTAssertEqual(error.solutions, [
-                .init(summary: "Remove '-abc123' to use overload group \n'func fourthTestMemberName(test: String) -> Double\'", replacements: [("", 56, 63)]),
+                .init(summary: "Remove '-abc123' to select preferred symbol\n'func fourthTestMemberName(test: String) -> Double\'", replacements: [("", 56, 63)]),
+                .init(summary: "Replace 'abc123' with '8iuz7' for\n'func fourthTestMemberName(test: String) -> Double\'", replacements: [("-8iuz7", 56, 63)]),
+                .init(summary: "Replace 'abc123' with '1h173' for\n'func fourthTestMemberName(test: String) -> Float\'", replacements: [("-1h173", 56, 63)]),
+                .init(summary: "Replace 'abc123' with '91hxs' for\n'func fourthTestMemberName(test: String) -> Int\'", replacements: [("-91hxs", 56, 63)]),
+                .init(summary: "Replace 'abc123' with '961zx' for\n'func fourthTestMemberName(test: String) -> String\'", replacements: [("-961zx", 56, 63)]),
             ])
         }
     }


### PR DESCRIPTION
Add logic to look for overload groups when emitting warnings and suggestions about ambiguous symbols. If exactly one of the ambiguous symbols is an overload group, then suggest the author simply remove the incorrect disambiguation instead of selecting a different disambiguation hash.

rdar://126382989

## Summary

Today when an author links to a page using an invalid disambiguation hash, DocC emits a warning similar to this listing all of the valid disambiguation hashes:

```
warning: '7w26t' isn't a disambiguation for 'init(content:)' at '/MyFramework/SomeStruct'
 --> SomeStruct.md:7:19-7:25
5 | ### Some Interesting Topic
6 |
7 + - ``init(content:)-7w26t``
  |                   ├─suggestion: Replace '7w26t' with '25rvu' for'something'
  |                   ├─suggestion: Replace '7w26t' with '4tm5u' for'something-else'
  |                   ╰─suggestion: Replace '7w26t' with '5di5z' for'something-even-different'
8 | - ``init(content:)-8mfe``
```

However, we expect that most of the time authors need to specify disambiguation hashes when they are linking directly to one member of a set of overloaded symbols. (Symbols that have the same parameters but different types).

Therefore, this PR changes the diagnostic logic for ambiguous symbols to emit a warning similar to this instead:

```
warning: '7w26t' isn't a disambiguation for 'init(content:)' at '/MyFramework/SomeStruct'
 --> SomeStruct.md:7:19-7:25
5 | ### Some Interesting Topic
6 |
7 + - ``init(content:)-7w26t``
  |                   ╰─suggestion: Remove '-7w26t' to use overload group 'something'
8 | - ``init(content:)-8mfe``
```

Now DocC will encourage writers to use simpler paths when possible, allowing readers to navigate to overload group pages.

We might consider adding logic in a follow-on PR to emit warnings for _valid links_ that use disambiguation hashes unnecessarily.

## Dependencies

None

## Testing

Steps:
1. Compile documentation that contains a broken link due to an incorrect disambiguation hash. Use the `--enable-experimental-overloaded-symbol-presentation` command line argument to enable the experimental overloads feature flag.
2. Check that the target page is one symbol is a set of overloaded symbols
3. Test that DocC emits a warning similar to the example above.
4. Repeat the test when the broken link selects ambiguous symbols that are not all overloads in the same group. DocC should emit the original warning.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x ] Added tests
- [x ] Ran the `./bin/test` script and it succeeded
- ~~[ ] Updated documentation if necessary~~
