### PR TITLE
Ignore precise line number in unit test expectation

### DIFF
--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationBundleInfoTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationBundleInfoTests.swift
@@ -336,7 +336,7 @@ class DocumentationBundleInfoTests: XCTestCase {
                 errorTypeChecking = false
             }
             XCTAssertTrue(errorTypeChecking)
-            XCTAssertEqual(error.localizedDescription, "Unable to decode Info.plist file. Verify that it is correctly formed. Value missing for key inside <dict> at line 24")
+            XCTAssert(error.localizedDescription.starts(with: "Unable to decode Info.plist file. Verify that it is correctly formed. Value missing for key inside <dict> at line"))
         }
     }
     


### PR DESCRIPTION
Bug/issue #, if applicable: 

rdar://126504994

## Summary

A unit test failed under certain circumstances because it tested for a precise line in an expected error message.

## Dependencies

None

## Testing

Run the unit test as follows:

```
% swift test --filter testDataCorruptedPlist
```

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- ~~[ ] Added tests~~
- [x ] Ran the `./bin/test` script and it succeeded
- ~~[ ] Updated documentation if necessary~~
