### PR TITLE
Fix to auto-capitalization PR [draft]

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/Content/RenderBlockContent+Capitalization.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Content/RenderBlockContent+Capitalization.swift
@@ -12,26 +12,24 @@
 protocol AutoCapitalizable {
     
     /// Any type that conforms to the AutoCapitalizable protocol will have the first letter of the first word capitalized (if applicable).
-    var withFirstWordCapitalized: Self {
-        get
-    }
+    func capitalizeFirstWord() -> Self
     
 }
 
 extension AutoCapitalizable {
-    var withFirstWordCapitalized: Self { return self }
+    func capitalizeFirstWord() -> Self { return self }
 }
 
 extension RenderInlineContent: AutoCapitalizable {
     /// Capitalize the first word for normal text content, as well as content that has emphasis or strong applied.
-    var withFirstWordCapitalized: Self {
+    func capitalizeFirstWord() -> Self {
         switch self {
         case .text(let text):
             return .text(text.capitalizeFirstWord())
         case .emphasis(inlineContent: let embeddedContent):
-            return .emphasis(inlineContent: [embeddedContent[0].withFirstWordCapitalized] + embeddedContent[1...])
+            return .emphasis(inlineContent: [embeddedContent[0].capitalizeFirstWord()] + embeddedContent[1...])
         case .strong(inlineContent: let embeddedContent):
-            return .strong(inlineContent: [embeddedContent[0].withFirstWordCapitalized] + embeddedContent[1...])
+            return .strong(inlineContent: [embeddedContent[0].capitalizeFirstWord()] + embeddedContent[1...])
         default:
             return self
         }
@@ -41,14 +39,14 @@ extension RenderInlineContent: AutoCapitalizable {
 
 extension RenderBlockContent: AutoCapitalizable {
     /// Capitalize the first word for paragraphs, asides, headings, and small content.
-    var withFirstWordCapitalized: Self {
+    func capitalizeFirstWord() -> Self {
         switch self {
         case .paragraph(let paragraph):
-            return .paragraph(paragraph.withFirstWordCapitalized)
+            return .paragraph(paragraph.capitalizeFirstWord())
         case .aside(let aside):
-            return .aside(aside.withFirstWordCapitalized)
+            return .aside(aside.capitalizeFirstWord())
         case .small(let small):
-            return .small(small.withFirstWordCapitalized)
+            return .small(small.capitalizeFirstWord())
         case .heading(let heading):
             return .heading(.init(level: heading.level, text: heading.text.capitalizeFirstWord(), anchor: heading.anchor))
         default:
@@ -58,34 +56,34 @@ extension RenderBlockContent: AutoCapitalizable {
 }
 
 extension RenderBlockContent.Paragraph: AutoCapitalizable {
-    var withFirstWordCapitalized: RenderBlockContent.Paragraph {
+    func capitalizeFirstWord() -> RenderBlockContent.Paragraph {
         guard !self.inlineContent.isEmpty else {
             return self
         }
         
-        let inlineContent = [self.inlineContent[0].withFirstWordCapitalized] + self.inlineContent[1...]
+        let inlineContent = [self.inlineContent[0].capitalizeFirstWord()] + self.inlineContent[1...]
         return .init(inlineContent: inlineContent)
     }
 }
 
 extension RenderBlockContent.Aside: AutoCapitalizable {
-    var withFirstWordCapitalized: RenderBlockContent.Aside {
+    func capitalizeFirstWord() -> RenderBlockContent.Aside {
         guard !self.content.isEmpty else {
             return self
         }
         
-        let content = [self.content[0].withFirstWordCapitalized] + self.content[1...]
+        let content = [self.content[0].capitalizeFirstWord()] + self.content[1...]
         return .init(style: self.style, content: content)
     }
 }
 
 extension RenderBlockContent.Small: AutoCapitalizable {
-    var withFirstWordCapitalized: RenderBlockContent.Small {
+    func capitalizeFirstWord() -> RenderBlockContent.Small {
         guard !self.inlineContent.isEmpty else {
             return self
         }
         
-        let inlineContent = [self.inlineContent[0].withFirstWordCapitalized] + self.inlineContent[1...]
+        let inlineContent = [self.inlineContent[0].capitalizeFirstWord()] + self.inlineContent[1...]
         return .init(inlineContent: inlineContent)
     }
 }

--- a/Sources/SwiftDocC/Model/Rendering/RenderContentCompiler.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderContentCompiler.swift
@@ -42,7 +42,7 @@ struct RenderContentCompiler: MarkupVisitor {
             content: aside.content.reduce(into: [], { result, child in result.append(contentsOf: visit(child))}) as! [RenderBlockContent]
         )
             
-        return [RenderBlockContent.aside(newAside.withFirstWordCapitalized)]
+        return [RenderBlockContent.aside(newAside.capitalizeFirstWord())]
     }
     
     mutating func visitCodeBlock(_ codeBlock: CodeBlock) -> [RenderContent] {

--- a/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/DiscussionSectionTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/DiscussionSectionTranslator.swift
@@ -27,7 +27,7 @@ struct DiscussionSectionTranslator: RenderSectionTranslator {
                 return nil
             }
             
-            let capitalizedDiscussionContent = [discussionContent[0].withFirstWordCapitalized] + discussionContent[1...]
+            let capitalizedDiscussionContent = [discussionContent[0].capitalizeFirstWord()] + discussionContent[1...]
             
             let title: String?
             if let first = discussionContent.first, case RenderBlockContent.heading = first {

--- a/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/ParametersSectionTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/ParametersSectionTranslator.swift
@@ -33,7 +33,7 @@ struct ParametersSectionTranslator: RenderSectionTranslator {
                             return ParameterRenderSection(name: parameter.name, content: parameterContent)
                         }
                         
-                        let capitalizedParameterContent = [parameterContent[0].withFirstWordCapitalized] + parameterContent[1...]
+                        let capitalizedParameterContent = [parameterContent[0].capitalizeFirstWord()] + parameterContent[1...]
                         
                         return ParameterRenderSection(name: parameter.name, content: capitalizedParameterContent)
                     }

--- a/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/ReturnsSectionTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/ReturnsSectionTranslator.swift
@@ -28,7 +28,7 @@ struct ReturnsSectionTranslator: RenderSectionTranslator {
                 return nil
             }
             
-            let capitalizedReturnsContent = [returnsContent[0].withFirstWordCapitalized] + returnsContent[1...]
+            let capitalizedReturnsContent = [returnsContent[0].capitalizeFirstWord()] + returnsContent[1...]
             
             return ContentRenderSection(kind: .content, content: capitalizedReturnsContent, heading: "Return Value")
         }

--- a/Tests/SwiftDocCTests/Model/RenderBlockContent+CapitalizationTests.swift
+++ b/Tests/SwiftDocCTests/Model/RenderBlockContent+CapitalizationTests.swift
@@ -19,52 +19,52 @@ class RenderBlockContent_CapitalizationTests: XCTestCase {
     // Text, Emphasis, Strong are all auto-capitalized, and everything else defaults to not capitalized.
     
     func testRenderInlineContentText() {
-        let text = RenderInlineContent.text("hello, world!").withFirstWordCapitalized
+        let text = RenderInlineContent.text("hello, world!").capitalizeFirstWord()
         XCTAssertEqual("Hello, world!", text.plainText)
     }
     
     func testRenderInlineContentEmphasis() {
-        let emphasis = RenderInlineContent.emphasis(inlineContent: [.text("hello, world!")]).withFirstWordCapitalized
+        let emphasis = RenderInlineContent.emphasis(inlineContent: [.text("hello, world!")]).capitalizeFirstWord()
         XCTAssertEqual("Hello, world!", emphasis.plainText)
     }
     
     func testRenderInlineContentStrong() {
-        let strong = RenderInlineContent.strong(inlineContent: [.text("hello, world!")]).withFirstWordCapitalized
+        let strong = RenderInlineContent.strong(inlineContent: [.text("hello, world!")]).capitalizeFirstWord()
         XCTAssertEqual("Hello, world!", strong.plainText)
     }
     
     func testRenderInlineContentCodeVoice() {
-        let codeVoice = RenderInlineContent.codeVoice(code: "code voice").withFirstWordCapitalized
+        let codeVoice = RenderInlineContent.codeVoice(code: "code voice").capitalizeFirstWord()
         XCTAssertEqual("code voice", codeVoice.plainText)
     }
     
     func testRenderInlineContentReference() {
-        let reference = RenderInlineContent.reference(identifier: .init("Test"), isActive: true, overridingTitle: "hello, world!", overridingTitleInlineContent: [.text("hello, world!")]).withFirstWordCapitalized
+        let reference = RenderInlineContent.reference(identifier: .init("Test"), isActive: true, overridingTitle: "hello, world!", overridingTitleInlineContent: [.text("hello, world!")]).capitalizeFirstWord()
         XCTAssertEqual("hello, world!", reference.plainText)
     }
     
     func testRenderInlineContentNewTerm() {
-        let newTerm = RenderInlineContent.newTerm(inlineContent: [.text("helloWorld")]).withFirstWordCapitalized
+        let newTerm = RenderInlineContent.newTerm(inlineContent: [.text("helloWorld")]).capitalizeFirstWord()
         XCTAssertEqual("helloWorld", newTerm.plainText)
     }
     
     func testRenderInlineContentInlineHead() {
-        let inlineHead = RenderInlineContent.inlineHead(inlineContent: [.text("hello, world!")]).withFirstWordCapitalized
+        let inlineHead = RenderInlineContent.inlineHead(inlineContent: [.text("hello, world!")]).capitalizeFirstWord()
         XCTAssertEqual("hello, world!", inlineHead.plainText)
     }
     
     func testRenderInlineContentSubscript() {
-        let subscriptContent = RenderInlineContent.subscript(inlineContent: [.text("hello, world!")]).withFirstWordCapitalized
+        let subscriptContent = RenderInlineContent.subscript(inlineContent: [.text("hello, world!")]).capitalizeFirstWord()
         XCTAssertEqual("hello, world!", subscriptContent.plainText)
     }
     
     func testRenderInlineContentSuperscript() {
-        let superscriptContent = RenderInlineContent.superscript(inlineContent: [.text("hello, world!")]).withFirstWordCapitalized
+        let superscriptContent = RenderInlineContent.superscript(inlineContent: [.text("hello, world!")]).capitalizeFirstWord()
         XCTAssertEqual("hello, world!", superscriptContent.plainText)
     }
     
     func testRenderInlineContentStrikethrough() {
-        let strikethrough = RenderInlineContent.strikethrough(inlineContent: [.text("hello, world!")]).withFirstWordCapitalized
+        let strikethrough = RenderInlineContent.strikethrough(inlineContent: [.text("hello, world!")]).capitalizeFirstWord()
         XCTAssertEqual("hello, world!", strikethrough.plainText)
     }
     
@@ -72,22 +72,22 @@ class RenderBlockContent_CapitalizationTests: XCTestCase {
     // Paragraphs, asides, headings, and small content are all auto-capitalized, and everything else defaults to not capitalized.
     
     func testRenderBlockContentParagraph() {
-        let paragraph = RenderBlockContent.paragraph(.init(inlineContent: [.text("hello, world!")])).withFirstWordCapitalized
+        let paragraph = RenderBlockContent.paragraph(.init(inlineContent: [.text("hello, world!")])).capitalizeFirstWord()
         XCTAssertEqual("Hello, world!", paragraph.rawIndexableTextContent(references: [:]))
     }
     
     func testRenderBlockContentAside() {
-        let aside = RenderBlockContent.aside(.init(style: .init(rawValue: "Experiment"), content: [.paragraph(.init(inlineContent: [.text("hello, world!")]))])).withFirstWordCapitalized
+        let aside = RenderBlockContent.aside(.init(style: .init(rawValue: "Experiment"), content: [.paragraph(.init(inlineContent: [.text("hello, world!")]))])).capitalizeFirstWord()
         XCTAssertEqual("Hello, world!", aside.rawIndexableTextContent(references: [:]))
     }
     
     func testRenderBlockContentSmall() {
-        let small = RenderBlockContent.small(.init(inlineContent: [.text("hello, world!")])).withFirstWordCapitalized
+        let small = RenderBlockContent.small(.init(inlineContent: [.text("hello, world!")])).capitalizeFirstWord()
         XCTAssertEqual("Hello, world!", small.rawIndexableTextContent(references: [:]))
     }
     
     func testRenderBlockContentHeading() {
-        let heading = RenderBlockContent.heading(.init(level: 1, text: "hello, world!", anchor: "hi")).withFirstWordCapitalized
+        let heading = RenderBlockContent.heading(.init(level: 1, text: "hello, world!", anchor: "hi")).capitalizeFirstWord()
         XCTAssertEqual("Hello, world!", heading.rawIndexableTextContent(references: [:]))
     }
     
@@ -99,12 +99,12 @@ class RenderBlockContent_CapitalizationTests: XCTestCase {
             .init(content: [
                 .paragraph(.init(inlineContent: [.text("world!")])),
                 ]),
-        ])).withFirstWordCapitalized
+        ])).capitalizeFirstWord()
         XCTAssertEqual("hello, world!", list.rawIndexableTextContent(references: [:]))
     }
     
     func testRenderBlockContentStep() {
-        let step = RenderBlockContent.step(.init(content: [.paragraph(.init(inlineContent: [.text("hello, world!")]))], caption: [.paragraph(.init(inlineContent: [.text("Step caption")]))], media: RenderReferenceIdentifier("Media"), code: RenderReferenceIdentifier("Code"), runtimePreview: RenderReferenceIdentifier("Preview"))).withFirstWordCapitalized
+        let step = RenderBlockContent.step(.init(content: [.paragraph(.init(inlineContent: [.text("hello, world!")]))], caption: [.paragraph(.init(inlineContent: [.text("Step caption")]))], media: RenderReferenceIdentifier("Media"), code: RenderReferenceIdentifier("Code"), runtimePreview: RenderReferenceIdentifier("Preview"))).capitalizeFirstWord()
         XCTAssertEqual("hello, world! Step caption", step.rawIndexableTextContent(references: [:]))
     }
     
@@ -117,7 +117,7 @@ class RenderBlockContent_CapitalizationTests: XCTestCase {
             .init(content: [
                 .paragraph(.init(inlineContent: [.text("world!")])),
                 ]),
-        ])).withFirstWordCapitalized
+        ])).capitalizeFirstWord()
         XCTAssertEqual("hello, world!", list.rawIndexableTextContent(references: [:]))
     }
     


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://122167705

## Summary

Follow-up PR after #880. Notable changes:
- Changed withFirstWordCapitalized from a computed property to a function.
- 

## Dependencies

N/A

## Testing

Add documentation via doc comments with anything after the colon (e.g. a parameter, aside, warning, important, todo, note, throws, returns) written in lowercase, then compile the documentation. The rendered documentation should now include an uppercased first character if the first word in the sentence is all lowercase and/or punctuation belonging to the CharacterSet punctuation characters.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
