### PR TITLE
drop uncurated symbols from the navigator index

### DIFF
--- a/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
+++ b/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
@@ -358,7 +358,20 @@ public class NavigatorIndex {
             default: self = .article
             }
         }
-        
+
+        /// Whether this page kind references a symbol.
+        var isSymbolKind: Bool {
+            // This switch is written with the non-symbol kinds written explicitly on the assumption
+            // that new symbol kinds will be added over time, but that non-symbol kinds are much
+            // more rare to add.
+            switch self {
+            case .root, .article, .tutorial, .section, .learn, .overview, .resources, .framework,
+                    .buildSetting, .sampleCode, .languageGroup, .container, .groupMarker:
+                return false
+            default:
+                return true
+            }
+        }
     }
     
     // MARK: - Read Navigator Tree
@@ -918,7 +931,11 @@ extension NavigatorIndex {
             
             // The rest have no parent, so they need to be under the root.
             for nodeID in pendingUncuratedReferences {
-                if let node = identifierToNode[nodeID] {
+                // Don't add symbol nodes to the root; if they have been dropped by automatic
+                // curation, then they should not be in the navigator. In addition, treat unknown
+                // page types as symbol nodes on the assumption that an unknown page type is a
+                // symbol kind added in a future version of Swift-DocC.
+                if let node = identifierToNode[nodeID], PageType(rawValue: node.item.pageType)?.isSymbolKind == false {
 
                     // If an uncurated page has been curated in another language, don't add it to the top-level.
                     if curatedReferences.contains(where: { curatedNodeID in

--- a/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
+++ b/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
@@ -361,14 +361,15 @@ public class NavigatorIndex {
 
         /// Whether this page kind references a symbol.
         var isSymbolKind: Bool {
-            // This switch is written with the non-symbol kinds written explicitly on the assumption
-            // that new symbol kinds will be added over time, but that non-symbol kinds are much
-            // more rare to add.
             switch self {
             case .root, .article, .tutorial, .section, .learn, .overview, .resources, .framework,
                     .buildSetting, .sampleCode, .languageGroup, .container, .groupMarker:
                 return false
-            default:
+            case .symbol, .class, .structure, .protocol, .enumeration, .function, .extension,
+                    .localVariable, .globalVariable, .typeAlias, .associatedType, .operator, .macro,
+                    .union, .enumerationCase, .initializer, .instanceMethod, .instanceProperty,
+                    .instanceVariable, .subscript, .typeMethod, .typeProperty, .propertyListKey,
+                    .httpRequest, .dictionarySymbol, .propertyListKeyReference, .namespace:
                 return true
             }
         }

--- a/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
@@ -1628,16 +1628,51 @@ Root
             for: "OverloadedSymbols",
             bundleIdentifier: "com.shapes.ShapeKit")
 
-        let protocolID = try XCTUnwrap(navigatorIndex.id(for: "/documentation/shapekit/overloadedprotocol", with: .swift))
-        let protocolNode = try XCTUnwrap(search(node: navigatorIndex.navigatorTree.root) { $0.id == protocolID })
-        XCTAssertEqual(protocolNode.children.map(\.item.title), [
-            "Instance Methods",
-            "func fourthTestMemberName(test:)",
-        ])
-
-        let overloadGroupID = try XCTUnwrap(navigatorIndex.id(for: "/documentation/shapekit/overloadedprotocol/fourthtestmembername(test:)-9b6be", with: .swift))
-        let overloadGroupNode = try XCTUnwrap(search(node: navigatorIndex.navigatorTree.root) { $0.id == overloadGroupID })
-        XCTAssert(overloadGroupNode.children.isEmpty)
+        XCTAssertEqual(
+            navigatorIndex.navigatorTree.root.dumpTree(),
+            """
+            [Root]
+            ┗╸Swift
+              ┗╸ShapeKit
+                ┣╸Protocols
+                ┣╸OverloadedProtocol
+                ┃ ┣╸Instance Methods
+                ┃ ┗╸func fourthTestMemberName(test:)
+                ┣╸Structures
+                ┣╸OverloadedByCaseStruct
+                ┃ ┣╸Instance Properties
+                ┃ ┣╸let ThirdTestMemberName: Int
+                ┃ ┣╸let thirdTestMemberNamE: Int
+                ┃ ┣╸let thirdTestMemberName: Int
+                ┃ ┗╸let thirdtestMemberName: Int
+                ┣╸OverloadedParentStruct
+                ┃ ┣╸Type Properties
+                ┃ ┗╸static let fifthTestMember: Int
+                ┣╸OverloadedStruct
+                ┃ ┣╸Instance Properties
+                ┃ ┣╸let secondTestMemberName: Int
+                ┃ ┣╸Type Properties
+                ┃ ┗╸static let secondTestMemberName: Int
+                ┣╸RegularParent
+                ┃ ┣╸Instance Properties
+                ┃ ┣╸let firstMember: Int
+                ┃ ┣╸Instance Methods
+                ┃ ┣╸func secondMember(first: Int, second: String)
+                ┃ ┣╸Type Properties
+                ┃ ┣╸static let thirdMember: Int
+                ┃ ┣╸Enumerations
+                ┃ ┗╸RegularParent.FourthMember
+                ┣╸overloadedparentstruct
+                ┃ ┣╸Instance Properties
+                ┃ ┗╸let fifthTestMember: Int
+                ┣╸Enumerations
+                ┗╸OverloadedEnum
+                  ┣╸Enumeration Cases
+                  ┣╸case firstTestMemberName(String)
+                  ┣╸Instance Methods
+                  ┗╸func firstTestMemberName(_:)
+            """
+        )
     }
 
     func generatedNavigatorIndex(for testBundleName: String, bundleIdentifier: String) throws -> NavigatorIndex {


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://125855186

## Summary

When building the navigator index, it first collects the nodes into a tree based on their topic group curation. Then, for any node that is not curated into another node, it inserts them all into the navigator root. However, this step can erroneously create a situation where symbols and articles can appear outside a rendered doc archive, depending on how the archive is being loaded. While this is useful and necessary for articles (if articles are not curated into a bundle and DocC is processing more than bundle, adding them outside the hierarchy is still useful), symbols should all already be curated into place via automatic curation. If automatic curation dropped a symbol (e.g. when an overloaded symbol is being condensed into an overload group), it should not suddenly reappear into the root of the navigator, outside of any documented module.

This PR adds a filter to the navigator index to prevent this root-insertion for symbol nodes.

## Dependencies

None

## Testing

Unfortunately, the nodes inserted at the root of the navigator tree only appear in the in-memory and LMDB representations of the index, so the bug doesn't manifest when building and previewing in the browser with Swift-DocC-Render. However, Xcode uses the LMDB index to show its navigator, so we can perform the test there.

Create an Xcode project (not a Swift package - we need to edit build settings) that includes the following Swift code:

```swift
public class MyClass {
    public func myFunc(param: String) {}
    public func myFunc(param: Int) {}
}
```

Steps:
1. In the project build settings, set `DOCC_EXEC` to your local build of Swift-DocC. (This needs to be set manually, via the plus-shaped button's "Add user-defined setting" option in the viewer.)
2. In the project build settings, add `--enable-experimental-overloaded-symbol-presentation` to the "Other DocC Flags" build setting (a.k.a. `OTHER_DOCC_FLAGS`).
3. Build documentation for the target that includes the above code.
4. Ensure that the individual `MyClass.myFunc(param:)` methods do not appear outside the target's documentation bundle:

<details>
<summary>Before</summary>

<img width="233" alt="framework documentation sidebar for 'SwiftDemo', showing excess methods after the framework" src="https://github.com/apple/swift-docc/assets/5217170/8fb7fb03-6594-4df6-a44b-d44295ca68d4">

</details>

<details>
<summary>After</summary>

<img width="229" alt="framework documentation sidebar for 'SwiftDemo', showing no excess methods" src="https://github.com/apple/swift-docc/assets/5217170/43f91bfc-e9cf-4d57-a72a-622047402e6d">

</details>

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ n/a ] Updated documentation if necessary
