### PR TITLE
add the ability to set a subset of feature flags from Info.plist

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -1182,7 +1182,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
                             }
                         }
 
-                        addOverloadGroupReferences(overloadGroups: overloadGroups)
+                        addOverloadGroupReferences(from: bundle, overloadGroups: overloadGroups)
                     }
                     
                     if let rootURL = symbolGraphLoader.mainModuleURL(forModule: moduleName), let rootModule = unifiedSymbolGraph.moduleData[rootURL] {
@@ -2348,8 +2348,8 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
         return automaticallyCuratedSymbols
     }
 
-    private func addOverloadGroupReferences(overloadGroups: [String: [String]]) {
-        guard FeatureFlags.current.isExperimentalOverloadedSymbolPresentationEnabled else {
+    private func addOverloadGroupReferences(from bundle: DocumentationBundle, overloadGroups: [String: [String]]) {
+        guard bundle.info.computedFeatureFlags.experimentalOverloadedSymbolPresentationEnabled else {
             return
         }
         

--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -2017,6 +2017,14 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
         if let bundleFlags = bundle.info.featureFlags {
             currentFeatureFlags = FeatureFlags.current
             FeatureFlags.current.loadFlagsFromBundle(bundleFlags)
+
+            for unknownFeatureFlag in bundleFlags.unknownFeatureFlags {
+                diagnosticEngine.emit(.init(diagnostic:
+                        .init(
+                            severity: .warning,
+                            identifier: "org.swift.docc.UnknownBundleFeatureFlag",
+                            summary: "Unknown feature flag in Info.plist: \(unknownFeatureFlag.singleQuoted)")))
+            }
         } else {
             currentFeatureFlags = nil
         }

--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -2019,11 +2019,19 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
             FeatureFlags.current.loadFlagsFromBundle(bundleFlags)
 
             for unknownFeatureFlag in bundleFlags.unknownFeatureFlags {
+                let suggestions = NearMiss.bestMatches(
+                    for: DocumentationBundle.Info.BundleFeatureFlags.CodingKeys.allCases.map({ $0.stringValue }),
+                    against: unknownFeatureFlag)
+                var summary: String = "Unknown feature flag in Info.plist: \(unknownFeatureFlag.singleQuoted)"
+                if !suggestions.isEmpty {
+                    summary += ". Possible suggestions: \(suggestions.map(\.singleQuoted).joined(separator: ", "))"
+                }
                 diagnosticEngine.emit(.init(diagnostic:
                         .init(
                             severity: .warning,
                             identifier: "org.swift.docc.UnknownBundleFeatureFlag",
-                            summary: "Unknown feature flag in Info.plist: \(unknownFeatureFlag.singleQuoted)")))
+                            summary: summary
+                        )))
             }
         } else {
             currentFeatureFlags = nil

--- a/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphLoader.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphLoader.swift
@@ -78,7 +78,7 @@ struct SymbolGraphLoader {
                 
                 configureSymbolGraph?(&symbolGraph)
 
-                if bundle.info.computedFeatureFlags.experimentalOverloadedSymbolPresentationEnabled {
+                if FeatureFlags.current.isExperimentalOverloadedSymbolPresentationEnabled {
                     symbolGraph.createOverloadGroupSymbols()
                 }
 

--- a/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphLoader.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphLoader.swift
@@ -78,7 +78,7 @@ struct SymbolGraphLoader {
                 
                 configureSymbolGraph?(&symbolGraph)
 
-                if FeatureFlags.current.isExperimentalOverloadedSymbolPresentationEnabled {
+                if bundle.info.computedFeatureFlags.experimentalOverloadedSymbolPresentationEnabled {
                     symbolGraph.createOverloadGroupSymbols()
                 }
 

--- a/Sources/SwiftDocC/Infrastructure/Workspace/DocumentationBundle+Info.swift
+++ b/Sources/SwiftDocC/Infrastructure/Workspace/DocumentationBundle+Info.swift
@@ -255,7 +255,8 @@ extension DocumentationBundle {
             version: String? = nil,
             defaultCodeListingLanguage: String? = nil,
             defaultModuleKind: String? = nil,
-            defaultAvailability: DefaultAvailability? = nil
+            defaultAvailability: DefaultAvailability? = nil,
+            featureFlags: FeatureFlags? = nil
         ) {
             self.displayName = displayName
             self.identifier = identifier
@@ -263,6 +264,7 @@ extension DocumentationBundle {
             self.defaultCodeListingLanguage = defaultCodeListingLanguage
             self.defaultModuleKind = defaultModuleKind
             self.defaultAvailability = defaultAvailability
+            self.featureFlags = featureFlags
         }
     }
 }

--- a/Sources/SwiftDocC/Infrastructure/Workspace/DocumentationBundle+Info.swift
+++ b/Sources/SwiftDocC/Infrastructure/Workspace/DocumentationBundle+Info.swift
@@ -272,6 +272,7 @@ extension BundleDiscoveryOptions {
     ///   - fallbackVersion: A fallback version for the bundle.
     ///   - fallbackDefaultCodeListingLanguage: A fallback default code listing language for the bundle.
     ///   - fallbackDefaultAvailability: A fallback default availability for the bundle.
+    ///   - fallbackFeatureFlags: A fallback set of feature flags for the bundle.
     ///   - additionalSymbolGraphFiles: Additional symbol graph files to augment any discovered bundles.
     public init(
         fallbackDisplayName: String? = nil,

--- a/Sources/SwiftDocC/Infrastructure/Workspace/DocumentationBundle+Info.swift
+++ b/Sources/SwiftDocC/Infrastructure/Workspace/DocumentationBundle+Info.swift
@@ -91,6 +91,7 @@ extension DocumentationBundle {
         ///   - defaultCodeListingLanguage: The default language identifier for code listings in the bundle.
         ///   - defaultAvailability: The default availability for the various modules in the bundle.
         ///   - defaultModuleKind: The default kind for the various modules in the bundle.
+        ///   - featureFlags: The feature flags enabled in the bundle.
         public init(
             displayName: String,
             identifier: String,

--- a/Sources/SwiftDocC/Infrastructure/Workspace/DocumentationBundle+Info.swift
+++ b/Sources/SwiftDocC/Infrastructure/Workspace/DocumentationBundle+Info.swift
@@ -34,15 +34,15 @@ extension DocumentationBundle {
         public var defaultModuleKind: String?
 
         /// The parsed feature flags that were set for this bundle.
-        public var featureFlags: FeatureFlags?
+        public var featureFlags: BundleFeatureFlags?
 
         /// A computed ``FeatureFlags`` that defers to a default-initialized instance in case this
         /// bundle didn't specify any feature flags.
         ///
         /// This is useful to fall back to the global ``SwiftDocC/FeatureFlags`` set via the
         /// command-line when determining whether a feature flag is set.
-        public var computedFeatureFlags: FeatureFlags {
-            self.featureFlags ?? FeatureFlags()
+        public var computedFeatureFlags: BundleFeatureFlags {
+            self.featureFlags ?? BundleFeatureFlags()
         }
 
         /// The keys that must be present in an Info.plist file in order for doc compilation to proceed.
@@ -107,7 +107,7 @@ extension DocumentationBundle {
             defaultCodeListingLanguage: String?,
             defaultAvailability: DefaultAvailability?,
             defaultModuleKind: String?,
-            featureFlags: FeatureFlags?
+            featureFlags: BundleFeatureFlags?
         ) {
             self.displayName = displayName
             self.identifier = identifier
@@ -246,7 +246,7 @@ extension DocumentationBundle {
             self.defaultCodeListingLanguage = try decodeOrFallbackIfPresent(String.self, with: .defaultCodeListingLanguage)
             self.defaultModuleKind = try decodeOrFallbackIfPresent(String.self, with: .defaultModuleKind)
             self.defaultAvailability = try decodeOrFallbackIfPresent(DefaultAvailability.self, with: .defaultAvailability)
-            self.featureFlags = try decodeOrFallbackIfPresent(FeatureFlags.self, with: .featureFlags)
+            self.featureFlags = try decodeOrFallbackIfPresent(BundleFeatureFlags.self, with: .featureFlags)
         }
         
         init(
@@ -256,7 +256,7 @@ extension DocumentationBundle {
             defaultCodeListingLanguage: String? = nil,
             defaultModuleKind: String? = nil,
             defaultAvailability: DefaultAvailability? = nil,
-            featureFlags: FeatureFlags? = nil
+            featureFlags: BundleFeatureFlags? = nil
         ) {
             self.displayName = displayName
             self.identifier = identifier
@@ -289,7 +289,7 @@ extension BundleDiscoveryOptions {
         fallbackDefaultCodeListingLanguage: String? = nil,
         fallbackDefaultModuleKind: String? = nil,
         fallbackDefaultAvailability: DefaultAvailability? = nil,
-        fallbackFeatureFlags: DocumentationBundle.Info.FeatureFlags? = nil,
+        fallbackFeatureFlags: DocumentationBundle.Info.BundleFeatureFlags? = nil,
         additionalSymbolGraphFiles: [URL] = []
     ) {
         // Iterate over all possible coding keys with a switch

--- a/Sources/SwiftDocC/Infrastructure/Workspace/DocumentationBundle+Info.swift
+++ b/Sources/SwiftDocC/Infrastructure/Workspace/DocumentationBundle+Info.swift
@@ -34,7 +34,7 @@ extension DocumentationBundle {
         public var defaultModuleKind: String?
 
         /// The parsed feature flags that were set for this bundle.
-        public var featureFlags: BundleFeatureFlags?
+        internal var featureFlags: BundleFeatureFlags?
 
         /// The keys that must be present in an Info.plist file in order for doc compilation to proceed.
         static let requiredKeys: Set<CodingKeys> = [.displayName, .identifier]
@@ -91,15 +91,13 @@ extension DocumentationBundle {
         ///   - defaultCodeListingLanguage: The default language identifier for code listings in the bundle.
         ///   - defaultAvailability: The default availability for the various modules in the bundle.
         ///   - defaultModuleKind: The default kind for the various modules in the bundle.
-        ///   - featureFlags: The feature flags enabled in the bundle.
         public init(
             displayName: String,
             identifier: String,
             version: String?,
             defaultCodeListingLanguage: String?,
             defaultAvailability: DefaultAvailability?,
-            defaultModuleKind: String?,
-            featureFlags: BundleFeatureFlags?
+            defaultModuleKind: String?
         ) {
             self.displayName = displayName
             self.identifier = identifier
@@ -107,7 +105,6 @@ extension DocumentationBundle {
             self.defaultCodeListingLanguage = defaultCodeListingLanguage
             self.defaultAvailability = defaultAvailability
             self.defaultModuleKind = defaultModuleKind
-            self.featureFlags = featureFlags
         }
         
         /// Creates documentation bundle information from the given Info.plist data, falling back to the values
@@ -274,7 +271,6 @@ extension BundleDiscoveryOptions {
     ///   - fallbackDefaultCodeListingLanguage: A fallback default code listing language for the bundle.
     ///   - fallbackDefaultModuleKind: A fallback default module kind for the bundle.
     ///   - fallbackDefaultAvailability: A fallback default availability for the bundle.
-    ///   - fallbackFeatureFlags: A fallback set of feature flags for the bundle.
     ///   - additionalSymbolGraphFiles: Additional symbol graph files to augment any discovered bundles.
     public init(
         fallbackDisplayName: String? = nil,
@@ -283,7 +279,6 @@ extension BundleDiscoveryOptions {
         fallbackDefaultCodeListingLanguage: String? = nil,
         fallbackDefaultModuleKind: String? = nil,
         fallbackDefaultAvailability: DefaultAvailability? = nil,
-        fallbackFeatureFlags: DocumentationBundle.Info.BundleFeatureFlags? = nil,
         additionalSymbolGraphFiles: [URL] = []
     ) {
         // Iterate over all possible coding keys with a switch
@@ -308,7 +303,7 @@ extension BundleDiscoveryOptions {
             case .defaultModuleKind:
                 value = fallbackDefaultModuleKind
             case .featureFlags:
-                value = fallbackFeatureFlags
+                value = nil
             }
             
             guard let unwrappedValue = value else {

--- a/Sources/SwiftDocC/Infrastructure/Workspace/DocumentationBundle+Info.swift
+++ b/Sources/SwiftDocC/Infrastructure/Workspace/DocumentationBundle+Info.swift
@@ -36,15 +36,6 @@ extension DocumentationBundle {
         /// The parsed feature flags that were set for this bundle.
         public var featureFlags: BundleFeatureFlags?
 
-        /// A computed ``FeatureFlags`` that defers to a default-initialized instance in case this
-        /// bundle didn't specify any feature flags.
-        ///
-        /// This is useful to fall back to the global ``SwiftDocC/FeatureFlags`` set via the
-        /// command-line when determining whether a feature flag is set.
-        public var computedFeatureFlags: BundleFeatureFlags {
-            self.featureFlags ?? BundleFeatureFlags()
-        }
-
         /// The keys that must be present in an Info.plist file in order for doc compilation to proceed.
         static let requiredKeys: Set<CodingKeys> = [.displayName, .identifier]
         

--- a/Sources/SwiftDocC/Infrastructure/Workspace/FeatureFlags+Info.swift
+++ b/Sources/SwiftDocC/Infrastructure/Workspace/FeatureFlags+Info.swift
@@ -38,7 +38,7 @@ extension DocumentationBundle.Info {
         /// A list of decoded feature flag keys that didn't match a known feature flag.
         public let unknownFeatureFlags: [String]
 
-        enum CodingKeys: String, CodingKey {
+        enum CodingKeys: String, CodingKey, CaseIterable {
             case experimentalOverloadedSymbolPresentation = "ExperimentalOverloadedSymbolPresentation"
         }
 

--- a/Sources/SwiftDocC/Infrastructure/Workspace/FeatureFlags+Info.swift
+++ b/Sources/SwiftDocC/Infrastructure/Workspace/FeatureFlags+Info.swift
@@ -28,38 +28,29 @@ extension DocumentationBundle.Info {
         /// Whether or not experimental support for combining overloaded symbol pages is enabled.
         ///
         /// This feature flag corresponds to ``FeatureFlags/isExperimentalOverloadedSymbolPresentationEnabled``.
-        public var experimentalOverloadedSymbolPresentationEnabled: Bool {
-            get {
-                return _overloadsEnabled ?? SwiftDocC.FeatureFlags.current.isExperimentalOverloadedSymbolPresentationEnabled
-            }
-            set {
-                _overloadsEnabled = newValue
-            }
-        }
+        public var experimentalOverloadedSymbolPresentation: Bool?
 
-        private var _overloadsEnabled: Bool?
-
-        public init(experimentalOverloadedSymbolPresentationEnabled: Bool? = nil) {
-            // IMPORTANT: If you add more fields to this struct, ensure that this initializer sets
-            // them to nil or another suitable default value, since it's called to set
-            // `computedFeatureFlags` on the parent Info struct.
-            self._overloadsEnabled = experimentalOverloadedSymbolPresentationEnabled
+        public init(experimentalOverloadedSymbolPresentation: Bool? = nil) {
+            self.experimentalOverloadedSymbolPresentation = experimentalOverloadedSymbolPresentation
         }
 
         enum CodingKeys: String, CodingKey {
-            case experimentalOverloadedSymbolPresentationEnabled = "ExperimentalOverloadedSymbolPresentation"
+            case experimentalOverloadedSymbolPresentation = "ExperimentalOverloadedSymbolPresentation"
         }
 
         public init(from decoder: any Decoder) throws {
             let values = try decoder.container(keyedBy: CodingKeys.self)
 
-            self._overloadsEnabled = try values.decodeIfPresent(Bool.self, forKey: .experimentalOverloadedSymbolPresentationEnabled)
+            self.experimentalOverloadedSymbolPresentation = try values.decodeIfPresent(Bool.self, forKey: .experimentalOverloadedSymbolPresentation)
+            if let overloadsFlag = self.experimentalOverloadedSymbolPresentation {
+                FeatureFlags.current.isExperimentalOverloadedSymbolPresentationEnabled = overloadsFlag
+            }
         }
 
         public func encode(to encoder: any Encoder) throws {
             var container = encoder.container(keyedBy: CodingKeys.self)
 
-            try container.encode(_overloadsEnabled, forKey: .experimentalOverloadedSymbolPresentationEnabled)
+            try container.encode(experimentalOverloadedSymbolPresentation, forKey: .experimentalOverloadedSymbolPresentation)
         }
     }
 }

--- a/Sources/SwiftDocC/Infrastructure/Workspace/FeatureFlags+Info.swift
+++ b/Sources/SwiftDocC/Infrastructure/Workspace/FeatureFlags+Info.swift
@@ -24,7 +24,9 @@ extension DocumentationBundle.Info {
     ///     <true/>
     /// </dict>
     /// ```
-    public struct BundleFeatureFlags: Codable, Equatable {
+    internal struct BundleFeatureFlags: Codable, Equatable {
+        // FIXME: Automatically expose all the feature flags from the global FeatureFlags struct
+
         /// Whether or not experimental support for combining overloaded symbol pages is enabled.
         ///
         /// This feature flag corresponds to ``FeatureFlags/isExperimentalOverloadedSymbolPresentationEnabled``.

--- a/Sources/SwiftDocC/Infrastructure/Workspace/FeatureFlags+Info.swift
+++ b/Sources/SwiftDocC/Infrastructure/Workspace/FeatureFlags+Info.swift
@@ -1,0 +1,65 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2024 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+
+extension DocumentationBundle.Info {
+    /// A collection of feature flags that can be enabled from a bundle's Info.plist.
+    ///
+    /// This is a subset of flags from ``/SwiftDocC/FeatureFlags`` that can influence how a documentation
+    /// bundle is written, and so can be considered a property of the documentation itself, rather
+    /// than as an experimental behavior that can be enabled for one-off builds.
+    ///
+    /// ```xml
+    /// <key>CDExperimentalFeatureFlags</key>
+    /// <dict>
+    ///     <key>ExperimentalOverloadedSymbolPresentation</key>
+    ///     <true/>
+    /// </dict>
+    /// ```
+    public struct FeatureFlags: Codable, Equatable {
+        /// Whether or not experimental support for combining overloaded symbol pages is enabled.
+        ///
+        /// This feature flag corresponds to ``FeatureFlags/isExperimentalOverloadedSymbolPresentationEnabled``.
+        public var experimentalOverloadedSymbolPresentationEnabled: Bool {
+            get {
+                return _overloadsEnabled ?? SwiftDocC.FeatureFlags.current.isExperimentalOverloadedSymbolPresentationEnabled
+            }
+            set {
+                _overloadsEnabled = newValue
+            }
+        }
+
+        private var _overloadsEnabled: Bool?
+
+        public init(experimentalOverloadedSymbolPresentationEnabled: Bool? = nil) {
+            // IMPORTANT: If you add more fields to this struct, ensure that this initializer sets
+            // them to nil or another suitable default value, since it's called to set
+            // `computedFeatureFlags` on the parent Info struct.
+            self._overloadsEnabled = experimentalOverloadedSymbolPresentationEnabled
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case experimentalOverloadedSymbolPresentationEnabled = "ExperimentalOverloadedSymbolPresentation"
+        }
+
+        public init(from decoder: any Decoder) throws {
+            let values = try decoder.container(keyedBy: CodingKeys.self)
+
+            self._overloadsEnabled = try values.decodeIfPresent(Bool.self, forKey: .experimentalOverloadedSymbolPresentationEnabled)
+        }
+
+        public func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+
+            try container.encode(_overloadsEnabled, forKey: .experimentalOverloadedSymbolPresentationEnabled)
+        }
+    }
+}

--- a/Sources/SwiftDocC/Infrastructure/Workspace/FeatureFlags+Info.swift
+++ b/Sources/SwiftDocC/Infrastructure/Workspace/FeatureFlags+Info.swift
@@ -13,7 +13,7 @@ import Foundation
 extension DocumentationBundle.Info {
     /// A collection of feature flags that can be enabled from a bundle's Info.plist.
     ///
-    /// This is a subset of flags from ``/SwiftDocC/FeatureFlags`` that can influence how a documentation
+    /// This is a subset of flags from ``FeatureFlags`` that can influence how a documentation
     /// bundle is written, and so can be considered a property of the documentation itself, rather
     /// than as an experimental behavior that can be enabled for one-off builds.
     ///
@@ -24,7 +24,7 @@ extension DocumentationBundle.Info {
     ///     <true/>
     /// </dict>
     /// ```
-    public struct FeatureFlags: Codable, Equatable {
+    public struct BundleFeatureFlags: Codable, Equatable {
         /// Whether or not experimental support for combining overloaded symbol pages is enabled.
         ///
         /// This feature flag corresponds to ``FeatureFlags/isExperimentalOverloadedSymbolPresentationEnabled``.

--- a/Sources/SwiftDocC/Infrastructure/Workspace/FeatureFlags+Info.swift
+++ b/Sources/SwiftDocC/Infrastructure/Workspace/FeatureFlags+Info.swift
@@ -71,10 +71,6 @@ extension DocumentationBundle.Info {
             }
 
             self.unknownFeatureFlags = unknownFeatureFlags
-
-            if let overloadsFlag = self.experimentalOverloadedSymbolPresentation {
-                FeatureFlags.current.isExperimentalOverloadedSymbolPresentationEnabled = overloadsFlag
-            }
         }
 
         public func encode(to encoder: any Encoder) throws {

--- a/Sources/SwiftDocC/SwiftDocC.docc/SwiftDocC.md
+++ b/Sources/SwiftDocC/SwiftDocC.docc/SwiftDocC.md
@@ -54,5 +54,6 @@ Converting in-memory documentation into rendering nodes and persisting them on d
 ### Development
 
 - <doc:Features>
+- <doc:AddingFeatureFlags>
 
-<!-- Copyright (c) 2021-2023 Apple Inc and the Swift Project authors. All Rights Reserved. -->
+<!-- Copyright (c) 2021-2024 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Sources/SwiftDocC/SwiftDocC.docc/SwiftDocC/AddingFeatureFlags.md
+++ b/Sources/SwiftDocC/SwiftDocC.docc/SwiftDocC/AddingFeatureFlags.md
@@ -4,10 +4,9 @@ Develop experimental features by adding feature flags.
 
 ## Overview
 
-When developing a new feature in Swift-DocC, it's recommended to make it optional while it's being
-actively developed by creating a command-line flag that enables the new behavior. This flag can then
-be used to set a flag in the ``FeatureFlags``' ``FeatureFlags/current`` instance, which is then
-available for the rest of the compilation process.
+Make new features in Swift-DocC optional during active development by creating a command-line flag that
+enables the new behavior. Then set the new flag in the ``FeatureFlags``' ``FeatureFlags/current`` instance,
+making it available for the rest of the compilation process.
 
 ### The FeatureFlags structure
 

--- a/Sources/SwiftDocC/SwiftDocC.docc/SwiftDocC/AddingFeatureFlags.md
+++ b/Sources/SwiftDocC/SwiftDocC.docc/SwiftDocC/AddingFeatureFlags.md
@@ -1,0 +1,63 @@
+# Adding Feature Flags
+
+Develop experimental features by adding feature flags.
+
+## Overview
+
+When developing a new feature in Swift-DocC, it's recommended to make it optional while it's being
+actively developed by creating a command-line flag that enables the new behavior. This flag can then
+be used to set a flag in the ``FeatureFlags``' ``FeatureFlags/current`` instance, which is then
+available for the rest of the compilation process.
+
+### The FeatureFlags structure
+
+Feature flags are defined in the ``FeatureFlags`` structure. This type has a static
+``FeatureFlags/current`` property that contains a global instance of the flags that can be accessed
+throughout the compiler. When adding a flag property to this struct, give it a reasonable default
+value so that the default initializer can be used.
+
+### Feature flags on the command line
+
+Command-line feature flags live in the `Docc.Convert.FeatureFlagOptions` in `SwiftDocCUtilities`.
+This type implements the `ParsableArguments` protocol from Swift Argument Parser to create an option
+group for the `convert` and `preview` commands.
+
+These options are then handled in `ConvertAction.init(fromConvertCommand:)`, still in
+`SwiftDocCUtilities`, where they are written into the global feature flags ``FeatureFlags/current``
+instance, which can then be used during the compilation process.
+
+### Feature flags in Info.plist
+
+A subset of feature flags can affect how a documentation bundle is authored. For example, the
+experimental overloaded symbol presentation can affect how a bundle curates its symbols due to the 
+creation of overload group pages. These flags should also be added to the
+``DocumentationBundle/Info/FeatureFlags`` type, with a computed property that falls back to the
+global ``FeatureFlags`` when the flag is unset:
+
+```swift
+public var experimentalExampleFeatureEnabled: Bool {
+    get {
+        _exampleFeatureEnabled ?? SwiftDocC.FeatureFlags.current.isExperimentalExampleFeatureEnabled
+    }
+    set {
+        _exampleFeatureEnabled = newValue
+    }
+}
+
+private var _exampleFeatureEnabled: Bool?
+
+enum CodingKeys: String, CodingKey {
+    case experimentalExampleFeatureEnabled = "ExperimentalExampleFeature"
+}
+```
+
+When a flag is defined in this way, it should be treated as a property of the bundle that is being
+converted, rather than a global property of the current execution of Swift-DocC. To facilitate this,
+the ``DocumentationBundle/Info`` type has a ``DocumentationBundle/Info/computedFeatureFlags``
+property that can be used to consistently refer to a feature flag, regardless of whether a bundle
+has specified it in its Info.plist or via the command line. Whereas the
+``DocumentationBundle/Info/featureFlags`` property contains the parsed feature flags, and will be
+`nil` if no feature flags were specified, `computedFeatureFlags` instead creates an empty set of
+bundle feature flags that can transparently defer to the global feature flags.
+
+<!-- Copyright (c) 2024 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Sources/SwiftDocC/SwiftDocC.docc/SwiftDocC/AddingFeatureFlags.md
+++ b/Sources/SwiftDocC/SwiftDocC.docc/SwiftDocC/AddingFeatureFlags.md
@@ -31,7 +31,7 @@ instance, which can then be used during the compilation process.
 A subset of feature flags can affect how a documentation bundle is authored. For example, the
 experimental overloaded symbol presentation can affect how a bundle curates its symbols due to the 
 creation of overload group pages. These flags should also be added to the
-``DocumentationBundle/Info/FeatureFlags`` type, with a computed property that falls back to the
+``DocumentationBundle/Info/BundleFeatureFlags`` type, with a computed property that falls back to the
 global ``FeatureFlags`` when the flag is unset:
 
 ```swift

--- a/Sources/SwiftDocC/SwiftDocC.docc/SwiftDocC/AddingFeatureFlags.md
+++ b/Sources/SwiftDocC/SwiftDocC.docc/SwiftDocC/AddingFeatureFlags.md
@@ -31,33 +31,11 @@ instance, which can then be used during the compilation process.
 A subset of feature flags can affect how a documentation bundle is authored. For example, the
 experimental overloaded symbol presentation can affect how a bundle curates its symbols due to the 
 creation of overload group pages. These flags should also be added to the
-``DocumentationBundle/Info/BundleFeatureFlags`` type, with a computed property that falls back to the
-global ``FeatureFlags`` when the flag is unset:
+``DocumentationBundle/Info/BundleFeatureFlags`` type, so that they can be parsed out of a bundle's
+Info.plist.
 
-```swift
-public var experimentalExampleFeatureEnabled: Bool {
-    get {
-        _exampleFeatureEnabled ?? SwiftDocC.FeatureFlags.current.isExperimentalExampleFeatureEnabled
-    }
-    set {
-        _exampleFeatureEnabled = newValue
-    }
-}
-
-private var _exampleFeatureEnabled: Bool?
-
-enum CodingKeys: String, CodingKey {
-    case experimentalExampleFeatureEnabled = "ExperimentalExampleFeature"
-}
-```
-
-When a flag is defined in this way, it should be treated as a property of the bundle that is being
-converted, rather than a global property of the current execution of Swift-DocC. To facilitate this,
-the ``DocumentationBundle/Info`` type has a ``DocumentationBundle/Info/computedFeatureFlags``
-property that can be used to consistently refer to a feature flag, regardless of whether a bundle
-has specified it in its Info.plist or via the command line. Whereas the
-``DocumentationBundle/Info/featureFlags`` property contains the parsed feature flags, and will be
-`nil` if no feature flags were specified, `computedFeatureFlags` instead creates an empty set of
-bundle feature flags that can transparently defer to the global feature flags.
+Feature flags that are loaded from an Info.plist file are saved into the global feature flags while
+the bundle is being registered. To ensure that your new feature flag is properly loaded, update the
+``FeatureFlags/loadFlagsFromBundle(_:)`` method to load your new field into the global flags.
 
 <!-- Copyright (c) 2024 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Sources/SwiftDocC/Utility/FeatureFlags.swift
+++ b/Sources/SwiftDocC/Utility/FeatureFlags.swift
@@ -40,4 +40,11 @@ public struct FeatureFlags: Codable {
         additionalFlags: [String : Bool] = [:]
     ) {
     }
+
+    /// Set feature flags that were loaded from a bundle's Info.plist.
+    public mutating func loadFlagsFromBundle(_ bundleFlags: DocumentationBundle.Info.BundleFeatureFlags) {
+        if let overloadsPresentation = bundleFlags.experimentalOverloadedSymbolPresentation {
+            self.isExperimentalOverloadedSymbolPresentationEnabled = overloadsPresentation
+        }
+    }
 }

--- a/Sources/SwiftDocC/Utility/FeatureFlags.swift
+++ b/Sources/SwiftDocC/Utility/FeatureFlags.swift
@@ -48,7 +48,7 @@ public struct FeatureFlags: Codable {
     }
 
     /// Set feature flags that were loaded from a bundle's Info.plist.
-    public mutating func loadFlagsFromBundle(_ bundleFlags: DocumentationBundle.Info.BundleFeatureFlags) {
+    internal mutating func loadFlagsFromBundle(_ bundleFlags: DocumentationBundle.Info.BundleFeatureFlags) {
         if let overloadsPresentation = bundleFlags.experimentalOverloadedSymbolPresentation {
             self.isExperimentalOverloadedSymbolPresentationEnabled = overloadsPresentation
         }

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationBundleInfoTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationBundleInfoTests.swift
@@ -440,34 +440,6 @@ class DocumentationBundleInfoTests: XCTestCase {
             bundleDiscoveryOptions: nil)
 
         let featureFlags = try XCTUnwrap(info.featureFlags)
-        XCTAssertTrue(featureFlags.experimentalOverloadedSymbolPresentationEnabled)
-    }
-
-    func testComputedFeatureFlags() throws {
-        let infoPlistWithoutFeatureFlags = """
-        <plist version="1.0">
-        <dict>
-            <key>CFBundleDisplayName</key>
-            <string>Info Plist Display Name</string>
-            <key>CFBundleIdentifier</key>
-            <string>com.info.Plist</string>
-            <key>CFBundleVersion</key>
-            <string>1.0.0</string>
-        </dict>
-        </plist>
-        """
-
-        let infoPlistData = Data(infoPlistWithoutFeatureFlags.utf8)
-        let info = try DocumentationBundle.Info(
-            from: infoPlistData,
-            bundleDiscoveryOptions: nil)
-
-        XCTAssertNil(info.featureFlags)
-        XCTAssertEqual(
-            info.computedFeatureFlags.experimentalOverloadedSymbolPresentationEnabled,
-            FeatureFlags.current.isExperimentalOverloadedSymbolPresentationEnabled)
-
-        enableFeatureFlag(\.isExperimentalOverloadedSymbolPresentationEnabled)
-        XCTAssertTrue(info.computedFeatureFlags.experimentalOverloadedSymbolPresentationEnabled)
+        XCTAssertTrue(try XCTUnwrap(featureFlags.experimentalOverloadedSymbolPresentation))
     }
 }

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationBundleInfoTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationBundleInfoTests.swift
@@ -414,4 +414,60 @@ class DocumentationBundleInfoTests: XCTestCase {
             )
         )
     }
+
+    func testFeatureFlags() throws {
+        let infoPlistWithFeatureFlags = """
+        <plist version="1.0">
+        <dict>
+            <key>CFBundleDisplayName</key>
+            <string>Info Plist Display Name</string>
+            <key>CFBundleIdentifier</key>
+            <string>com.info.Plist</string>
+            <key>CFBundleVersion</key>
+            <string>1.0.0</string>
+            <key>CDExperimentalFeatureFlags</key>
+            <dict>
+                <key>ExperimentalOverloadedSymbolPresentation</key>
+                <true/>
+            </dict>
+        </dict>
+        </plist>
+        """
+
+        let infoPlistWithFeatureFlagsData = Data(infoPlistWithFeatureFlags.utf8)
+        let info = try DocumentationBundle.Info(
+            from: infoPlistWithFeatureFlagsData,
+            bundleDiscoveryOptions: nil)
+
+        let featureFlags = try XCTUnwrap(info.featureFlags)
+        XCTAssertTrue(featureFlags.experimentalOverloadedSymbolPresentationEnabled)
+    }
+
+    func testComputedFeatureFlags() throws {
+        let infoPlistWithoutFeatureFlags = """
+        <plist version="1.0">
+        <dict>
+            <key>CFBundleDisplayName</key>
+            <string>Info Plist Display Name</string>
+            <key>CFBundleIdentifier</key>
+            <string>com.info.Plist</string>
+            <key>CFBundleVersion</key>
+            <string>1.0.0</string>
+        </dict>
+        </plist>
+        """
+
+        let infoPlistData = Data(infoPlistWithoutFeatureFlags.utf8)
+        let info = try DocumentationBundle.Info(
+            from: infoPlistData,
+            bundleDiscoveryOptions: nil)
+
+        XCTAssertNil(info.featureFlags)
+        XCTAssertEqual(
+            info.computedFeatureFlags.experimentalOverloadedSymbolPresentationEnabled,
+            FeatureFlags.current.isExperimentalOverloadedSymbolPresentationEnabled)
+
+        enableFeatureFlag(\.isExperimentalOverloadedSymbolPresentationEnabled)
+        XCTAssertTrue(info.computedFeatureFlags.experimentalOverloadedSymbolPresentationEnabled)
+    }
 }

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -4597,7 +4597,54 @@ let expected = """
             }
         }
     }
-    
+
+    func testContextRecognizesOverloadsFromPlistFlag() throws {
+        let overloadableKindIDs = SymbolGraph.Symbol.KindIdentifier.allCases.filter { $0.isOverloadableKind }
+        // Generate a 4 symbols with the same name for every overloadable symbol kind
+        let symbols: [SymbolGraph.Symbol] = overloadableKindIDs.flatMap { [
+            makeSymbol(identifier: "first-\($0.identifier)-id", kind: $0),
+            makeSymbol(identifier: "second-\($0.identifier)-id", kind: $0),
+            makeSymbol(identifier: "third-\($0.identifier)-id", kind: $0),
+            makeSymbol(identifier: "fourth-\($0.identifier)-id", kind: $0),
+        ] }
+
+        let tempURL = try createTempFolder(content: [
+            Folder(name: "unit-test.docc", content: [
+                JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(
+                    moduleName: "ModuleName",
+                    symbols: symbols
+                )),
+                DataFile(name: "Info.plist", data: Data("""
+                <plist version="1.0">
+                <dict>
+                    <key>CDExperimentalFeatureFlags</key>
+                    <dict>
+                        <key>ExperimentalOverloadedSymbolPresentation</key>
+                        <true/>
+                    </dict>
+                </dict>
+                </plist>
+                """.utf8))
+            ])
+        ])
+        let (_, bundle, context) = try loadBundle(from: tempURL)
+        let moduleReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ModuleName", sourceLanguage: .swift)
+
+        for kindID in overloadableKindIDs {
+            switch context.resolve(.unresolved(.init(topicURL: .init(symbolPath: "SymbolName-\(kindID.identifier)"))), in: moduleReference, fromSymbolLink: true) {
+            case let .failure(_, errorMessage):
+                XCTFail("Could not resolve overload group page for \(kindID.identifier). Error message: \(errorMessage)")
+                continue
+            case let .success(overloadGroupReference):
+                let overloadGroupNode = try context.entity(with: overloadGroupReference)
+                let overloadGroupSymbol = try XCTUnwrap(overloadGroupNode.semantic as? Symbol)
+                let overloadGroupReferences = try XCTUnwrap(overloadGroupSymbol.overloadsVariants.firstValue)
+
+                XCTAssertEqual(overloadGroupReferences.displayIndex, 0)
+            }
+        }
+    }
+
     // The overload behavior doesn't apply to symbol kinds that don't support overloading
     func testContextDoesNotRecognizeNonOverloadableSymbolKinds() throws {
         enableFeatureFlag(\.isExperimentalOverloadedSymbolPresentationEnabled)


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://126305435

## Summary

This PR adds a new field to the Info.plist to set feature flags without using the command line. Right now, this only adds support for the overloads feature, but this mechanism is in place to facilitate adopting experimental features that affect how a bundle is written.

## Dependencies

None

## Testing

To test this feature, make a copy of the `OverloadedSymbols.docc` test bundle and modify its Info.plist to look like this:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
	<key>CFBundleName</key>
	<string>ShapeKit</string>
	<key>CFBundleDisplayName</key>
	<string>ShapeKit</string>
	<key>CFBundleIdentifier</key>
	<string>com.shapes.ShapeKit</string>
	<key>CFBundleVersion</key>
	<string>0.1.0</string>
	<key>CDExperimentalFeatureFlags</key>
	<dict>
		<key>ExperimentalOverloadedSymbolPresentation</key>
		<true/>
	</dict>
</dict>
</plist>
```

Steps:
1. Overwrite `Tests/SwiftDocCTests/Test Bundles/OverloadedSymbols.docc/Info.plist` with the above content, or copy `OverloadedSymbols.docc` into a new location and overwrite its Info.plist there.
2. Ensure that `DOCC_HTML_DIR` is set to a recent main branch of Swift-DocC-Render or `swift-docc-render-artifact`.
3. `swift run docc preview Tests/SwiftDocCTests/Test\ Bundles/OverloadedSymbols.docc` (replace the bundle path if you copied it to a new location)
4. Navigate to `OverloadedProtocol` and ensure that only one `fourthTestMemberName(test:)` is curated in the topic groups.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
