### PR TITLE
[6.0] Ignore precise line number in unit test expectation

### DIFF
--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationBundleInfoTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationBundleInfoTests.swift
@@ -336,7 +336,7 @@ class DocumentationBundleInfoTests: XCTestCase {
                 errorTypeChecking = false
             }
             XCTAssertTrue(errorTypeChecking)
-            XCTAssertEqual(error.localizedDescription, "Unable to decode Info.plist file. Verify that it is correctly formed. Value missing for key inside <dict> at line 24")
+            XCTAssert(error.localizedDescription.starts(with: "Unable to decode Info.plist file. Verify that it is correctly formed. Value missing for key inside <dict> at line"))
         }
     }
     


### PR DESCRIPTION
**Explanation:** A unit test failed under certain circumstances because it tested for a precise line in an expected error message.
**Scope:** One unit test change
**Issue:** rdar://126504994
**Risk:** Low.
**Testing:** Existing tests pass.
**Reviewer:** @QuietMisdreavus 
**Original PR:** https://github.com/apple/swift-docc/pull/887