### PR TITLE
Fix inconsistent assertions with some language variant symbols

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
@@ -294,8 +294,9 @@ struct PathHierarchy {
                     assert(element.node.parent === node, {
                         func describe(_ node: Node?) -> String {
                             guard let node else { return "<nil>" }
-                            guard let identifier = node.symbol?.identifier else { return node.name }
-                            return "\(identifier.precise) (\(identifier.interfaceLanguage))"
+                            guard let symbol = node.symbol else { return node.name }
+                            let id = symbol.identifier
+                            return "\(id.precise) (\(id.interfaceLanguage).\(symbol.kind.identifier.identifier)) [\(symbol.pathComponents.joined(separator: "/"))]"
                         }
                         return """
                             Every child node should point back to its parent so that the tree can be traversed both up and down without any dead-ends. \

--- a/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
@@ -1716,7 +1716,7 @@ class PathHierarchyTests: XCTestCase {
         let exampleDocumentation = Folder(name: "unit-test.docc", content: [
             JSONFile(name: "Module.symbols.json", content: makeSymbolGraph(
                 moduleName: "Module",
-                symbols: symbolPaths.map { ($0.joined(separator: "."), .swift, $0) }
+                symbols: symbolPaths.map { ($0.joined(separator: "."), .swift, $0, .class) }
             )),
         ])
         let tempURL = try createTemporaryDirectory()
@@ -1744,7 +1744,7 @@ class PathHierarchyTests: XCTestCase {
         XCTAssertEqual(paths["X.Y2.Z.W"], "/Module/X/Y2/Z/W")
     }
     
-    func testMixedLanguageSymbolAndItsExtendingModule() throws {
+    func testMixedLanguageSymbolWithSameKindAndAddedMemberFromExtendingModule() throws {
         let containerID = "some-container-symbol-id"
         let memberID = "some-member-symbol-id"
         
@@ -1753,7 +1753,7 @@ class PathHierarchyTests: XCTestCase {
                 JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(
                     moduleName: "ModuleName", 
                     symbols: [
-                        (containerID, .objectiveC, ["ContainerName"])
+                        (containerID, .objectiveC, ["ContainerName"], .class)
                     ]
                 )),
             ]),
@@ -1762,14 +1762,57 @@ class PathHierarchyTests: XCTestCase {
                 JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(
                     moduleName: "ModuleName",
                     symbols: [
-                        (containerID, .swift, ["ContainerName"])
+                        (containerID, .swift, ["ContainerName"], .class)
                     ]
                 )),
                 
                 JSONFile(name: "ExtendingModule@ModuleName.symbols.json", content: makeSymbolGraph(
                     moduleName: "ExtendingModule",
                     symbols: [
-                        (memberID, .swift, ["ContainerName", "MemberName"])
+                        (memberID, .swift, ["ContainerName", "MemberName"], .property)
+                    ],
+                    relationships: [
+                        .init(source: memberID, target: containerID, kind: .memberOf, targetFallback: nil)
+                    ]
+                )),
+            ])
+        ])
+        
+        let tempURL = try createTempFolder(content: [exampleDocumentation])
+        let (_, _, context) = try loadBundle(from: tempURL)
+        let tree = context.linkResolver.localResolver.pathHierarchy
+        
+        let paths = tree.caseInsensitiveDisambiguatedPaths()
+        XCTAssertEqual(paths[containerID], "/ModuleName/ContainerName")
+        XCTAssertEqual(paths[memberID], "/ModuleName/ContainerName/MemberName")
+    }
+    
+    func testMixedLanguageSymbolWithDifferentKindsAndAddedMemberFromExtendingModule() throws {
+        let containerID = "some-container-symbol-id"
+        let memberID = "some-member-symbol-id"
+        
+        let exampleDocumentation = Folder(name: "unit-test.docc", content: [
+            Folder(name: "clang", content: [
+                JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(
+                    moduleName: "ModuleName",
+                    symbols: [
+                        (containerID, .objectiveC, ["ContainerName"], .typealias)
+                    ]
+                )),
+            ]),
+            
+            Folder(name: "swift", content: [
+                JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(
+                    moduleName: "ModuleName",
+                    symbols: [
+                        (containerID, .swift, ["ContainerName"], .struct)
+                    ]
+                )),
+                
+                JSONFile(name: "ExtendingModule@ModuleName.symbols.json", content: makeSymbolGraph(
+                    moduleName: "ExtendingModule",
+                    symbols: [
+                        (memberID, .swift, ["ContainerName", "MemberName"], .property)
                     ],
                     relationships: [
                         .init(source: memberID, target: containerID, kind: .memberOf, targetFallback: nil)
@@ -1796,8 +1839,8 @@ class PathHierarchyTests: XCTestCase {
                 JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(
                     moduleName: "ModuleName", 
                     symbols: [
-                        (containerID, .objectiveC, ["ContainerName"]),
-                        (memberID, .objectiveC, ["ContainerName", "MemberName"]), // member starts with uppercase "M"
+                        (containerID, .objectiveC, ["ContainerName"], .class),
+                        (memberID, .objectiveC, ["ContainerName", "MemberName"], .property), // member starts with uppercase "M"
                     ],
                     relationships: [
                         .init(source: memberID, target: containerID, kind: .memberOf, targetFallback: nil)
@@ -1809,8 +1852,8 @@ class PathHierarchyTests: XCTestCase {
                 JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(
                     moduleName: "ModuleName",
                     symbols: [
-                        (containerID, .swift, ["ContainerName"]),
-                        (memberID, .swift, ["ContainerName", "memberName"]), // member starts with lowercase "m"
+                        (containerID, .swift, ["ContainerName"], .class),
+                        (memberID, .swift, ["ContainerName", "memberName"], .property), // member starts with lowercase "m"
                     ],
                     relationships: [
                         .init(source: memberID, target: containerID, kind: .memberOf, targetFallback: nil)
@@ -1837,7 +1880,7 @@ class PathHierarchyTests: XCTestCase {
                 JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(
                     moduleName: "ModuleName",
                     symbols: [
-                        (containerID, .objectiveC, ["ObjectiveCContainerName"])
+                        (containerID, .objectiveC, ["ObjectiveCContainerName"], .class)
                     ]
                 )),
             ]),
@@ -1846,14 +1889,14 @@ class PathHierarchyTests: XCTestCase {
                 JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(
                     moduleName: "ModuleName",
                     symbols: [
-                        (containerID, .swift, ["SwiftContainerName"])
+                        (containerID, .swift, ["SwiftContainerName"], .class)
                     ]
                 )),
                 
                 JSONFile(name: "ExtendingModule@ModuleName.symbols.json", content: makeSymbolGraph(
                     moduleName: "ExtendingModule",
                     symbols: [
-                        (memberID, .swift, ["SwiftContainerName", "MemberName"])
+                        (memberID, .swift, ["SwiftContainerName", "MemberName"], .property)
                     ],
                     relationships: [
                         .init(source: memberID, target: containerID, kind: .memberOf, targetFallback: nil)
@@ -1880,9 +1923,9 @@ class PathHierarchyTests: XCTestCase {
             JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(
                 moduleName: "ModuleName",
                 symbols: [
-                    (containerID, .swift, ["ContainerName"]),
-                    (otherID, .swift, ["ContainerName"]),
-                    (memberID, .swift, ["ContainerName", "MemberName1"]),
+                    (containerID, .swift, ["ContainerName"], .class),
+                    (otherID, .swift, ["ContainerName"], .class),
+                    (memberID, .swift, ["ContainerName", "MemberName1"], .property),
                 ],
                 relationships: [
                     .init(source: memberID, target: containerID, kind: .optionalMemberOf, targetFallback: nil),
@@ -1905,7 +1948,7 @@ class PathHierarchyTests: XCTestCase {
             JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(
                 moduleName: "ModuleName",
                 symbols: [
-                    ("some-symbol-id", .swift, ["SymbolName"]),
+                    ("some-symbol-id", .swift, ["SymbolName"], .class),
                 ],
                 relationships: []
             )),
@@ -2004,7 +2047,7 @@ class PathHierarchyTests: XCTestCase {
             JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(
                 moduleName: "ModuleName",
                 symbols: [
-                    (symbolID, .swift, ["SymbolName"]),
+                    (symbolID, .swift, ["SymbolName"], .class),
                 ],
                 relationships: []
             )),
@@ -2038,9 +2081,9 @@ class PathHierarchyTests: XCTestCase {
                 moduleName: "ModuleName",
                 platformName: platformName,
                 symbols: [
-                    (protocolID, .swift, ["SomeProtocolName"]),
-                    (protocolRequirementID, .swift, ["SomeProtocolName", "someProtocolRequirement()"]),
-                    (defaultImplementationID, .swift, ["SomeConformingType", "someProtocolRequirement()"]),
+                    (protocolID, .swift, ["SomeProtocolName"], .class),
+                    (protocolRequirementID, .swift, ["SomeProtocolName", "someProtocolRequirement()"], .class),
+                    (defaultImplementationID, .swift, ["SomeConformingType", "someProtocolRequirement()"], .class),
                 ],
                 relationships: [
                     .init(source: protocolRequirementID, target: protocolID, kind: .requirementOf, targetFallback: nil),
@@ -2130,20 +2173,20 @@ class PathHierarchyTests: XCTestCase {
     private func makeSymbolGraph(
         moduleName: String,
         platformName: String? = nil,
-        symbols: [(identifier: String, language: SourceLanguage, pathComponents: [String])],
+        symbols: [(identifier: String, language: SourceLanguage, pathComponents: [String], kindID: SymbolGraph.Symbol.KindIdentifier)],
         relationships: [SymbolGraph.Relationship] = []
     ) -> SymbolGraph {
         return SymbolGraph(
             metadata: SymbolGraph.Metadata(formatVersion: .init(major: 0, minor: 5, patch: 3), generator: "unit-test"),
             module: SymbolGraph.Module(name: moduleName, platform: .init(operatingSystem: platformName.map { .init(name: $0) })),
-            symbols: symbols.map { identifier, language, pathComponents in
+            symbols: symbols.map { identifier, language, pathComponents, kindID in
                 SymbolGraph.Symbol(
                     identifier: .init(precise: identifier, interfaceLanguage: language.id),
                     names: .init(title: "SymbolName", navigator: nil, subHeading: nil, prose: nil), // names doesn't matter for path disambiguation
                     pathComponents: pathComponents,
                     docComment: nil,
                     accessLevel: .public,
-                    kind: .init(parsedIdentifier: .class, displayName: "Kind Display Name"), // kind display names doesn't matter for path disambiguation
+                    kind: .init(parsedIdentifier: kindID, displayName: "Kind Display Name"), // kind display names doesn't matter for path disambiguation
                     mixins: [:]
                 )
             },


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://125948615

## Summary

This fixes two different bugs found in the same project:

- If two language variants of the same symbol, of the same symbol kind, have the same name with different capitalization, then that symbol would sometimes not be assigned a path (hitting an precondition later in the build) depending on which language variant was processed first.
- If an extension adds a member to a symbol with different kinds in different language representations, then DocC would sometimes hit an assertion about the symbol having an unexpected parent in the hierarchy depending on which language variant was processed first.

## Dependencies

None

## Testing

#### Bug 1

- Configure a project to build documentation for both Swift and Objective-C
- Define a class in either language with a member with different capitalization in both languages, for example
   ```swift
   @objc
   public class ContainerName: NSObject {
       @objc(MemberName)
       public var memberName: Int = 1
   }
   ```
- Run `docc convert --additional-symbol-graph-dir` with the path to a directory containing both the Swift and Objective-C symbol graphs.

  - DocC shouldn't hit this precondition:
    ```
    Fatal error: Symbol with identifier 'c:@M@ModuleName@objc(cs)ContainerName(py)MemberName' has no reference. A symbol will always have at least one reference.
    ```
    
#### Bug 2

> Note: this uses a non-standard build setup that mixes ways of extracting SGFs and mixes SGFs from different targets.

- Configure a project with two different targets ("ModuleName" and "ExtendingModule") to build documentation for both Swift and Objective-C

- In the "ModuleName" target, define a public extensible string enum in Objective-C:
  ```objc
  typedef NSString *MyExtensibleStringEnum NS_EXTENSIBLE_STRING_ENUM;
  
  MyExtensibleStringEnum const MyExtensibleStringEnumFirst = @"MyExtensibleStringEnum";
  ```
  
- Configure the "ExtendingModule" target to depend on the "ModuleName" target and add a case to the extensible string enum
  ```objc
  extern MyExtensibleStringEnum MySomething;
  ```
  
- Build documentation for the "ModuleName" target only.

- Build the "ExtendingModule" target (without building documentation).

- Use `swift symbolgraph-extract` to extract symbol graphs files for the second target

- Copy the `ExtendingModule@ModuleName.symbols.json` from the manually extracted symbol graphs into the directory of symbol graphs for the "ModuleName" target

- Run `swift run docc convert --additional-symbol-graph-dir /path/to/dir-with-ModuleName-SGFs-and-manually-copied-extension-SGF`

    - DocC shouldn't hit this debug assertion:
      ```
      Assertion failed: Every child node should point back to its parent so that the tree can be traversed both up and down without any dead-end
      ```

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] ~Updated documentation if necessary~ Not applicable
