### PR TITLE
Fix a few issues with infinite recursions if the content contains cyclic curation

### DIFF
--- a/Sources/SwiftDocC/Catalog Processing/GeneratedCurationWriter.swift
+++ b/Sources/SwiftDocC/Catalog Processing/GeneratedCurationWriter.swift
@@ -133,7 +133,7 @@ public struct GeneratedCurationWriter {
         for (usr, reference) in context.documentationCache.referencesBySymbolID {
             // Filter out symbols that aren't in the specified sub hierarchy.
             if symbolLink != nil || depthLimit != nil {
-                guard reference == curationCrawlRoot || context.pathsTo(reference).contains(where: { path in path.suffix(depthLimit ?? .max).contains(curationCrawlRoot)}) else {
+                guard reference == curationCrawlRoot || context.finitePaths(to: reference).contains(where: { path in path.suffix(depthLimit ?? .max).contains(curationCrawlRoot)}) else {
                     continue
                 }
             }

--- a/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
+++ b/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
@@ -255,8 +255,7 @@ public class NavigatorIndex {
     }
     
     /// Indicates the page type of a given item inside the tree.
-    /// - Note: This information is stored as UInt8 to decrease the required size to store it and make
-    ///         the comparision faster between types.
+    /// - Note: This information is stored as `UInt8` to decrease the required size to store it and make the comparison faster between types.
     public enum PageType: UInt8 {
         case root = 0
         case article = 1

--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext+Breadcrumbs.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext+Breadcrumbs.swift
@@ -1,0 +1,49 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2024 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+extension DocumentationContext {
+    /// Options to consider when producing node breadcrumbs.
+    struct PathOptions: OptionSet {
+        let rawValue: Int
+        
+        /// Prefer a technology as the canonical path over a shorter path.
+        static let preferTechnologyRoot = PathOptions(rawValue: 1 << 0)
+    }
+    
+    /// Finds all finite paths (breadcrumbs) to the given node reference.
+    ///
+    /// Each path is a list of references for the nodes traversed while walking the topic graph from a root node to, but not including, the given `reference`.
+    ///
+    /// The first path is the canonical path to the node. The other paths are sorted by increasing length (number of components).
+    ///
+    /// - Parameters:
+    ///   - reference: The reference to build that paths to.
+    ///   - options: Options to consider when producing node breadcrumbs.
+    /// - Returns: A list of finite paths to the given reference in the topic graph.
+    func pathsTo(_ reference: ResolvedTopicReference, options: PathOptions = []) -> [[ResolvedTopicReference]] {
+        return DirectedGraph(neighbors: topicGraph.reverseEdges)
+            .allFinitePaths(from: reference)
+            .map { $0.dropFirst().reversed() }
+            .sorted { (lhs, rhs) -> Bool in
+                // Order a path rooted in a technology as the canonical one.
+                if options.contains(.preferTechnologyRoot), let first = lhs.first {
+                    return try! entity(with: first).semantic is Technology
+                }
+                
+                // If the breadcrumbs have equal amount of components
+                // sort alphabetically to produce stable paths order.
+                guard lhs.count != rhs.count else {
+                    return lhs.map({ $0.path }).joined(separator: ",") < rhs.map({ $0.path }).joined(separator: ",")
+                }
+                // Order by the length of the breadcrumb.
+                return lhs.count < rhs.count
+            }
+    }
+}

--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext+Breadcrumbs.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext+Breadcrumbs.swift
@@ -28,7 +28,7 @@ extension DocumentationContext {
     ///   - options: Options for how the context produces node breadcrumbs.
     /// - Returns: A list of finite paths to the given reference in the topic graph.
     func pathsTo(_ reference: ResolvedTopicReference, options: PathOptions = []) -> [[ResolvedTopicReference]] {
-        return DirectedGraph(neighbors: topicGraph.reverseEdges)
+        reverseEdgesGraph
             .allFinitePaths(from: reference)
             .map { $0.dropFirst().reversed() }
             .sorted { (lhs, rhs) -> Bool in
@@ -46,10 +46,26 @@ extension DocumentationContext {
     /// - Parameter reference: The reference to find the shortest path to.
     /// - Returns: The shortest path to the given reference, or `nil` if all paths to the reference are infinite (contain cycles).
     func shortestFinitePathTo(_ reference: ResolvedTopicReference) -> [ResolvedTopicReference]? {
-        return DirectedGraph(neighbors: topicGraph.reverseEdges)
+        reverseEdgesGraph
             .shortestFinitePaths(from: reference)
             .map { $0.dropFirst().reversed() }
             .min(by: breadcrumbsAreInIncreasingOrder)
+    }
+    
+    /// Finds all the reachable root node references from the given reference.
+    ///
+    /// > Note:
+    /// If all paths from the given reference are infinite (contain cycles) then it can't reach any roots and will return an empty set.
+    ///
+    /// - Parameter reference: The reference to find reachable root node references from.
+    /// - Returns: The references of the root nodes that are reachable fro the given reference, or `[]` if all paths from the reference are infinite (contain cycles).
+    func reachableRoots(from reference: ResolvedTopicReference) -> Set<ResolvedTopicReference> {
+        reverseEdgesGraph.reachableLeafNodes(from: reference)
+    }
+    
+    /// The directed graph of reverse edges in the topic graph.
+    private var reverseEdgesGraph: DirectedGraph<ResolvedTopicReference> {
+        DirectedGraph(neighbors: topicGraph.reverseEdges)
     }
 }
 

--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext+Breadcrumbs.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext+Breadcrumbs.swift
@@ -27,7 +27,7 @@ extension DocumentationContext {
     ///   - reference: The reference to find paths to.
     ///   - options: Options for how the context produces node breadcrumbs.
     /// - Returns: A list of finite paths to the given reference in the topic graph.
-    func pathsTo(_ reference: ResolvedTopicReference, options: PathOptions = []) -> [[ResolvedTopicReference]] {
+    func finitePaths(to reference: ResolvedTopicReference, options: PathOptions = []) -> [[ResolvedTopicReference]] {
         reverseEdgesGraph
             .allFinitePaths(from: reference)
             .map { $0.dropFirst().reversed() }
@@ -45,7 +45,7 @@ extension DocumentationContext {
     ///
     /// - Parameter reference: The reference to find the shortest path to.
     /// - Returns: The shortest path to the given reference, or `nil` if all paths to the reference are infinite (contain cycles).
-    func shortestFinitePathTo(_ reference: ResolvedTopicReference) -> [ResolvedTopicReference]? {
+    func shortestFinitePath(to reference: ResolvedTopicReference) -> [ResolvedTopicReference]? {
         reverseEdgesGraph
             .shortestFinitePaths(from: reference)
             .map { $0.dropFirst().reversed() }

--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext+Breadcrumbs.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext+Breadcrumbs.swift
@@ -17,19 +17,25 @@ extension DocumentationContext {
         static let preferTechnologyRoot = PathOptions(rawValue: 1 << 0)
     }
     
-    /// Finds all finite paths (breadcrumbs) to the given reference.
+    /// Finds all finite (acyclic) paths, also called "breadcrumbs", to the given reference in the topic graph.
     ///
-    /// Each path is a list of references for the nodes traversed while walking the topic graph from a root node to, but not including, the given `reference`.
+    /// Each path is a list of references that describe a walk through the topic graph from a leaf node up to, but not including, the given `reference`.
     ///
     /// The first path is the canonical path to the node. The other paths are sorted by increasing length (number of components).
+    ///
+    /// > Note:
+    /// If all paths from the given reference are infinite (cycle back on themselves) then this function will return an empty list, because there are no _finite_ paths in the topic graph from that reference.
     ///
     /// - Parameters:
     ///   - reference: The reference to find paths to.
     ///   - options: Options for how the context produces node breadcrumbs.
     /// - Returns: A list of finite paths to the given reference in the topic graph.
     func finitePaths(to reference: ResolvedTopicReference, options: PathOptions = []) -> [[ResolvedTopicReference]] {
-        reverseEdgesGraph
+        topicGraph.reverseEdgesGraph
             .allFinitePaths(from: reference)
+            // Graph traversal typically happens from the starting point outwards, but the callers of `finitePaths(to:options:)`
+            // expect paths going inwards from the leaves to the starting point, excluding the starting point itself.
+            // To match the caller's expectations we remove the starting point and then flip the paths.
             .map { $0.dropFirst().reversed() }
             .sorted { (lhs, rhs) -> Bool in
                 // Order a path rooted in a technology as the canonical one.
@@ -41,13 +47,21 @@ extension DocumentationContext {
             }
     }
     
-    /// Finds the shortest finite path (breadcrumb) to the given reference.
+    /// Finds the shortest finite (acyclic) path, also called "breadcrumb", to the given reference in the topic graph.
+    ///
+    /// The path is a list of references that describe a walk through the topic graph from a leaf node up to, but not including, the given `reference`.
+    ///
+    /// > Note:
+    /// If all paths from the given reference are infinite (cycle back on themselves) then this function will return `nil`, because there are no _finite_ paths in the topic graph from that reference.
     ///
     /// - Parameter reference: The reference to find the shortest path to.
     /// - Returns: The shortest path to the given reference, or `nil` if all paths to the reference are infinite (contain cycles).
     func shortestFinitePath(to reference: ResolvedTopicReference) -> [ResolvedTopicReference]? {
-        reverseEdgesGraph
+        topicGraph.reverseEdgesGraph
             .shortestFinitePaths(from: reference)
+            // Graph traversal typically happens from the starting point outwards, but the callers of `shortestFinitePaths(to:)`
+            // expect paths going inwards from the leaves to the starting point, excluding the starting point itself.
+            // To match the caller's expectations we remove the starting point and then flip the paths.
             .map { $0.dropFirst().reversed() }
             .min(by: breadcrumbsAreInIncreasingOrder)
     }
@@ -55,21 +69,16 @@ extension DocumentationContext {
     /// Finds all the reachable root node references from the given reference.
     ///
     /// > Note:
-    /// If all paths from the given reference are infinite (contain cycles) then it can't reach any roots and will return an empty set.
+    /// If all paths from the given reference are infinite (cycle back on themselves) then this function will return an empty set, because there are no reachable roots in the topic graph from that reference.
     ///
     /// - Parameter reference: The reference to find reachable root node references from.
     /// - Returns: The references of the root nodes that are reachable fro the given reference, or `[]` if all paths from the reference are infinite (contain cycles).
     func reachableRoots(from reference: ResolvedTopicReference) -> Set<ResolvedTopicReference> {
-        reverseEdgesGraph.reachableLeafNodes(from: reference)
-    }
-    
-    /// The directed graph of reverse edges in the topic graph.
-    private var reverseEdgesGraph: DirectedGraph<ResolvedTopicReference> {
-        DirectedGraph(neighbors: topicGraph.reverseEdges)
+        topicGraph.reverseEdgesGraph.reachableLeafNodes(from: reference)
     }
 }
 
-/// Compares two breadcrumbs for sorting so that the breadcrumb with fewer components come first and breadcrumbs with the same number of components are sorter alphabetically.
+/// Compares two breadcrumbs for sorting so that the breadcrumb with fewer components come first and breadcrumbs with the same number of components are sorted alphabetically.
 private func breadcrumbsAreInIncreasingOrder(_ lhs: [ResolvedTopicReference], _ rhs: [ResolvedTopicReference]) -> Bool {
     // If the breadcrumbs have the same number of components, sort alphabetically to produce stable results.
     guard lhs.count != rhs.count else {

--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -2279,15 +2279,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
     ///
     /// - Parameter automaticallyCurated: A list of topics that have been automatically curated.
     func removeUnneededAutomaticCuration(_ automaticallyCurated: [(child: ResolvedTopicReference, parent: ResolvedTopicReference)]) {
-        for pair in automaticallyCurated {
-            let paths = pathsTo(pair.child)
-            
-            // Collect all current unique parents of the child.
-            let parents = Set(paths.map({ $0.last?.path }))
-            
-            // Check if the topic has multiple curation paths
-            guard parents.count > 1 else { continue }
-            
+        for pair in automaticallyCurated where parents(of: pair.child).count > 1 {
             // The topic has been manually curated, remove the automatic curation now.
             topicGraph.removeEdge(fromReference: pair.parent, toReference: pair.child)
         }

--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -2707,15 +2707,9 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
         return topicGraph.nodes[reference]?.title
     }
     
-    /**
-     Traverse the Topic Graph breadth-first, starting at the given reference.
-     */
-    func traverseBreadthFirst(from reference: ResolvedTopicReference, _ observe: (TopicGraph.Node) -> TopicGraph.Traversal) {
-        guard let node = topicGraph.nodeWithReference(reference) else {
-            return
-        }
-        
-        topicGraph.traverseBreadthFirst(from: node, observe)
+    /// Returns a sequence that traverses the topic graph in breadth first order from a given reference, without visiting the same node more than once.
+    func breadthFirstSearch(from reference: ResolvedTopicReference) -> some Sequence<TopicGraph.Node> {
+        topicGraph.breadthFirstSearch(from: reference)
     }
     
     /**

--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -2378,14 +2378,14 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
                 return
             }
             
-            guard let topicGraphParentNode = topicGraph.nodeWithReference(parentReference) else { return }
+            guard let topicGraphParentNode = topicGraph.nodeWithReference(parentReference) else {
+                preconditionFailure("Node with reference \(parentReference.absoluteString) exist in link resolver but not in topic graph.")
+            }
             topicGraph.addEdge(from: topicGraphParentNode, to: topicGraphNode)
             
             if let counterpartParentReference {
-                guard let topicGraphCounterpartParentNode = topicGraph.nodeWithReference(counterpartParentReference) else { 
-                    // If the counterpart parent doesn't exist. Return the auto curation record without the it.
-                    automaticallyCuratedSymbols.append((reference, parentReference, nil))
-                    return
+                guard let topicGraphCounterpartParentNode = topicGraph.nodeWithReference(counterpartParentReference) else {
+                    preconditionFailure("Node with reference \(counterpartParentReference.absoluteString) exist in link resolver but not in topic graph.")
                 }
                 topicGraph.addEdge(from: topicGraphCounterpartParentNode, to: topicGraphNode)
             }

--- a/Sources/SwiftDocC/Infrastructure/DocumentationCurator.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationCurator.swift
@@ -127,7 +127,7 @@ struct DocumentationCurator {
     }
     
     private func isReference(_ childReference: ResolvedTopicReference, anAncestorOf nodeReference: ResolvedTopicReference) -> Bool {
-        DirectedGraph(neighbors: context.topicGraph.reverseEdges)
+        context.topicGraph.reverseEdgesGraph
             .breadthFirstSearch(from: nodeReference)
             .contains(childReference)
     }

--- a/Sources/SwiftDocC/Infrastructure/DocumentationCurator.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationCurator.swift
@@ -127,7 +127,9 @@ struct DocumentationCurator {
     }
     
     private func isReference(_ childReference: ResolvedTopicReference, anAncestorOf nodeReference: ResolvedTopicReference) -> Bool {
-        return context.pathsTo(nodeReference).contains { $0.contains(childReference) }
+        DirectedGraph(neighbors: context.topicGraph.reverseEdges)
+            .breadthFirstSearch(from: nodeReference)
+            .contains(childReference)
     }
     
     /// Crawls the topic graph starting at a given root node, curates articles during.

--- a/Sources/SwiftDocC/Infrastructure/DocumentationCurator.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationCurator.swift
@@ -237,10 +237,7 @@ struct DocumentationCurator {
                         return node.kind == .module && documentationNode.kind.isSymbol == false
                     }
         
-                    let hasTechnologyRoot = isTechnologyRoot(nodeReference) || context.pathsTo(nodeReference).contains { path in
-                        guard let root = path.first else { return false }
-                        return isTechnologyRoot(root)
-                    }
+                    let hasTechnologyRoot = isTechnologyRoot(nodeReference) || context.reachableRoots(from: nodeReference).contains(where: isTechnologyRoot)
 
                     if !hasTechnologyRoot {
                         problems.append(Problem(diagnostic: Diagnostic(source: source(), severity: .warning, range: range(), identifier: "org.swift.docc.ModuleCuration", summary: "Linking to \((link.destination ?? "").singleQuoted) from a Topics group in \(nodeReference.absoluteString.singleQuoted) isn't allowed", explanation: "The former is a module, and modules only exist at the root"), possibleSolutions: []))

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchyBasedLinkResolver.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchyBasedLinkResolver.swift
@@ -45,15 +45,21 @@ final class PathHierarchyBasedLinkResolver {
         return "\(unresolved.path)#\(urlReadableFragment(fragment))"
     }
     
-    /// Traverse all the pairs of symbols and their parents.
-    func traverseSymbolAndParentPairs(_ observe: (_ symbol: ResolvedTopicReference, _ parent: ResolvedTopicReference) -> Void) {
+    /// Traverse all the pairs of symbols and their parents and counterpart parents.
+    func traverseSymbolAndParents(_ observe: (_ symbol: ResolvedTopicReference, _ parent: ResolvedTopicReference, _ counterpartParent: ResolvedTopicReference?) -> Void) {
+        let swiftLanguageID = SourceLanguage.swift.id
         for (id, node) in pathHierarchy.lookup {
-            guard node.symbol != nil else { continue }
-            guard let parentID = node.parent?.identifier else { continue }
-            
+            guard let symbol = node.symbol,
+                  let parentID = node.parent?.identifier,
+                  // Symbols that exist in more than one source language may have more than one parent.
+                  // If this symbol has language counterparts, only call `observe` for one of the counterparts.
+                  node.counterpart == nil || symbol.identifier.interfaceLanguage == swiftLanguageID
+            else { continue }
+                
             // Only symbols in the symbol index are added to the reference map.
             guard let reference = resolvedReferenceMap[id], let parentReference = resolvedReferenceMap[parentID] else { continue }
-            observe(reference, parentReference)
+           
+            observe(reference, parentReference, node.counterpart?.parent?.identifier.flatMap { resolvedReferenceMap[$0] })
         }
     }
 

--- a/Sources/SwiftDocC/Infrastructure/Topic Graph/AutomaticCuration.swift
+++ b/Sources/SwiftDocC/Infrastructure/Topic Graph/AutomaticCuration.swift
@@ -152,7 +152,7 @@ public struct AutomaticCuration {
         }
         
         // First try getting the canonical path from a render context, default to the documentation context
-        guard let canonicalPath = renderContext?.store.content(for: node.reference)?.canonicalPath ?? context.shortestFinitePathTo(node.reference),
+        guard let canonicalPath = renderContext?.store.content(for: node.reference)?.canonicalPath ?? context.shortestFinitePath(to: node.reference),
               let parentReference = canonicalPath.last
         else {
             // If the symbol is not curated or is a root symbol, no See Also please.

--- a/Sources/SwiftDocC/Infrastructure/Topic Graph/AutomaticCuration.swift
+++ b/Sources/SwiftDocC/Infrastructure/Topic Graph/AutomaticCuration.swift
@@ -152,7 +152,7 @@ public struct AutomaticCuration {
         }
         
         // First try getting the canonical path from a render context, default to the documentation context
-        guard let canonicalPath = renderContext?.store.content(for: node.reference)?.canonicalPath ?? context.pathsTo(node.reference).first,
+        guard let canonicalPath = renderContext?.store.content(for: node.reference)?.canonicalPath ?? context.shortestFinitePathTo(node.reference),
               let parentReference = canonicalPath.last
         else {
             // If the symbol is not curated or is a root symbol, no See Also please.

--- a/Sources/SwiftDocC/Infrastructure/Topic Graph/TopicGraph.swift
+++ b/Sources/SwiftDocC/Infrastructure/Topic Graph/TopicGraph.swift
@@ -334,7 +334,14 @@ struct TopicGraph {
     /// │   ╰ doc://com.testbundle/documentation/MyFramework/MyClass/init()
     /// ...
     /// ```
+    ///
+    /// - Precondition: All paths through the topic graph from the starting node are finite (acyclic).
     func dump(startingAt node: Node, keyPath: KeyPath<TopicGraph.Node, String> = \.title, decorator: String = "") -> String {
+        if let cycle = edgesGraph.firstCycle(from: node.reference) {
+            let cycleDescription = cycle.map(\.absoluteString).joined(separator: " -> ")
+            preconditionFailure("Traversing the topic graph from \(node.reference.absoluteString) encounters an infinite cyclic path: \(cycleDescription) -cycle-> \(cycleDescription) ...")
+        }
+        
         var result = ""
         result.append("\(decorator) \(node[keyPath: keyPath])\r\n")
         if let childEdges = edges[node.reference]?.sorted(by: { $0.path < $1.path }) {

--- a/Sources/SwiftDocC/Infrastructure/Topic Graph/TopicGraph.swift
+++ b/Sources/SwiftDocC/Infrastructure/Topic Graph/TopicGraph.swift
@@ -277,7 +277,7 @@ struct TopicGraph {
     
     /// Returns a sequence that traverses the topic graph in depth first order from a given reference, without visiting the same node more than once.
     func depthFirstSearch(from reference: ResolvedTopicReference) -> some Sequence<Node> {
-        DirectedGraph(neighbors: edges)
+        edgesGraph
             .depthFirstSearch(from: reference)
             .lazy
             .map { nodeWithReference($0)! }
@@ -285,10 +285,20 @@ struct TopicGraph {
     
     /// Returns a sequence that traverses the topic graph in breadth first order from a given reference, without visiting the same node more than once.
     func breadthFirstSearch(from reference: ResolvedTopicReference) -> some Sequence<Node> {
-        DirectedGraph(neighbors: edges)
+        edgesGraph
             .breadthFirstSearch(from: reference)
             .lazy
             .map { nodeWithReference($0)! }
+    }
+    
+    /// A directed graph of the edges in the topic graph.
+    var edgesGraph: DirectedGraph<ResolvedTopicReference> {
+        DirectedGraph(edges: edges)
+    }
+    
+    /// A directed graph of the reverse edges in the topic graph.
+    var reverseEdgesGraph: DirectedGraph<ResolvedTopicReference> {
+        DirectedGraph(edges: reverseEdges)
     }
 
     /// Returns the children of this node that reference it as their overload group.

--- a/Sources/SwiftDocC/Infrastructure/Topic Graph/TopicGraph.swift
+++ b/Sources/SwiftDocC/Infrastructure/Topic Graph/TopicGraph.swift
@@ -23,15 +23,6 @@ import Markdown
  > If you need information about source language specific edged between nodes, you need to query another source of information.
  */
 struct TopicGraph {
-    /// A decision about whether to continue a depth-first or breadth-first traversal after visiting a node.
-    enum Traversal {
-        /// Stop here, do not visit any more nodes.
-        case stop
-        
-        /// Continue to visit nodes.
-        case `continue`
-    }
-    
     /// A node in the graph.
     class Node: Hashable, CustomDebugStringConvertible {
         /// The location of the node's contents.
@@ -284,44 +275,20 @@ struct TopicGraph {
         return edges[node.reference] ?? []
     }
     
-    /// Traverses the graph depth-first and passes each node to `observe`.
-    func traverseDepthFirst(from startingNode: Node, _ observe: (Node) -> Traversal) {
-        var seen = Set<Node>()
-        var nodesToVisit = [startingNode]
-        while !nodesToVisit.isEmpty {
-            let node = nodesToVisit.removeLast()
-            guard !seen.contains(node) else {
-                continue
-            }
-            let children = self[node].map {
-                nodeWithReference($0)!
-            }
-            nodesToVisit.append(contentsOf: children)
-            guard case .continue = observe(node) else {
-                break
-            }
-            seen.insert(node)
-        }
+    /// Returns a sequence that traverses the topic graph in depth first order from a given reference, without visiting the same node more than once.
+    func depthFirstSearch(from reference: ResolvedTopicReference) -> some Sequence<Node> {
+        DirectedGraph(neighbors: edges)
+            .depthFirstSearch(from: reference)
+            .lazy
+            .map { nodeWithReference($0)! }
     }
     
-    /// Traverses the graph breadth-first and passes each node to `observe`.
-    func traverseBreadthFirst(from startingNode: Node, _ observe: (Node) -> Traversal) {
-        var seen = Set<Node>()
-        var nodesToVisit = [startingNode]
-        while !nodesToVisit.isEmpty {
-            let node = nodesToVisit.removeFirst()
-            guard !seen.contains(node) else {
-                continue
-            }
-            let children = self[node].map {
-                nodeWithReference($0)!
-            }
-            nodesToVisit.append(contentsOf: children)
-            guard case .continue = observe(node) else {
-                break
-            }
-            seen.insert(node)
-        }
+    /// Returns a sequence that traverses the topic graph in breadth first order from a given reference, without visiting the same node more than once.
+    func breadthFirstSearch(from reference: ResolvedTopicReference) -> some Sequence<Node> {
+        DirectedGraph(neighbors: edges)
+            .breadthFirstSearch(from: reference)
+            .lazy
+            .map { nodeWithReference($0)! }
     }
 
     /// Returns the children of this node that reference it as their overload group.

--- a/Sources/SwiftDocC/Model/Rendering/Navigation Tree/RenderHierarchyTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Navigation Tree/RenderHierarchyTranslator.swift
@@ -37,7 +37,7 @@ struct RenderHierarchyTranslator {
     ///   - omittingChapters: If `true`, don't include chapters in the returned hierarchy.
     /// - Returns: A tuple of 1) a tutorials hierarchy and 2) the root reference of the tutorials hierarchy.
     mutating func visitTechnologyNode(_ reference: ResolvedTopicReference, omittingChapters: Bool = false) -> (hierarchy: RenderHierarchy, technology: ResolvedTopicReference)? {
-        let paths = context.pathsTo(reference, options: [.preferTechnologyRoot])
+        let paths = context.finitePaths(to: reference, options: [.preferTechnologyRoot])
         
         // If the node is a technology return immediately without generating breadcrumbs
         if let _ = (try? context.entity(with: reference))?.semantic as? Technology {
@@ -196,7 +196,7 @@ struct RenderHierarchyTranslator {
     /// multiple times under other API symbols, articles, or API collections. This method
     /// returns all the paths (breadcrumbs) between the framework landing page and the given symbol.
     mutating func visitSymbol(_ symbolReference: ResolvedTopicReference) -> RenderHierarchy {
-        let pathReferences = context.pathsTo(symbolReference)
+        let pathReferences = context.finitePaths(to: symbolReference)
         pathReferences.forEach({
             collectedTopicReferences.formUnion($0)
         })

--- a/Sources/SwiftDocC/Model/Rendering/RenderContext.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderContext.swift
@@ -46,7 +46,7 @@ public struct RenderContext {
         let renderContentFor: (ResolvedTopicReference) -> RenderReferenceStore.TopicContent = { reference in
             var dependencies = RenderReferenceDependencies()
             let renderReference = renderer.renderReference(for: reference, dependencies: &dependencies)
-            let canonicalPath = documentationContext.pathsTo(reference).first.flatMap { $0.isEmpty ? nil : $0 }
+            let canonicalPath = documentationContext.shortestFinitePathTo(reference).flatMap { $0.isEmpty ? nil : $0 }
             let reverseLookup = renderer.taskGroups(for: reference)
             
             return RenderReferenceStore.TopicContent(

--- a/Sources/SwiftDocC/Model/Rendering/RenderContext.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderContext.swift
@@ -46,7 +46,7 @@ public struct RenderContext {
         let renderContentFor: (ResolvedTopicReference) -> RenderReferenceStore.TopicContent = { reference in
             var dependencies = RenderReferenceDependencies()
             let renderReference = renderer.renderReference(for: reference, dependencies: &dependencies)
-            let canonicalPath = documentationContext.shortestFinitePathTo(reference).flatMap { $0.isEmpty ? nil : $0 }
+            let canonicalPath = documentationContext.shortestFinitePath(to: reference).flatMap { $0.isEmpty ? nil : $0 }
             let reverseLookup = renderer.taskGroups(for: reference)
             
             return RenderReferenceStore.TopicContent(

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -198,7 +198,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
         // We guarantee there will be at least 1 path with at least 4 nodes in that path if the tutorial is curated.
         // The way to curate tutorials is to link them from a Technology page and that generates the following hierarchy:
         // technology -> volume -> chapter -> tutorial.
-        let technologyPath = context.pathsTo(identifier, options: [.preferTechnologyRoot])[0]
+        let technologyPath = context.finitePaths(to: identifier, options: [.preferTechnologyRoot])[0]
         
         if technologyPath.count >= 2 {
             let volume = technologyPath[technologyPath.count - 2]
@@ -920,7 +920,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
         }
         
         // Guaranteed to have at least one path
-        let technologyPath = context.pathsTo(identifier, options: [.preferTechnologyRoot])[0]
+        let technologyPath = context.finitePaths(to: identifier, options: [.preferTechnologyRoot])[0]
                 
         node.sections.append(intro)
         

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -225,11 +225,8 @@ public struct RenderNodeTranslator: SemanticVisitor {
         // Get all the tutorials and tutorial articles in the learning path, ordered.
 
         var surroundingTopics = [(reference: ResolvedTopicReference, kind: DocumentationNode.Kind)]()
-        context.traverseBreadthFirst(from: volume) { node in
-            if node.kind == .tutorial || node.kind == .tutorialArticle {
-                surroundingTopics.append((node.reference, node.kind))
-            }
-            return .continue
+        for node in context.breadthFirstSearch(from: volume) where node.kind == .tutorial || node.kind == .tutorialArticle {
+            surroundingTopics.append((node.reference, node.kind))
         }
         
         // Find the tutorial or article that comes after the current page, if one exists.
@@ -362,19 +359,18 @@ public struct RenderNodeTranslator: SemanticVisitor {
     private func totalEstimatedDuration(for technology: Technology) -> String? {
         var totalDurationMinutes: Int? = nil
 
-        context.traverseBreadthFirst(from: identifier) { node in
-            if let entity = try? context.entity(with: node.reference),
-                let durationMinutes = (entity.semantic as? Timed)?.durationMinutes
-            {
-                if totalDurationMinutes == nil {
-                    totalDurationMinutes = 0
-                }
-                totalDurationMinutes! += durationMinutes
+        for node in context.breadthFirstSearch(from: identifier) {
+            guard let entity = try? context.entity(with: node.reference),
+                  let durationMinutes = (entity.semantic as? Timed)?.durationMinutes
+            else {
+                continue
             }
-
-            return .continue
+            
+            if totalDurationMinutes == nil {
+                totalDurationMinutes = 0
+            }
+            totalDurationMinutes! += durationMinutes
         }
-
 
         return totalDurationMinutes.flatMap(contentRenderer.formatEstimatedDuration(minutes:))
     }

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -605,7 +605,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
         
         // Detect the article modules from its breadcrumbs.
         var modules = Set<ResolvedTopicReference>()
-        for reference in DirectedGraph(neighbors: context.topicGraph.reverseEdges).breadthFirstSearch(from: identifier) {
+        for reference in context.topicGraph.reverseEdgesGraph.breadthFirstSearch(from: identifier) {
             if let moduleReference = (try? context.entity(with: reference).semantic as? Symbol)?.moduleReference {
                 modules.insert(moduleReference)
             }

--- a/Sources/SwiftDocC/Utility/Graphs/DirectedGraph+Cycles.swift
+++ b/Sources/SwiftDocC/Utility/Graphs/DirectedGraph+Cycles.swift
@@ -1,0 +1,63 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2024 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+extension DirectedGraph {
+    /// Returns the first cycle in the graph encountered through breadth first traversal from a given starting point
+    ///
+    /// The cycle starts at the earliest repeated node and ends with the node that links back to the starting point.
+    ///
+    /// - Note: A cycle, if found, is guaranteed to contain at least one node.
+    func firstCycle(from startingPoint: Node) -> Path? {
+        for case let (path, _, cycleStartIndex?) in accumulatingPaths(from: startingPoint) {
+            return Array(path[cycleStartIndex...])
+        }
+        return nil
+    }
+    
+    /// Returns a list of all the unique cycles in the graph encountered through breadth first traversal from a given starting point.
+    ///
+    /// Each cycle starts at the earliest repeated node and ends with the node that links back to the starting point.
+    ///
+    /// Two cycles are considered the same if they have either:
+    /// - The same start and end points, for example: `1,2,3` and `1,3`.
+    /// - A rotation of the same cycle, for example: `1,2,3`, `2,3,1`, and `3,1,2`.
+    func cycles(from startingPoint: Node) -> [Path] {
+        var cycles = [Path]()
+        
+        for case let (path, _, cycleStartIndex?) in accumulatingPaths(from: startingPoint) {
+            let cycle = path[cycleStartIndex...]
+            guard !cycles.contains(where: { areSameCycle(cycle, $0) }) else {
+                continue
+            }
+            cycles.append(Array(cycle))
+        }
+        
+        return cycles
+    }
+    
+    private func areSameCycle(_ lhs: Path.SubSequence, _ rhs: Path) -> Bool {
+        // Check if the cycles have the same start and end points.
+        // A cycle has to contain at least one node, so it's always safe to unwrap 'first' and 'last'.
+        if lhs.first! == rhs.first!, lhs.last! == rhs.last! {
+            return true
+        }
+        
+        // Check if the cycles are rotations of each other
+        if lhs.count == rhs.count {
+            let rhsStart = rhs.first!
+            
+            return (lhs + lhs)                   // Repeat one of the cycles once
+                .drop(while: { $0 != rhsStart }) // Align it with the other cycle by removing its leading nodes
+                .starts(with: rhs)               // See if the cycles match
+        }
+        // The two cycles are different.
+        return false
+    }
+}

--- a/Sources/SwiftDocC/Utility/Graphs/DirectedGraph+Cycles.swift
+++ b/Sources/SwiftDocC/Utility/Graphs/DirectedGraph+Cycles.swift
@@ -9,9 +9,43 @@
 */
 
 extension DirectedGraph {
-    /// Returns the first cycle in the graph encountered through breadth first traversal from a given starting point
+    /// Returns the first cycle in the graph encountered through breadth first traversal from a given starting point.
     ///
-    /// The cycle starts at the earliest repeated node and ends with the node that links back to the starting point.
+    /// The cycle starts at the earliest repeated node and ends with the node that links back to the repeated node.
+    ///
+    /// ## Example
+    ///
+    /// For example, consider the following subgraph, which can be entered from different directions:
+    /// ```
+    ///    ┌──────▶2◀──
+    ///    │       │
+    /// ──▶1───┐   │
+    ///    ▲   ▼   │
+    ///    └───3◀──┘
+    ///        ▲
+    ///        │
+    /// ```
+    ///
+    /// When entering the subgraph from "1", there are two cycles in this graph; `1,3` and `1,2,3`.
+    ///
+    /// ```
+    ///     ┌──────▶2         ┏━━━━━━▶2
+    ///     │       │         ┃       ┃
+    /// 0──▶1━━━┓   │     0──▶1───┐   ┃
+    ///     ▲   ▼   │         ▲   ▼   ┃
+    ///     ┗━━━3◀──┘         ┗━━━3◀━━┛
+    /// ```
+    ///
+    /// Breadth first traversal through the graph encounters the `1,3` cycle first, so it stops iterating and only returns that cycle.
+    ///
+    /// Entering the same subgraph from "2" encounters the same cycle, but with "3" as the earliest repeated node, so it returns `1,3` instead.
+    /// ```
+    /// ┌──────▶2◀──0
+    /// │       │
+    /// 1━━━┓   │
+    /// ▲   ▼   │
+    /// ┗━━━3◀──┘
+    /// ```
     ///
     /// - Note: A cycle, if found, is guaranteed to contain at least one node.
     func firstCycle(from startingPoint: Node) -> Path? {
@@ -21,13 +55,104 @@ extension DirectedGraph {
         return nil
     }
     
-    /// Returns a list of all the unique cycles in the graph encountered through breadth first traversal from a given starting point.
+    /// Returns a list of all the "unique" cycles in the graph encountered through breadth first traversal from a given starting point.
     ///
-    /// Each cycle starts at the earliest repeated node and ends with the node that links back to the starting point.
+    /// Each cycle starts at the earliest repeated node and ends with the node that links back to the repeated node.
     ///
-    /// Two cycles are considered the same if they have either:
-    /// - The same start and end points, for example: `1,2,3` and `1,3`.
-    /// - A rotation of the same cycle, for example: `1,2,3`, `2,3,1`, and `3,1,2`.
+    /// Two cycles are considered the "same" if both cycles can be broken by removing the same edge in the graph. This happens when they either:
+    /// - Have the same start and end points, for example: `1,2,3` and `1,3`.
+    /// - Are rotations of each other, for example: `1,2,3` and `2,3,1` and `3,1,2`.
+    ///
+    ///  > Important:
+    /// There graph may have different cycles that are reached from different starting points.
+    ///
+    /// ## Example: Single entry point to cycle
+    ///
+    /// For example, consider the following subgraph, which can be entered from different directions:
+    /// ```
+    ///    ┌──────▶2◀──
+    ///    │       │
+    /// ──▶1───┐   │
+    ///    ▲   ▼   │
+    ///    └───3◀──┘
+    ///        ▲
+    ///        │
+    /// ```
+    ///
+    /// When entering the subgraph from "1", there are two cycles in this graph; `1,3` and `1,2,3`.
+    /// These are considered the _same_ cycle because removing the `1─▶3` edge breaks both cycles.
+    /// ```
+    ///      ┏━━━━━━▶2
+    ///      ┃       ┃
+    ///  0──▶1━━━┓   ┃
+    ///          ▼   ┃
+    ///      └ ─ 3◀━━┛
+    /// ```
+    ///
+    /// On the other hand, when entering the same subgraph from "2" there are two other cycles; `3,1` and `2,3,1`.
+    /// These are considered _different_ cycles because they each require removing a different edge to break that cycle;
+    /// `1─▶3` for the `3,1` cycle and `1─▶2` for the `2,3,1` cycle;
+    /// ```
+    /// ┌ ─ ─ ─ 2◀──0
+    ///         ┃
+    /// 1 ─ ┐   ┃
+    /// ▲       ┃
+    /// ┗━━━3◀━━┛
+    /// ```
+    ///
+    /// ## Example: Multiple entry points to cycle
+    ///
+    /// Consider the same subgraph as before, which can be entered from different directions, where the starting point "0" enters the subgraph more than once:
+    /// ```
+    ///                      0──────────┐
+    ///                      │          ▼
+    ///     ┏━━━━━━▶2        │  ┏━━━━━━▶2         ┏━━━━━━▶2◀──┐
+    ///     ┃       ┃        │  ┃       ┃         ┃       ┃   │
+    /// ┌──▶1━━━┓   ┃        └─▶1━━━┓   ┃         1━━━┓   ┃   │
+    /// │   ▲   ▼   ┃           ▲   ▼   ┃         ▲   ▼   ┃   │
+    /// │   ┗━━━3◀━━┛           ┗━━━3◀━━┛         ┗━━━3◀━━┛   │
+    /// │       ▲                                     ▲       │
+    /// 0───────┘                                     └───────0
+    /// ```
+    ///
+    /// For each of these starting points:
+    /// - `1,3` and `3,1,2` are considered _different_ cycles because we need to remove the `3─▶1` edge to break the `1,3` cycle and remove the `2─▶3` to break the `3,1,2` cycle.
+    /// - `1,3` and `2,3,1` are considered _different_ cycles because we need to remove the `3─▶1` edge to break the `1,3` cycle and remove the `1─▶2` to break the `2,3,1` cycle.
+    /// - `3,1` and `2,3,1` are considered _different_ cycles because we need to remove the `1─▶3` edge to break the `3,1` cycle and remove the `1─▶2` to break the `2,3,1` cycle.
+    ///
+    /// ```
+    ///                      0──────────┐
+    ///                      │          ▼
+    ///     ┏━━━━━━▶2        │  ┌ ─ ─ ─ 2         ┌ ─ ─ ─ 2◀──┐
+    ///     ┃       ╵        │  ╷       ┃         ╷       ┃   │
+    /// ┌──▶1━━━┓   ╵        └─▶1━━━┓   ┃         1 ─ ┐   ┃   │
+    /// │   ╵   ▼   ╵           ╵   ▼   ┃         ▲   ╷   ┃   │
+    /// │   └ ─ 3 ─ ┘           └ ─ 3◀━━┛         ┗━━━3◀━━┛   │
+    /// │       ▲                                     ▲       │
+    /// 0───────┘                                     └───────0
+    /// ```
+    ///
+    /// If you remove the edge from `cycle.last` to `cycle.first` for each cycle in the returned list, you'll break all the cycles from _that_ starting point in the graph.
+    /// This _doesn't_ guarantee that the graph is free of cycles from other starting points.
+    ///
+    /// ## Example: Rotation of cycle
+    ///
+    /// Consider this cyclic subgraph which can be entered from different directions:
+    /// ```
+    /// ┌────▶1━━━━▶2
+    /// │     ▲     ┃
+    /// │     ┃     ┃
+    /// 0────▶3◀━━━━┛
+    /// ```
+    ///
+    /// With two ways to enter the cycle, it will encounter both the `1,2,3` and the `3,1,2` cycle.
+    /// These are considered the _same_ cycle because removing the `3─▶1` edge breaks both cycles.
+    /// ```
+    /// ┌────▶1━━━━▶2
+    /// │     ╷     ┃
+    /// │     ╷     ┃
+    /// 0────▶3◀━━━━┛
+    /// ```
     func cycles(from startingPoint: Node) -> [Path] {
         var cycles = [Path]()
         

--- a/Sources/SwiftDocC/Utility/Graphs/DirectedGraph+Paths.swift
+++ b/Sources/SwiftDocC/Utility/Graphs/DirectedGraph+Paths.swift
@@ -1,0 +1,64 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2024 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+extension DirectedGraph {
+    /// Returns a list of all finite paths through the graph from a given starting point.
+    ///
+    /// The paths are found in breadth first order, so shorter paths are earlier in the returned list.
+    ///
+    /// - Note: Nodes that are reachable through multiple paths will be visited more than once.
+    ///
+    /// - Important: If all paths through the graph result in cycles, the returned list will be empty.
+    func allFinitePaths(from startingPoint: Node) -> [Path] {
+        var foundPaths = [Path]()
+        
+        for (path, isLeaf, _) in accumulatingPaths(from: startingPoint) where isLeaf {
+            foundPaths.append(path)
+        }
+
+        return foundPaths
+    }
+    
+    /// Returns a list of the finite paths through the graph with the shortest length from a given starting point.
+    ///
+    /// The paths are found in breadth first order, so shorter paths are earlier in the returned list.
+    ///
+    /// - Note: Nodes that are reachable through multiple paths will be visited more than once.
+    ///
+    /// - Important: If all paths through the graph result in cycles, the returned list will be empty.
+    func shortestFinitePaths(from startingPoint: Node) -> [Path] {
+        var foundPaths = [Path]()
+        
+        for (path, isLeaf, _) in accumulatingPaths(from: startingPoint) where isLeaf {
+            if let lengthOfFoundPath = foundPaths.first?.count, lengthOfFoundPath < path.count {
+                // This path is longer than an already found path.
+                // All paths found from here on will be longer than what's already found.
+                break
+            }
+            
+            foundPaths.append(path)
+        }
+
+        return foundPaths
+    }
+    
+    /// Returns a set of all the reachable leaf nodes by traversing the graph from a given starting point.
+    ///
+    /// - Important: If all paths through the graph result in cycles, the returned set will be empty.
+    func reachableLeafNodes(from startingPoint: Node) -> Set<Node> {
+        var foundLeafNodes: Set<Node> = []
+        
+        for (path, isLeaf, _) in accumulatingPaths(from: startingPoint) where isLeaf {
+            foundLeafNodes.insert(path.last!)
+        }
+
+        return foundLeafNodes
+    }
+}

--- a/Sources/SwiftDocC/Utility/Graphs/DirectedGraph+Paths.swift
+++ b/Sources/SwiftDocC/Utility/Graphs/DirectedGraph+Paths.swift
@@ -9,13 +9,13 @@
 */
 
 extension DirectedGraph {
-    /// Returns a list of all finite paths through the graph from a given starting point.
+    /// Returns a list of all finite (acyclic) paths through the graph from a given starting point.
     ///
     /// The paths are found in breadth first order, so shorter paths are earlier in the returned list.
     ///
     /// - Note: Nodes that are reachable through multiple paths will be visited more than once.
     ///
-    /// - Important: If all paths through the graph result in cycles, the returned list will be empty.
+    /// - Important: If all paths through the graph are infinite (cyclic), this function return an empty list.
     func allFinitePaths(from startingPoint: Node) -> [Path] {
         var foundPaths = [Path]()
         
@@ -26,13 +26,13 @@ extension DirectedGraph {
         return foundPaths
     }
     
-    /// Returns a list of the finite paths through the graph with the shortest length from a given starting point.
+    /// Returns a list of the finite (acyclic) paths through the graph with the shortest length from a given starting point.
     ///
     /// The paths are found in breadth first order, so shorter paths are earlier in the returned list.
     ///
     /// - Note: Nodes that are reachable through multiple paths will be visited more than once.
     ///
-    /// - Important: If all paths through the graph result in cycles, the returned list will be empty.
+    /// - Important: If all paths through the graph are infinite (cyclic), this function return an empty list.
     func shortestFinitePaths(from startingPoint: Node) -> [Path] {
         var foundPaths = [Path]()
         
@@ -51,7 +51,7 @@ extension DirectedGraph {
     
     /// Returns a set of all the reachable leaf nodes by traversing the graph from a given starting point.
     ///
-    /// - Important: If all paths through the graph result in cycles, the returned set will be empty.
+    /// - Important: If all paths through the graph are infinite (cyclic), this function return an empty set.
     func reachableLeafNodes(from startingPoint: Node) -> Set<Node> {
         var foundLeafNodes: Set<Node> = []
         
@@ -60,5 +60,50 @@ extension DirectedGraph {
         }
 
         return foundLeafNodes
+    }
+}
+
+// MARK: Path sequence
+
+extension DirectedGraph {
+    /// A path through the graph, including the start and end nodes.
+    typealias Path = [Node]
+    /// Information about the current accumulated path during iteration.
+    typealias PathIterationElement = (path: Path, isLeaf: Bool, cycleStartIndex: Int?)
+    
+    /// Returns a sequence of accumulated path information from traversing the graph in breadth first order.
+    func accumulatingPaths(from startingPoint: Node) -> some Sequence<PathIterationElement> {
+        IteratorSequence(GraphPathIterator(from: startingPoint, in: self))
+    }
+}
+
+// MARK: Iterator
+
+/// An iterator that traverses a graph in breadth first order and returns information about the accumulated path through the graph, up to the current node.
+private struct GraphPathIterator<Node: Hashable>: IteratorProtocol {
+    var pathsToTraverse: [(Node, [Node])]
+    var graph: DirectedGraph<Node>
+    
+    init(from startingPoint: Node, in graph: DirectedGraph<Node>) {
+        self.pathsToTraverse = [(startingPoint, [])]
+        self.graph = graph
+    }
+    
+    mutating func next() -> DirectedGraph<Node>.PathIterationElement? {
+        guard !pathsToTraverse.isEmpty else { return nil }
+        // This is a breadth first search through the graph.
+        let (node, path) = pathsToTraverse.removeFirst()
+        
+        // Note: unlike `GraphNodeIterator`, the same node may be visited more than once.
+        
+        if let cycleStartIndex = path.firstIndex(of: node) {
+            return (path, false, cycleStartIndex)
+        }
+        
+        let newPath = path + [node]
+        let neighbors = graph.neighbors(of: node)
+        pathsToTraverse.append(contentsOf: neighbors.map { ($0, newPath) })
+        
+        return (newPath, neighbors.isEmpty, nil)
     }
 }

--- a/Sources/SwiftDocC/Utility/Graphs/DirectedGraph+Traversal.swift
+++ b/Sources/SwiftDocC/Utility/Graphs/DirectedGraph+Traversal.swift
@@ -1,0 +1,105 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2024 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+extension DirectedGraph {
+    /// Returns a sequence that traverses the graph in breadth first order from a given element, without visiting the same node more than once.
+    func breadthFirstSearch(from startingPoint: Node) -> some Sequence<Node> {
+        IteratorSequence(GraphNodeIterator(from: startingPoint, traversal: .breadthFirst, in: self))
+    }
+    
+    /// Returns a sequence that traverses the graph in depth first order from a given element, without visiting the same node more than once.
+    func depthFirstSearch(from startingPoint: Node) -> some Sequence<Node> {
+        IteratorSequence(GraphNodeIterator(from: startingPoint, traversal: .depthFirst, in: self))
+    }
+}
+
+extension DirectedGraph {
+    /// A path through the graph, including the start and end nodes.
+    typealias Path = [Node]
+    /// Information about the current accumulated path during iteration.
+    typealias PathIterationElement = (path: Path, isLeaf: Bool, cycleStartIndex: Int?)
+    
+    /// Returns a sequence of accumulated path information from traversing the graph in breadth first order.
+    func accumulatingPaths(from startingPoint: Node) -> some Sequence<PathIterationElement> {
+        IteratorSequence(GraphBreadthFirstPathIterator(from: startingPoint, in: self))
+    }
+}
+
+// MARK: Node iterator
+
+/// An iterator that traverses a graph in either breadth first or depth first order depending on the buffer it uses to track nodes to traverse next.
+private struct GraphNodeIterator<Node: Hashable>: IteratorProtocol {
+    enum Traversal {
+        case breadthFirst, depthFirst
+    }
+    var traversal: Traversal
+    var graph: DirectedGraph<Node>
+    
+    private var nodesToTraverse: [Node]
+    private var seen: Set<Node>
+    
+    init(from startingPoint: Node, traversal: Traversal, in graph: DirectedGraph<Node>) {
+        self.traversal = traversal
+        self.graph = graph
+        self.nodesToTraverse = [startingPoint]
+        self.seen = []
+    }
+    
+    private mutating func pop() -> Node? {
+        guard !nodesToTraverse.isEmpty else { return nil }
+        
+        switch traversal {
+        case .breadthFirst:
+            return nodesToTraverse.removeFirst()
+        case .depthFirst:
+            return nodesToTraverse.removeLast()
+        }
+    }
+    
+    mutating func next() -> Node? {
+        while let node = pop() {
+            guard !seen.contains(node) else { continue }
+            seen.insert(node)
+            
+            nodesToTraverse.append(contentsOf: graph.neighbors(of: node))
+            
+            return node
+        }
+        return nil
+    }
+}
+
+// MARK: Path iterator
+
+/// An iterator that traverses a graph in breadth first order and returns information about the accumulated path through the graph, up to the current node.
+private struct GraphBreadthFirstPathIterator<Node: Hashable>: IteratorProtocol {
+    var pathsToTraverse: [(Node, [Node])]
+    var graph: DirectedGraph<Node>
+    
+    init(from startingPoint: Node, in graph: DirectedGraph<Node>) {
+        self.pathsToTraverse = [(startingPoint, [])]
+        self.graph = graph
+    }
+    
+    mutating func next() -> DirectedGraph<Node>.PathIterationElement? {
+        guard !pathsToTraverse.isEmpty else { return nil }
+        let (node, path) = pathsToTraverse.removeFirst()
+        
+        if let cycleStartIndex = path.lastIndex(of: node) {
+            return (path, false, cycleStartIndex)
+        }
+        
+        let newPath = path + [node]
+        let neighbors = graph.neighbors(of: node)
+        pathsToTraverse.append(contentsOf: neighbors.map { ($0, newPath) })
+        
+        return (newPath, neighbors.isEmpty, nil)
+    }
+}

--- a/Sources/SwiftDocC/Utility/Graphs/DirectedGraph+Traversal.swift
+++ b/Sources/SwiftDocC/Utility/Graphs/DirectedGraph+Traversal.swift
@@ -20,19 +20,7 @@ extension DirectedGraph {
     }
 }
 
-extension DirectedGraph {
-    /// A path through the graph, including the start and end nodes.
-    typealias Path = [Node]
-    /// Information about the current accumulated path during iteration.
-    typealias PathIterationElement = (path: Path, isLeaf: Bool, cycleStartIndex: Int?)
-    
-    /// Returns a sequence of accumulated path information from traversing the graph in breadth first order.
-    func accumulatingPaths(from startingPoint: Node) -> some Sequence<PathIterationElement> {
-        IteratorSequence(GraphBreadthFirstPathIterator(from: startingPoint, in: self))
-    }
-}
-
-// MARK: Node iterator
+// MARK: Iterator
 
 /// An iterator that traverses a graph in either breadth first or depth first order depending on the buffer it uses to track nodes to traverse next.
 private struct GraphNodeIterator<Node: Hashable>: IteratorProtocol {
@@ -73,33 +61,5 @@ private struct GraphNodeIterator<Node: Hashable>: IteratorProtocol {
             return node
         }
         return nil
-    }
-}
-
-// MARK: Path iterator
-
-/// An iterator that traverses a graph in breadth first order and returns information about the accumulated path through the graph, up to the current node.
-private struct GraphBreadthFirstPathIterator<Node: Hashable>: IteratorProtocol {
-    var pathsToTraverse: [(Node, [Node])]
-    var graph: DirectedGraph<Node>
-    
-    init(from startingPoint: Node, in graph: DirectedGraph<Node>) {
-        self.pathsToTraverse = [(startingPoint, [])]
-        self.graph = graph
-    }
-    
-    mutating func next() -> DirectedGraph<Node>.PathIterationElement? {
-        guard !pathsToTraverse.isEmpty else { return nil }
-        let (node, path) = pathsToTraverse.removeFirst()
-        
-        if let cycleStartIndex = path.lastIndex(of: node) {
-            return (path, false, cycleStartIndex)
-        }
-        
-        let newPath = path + [node]
-        let neighbors = graph.neighbors(of: node)
-        pathsToTraverse.append(contentsOf: neighbors.map { ($0, newPath) })
-        
-        return (newPath, neighbors.isEmpty, nil)
     }
 }

--- a/Sources/SwiftDocC/Utility/Graphs/DirectedGraph.swift
+++ b/Sources/SwiftDocC/Utility/Graphs/DirectedGraph.swift
@@ -38,13 +38,13 @@ struct DirectedGraph<Node: Hashable> {
     // but all our current usages of graph structures use dictionaries to track the neighboring nodes.
     //
     // This type is internal so we can change it's implementation later when there's new data that's structured differently.
-    private let _neighbors: [Node: [Node]]
-    init(neighbors: [Node: [Node]]) {
-        _neighbors = neighbors
+    private let edges: [Node: [Node]]
+    init(edges: [Node: [Node]]) {
+        self.edges = edges
     }
     
     /// Returns the nodes that are reachable from the given node
     func neighbors(of node: Node) -> [Node] {
-        _neighbors[node] ?? []
+        edges[node] ?? []
     }
 }

--- a/Sources/SwiftDocC/Utility/Graphs/DirectedGraph.swift
+++ b/Sources/SwiftDocC/Utility/Graphs/DirectedGraph.swift
@@ -1,0 +1,50 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2024 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+/// A directed, unweighted graph of nodes.
+///
+/// Use a `DirectedGraph` to operate on data that describe the edges between nodes in a directed graph.
+///
+/// ## Topics
+///
+/// ### Search
+///
+/// - ``breadthFirstSearch(from:)``
+/// - ``depthFirstSearch(from:)``
+///
+/// ### Paths
+///
+/// - ``shortestFinitePaths(from:)``
+/// - ``allFinitePaths(from:)``
+/// - ``reachableLeafNodes(from:)``
+///
+/// ### Cycle detection
+///
+/// - ``firstCycle(from:)``
+/// - ``cycles(from:)``
+///
+/// ### Low-level path traversal
+///
+/// - ``accumulatingPaths(from:)``
+struct DirectedGraph<Node: Hashable> {
+    // There are more generic ways to describe a graph that doesn't require that the elements are Hashable,
+    // but all our current usages of graph structures use dictionaries to track the neighboring nodes.
+    //
+    // This type is internal so we can change it's implementation later when there's new data that's structured differently.
+    private let _neighbors: [Node: [Node]]
+    init(neighbors: [Node: [Node]]) {
+        _neighbors = neighbors
+    }
+    
+    /// Returns the nodes that are reachable from the given node
+    func neighbors(of node: Node) -> [Node] {
+        _neighbors[node] ?? []
+    }
+}

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -1426,7 +1426,7 @@ let expected = """
         let (cccNode, cccTgNode) = try createNode(in: context, bundle: bundle, parent: aaaNode.reference, name: "CCC")
         context.topicGraph.addEdge(from: bbbTgNode, to: cccTgNode)
         
-        let canonicalPathCCC = try XCTUnwrap(context.pathsTo(cccNode.reference).first)
+        let canonicalPathCCC = try XCTUnwrap(context.shortestFinitePathTo(cccNode.reference))
         XCTAssertEqual(["/documentation/MyKit", "/documentation/MyKit/AAA"], canonicalPathCCC.map({ $0.path }))
         
         ///
@@ -1440,7 +1440,7 @@ let expected = """
         let (fffNode, fffTgNode) = try createNode(in: context, bundle: bundle, parent: eeeNode.reference, name: "FFF")
         context.topicGraph.addEdge(from: dddTgNode, to: fffTgNode)
         
-        let canonicalPathFFF = try XCTUnwrap(context.pathsTo(fffNode.reference).first)
+        let canonicalPathFFF = try XCTUnwrap(context.shortestFinitePathTo(fffNode.reference))
         XCTAssertEqual(["/documentation/MyKit", "/documentation/MyKit/DDD"], canonicalPathFFF.map({ $0.path }))
     }
     
@@ -1463,7 +1463,7 @@ let expected = """
         context.topicGraph.addEdge(from: aaaTgNode, to: cccTgNode)
         context.topicGraph.addEdge(from: bbbTgNode, to: cccTgNode)
         
-        let canonicalPathCCC = try XCTUnwrap(context.pathsTo(cccNode.reference).first)
+        let canonicalPathCCC = try XCTUnwrap(context.shortestFinitePathTo(cccNode.reference))
         XCTAssertEqual(["/documentation/MyKit"], canonicalPathCCC.map({ $0.path }))
         
         ///
@@ -1479,7 +1479,7 @@ let expected = """
         context.topicGraph.addEdge(from: dddTgNode, to: fffTgNode)
         context.topicGraph.addEdge(from: tgMykitNode, to: fffTgNode)
         
-        let canonicalPathFFF = try XCTUnwrap(context.pathsTo(fffNode.reference).first)
+        let canonicalPathFFF = try XCTUnwrap(context.shortestFinitePathTo(fffNode.reference))
         XCTAssertEqual(["/documentation/MyKit"], canonicalPathFFF.map({ $0.path }))
     }
 

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -1390,10 +1390,10 @@ let expected = """
         assertEqualDumps(context.dumpGraph(), expected)
         
         // Test correct symbol hierarchy in context
-        XCTAssertEqual(context.pathsTo(ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit/MyClass", sourceLanguage: .swift)).map { $0.map {$0.absoluteString} },
+        XCTAssertEqual(context.finitePaths(to: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit/MyClass", sourceLanguage: .swift)).map { $0.map {$0.absoluteString} },
                        [["doc://org.swift.docc.example/documentation/MyKit"], ["doc://org.swift.docc.example/documentation/MyKit", "doc://org.swift.docc.example/documentation/MyKit/MyProtocol"]])
         
-        XCTAssertEqual(context.pathsTo(ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit/MyClass/init()-33vaw", sourceLanguage: .swift)).map { $0.map {$0.absoluteString} },
+        XCTAssertEqual(context.finitePaths(to: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit/MyClass/init()-33vaw", sourceLanguage: .swift)).map { $0.map {$0.absoluteString} },
                        [["doc://org.swift.docc.example/documentation/MyKit", "doc://org.swift.docc.example/documentation/MyKit/MyClass"], ["doc://org.swift.docc.example/documentation/MyKit", "doc://org.swift.docc.example/documentation/MyKit/MyProtocol", "doc://org.swift.docc.example/documentation/MyKit/MyClass"]])
     }
     
@@ -1426,7 +1426,7 @@ let expected = """
         let (cccNode, cccTgNode) = try createNode(in: context, bundle: bundle, parent: aaaNode.reference, name: "CCC")
         context.topicGraph.addEdge(from: bbbTgNode, to: cccTgNode)
         
-        let canonicalPathCCC = try XCTUnwrap(context.shortestFinitePathTo(cccNode.reference))
+        let canonicalPathCCC = try XCTUnwrap(context.shortestFinitePath(to: cccNode.reference))
         XCTAssertEqual(["/documentation/MyKit", "/documentation/MyKit/AAA"], canonicalPathCCC.map({ $0.path }))
         
         ///
@@ -1440,7 +1440,7 @@ let expected = """
         let (fffNode, fffTgNode) = try createNode(in: context, bundle: bundle, parent: eeeNode.reference, name: "FFF")
         context.topicGraph.addEdge(from: dddTgNode, to: fffTgNode)
         
-        let canonicalPathFFF = try XCTUnwrap(context.shortestFinitePathTo(fffNode.reference))
+        let canonicalPathFFF = try XCTUnwrap(context.shortestFinitePath(to: fffNode.reference))
         XCTAssertEqual(["/documentation/MyKit", "/documentation/MyKit/DDD"], canonicalPathFFF.map({ $0.path }))
     }
     
@@ -1463,7 +1463,7 @@ let expected = """
         context.topicGraph.addEdge(from: aaaTgNode, to: cccTgNode)
         context.topicGraph.addEdge(from: bbbTgNode, to: cccTgNode)
         
-        let canonicalPathCCC = try XCTUnwrap(context.shortestFinitePathTo(cccNode.reference))
+        let canonicalPathCCC = try XCTUnwrap(context.shortestFinitePath(to: cccNode.reference))
         XCTAssertEqual(["/documentation/MyKit"], canonicalPathCCC.map({ $0.path }))
         
         ///
@@ -1479,7 +1479,7 @@ let expected = """
         context.topicGraph.addEdge(from: dddTgNode, to: fffTgNode)
         context.topicGraph.addEdge(from: tgMykitNode, to: fffTgNode)
         
-        let canonicalPathFFF = try XCTUnwrap(context.shortestFinitePathTo(fffNode.reference))
+        let canonicalPathFFF = try XCTUnwrap(context.shortestFinitePath(to: fffNode.reference))
         XCTAssertEqual(["/documentation/MyKit"], canonicalPathFFF.map({ $0.path }))
     }
 
@@ -1519,7 +1519,7 @@ let expected = """
         let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/tutorials/Test-Bundle/TestTutorial", sourceLanguage: .swift))
         
         // Get the breadcrumbs as paths
-        let paths = context.pathsTo(node.reference).sorted { (path1, path2) -> Bool in
+        let paths = context.finitePaths(to: node.reference).sorted { (path1, path2) -> Bool in
             return path1.count < path2.count
         }
         .map { return $0.map { $0.url.path } }
@@ -4647,7 +4647,7 @@ let expected = """
         )
         
         XCTAssertEqual(
-            context.pathsTo(reference).map { $0.map(\.lastPathComponent) },
+            context.finitePaths(to: reference).map { $0.map(\.lastPathComponent) },
             [ ["ModuleName", "Code-swift.enum"] ],
             "There is only one _finite_ path from the 'someCase' enum case, through the reverse edges in the topic graph."
         )

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -4641,7 +4641,7 @@ let expected = """
         let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ModuleName/SomeError/Code-swift.enum/someCase", sourceLanguage: .swift)
         
         XCTAssertEqual(
-            DirectedGraph(neighbors: context.topicGraph.reverseEdges).cycles(from: reference).map { $0.map(\.lastPathComponent) },
+            context.topicGraph.reverseEdgesGraph.cycles(from: reference).map { $0.map(\.lastPathComponent) },
             [ ["Code-swift.enum", "SomeError", "SomeClass"] ],
             "There is one cyclic path encountered while traversing the reverse edges from the 'someCase' enum case."
         )

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -4486,6 +4486,173 @@ let expected = """
         XCTAssertEqual(start..<end, range)
     }
     
+    func testPathsToHandlesCyclicCuration() throws {
+        let tempURL = try createTempFolder(content: [
+            Folder(name: "unit-test.docc", content: [
+                Folder(name: "clang", content: [
+                    JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(
+                        moduleName: "ModuleName",
+                        symbols: [
+                            // Any class declaration.
+                            makeSymbol(
+                                name: "SomeClass",
+                                identifier: "some-class-id",
+                                language: .objectiveC,
+                                kind: .class
+                            ),
+                            
+                            // extern NSErrorDomain const SomeErrorDomain;
+                            makeSymbol(
+                                name: "SomeErrorDomain",
+                                identifier: "some-error-domain-id",
+                                language: .objectiveC,
+                                kind: .var
+                            ),
+                            
+                            // typedef NS_ERROR_ENUM(SomeErrorDomain, SomeErrorCode) {
+                            //     SomeErrorCodeSomeCase = 1
+                            // };
+                            makeSymbol(
+                                name: "SomeErrorCode",
+                                identifier: "some-error-code-id",
+                                language: .objectiveC,
+                                kind: .enum
+                            ),
+                            makeSymbol(
+                                name: "SomeErrorCodeSomeCase",
+                                identifier: "some-error-code-case-id",
+                                language: .objectiveC,
+                                kind: .case,
+                                pathComponents: ["SomeErrorCode", "SomeErrorCodeSomeCase"]
+                            ),
+                        ],
+                        relationships: [
+                            .init(source: "some-error-code-case-id", target: "some-error-code-id", kind: .memberOf, targetFallback: nil),
+                        ]
+                    ))
+                ]),
+                
+                Folder(name: "swift", content: [
+                    JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(
+                        moduleName: "ModuleName",
+                        symbols: [
+                            // The Swift representation of the Objective-C class above.
+                            makeSymbol(
+                                name: "SomeClass",
+                                identifier: "some-class-id",
+                                kind: .class
+                            ),
+                            
+                            // The domain defined using NS_ERROR_ENUM translates to a struct with an 'errorDomain' and 'code'. Something like:
+                            //
+                            // let SomeErrorDomain: String
+                            // struct SomeError: CustomNSError, Error {
+                            //     static var errorDomain: String
+                            //     static var code: Code
+                            //     enum Code {
+                            //         someCase = 1
+                            //     }
+                            // }
+                            makeSymbol(
+                                name: "SomeErrorDomain",
+                                identifier: "some-error-domain-id",
+                                kind: .var
+                            ),
+                            
+                            makeSymbol(
+                                name: "SomeError",
+                                identifier: "some-error-id",
+                                kind: .struct
+                            ),
+                            makeSymbol(
+                                name: "errorDomain",
+                                identifier: "some-error-domain-property-id",
+                                kind: .typeProperty,
+                                pathComponents: ["SomeError", "errorDomain"]
+                            ),
+                            makeSymbol(
+                                name: "code",
+                                identifier: "some-error-code-property-id",
+                                kind: .typeProperty,
+                                pathComponents: ["SomeError", "code"]
+                            ),
+                            makeSymbol(
+                                name: "Code",
+                                identifier: "some-error-code-id",
+                                kind: .enum,
+                                pathComponents: ["SomeError", "Code"]
+                            ),
+                            makeSymbol(
+                                name: "someCase",
+                                identifier: "some-error-code-case-id",
+                                kind: .case,
+                                pathComponents: ["SomeError", "Code", "someCase"]
+                            ),
+                        ],
+                        relationships: [
+                            // static properties are members of struct
+                            .init(source: "some-error-domain-property-id", target: "some-error-id", kind: .memberOf, targetFallback: nil),
+                            .init(source: "some-error-code-property-id", target: "some-error-id", kind: .memberOf, targetFallback: nil),
+                            // enum is member of struct
+                            .init(source: "some-error-code-id", target: "some-error-id", kind: .memberOf, targetFallback: nil),
+                            // case is member of enum
+                            .init(source: "some-error-code-case-id", target: "some-error-code-id", kind: .memberOf, targetFallback: nil),
+                        ]
+                    ))
+                ]),
+                
+                // In addition to the automatic curation (thin lines) where all symbols are members of the module (SomeErrorCode is a top-level enum in Objective-C),
+                // Add manual curation (thick lines) from `SomeClass` to `SomeError` and from `SomeError/Code` to `SomeClass`, creating a cycle in the total curation.
+                //
+                //            ModuleName
+                //                 │
+                //     ┌───────┬───┴───┬─────────────┐
+                //     ▼       │       ▼             ▼
+                // SomeClass━━━━━━▶SomeError  SomeErrorDomain
+                //     ▲       │       │
+                //     ┃       ▼       │
+                //     ┗━━━━━Code◀─────┘
+                //             │
+                //             ▼
+                //          someCase
+                
+                TextFile(name: "SomeClass.md", utf8Content: """
+                # ``SomeClass``
+                
+                Curate the error
+                
+                ## Topics
+                
+                - ``SomeError``
+                """),
+                
+                TextFile(name: "SomeErrorCode.md", utf8Content: """
+                # ``SomeError/Code``
+                
+                Curate the class
+                
+                ## Topics
+                
+                - ``SomeClass``
+                """),
+            ])
+        ])
+        let (_, bundle, context) = try loadBundle(from: tempURL)
+        let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ModuleName/SomeError/Code-swift.enum/someCase", sourceLanguage: .swift)
+        
+        XCTAssertEqual(
+            DirectedGraph(neighbors: context.topicGraph.reverseEdges).cycles(from: reference).map { $0.map(\.lastPathComponent) },
+            [ ["Code-swift.enum", "SomeError", "SomeClass"] ],
+            "There is one cyclic path encountered while traversing the reverse edges from the 'someCase' enum case."
+        )
+        
+        XCTAssertEqual(
+            context.pathsTo(reference).map { $0.map(\.lastPathComponent) },
+            [ ["ModuleName", "Code-swift.enum"] ],
+            "There is only one _finite_ path from the 'someCase' enum case, through the reverse edges in the topic graph."
+        )
+    }
+    
     func testUnresolvedLinkWarnings() throws {
         var (_, _, context) = try testBundleAndContext(copying: "TestBundle") { url in
             let extensionFile = """
@@ -4655,11 +4822,12 @@ let expected = """
     private func makeSymbol(
         name: String = "SymbolName",
         identifier: String,
+        language: SourceLanguage = .swift,
         kind: SymbolGraph.Symbol.KindIdentifier,
         pathComponents: [String]? = nil
     ) -> SymbolGraph.Symbol {
         return SymbolGraph.Symbol(
-            identifier: .init(precise: identifier, interfaceLanguage: SourceLanguage.swift.id),
+            identifier: .init(precise: identifier, interfaceLanguage: language.id),
             names: .init(title: name, navigator: nil, subHeading: nil, prose: nil),
             pathComponents: pathComponents ?? [name],
             docComment: nil,

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationCuratorTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationCuratorTests.swift
@@ -167,7 +167,7 @@ class DocumentationCuratorTests: XCTestCase {
         XCTAssert(context.problems.isEmpty, "Expected no problems. Found: \(context.problems.map(\.diagnostic.summary))")
         
         guard let moduleNode = context.documentationCache["SourceLocations"],
-              let pathToRoot = context.pathsTo(moduleNode.reference).first,
+              let pathToRoot = context.finitePaths(to: moduleNode.reference).first,
               let root = pathToRoot.first else {
             
             XCTFail("Module doesn't have technology root as a predecessor in its path")
@@ -211,7 +211,7 @@ class DocumentationCuratorTests: XCTestCase {
         XCTAssert(context.problems.isEmpty, "Expected no problems. Found: \(context.problems.map(\.diagnostic.summary))")
         
         guard let moduleNode = context.documentationCache["SourceLocations"],
-              let pathToRoot = context.shortestFinitePathTo(moduleNode.reference),
+              let pathToRoot = context.shortestFinitePath(to: moduleNode.reference),
               let root = pathToRoot.first else {
             
             XCTFail("Module doesn't have technology root as a predecessor in its path")
@@ -453,14 +453,14 @@ class DocumentationCuratorTests: XCTestCase {
         // Verify that the ONLY curation for `TopClass/name` is the manual curation under `MyArticle`
         // and the automatic curation under `TopClass` is not present.
         let nameReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/TestBed/TopClass/name", sourceLanguage: .swift)
-        XCTAssertEqual(context.pathsTo(nameReference).map({ $0.map(\.path) }), [
+        XCTAssertEqual(context.finitePaths(to: nameReference).map({ $0.map(\.path) }), [
             ["/documentation/TestBed", "/documentation/TestBed/TopClass", "/documentation/TestBed/TopClass/NestedEnum", "/documentation/TestBed/TopClass/NestedEnum/SecondLevelNesting", "/documentation/TestBed/MyArticle"],
         ])
 
         // Verify that the BOTH manual curations for `TopClass/age` are preserved
         // even if one of the manual curations overlaps with the inheritance edge from the symbol graph.
         let ageReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/TestBed/TopClass/age", sourceLanguage: .swift)
-        XCTAssertEqual(context.pathsTo(ageReference).map({ $0.map(\.path) }), [
+        XCTAssertEqual(context.finitePaths(to: ageReference).map({ $0.map(\.path) }), [
             ["/documentation/TestBed", "/documentation/TestBed/TopClass"],
             ["/documentation/TestBed", "/documentation/TestBed/TopClass", "/documentation/TestBed/TopClass/NestedEnum", "/documentation/TestBed/TopClass/NestedEnum/SecondLevelNesting", "/documentation/TestBed/MyArticle"],
         ])
@@ -473,7 +473,7 @@ class DocumentationCuratorTests: XCTestCase {
         
         let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/TestBed/DoublyManuallyCuratedClass/type()", sourceLanguage: .swift)
         
-        XCTAssertEqual(context.pathsTo(reference).map({ $0.map({ $0.path }) }), [
+        XCTAssertEqual(context.finitePaths(to: reference).map({ $0.map({ $0.path }) }), [
             [
                 "/documentation/TestBed",
                 "/documentation/TestBed/TopClass",

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationCuratorTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationCuratorTests.swift
@@ -211,7 +211,7 @@ class DocumentationCuratorTests: XCTestCase {
         XCTAssert(context.problems.isEmpty, "Expected no problems. Found: \(context.problems.map(\.diagnostic.summary))")
         
         guard let moduleNode = context.documentationCache["SourceLocations"],
-              let pathToRoot = context.pathsTo(moduleNode.reference).first,
+              let pathToRoot = context.shortestFinitePathTo(moduleNode.reference),
               let root = pathToRoot.first else {
             
             XCTFail("Module doesn't have technology root as a predecessor in its path")

--- a/Tests/SwiftDocCTests/Infrastructure/TopicGraphTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/TopicGraphTests.swift
@@ -184,71 +184,43 @@ class TopicGraphTests: XCTestCase {
     func testBreadthFirstSearch() {
         let graph = TestGraphs.complex
         let A = TestGraphs.testNodeWithTitle("A")
-        var visited = [TopicGraph.Node]()
-        graph.traverseBreadthFirst(from: A) {
-            visited.append($0)
-            return .continue
-        }
-        XCTAssertEqual(["A", "B", "D", "C", "E"],
-                       visited.map { $0.title })
+        let visited = graph.breadthFirstSearch(from: A.reference).map(\.title)
+        XCTAssertEqual(["A", "B", "D", "C", "E"], visited)
     }
     
     func testBreadthFirstSearchWithCycle() {
         let graph = TestGraphs.withCycle
         let A = TestGraphs.testNodeWithTitle("A")
-        var visited = [TopicGraph.Node]()
-        graph.traverseBreadthFirst(from: A) {
-            visited.append($0)
-            return .continue
-        }
-        XCTAssertEqual(["A", "B", "C"],
-                       visited.map { $0.title })
+        let visited = graph.breadthFirstSearch(from: A.reference).map(\.title)
+        XCTAssertEqual(["A", "B", "C"], visited)
     }
     
     func testBreadthFirstSearchEarlyStop() {
         let graph = TestGraphs.complex
         let A = TestGraphs.testNodeWithTitle("A")
-        var visited = [TopicGraph.Node]()
-        graph.traverseBreadthFirst(from: A) {
-            visited.append($0)
-            return .stop
-        }
-        XCTAssertEqual(["A"], visited.map { $0.title })
+        let visited = graph.breadthFirstSearch(from: A.reference).prefix(1).map(\.title)
+        XCTAssertEqual(["A"], visited)
     }
     
     func testDepthFirstSearch() {
         let graph = TestGraphs.complex
         let A = TestGraphs.testNodeWithTitle("A")
-        var visited = [TopicGraph.Node]()
-        graph.traverseDepthFirst(from: A) {
-            visited.append($0)
-            return .continue
-        }
-        XCTAssertEqual(["A", "D", "E", "B", "C"],
-                       visited.map { $0.title })
+        let visited = graph.depthFirstSearch(from: A.reference).map(\.title)
+        XCTAssertEqual(["A", "D", "E", "B", "C"], visited)
     }
     
     func testDepthFirstSearchWithCycle() {
         let graph = TestGraphs.withCycle
         let A = TestGraphs.testNodeWithTitle("A")
-        var visited = [TopicGraph.Node]()
-        graph.traverseDepthFirst(from: A) {
-            visited.append($0)
-            return .continue
-        }
-        XCTAssertEqual(["A", "B", "C"],
-                       visited.map { $0.title })
+        let visited = graph.breadthFirstSearch(from: A.reference).map(\.title)
+        XCTAssertEqual(["A", "B", "C"], visited)
     }
     
     func testDepthFirstSearchEarlyStop() {
         let graph = TestGraphs.complex
         let A = TestGraphs.testNodeWithTitle("A")
-        var visited = [TopicGraph.Node]()
-        graph.traverseDepthFirst(from: A) {
-            visited.append($0)
-            return .stop
-        }
-        XCTAssertEqual(["A"], visited.map { $0.title })
+        let visited = graph.depthFirstSearch(from: A.reference).prefix(1).map(\.title)
+        XCTAssertEqual(["A"], visited)
     }
     
     func testEveryEdgeSourceHasNode() {

--- a/Tests/SwiftDocCUtilitiesTests/Utility/DirectedGraphTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/Utility/DirectedGraphTests.swift
@@ -21,7 +21,7 @@ final class DirectedGraphTests: XCTestCase {
         //      │    │
         //      ▼    ▼
         // 7───▶8◀───9
-        let graph = DirectedGraph(neighbors: [
+        let graph = DirectedGraph(edges: [
             1: [2],
             2: [5],
             3: [2],
@@ -77,7 +77,7 @@ final class DirectedGraphTests: XCTestCase {
         // 1─┼─▶3
         //   │
         //   └─▶4──▶7──▶8
-        let graph = DirectedGraph(neighbors: [
+        let graph = DirectedGraph(edges: [
             1: [2,3,4],
             2: [5,6],
             4: [7],
@@ -110,7 +110,7 @@ final class DirectedGraphTests: XCTestCase {
         // 1─┼─▶3─┼▶5──▶6
         //   │    │
         //   └─▶4─┘
-        let graph = DirectedGraph(neighbors: [
+        let graph = DirectedGraph(edges: [
             1: [2,3,4],
             2: [5],
             3: [5],
@@ -146,7 +146,7 @@ final class DirectedGraphTests: XCTestCase {
         // │   ▲  │       ▲
         // ▼   │  │       │
         // 3───┘  └──▶7───┘
-        let graph = DirectedGraph(neighbors: [
+        let graph = DirectedGraph(edges: [
             1: [2],
             2: [3,4],
             3: [4],
@@ -178,6 +178,60 @@ final class DirectedGraphTests: XCTestCase {
         }
     }
     
+    func testSimpleCycle() throws {
+        do {
+            // ┌──────▶2
+            // │       │
+            // 1───┐   │
+            // ▲   ▼   │
+            // └───3◀──┘
+            let graph = DirectedGraph(edges: [
+                0: [2,3],
+                1: [2,3],
+                2: [3],
+                3: [1],
+            ])
+            
+            XCTAssertEqual(graph.cycles(from: 1), [
+                [1,3],
+            ])
+            XCTAssertEqual(graph.cycles(from: 2), [
+                [2,3,1],
+                [3,1],
+            ])
+            XCTAssertEqual(graph.cycles(from: 3), [
+                [3,1],
+                [3,1,2],
+            ])
+            
+            for id in [1,2,3] {
+                XCTAssertEqual(graph.allFinitePaths(from: id), [], "The only path from '\(id)' is infinite (cyclic)")
+                XCTAssertEqual(graph.shortestFinitePaths(from: id), [], "The only path from '\(id)' is infinite (cyclic)")
+                XCTAssertEqual(graph.reachableLeafNodes(from: id), [], "The only path from '\(id)' is infinite (cyclic)")
+            }
+        }
+    }
+    
+    func testSimpleCycleRotation() throws {
+        do {
+            // ┌───▶1───▶2
+            // │    ▲    │
+            // │    │    │
+            // 0───▶3◀───┘
+            let graph = DirectedGraph(edges: [
+                0: [1,3],
+                1: [2,],
+                2: [3],
+                3: [1],
+            ])
+            
+            XCTAssertEqual(graph.cycles(from: 0), [
+                [1,2,3],
+                // '3,1,2' and '2,3,1' are both rotations of '1,2,3'.
+            ])
+        }
+    }
+    
     func testGraphWithCycleAndSingleAdjacency() throws {
         // 1───▶2◀───3
         //      │
@@ -186,7 +240,7 @@ final class DirectedGraphTests: XCTestCase {
         //      │    ▲
         //      ▼    │
         // 7───▶8───▶9
-        let graph = DirectedGraph(neighbors: [
+        let graph = DirectedGraph(edges: [
             1: [2],
             2: [5],
             3: [2],
@@ -235,10 +289,10 @@ final class DirectedGraphTests: XCTestCase {
             //             │    │
             //             ▼    ▼
             //             8   11
-            let graph = DirectedGraph(neighbors: [
+            let graph = DirectedGraph(edges: [
                 0: [1,2],
                 2: [3,4,5],
-                4: [6,7],
+                4: [5,6,7],
                 5: [8,9],
                 7: [10,9],
                 9: [11,7],
@@ -257,10 +311,13 @@ final class DirectedGraphTests: XCTestCase {
                 [0,2,3],
                 [0,2,4,6],
                 [0,2,5,8],
+                [0,2,4,5,8],
                 [0,2,4,7,10],
                 [0,2,5,9,11],
+                [0,2,4,5,9,11],
                 [0,2,4,7,9,11],
                 [0,2,5,9,7,10],
+                [0,2,4,5,9,7,10]
             ])
             
             XCTAssertEqual(graph.shortestFinitePaths(from: 0), [
@@ -280,7 +337,7 @@ final class DirectedGraphTests: XCTestCase {
         //    ║    ║    │    ║
         //    ║    ▼    ▼    ▼
         //    ╚═══▶3    8───▶9───▶11
-        let graph = DirectedGraph(neighbors: [
+        let graph = DirectedGraph(edges: [
             1: [1,2,3],
             2: [3,4,5],
             3: [1,2],
@@ -343,7 +400,7 @@ final class DirectedGraphTests: XCTestCase {
         //    │  │  ▲
         //    │  ▼  │
         //    └─▶4──┘
-        let graph = DirectedGraph(neighbors: [
+        let graph = DirectedGraph(edges: [
             1: [2,3,4],
             2: [3],
             3: [4],

--- a/Tests/SwiftDocCUtilitiesTests/Utility/DirectedGraphTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/Utility/DirectedGraphTests.swift
@@ -1,0 +1,377 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2024 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+@testable import SwiftDocC
+
+final class DirectedGraphTests: XCTestCase {
+    
+    func testGraphWithSingleAdjacency() throws {
+        // 1───▶2◀───3
+        //      │
+        //      ▼
+        // 4───▶5    6
+        //      │    │
+        //      ▼    ▼
+        // 7───▶8◀───9
+        let graph = DirectedGraph(neighbors: [
+            1: [2],
+            2: [5],
+            3: [2],
+            4: [5],
+            5: [8],
+            7: [8],
+            6: [9],
+            9: [8],
+        ])
+        
+        // With only a single neighbor per node, breadth first and depth first perform the same traversal
+        assertEqual(graph.breadthFirstSearch(from: 1), [1,2,5,8])
+        assertEqual(graph.breadthFirstSearch(from: 2), [2,5,8])
+        assertEqual(graph.breadthFirstSearch(from: 3), [3,2,5,8])
+        assertEqual(graph.breadthFirstSearch(from: 4), [4,5,8])
+        assertEqual(graph.breadthFirstSearch(from: 5), [5,8])
+        assertEqual(graph.breadthFirstSearch(from: 6), [6,9,8])
+        assertEqual(graph.breadthFirstSearch(from: 7), [7,8])
+        assertEqual(graph.breadthFirstSearch(from: 8), [8])
+        assertEqual(graph.breadthFirstSearch(from: 9), [9,8])
+        
+        assertEqual(graph.depthFirstSearch(from: 1), [1,2,5,8])
+        assertEqual(graph.depthFirstSearch(from: 2), [2,5,8])
+        assertEqual(graph.depthFirstSearch(from: 3), [3,2,5,8])
+        assertEqual(graph.depthFirstSearch(from: 4), [4,5,8])
+        assertEqual(graph.depthFirstSearch(from: 5), [5,8])
+        assertEqual(graph.depthFirstSearch(from: 6), [6,9,8])
+        assertEqual(graph.depthFirstSearch(from: 7), [7,8])
+        assertEqual(graph.depthFirstSearch(from: 8), [8])
+        assertEqual(graph.depthFirstSearch(from: 9), [9,8])
+        
+        // With only a single neighbor per node, the path is the same as the traversal
+        XCTAssertEqual(graph.allFinitePaths(from: 1), [[1,2,5,8]])
+        XCTAssertEqual(graph.allFinitePaths(from: 2), [[2,5,8]])
+        XCTAssertEqual(graph.allFinitePaths(from: 3), [[3,2,5,8]])
+        XCTAssertEqual(graph.allFinitePaths(from: 4), [[4,5,8]])
+        XCTAssertEqual(graph.allFinitePaths(from: 5), [[5,8]])
+        XCTAssertEqual(graph.allFinitePaths(from: 6), [[6,9,8]])
+        XCTAssertEqual(graph.allFinitePaths(from: 7), [[7,8]])
+        XCTAssertEqual(graph.allFinitePaths(from: 8), [[8]])
+        XCTAssertEqual(graph.allFinitePaths(from: 9), [[9,8]])
+        
+        for node in 1...9 {
+            XCTAssertNil(graph.firstCycle(from: node))
+            XCTAssertEqual(graph.cycles(from: node), [])
+        }
+    }
+    
+    func testGraphWithTreeStructure() throws {
+        //        ┌▶5
+        //   ┌─▶2─┤
+        //   │    └▶6
+        // 1─┼─▶3
+        //   │
+        //   └─▶4──▶7──▶8
+        let graph = DirectedGraph(neighbors: [
+            1: [2,3,4],
+            2: [5,6],
+            4: [7],
+            7: [8],
+        ])
+        
+        assertEqual(graph.breadthFirstSearch(from: 1), [1,2,3,4,5,6,7,8])
+        
+        assertEqual(graph.depthFirstSearch(from: 1), [1,4,7,8,3,2,6,5])
+        
+        XCTAssertEqual(graph.allFinitePaths(from: 1), [
+            [1,3],
+            [1,2,5],
+            [1,2,6],
+            [1,4,7,8],
+        ])
+        
+        XCTAssertEqual(graph.shortestFinitePaths(from: 1), [
+            [1,3],
+        ])
+        
+        for node in 1...8 {
+            XCTAssertNil(graph.firstCycle(from: node))
+        }
+    }
+    
+    func testGraphWithTreeStructureAndMultipleAdjacency() throws {
+        //   ┌─▶2─┐
+        //   │    │
+        // 1─┼─▶3─┼▶5──▶6
+        //   │    │
+        //   └─▶4─┘
+        let graph = DirectedGraph(neighbors: [
+            1: [2,3,4],
+            2: [5],
+            3: [5],
+            4: [5],
+            5: [6],
+        ])
+        
+        assertEqual(graph.breadthFirstSearch(from: 1), [1,2,3,4,5,6])
+        assertEqual(graph.depthFirstSearch(from: 1), [1,4,5,6,3,2])
+        
+        XCTAssertEqual(graph.allFinitePaths(from: 1), [
+            [1,2,5,6],
+            [1,3,5,6],
+            [1,4,5,6],
+        ])
+        
+        XCTAssertEqual(graph.shortestFinitePaths(from: 1), [
+            [1,2,5,6],
+            [1,3,5,6],
+            [1,4,5,6],
+        ])
+        
+        for node in 1...6 {
+            XCTAssertNil(graph.firstCycle(from: node))
+        }
+    }
+    
+    func testComplexGraphWithMultipleAdjacency() throws {
+        // 1      ┌──▶5
+        // │      │   │
+        // ▼      │   ▼
+        // 2──▶4──┼──▶6──▶8
+        // │   ▲  │       ▲
+        // ▼   │  │       │
+        // 3───┘  └──▶7───┘
+        let graph = DirectedGraph(neighbors: [
+            1: [2],
+            2: [3,4],
+            3: [4],
+            4: [5,6,7],
+            5: [6],
+            6: [8],
+            7: [8],
+        ])
+        
+        assertEqual(graph.breadthFirstSearch(from: 1), [1,2,3,4,5,6,7,8])
+        assertEqual(graph.depthFirstSearch(from: 1), [1,2,4,7,8,6,5,3])
+        
+        XCTAssertEqual(graph.allFinitePaths(from: 1), [
+            [1,2,4,6,8],
+            [1,2,4,7,8],
+            [1,2,3,4,6,8],
+            [1,2,3,4,7,8],
+            [1,2,4,5,6,8],
+            [1,2,3,4,5,6,8],
+        ])
+        
+        XCTAssertEqual(graph.shortestFinitePaths(from: 1), [
+            [1,2,4,6,8],
+            [1,2,4,7,8],
+        ])
+        
+        for node in 1...8 {
+            XCTAssertNil(graph.firstCycle(from: node))
+        }
+    }
+    
+    func testGraphWithCycleAndSingleAdjacency() throws {
+        // 1───▶2◀───3
+        //      │
+        //      ▼
+        // 4───▶5◀───6
+        //      │    ▲
+        //      ▼    │
+        // 7───▶8───▶9
+        let graph = DirectedGraph(neighbors: [
+            1: [2],
+            2: [5],
+            3: [2],
+            4: [5],
+            5: [8],
+            6: [5],
+            7: [8],
+            8: [9],
+            9: [6],
+        ])
+        
+        // With only a single neighbor per node, breadth first and depth first perform the same traversal
+        assertEqual(graph.breadthFirstSearch(from: 1), [1,2,5,8,9,6])
+        assertEqual(graph.depthFirstSearch(from: 1), [1,2,5,8,9,6])
+        
+        XCTAssertEqual(graph.allFinitePaths(from: 1), [], "The only path from '1' is infinite (cyclic)")
+        XCTAssertEqual(graph.shortestFinitePaths(from: 1), [], "The only path from '1' is infinite (cyclic)")
+        XCTAssertEqual(graph.reachableLeafNodes(from: 1), [], "The only path from '1' is infinite (cyclic)")
+        
+        for node in [1,2,3,4,5] {
+            XCTAssertEqual(graph.firstCycle(from: node), [5,8,9,6])
+            XCTAssertEqual(graph.cycles(from: node), [[5,8,9,6]])
+        }
+        
+        for node in [7,8] {
+            XCTAssertEqual(graph.firstCycle(from: node), [8,9,6,5])
+            XCTAssertEqual(graph.cycles(from: node), [[8,9,6,5]])
+        }
+        XCTAssertEqual(graph.firstCycle(from: 6), [6,5,8,9])
+        XCTAssertEqual(graph.cycles(from: 6), [[6,5,8,9]])
+        
+        XCTAssertEqual(graph.firstCycle(from: 9), [9,6,5,8])
+        XCTAssertEqual(graph.cycles(from: 9), [[9,6,5,8]])
+    }
+    
+    func testGraphsWithCycleAndManyLeafNodes() throws {
+        do {
+            //             6   10
+            //             ▲    ▲
+            //  1    3     │    │
+            //  ▲    ▲  ┌─▶4───▶7
+            //  │    │  │  │    ▲
+            //  0───▶2──┤  │    ║
+            //          │  ▼    ▼
+            //          └─▶5───▶9
+            //             │    │
+            //             ▼    ▼
+            //             8   11
+            let graph = DirectedGraph(neighbors: [
+                0: [1,2],
+                2: [3,4,5],
+                4: [6,7],
+                5: [8,9],
+                7: [10,9],
+                9: [11,7],
+            ])
+
+            XCTAssertEqual(graph.firstCycle(from: 0), [7,9])
+            XCTAssertEqual(graph.firstCycle(from: 4), [7,9])
+            XCTAssertEqual(graph.firstCycle(from: 5), [9,7])
+            
+            XCTAssertEqual(graph.cycles(from: 0), [
+                [7,9], // through breadth-first-traversal, 7 is reached before 9.
+            ])
+            
+            XCTAssertEqual(graph.allFinitePaths(from: 0), [
+                [0,1],
+                [0,2,3],
+                [0,2,4,6],
+                [0,2,5,8],
+                [0,2,4,7,10],
+                [0,2,5,9,11],
+                [0,2,4,7,9,11],
+                [0,2,5,9,7,10],
+            ])
+            
+            XCTAssertEqual(graph.shortestFinitePaths(from: 0), [
+                [0,1],
+            ])
+            
+            XCTAssertEqual(graph.reachableLeafNodes(from: 0), [1,3,6,8,10,11])
+        }
+    }
+    
+    func testGraphWithManyCycles() throws {
+        // ┌──┐    ┌───▶4────┐
+        // │  │    │    │    │
+        // │  │    │    ▼    ▼
+        // └─▶1───▶2───▶5───▶7───▶10
+        //    ▲    ▲    │    ▲
+        //    ║    ║    │    ║
+        //    ║    ▼    ▼    ▼
+        //    ╚═══▶3    8───▶9───▶11
+        let graph = DirectedGraph(neighbors: [
+            1: [1,2,3],
+            2: [3,4,5],
+            3: [1,2],
+            4: [5,7],
+            5: [8,7],
+            7: [10,9],
+            8: [9],
+            9: [11,7],
+        ])
+
+        XCTAssertEqual(graph.firstCycle(from: 1), [1])
+        XCTAssertEqual(graph.firstCycle(from: 2), [2,3])
+        XCTAssertEqual(graph.firstCycle(from: 4), [7,9])
+        XCTAssertEqual(graph.firstCycle(from: 8), [9,7])
+        
+        XCTAssertEqual(graph.cycles(from: 1), [
+            [1],
+            [1,3],
+            // There's also a [1,2,3] cycle but that can also be broken by removing the edge from 3 ──▶ 1.
+            [2,3],
+            [7,9]
+        ])
+        
+        XCTAssertEqual(graph.allFinitePaths(from: 1), [
+            [1, 2, 4, 7, 10],
+            [1, 2, 5, 7, 10],
+            [1, 2, 4, 5, 7, 10],
+            [1, 2, 4, 7, 9, 11],
+            [1, 2, 5, 8, 9, 11],
+            [1, 2, 5, 7, 9, 11],
+            [1, 3, 2, 4, 7, 10],
+            [1, 3, 2, 5, 7, 10],
+            [1, 2, 4, 5, 8, 9, 11],
+            [1, 2, 4, 5, 7, 9, 11],
+            [1, 2, 5, 8, 9, 7, 10],
+            [1, 3, 2, 4, 5, 7, 10],
+            [1, 3, 2, 4, 7, 9, 11],
+            [1, 3, 2, 5, 8, 9, 11],
+            [1, 3, 2, 5, 7, 9, 11],
+            [1, 2, 4, 5, 8, 9, 7, 10],
+            [1, 3, 2, 4, 5, 8, 9, 11],
+            [1, 3, 2, 4, 5, 7, 9, 11],
+            [1, 3, 2, 5, 8, 9, 7, 10],
+            [1, 3, 2, 4, 5, 8, 9, 7, 10]
+        ])
+        
+        XCTAssertEqual(graph.shortestFinitePaths(from: 1), [
+            [1, 2, 4, 7, 10],
+            [1, 2, 5, 7, 10],
+        ])
+        
+        XCTAssertEqual(graph.reachableLeafNodes(from: 1), [10, 11])
+    }
+    
+    func testGraphWithMultiplePathsToEnterCycle() throws {
+        //    ┌─▶2◀─┐
+        //    │  │  │
+        //    │  ▼  │
+        // 1──┼─▶3  5
+        //    │  │  ▲
+        //    │  ▼  │
+        //    └─▶4──┘
+        let graph = DirectedGraph(neighbors: [
+            1: [2,3,4],
+            2: [3],
+            3: [4],
+            4: [5],
+            5: [2],
+        ])
+        
+        // With only a single neighbor per node, breadth first and depth first perform the same traversal
+        assertEqual(graph.breadthFirstSearch(from: 1), [1,2,3,4,5])
+        assertEqual(graph.depthFirstSearch(from: 1), [1,4,5,2,3])
+        
+        XCTAssertEqual(graph.allFinitePaths(from: 1), [
+            // The only path from 1 is cyclic
+        ])
+        
+        XCTAssertEqual(graph.shortestFinitePaths(from: 1), [
+            // The only path from 1 is cyclic
+        ])
+        
+        XCTAssertEqual(graph.firstCycle(from: 1), [2,3,4,5])
+        XCTAssertEqual(graph.cycles(from: 1), [
+            [2,3,4,5]
+            // The other cycles are rotations of the first one.
+        ])
+    }
+}
+
+// A private helper to avoid needing to wrap the breadth first and depth first sequences into arrays to compare them.
+private func assertEqual<Element: Equatable>(_ lhs: some Sequence<Element>, _ rhs: some Sequence<Element>, file: StaticString = #filePath, line: UInt = #line) {
+    XCTAssertEqual(Array(lhs), Array(rhs), file: file, line: line)
+}


### PR DESCRIPTION
<!--
If you're opening a PR to cherry-pick a change for a release branch, use this template instead:
https://github.com/apple/swift-docc/blob/main/.github/PULL_REQUEST_TEMPLATE/CHERRY_PICK.md
-->

Bug/issue #, if applicable: rdar://126974763

## Summary

This fixes a few different issues with infinite recursion, which ultimately surface as crashes, when the content contains cyclic curation. 

There were two main issues:
- Multi source-language projects can have the same symbol in different places in the different language representation which are all mixed in the topic graph. These multiple paths to and from symbol in the hierarchy makes it possible to create cycles through a mix of automatic and manual curation. 
- Even if the topic graph didn't contain curation, the navigator is based on the rendered topic sections which don't filter out any curation. 

The first issue surfaced as an infinite recursion in `DocumentationContext/pathsTo(...)` which incorrectly assumed that the topic graph was acyclic. Ironically the infinite recursion occurred when DocC tried to identify and skip curation that would cause a cycle.

After fixing the `pathsTo(...)` implementation to make the distinction between finite and infinite parts in the graph, I noticed that a handful of the callers didn't need the the full paths and that there were faster/cheaper ways to compute the information that they needed.

The second issue surfaced as in infinite recursion in `NavigatorTree/Node/copy()` which had a faulty implementation that tried to identify and prevent infinite recursion. The issue with that implementation was that it checked `NavigatorTree/Node/parent` which didn't always match the node from the previous iteration of the recursion when the page that the node represents was curated in multiple places. This made the crash somewhat unreliable, but by adding multiple nodes in the path that are all curated in more than one place, the crash reproduces most of the time.

I tried making a more robust navigator builder implementation that worked in 2 steps:
- Identify and break all the cycles in the navigator
- Build up the navigator hierarchy bottom up (from the leaves to the root)

This does produce a nicer looking navigator hierarchy when there are cyclic curation (both implementations produce _stable_ navigator hierarchies across different executions) but it takes ~2-3x times as long to create the navigator hierarchy this way which increases the total documentation build time by ~2-3%. Since DocC already raises warnings about the cyclic curation, it didn't seem worth it to produce an "optimal" minimal navigation hierarchy when the there's cyclic curation, so I didn't push this commit.

## Dependencies

None

## Testing

The best way to test both of these issues are described by the added unit tests.

### To test the first issue:


- In a project that's configured for both Swift and Objective-C, define an error with `NS_ERROR_ENUM` and any class
  ```Objective-C
  extern NSErrorDomain const SomeErrorDomain;
  typedef NS_ERROR_ENUM(SomeErrorDomain, SomeErrorCode) {
      SomeErrorSomething = 1
  };
  
  @interface SomeClass: NSObject
  
  @end
  ```

- Add two documentation extension files,
  - One for the class to curate the generated Swift only error structure:
    ```md
    # ``SomeClass``
    
    Curate the error
    
    ## Topics
    
    - ``SomeError``
    ```

  - One for the error to curate the class:
    ```md
    # ``SomeError/Code``
    
    Curate the class
    
    ## Topics
    
    - ``SomeClass``
    ```

- Building documentation for this project should no longer cause a crash due to infinite recursion determining the paths to `SomeError/Code``.


### To test the second issue:

- In a Swift only project, create two public classes; one with two members and one empty.

- Curate most symbols in two places:
  ```swift
  /// ## Topics
  /// - ``SomeClass/second()``
  public class Empty {}

  /// ## Topics
  /// - ``first()``
  /// - ``Empty``
  public class SomeClass {
      /// ## Topics
      /// - ``second()``
      public find first() {}
      /// ## Topics
      /// - ``first()``
      public find second() {}
  }
  ```

- Add an API collection (an artile with curation) and curate both classes:
  ```md
  # My API collection
  
  ## Topics
  - ``SomeClass``
  - ``Empty``
  ```
  
- Add an documentation extension for the module and curate the API collection:
  ```md
  # ``ModuleName``
  
  ## Topics
  - <doc:my-api-collection>
  ```
  
- Building documentation for this project should no longer cause a crash due to infinite recursion copying the navigation tree nodes. Even with this many mulyi-curated symbols you may need to build documentation a few times to reproduce the crash.


## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] ~Updated documentation if necessary~ Not applicable
