### PR TITLE
Mark existential with `any` to unblock compiler bug fix

### DIFF
--- a/Sources/SwiftDocC/Checker/Checker.swift
+++ b/Sources/SwiftDocC/Checker/Checker.swift
@@ -270,7 +270,7 @@ public struct CompositeChecker: Checker {
     public var checkers: [AnyChecker]
 
     /// Creates a checker that performs the combined work of the given checkers.
-    public init(_ checkers: some Sequence<Checker>) {
+    public init(_ checkers: some Sequence<any Checker>) {
         self.checkers = checkers.map { $0.any() }
     }
     


### PR DESCRIPTION
<!--
If you're opening a PR to cherry-pick a change for a release branch, use this template instead:
https://github.com/apple/swift-docc/blob/main/.github/PULL_REQUEST_TEMPLATE/CHERRY_PICK.md
-->

## Summary

The compiler should enforce `any` syntax here. The fix (https://github.com/apple/swift/pull/72659) depends on this change because compiler pull request testing builds Swift-DocC.

## Checklist

This is a purely syntactic change.