### PR TITLE
Continues searching if a non-symbol matches a symbol link

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+Error.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+Error.swift
@@ -46,7 +46,7 @@ extension PathHierarchy {
         ///
         /// Includes information about:
         /// - The path to the non-symbol match.
-        case nonSymbolMatchForSymbolLink(path: Substring)
+        case nonSymbolMatchForSymbolLink(path: String)
         
         /// Encountered an unknown disambiguation for a found node.
         ///

--- a/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
@@ -1410,6 +1410,49 @@ class PathHierarchyTests: XCTestCase {
         try assertFindsPath("Inner/InnerClass/something()", in: tree, asSymbolID: "s:5Inner0A5ClassC5OuterE9somethingyyF")
     }
     
+    func testContinuesSearchingIfNonSymbolMatchesSymbolLink() throws {
+        let exampleDocumentation = Folder(name: "CatalogName.docc", content: [
+            JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(moduleName: "ModuleName", symbols: [
+                ("some-class-id", .swift, ["SomeClass"], .class),
+            ])),
+            
+            TextFile(name: "Some-Article.md", utf8Content: """
+             # Some article
+             
+             An article with a heading with the same name as a symbol and another heading.
+             
+             ### SomeClass
+             
+             - ``SomeClass``
+             
+             ### OtherHeading
+             """),
+        ])
+        let catalogURL = try exampleDocumentation.write(inside: createTemporaryDirectory())
+        let (_, _, context) = try loadBundle(from: catalogURL)
+        let tree = context.linkResolver.localResolver.pathHierarchy
+        
+        XCTAssert(context.problems.isEmpty, "Unexpected problems \(context.problems.map(\.diagnostic.summary))")
+        
+        let articleID = try tree.find(path: "/CatalogName/Some-Article", onlyFindSymbols: false)
+        
+        XCTAssertEqual(try tree.findNode(path: "SomeClass", onlyFindSymbols: false, parent: articleID).symbol?.identifier.precise, nil,
+                       "A general documentation link will find the heading because its closer than the symbol.")
+        XCTAssertEqual(try tree.findNode(path: "SomeClass", onlyFindSymbols: true, parent: articleID).symbol?.identifier.precise, "some-class-id",
+                       "A symbol link will skip the heading and continue searching until it finds the symbol.")
+        
+        XCTAssertEqual(try tree.findNode(path: "OtherHeading", onlyFindSymbols: false, parent: articleID).symbol?.identifier.precise, nil,
+                       "A general documentation link will find the other heading.")
+        XCTAssertThrowsError(
+            try tree.findNode(path: "OtherHeading", onlyFindSymbols: true, parent: articleID),
+            "A symbol link that find the header but doesn't find a symbol will raise the error about the heading not being a symbol"
+        ) { untypedError in
+            let error = untypedError as! PathHierarchy.Error
+            let referenceError = error.makeTopicReferenceResolutionErrorInfo() { context.linkResolver.localResolver.fullName(of: $0, in: context) }
+            XCTAssertEqual(referenceError.message, "Symbol links can only resolve symbols")
+        }
+    }
+    
     func testSnippets() throws {
         let (_, context) = try testBundleAndContext(named: "Snippets")
         let tree = context.linkResolver.localResolver.pathHierarchy


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://126580675

## Summary

This fixes a bug where DocC would stop searching as soon as it found any match while resolving a link, even if that match wasn't valid for the search (for example a non-symbol match for a symbol link). This resulted in "Symbol links can only resolve symbols" errors for some symbol links if there was a closer non-symbol match to the page that contained the link.

Now, DocC will check that the match is valid for the search, and if it's not; DocC will remember the error message from the first match but continue searching to see if there's another _valid_ match.

## Dependencies

None

## Testing

In a project with some top-level symbol, 

- Add an article with a heading (or topic section) with the same name as the symbol and also link to that symbol with a symbol link. For example:
  ```md
  # Some article
  
  An article with a heading with the same name as a symbol
  
  ### SomeClass
  
  - ``SomeClass``
  ```

- Build documentation for the project.
  - The link should resolve to the symbol without warnings.
  
- Change the link to a general documentation link (`<doc:SomeClass>`) and build documentation again.
  - The link should resolve to the heading without warnings.
 
- Add another heading to the article and link to it using a symbol link 
  ```diff
    # Some article
   
    An article with a heading with the same name as a symbol
   
  + ### OtherHeading
  +
    ### SomeClass
   
    - ``SomeClass``
  + - ``OtherHeading``
  ```

- Build documentation for the project again
  - The new link should result in a warning that "Symbol links can only resolve symbols"

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] ~Updated documentation if necessary~ Not applicable
