### PR TITLE
[6.0] drop uncurated symbols from the navigator index

### DIFF
--- a/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
+++ b/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
@@ -358,7 +358,21 @@ public class NavigatorIndex {
             default: self = .article
             }
         }
-        
+
+        /// Whether this page kind references a symbol.
+        var isSymbolKind: Bool {
+            switch self {
+            case .root, .article, .tutorial, .section, .learn, .overview, .resources, .framework,
+                    .buildSetting, .sampleCode, .languageGroup, .container, .groupMarker:
+                return false
+            case .symbol, .class, .structure, .protocol, .enumeration, .function, .extension,
+                    .localVariable, .globalVariable, .typeAlias, .associatedType, .operator, .macro,
+                    .union, .enumerationCase, .initializer, .instanceMethod, .instanceProperty,
+                    .instanceVariable, .subscript, .typeMethod, .typeProperty, .propertyListKey,
+                    .httpRequest, .dictionarySymbol, .propertyListKeyReference, .namespace:
+                return true
+            }
+        }
     }
     
     // MARK: - Read Navigator Tree
@@ -918,7 +932,11 @@ extension NavigatorIndex {
             
             // The rest have no parent, so they need to be under the root.
             for nodeID in pendingUncuratedReferences {
-                if let node = identifierToNode[nodeID] {
+                // Don't add symbol nodes to the root; if they have been dropped by automatic
+                // curation, then they should not be in the navigator. In addition, treat unknown
+                // page types as symbol nodes on the assumption that an unknown page type is a
+                // symbol kind added in a future version of Swift-DocC.
+                if let node = identifierToNode[nodeID], PageType(rawValue: node.item.pageType)?.isSymbolKind == false {
 
                     // If an uncurated page has been curated in another language, don't add it to the top-level.
                     if curatedReferences.contains(where: { curatedNodeID in

--- a/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
@@ -1629,16 +1629,51 @@ Root
             for: "OverloadedSymbols",
             bundleIdentifier: "com.shapes.ShapeKit")
 
-        let protocolID = try XCTUnwrap(navigatorIndex.id(for: "/documentation/shapekit/overloadedprotocol", with: .swift))
-        let protocolNode = try XCTUnwrap(search(node: navigatorIndex.navigatorTree.root) { $0.id == protocolID })
-        XCTAssertEqual(protocolNode.children.map(\.item.title), [
-            "Instance Methods",
-            "func fourthTestMemberName(test:)",
-        ])
-
-        let overloadGroupID = try XCTUnwrap(navigatorIndex.id(for: "/documentation/shapekit/overloadedprotocol/fourthtestmembername(test:)-9b6be", with: .swift))
-        let overloadGroupNode = try XCTUnwrap(search(node: navigatorIndex.navigatorTree.root) { $0.id == overloadGroupID })
-        XCTAssert(overloadGroupNode.children.isEmpty)
+        XCTAssertEqual(
+            navigatorIndex.navigatorTree.root.dumpTree(),
+            """
+            [Root]
+            ┗╸Swift
+              ┗╸ShapeKit
+                ┣╸Protocols
+                ┣╸OverloadedProtocol
+                ┃ ┣╸Instance Methods
+                ┃ ┗╸func fourthTestMemberName(test:)
+                ┣╸Structures
+                ┣╸OverloadedByCaseStruct
+                ┃ ┣╸Instance Properties
+                ┃ ┣╸let ThirdTestMemberName: Int
+                ┃ ┣╸let thirdTestMemberNamE: Int
+                ┃ ┣╸let thirdTestMemberName: Int
+                ┃ ┗╸let thirdtestMemberName: Int
+                ┣╸OverloadedParentStruct
+                ┃ ┣╸Type Properties
+                ┃ ┗╸static let fifthTestMember: Int
+                ┣╸OverloadedStruct
+                ┃ ┣╸Instance Properties
+                ┃ ┣╸let secondTestMemberName: Int
+                ┃ ┣╸Type Properties
+                ┃ ┗╸static let secondTestMemberName: Int
+                ┣╸RegularParent
+                ┃ ┣╸Instance Properties
+                ┃ ┣╸let firstMember: Int
+                ┃ ┣╸Instance Methods
+                ┃ ┣╸func secondMember(first: Int, second: String)
+                ┃ ┣╸Type Properties
+                ┃ ┣╸static let thirdMember: Int
+                ┃ ┣╸Enumerations
+                ┃ ┗╸RegularParent.FourthMember
+                ┣╸overloadedparentstruct
+                ┃ ┣╸Instance Properties
+                ┃ ┗╸let fifthTestMember: Int
+                ┣╸Enumerations
+                ┗╸OverloadedEnum
+                  ┣╸Enumeration Cases
+                  ┣╸case firstTestMemberName(String)
+                  ┣╸Instance Methods
+                  ┗╸func firstTestMemberName(_:)
+            """
+        )
     }
 
     func generatedNavigatorIndex(for testBundleName: String, bundleIdentifier: String) throws -> NavigatorIndex {


### PR DESCRIPTION
- **Explanation**: Remove symbols that were not curated by AutomaticCuration from the navigator index, to prevent them from appearing outside of any module.
- **Scope**: QOL fix for clients of the LMDB navigator index, e.g.  Xcode's documentation window.
- **Issue**: rdar://125855186
- **Original PR**: https://github.com/apple/swift-docc/pull/890
- **Risk**: Low. The symbols were already being dropped from the JSON representation of the navigator index (used by Swift-DocC-Render) without issue.
- **Testing**: Automated tests were updated to reflect the new behavior.
- **Reviewer**: @d-ronnqvist @patshaughnessy 