### PR TITLE
[6.0] add the ability to set a subset of feature flags from Info.plist

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Workspace/DocumentationBundle+Info.swift
+++ b/Sources/SwiftDocC/Infrastructure/Workspace/DocumentationBundle+Info.swift
@@ -32,7 +32,10 @@ extension DocumentationBundle {
         
         /// The default kind for the various modules in the bundle.
         public var defaultModuleKind: String?
-        
+
+        /// The parsed feature flags that were set for this bundle.
+        internal var featureFlags: BundleFeatureFlags?
+
         /// The keys that must be present in an Info.plist file in order for doc compilation to proceed.
         static let requiredKeys: Set<CodingKeys> = [.displayName, .identifier]
         
@@ -43,7 +46,8 @@ extension DocumentationBundle {
             case defaultCodeListingLanguage = "CDDefaultCodeListingLanguage"
             case defaultAvailability = "CDAppleDefaultAvailability"
             case defaultModuleKind = "CDDefaultModuleKind"
-            
+            case featureFlags = "CDExperimentalFeatureFlags"
+
             var argumentName: String? {
                 switch self {
                 case .displayName:
@@ -56,7 +60,7 @@ extension DocumentationBundle {
                     return "--default-code-listing-language"
                 case .defaultModuleKind:
                     return "--fallback-default-module-kind"
-                case .defaultAvailability:
+                case .defaultAvailability, .featureFlags:
                     return nil
                 }
             }
@@ -231,6 +235,7 @@ extension DocumentationBundle {
             self.defaultCodeListingLanguage = try decodeOrFallbackIfPresent(String.self, with: .defaultCodeListingLanguage)
             self.defaultModuleKind = try decodeOrFallbackIfPresent(String.self, with: .defaultModuleKind)
             self.defaultAvailability = try decodeOrFallbackIfPresent(DefaultAvailability.self, with: .defaultAvailability)
+            self.featureFlags = try decodeOrFallbackIfPresent(BundleFeatureFlags.self, with: .featureFlags)
         }
         
         init(
@@ -239,7 +244,8 @@ extension DocumentationBundle {
             version: String? = nil,
             defaultCodeListingLanguage: String? = nil,
             defaultModuleKind: String? = nil,
-            defaultAvailability: DefaultAvailability? = nil
+            defaultAvailability: DefaultAvailability? = nil,
+            featureFlags: BundleFeatureFlags? = nil
         ) {
             self.displayName = displayName
             self.identifier = identifier
@@ -247,6 +253,7 @@ extension DocumentationBundle {
             self.defaultCodeListingLanguage = defaultCodeListingLanguage
             self.defaultModuleKind = defaultModuleKind
             self.defaultAvailability = defaultAvailability
+            self.featureFlags = featureFlags
         }
     }
 }
@@ -295,6 +302,8 @@ extension BundleDiscoveryOptions {
                 value = fallbackDefaultAvailability
             case .defaultModuleKind:
                 value = fallbackDefaultModuleKind
+            case .featureFlags:
+                value = nil
             }
             
             guard let unwrappedValue = value else {

--- a/Sources/SwiftDocC/Infrastructure/Workspace/FeatureFlags+Info.swift
+++ b/Sources/SwiftDocC/Infrastructure/Workspace/FeatureFlags+Info.swift
@@ -1,0 +1,84 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2024 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+
+extension DocumentationBundle.Info {
+    /// A collection of feature flags that can be enabled from a bundle's Info.plist.
+    ///
+    /// This is a subset of flags from ``FeatureFlags`` that can influence how a documentation
+    /// bundle is written, and so can be considered a property of the documentation itself, rather
+    /// than as an experimental behavior that can be enabled for one-off builds.
+    ///
+    /// ```xml
+    /// <key>CDExperimentalFeatureFlags</key>
+    /// <dict>
+    ///     <key>ExperimentalOverloadedSymbolPresentation</key>
+    ///     <true/>
+    /// </dict>
+    /// ```
+    internal struct BundleFeatureFlags: Codable, Equatable {
+        // FIXME: Automatically expose all the feature flags from the global FeatureFlags struct
+
+        /// Whether or not experimental support for combining overloaded symbol pages is enabled.
+        ///
+        /// This feature flag corresponds to ``FeatureFlags/isExperimentalOverloadedSymbolPresentationEnabled``.
+        public var experimentalOverloadedSymbolPresentation: Bool?
+
+        public init(experimentalOverloadedSymbolPresentation: Bool? = nil) {
+            self.experimentalOverloadedSymbolPresentation = experimentalOverloadedSymbolPresentation
+            self.unknownFeatureFlags = []
+        }
+
+        /// A list of decoded feature flag keys that didn't match a known feature flag.
+        public let unknownFeatureFlags: [String]
+
+        enum CodingKeys: String, CodingKey, CaseIterable {
+            case experimentalOverloadedSymbolPresentation = "ExperimentalOverloadedSymbolPresentation"
+        }
+
+        struct AnyCodingKeys: CodingKey {
+            var stringValue: String
+
+            init?(stringValue: String) {
+                self.stringValue = stringValue
+            }
+
+            var intValue: Int? { nil }
+            init?(intValue: Int) {
+                return nil
+            }
+        }
+
+        public init(from decoder: any Decoder) throws {
+            let values = try decoder.container(keyedBy: AnyCodingKeys.self)
+            var unknownFeatureFlags: [String] = []
+
+            for flagName in values.allKeys {
+                if let codingKey = CodingKeys(stringValue: flagName.stringValue) {
+                    switch codingKey {
+                    case .experimentalOverloadedSymbolPresentation:
+                        self.experimentalOverloadedSymbolPresentation = try values.decode(Bool.self, forKey: flagName)
+                    }
+                } else {
+                    unknownFeatureFlags.append(flagName.stringValue)
+                }
+            }
+
+            self.unknownFeatureFlags = unknownFeatureFlags
+        }
+
+        public func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+
+            try container.encode(experimentalOverloadedSymbolPresentation, forKey: .experimentalOverloadedSymbolPresentation)
+        }
+    }
+}

--- a/Sources/SwiftDocC/SwiftDocC.docc/SwiftDocC.md
+++ b/Sources/SwiftDocC/SwiftDocC.docc/SwiftDocC.md
@@ -54,5 +54,6 @@ Converting in-memory documentation into rendering nodes and persisting them on d
 ### Development
 
 - <doc:Features>
+- <doc:AddingFeatureFlags>
 
-<!-- Copyright (c) 2021-2023 Apple Inc and the Swift Project authors. All Rights Reserved. -->
+<!-- Copyright (c) 2021-2024 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Sources/SwiftDocC/SwiftDocC.docc/SwiftDocC/AddingFeatureFlags.md
+++ b/Sources/SwiftDocC/SwiftDocC.docc/SwiftDocC/AddingFeatureFlags.md
@@ -1,0 +1,40 @@
+# Adding Feature Flags
+
+Develop experimental features by adding feature flags.
+
+## Overview
+
+Make new features in Swift-DocC optional during active development by creating a command-line flag that
+enables the new behavior. Then set the new flag in the ``FeatureFlags``' ``FeatureFlags/current`` instance,
+making it available for the rest of the compilation process.
+
+### The FeatureFlags structure
+
+Feature flags are defined in the ``FeatureFlags`` structure. This type has a static
+``FeatureFlags/current`` property that contains a global instance of the flags that can be accessed
+throughout the compiler. When adding a flag property to this struct, give it a reasonable default
+value so that the default initializer can be used.
+
+### Feature flags on the command line
+
+Command-line feature flags live in the `Docc.Convert.FeatureFlagOptions` in `SwiftDocCUtilities`.
+This type implements the `ParsableArguments` protocol from Swift Argument Parser to create an option
+group for the `convert` and `preview` commands.
+
+These options are then handled in `ConvertAction.init(fromConvertCommand:)`, still in
+`SwiftDocCUtilities`, where they are written into the global feature flags ``FeatureFlags/current``
+instance, which can then be used during the compilation process.
+
+### Feature flags in Info.plist
+
+A subset of feature flags can affect how a documentation bundle is authored. For example, the
+experimental overloaded symbol presentation can affect how a bundle curates its symbols due to the 
+creation of overload group pages. These flags should also be added to the
+``DocumentationBundle/Info/BundleFeatureFlags`` type, so that they can be parsed out of a bundle's
+Info.plist.
+
+Feature flags that are loaded from an Info.plist file are saved into the global feature flags while
+the bundle is being registered. To ensure that your new feature flag is properly loaded, update the
+``FeatureFlags/loadFlagsFromBundle(_:)`` method to load your new field into the global flags.
+
+<!-- Copyright (c) 2024 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Sources/SwiftDocC/Utility/FeatureFlags.swift
+++ b/Sources/SwiftDocC/Utility/FeatureFlags.swift
@@ -50,4 +50,11 @@ public struct FeatureFlags: Codable {
         additionalFlags: [String : Bool] = [:]
     ) {
     }
+
+    /// Set feature flags that were loaded from a bundle's Info.plist.
+    internal mutating func loadFlagsFromBundle(_ bundleFlags: DocumentationBundle.Info.BundleFeatureFlags) {
+        if let overloadsPresentation = bundleFlags.experimentalOverloadedSymbolPresentation {
+            self.isExperimentalOverloadedSymbolPresentationEnabled = overloadsPresentation
+        }
+    }
 }

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationBundleInfoTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationBundleInfoTests.swift
@@ -414,4 +414,32 @@ class DocumentationBundleInfoTests: XCTestCase {
             )
         )
     }
+
+    func testFeatureFlags() throws {
+        let infoPlistWithFeatureFlags = """
+        <plist version="1.0">
+        <dict>
+            <key>CFBundleDisplayName</key>
+            <string>Info Plist Display Name</string>
+            <key>CFBundleIdentifier</key>
+            <string>com.info.Plist</string>
+            <key>CFBundleVersion</key>
+            <string>1.0.0</string>
+            <key>CDExperimentalFeatureFlags</key>
+            <dict>
+                <key>ExperimentalOverloadedSymbolPresentation</key>
+                <true/>
+            </dict>
+        </dict>
+        </plist>
+        """
+
+        let infoPlistWithFeatureFlagsData = Data(infoPlistWithFeatureFlags.utf8)
+        let info = try DocumentationBundle.Info(
+            from: infoPlistWithFeatureFlagsData,
+            bundleDiscoveryOptions: nil)
+
+        let featureFlags = try XCTUnwrap(info.featureFlags)
+        XCTAssertTrue(try XCTUnwrap(featureFlags.experimentalOverloadedSymbolPresentation))
+    }
 }


### PR DESCRIPTION
* **Explanation**: Adds new fields to Info.plist to allow enabling the overloads feature without using the command-line flag.
* **Scope**: Enhancement for users of the overloads feature in a managed environment like Swift Package Index.
* **Issue**: rdar://126305435
* **Original PR**: https://github.com/apple/swift-docc/pull/891
* **Risk**: Low. Existing documentation catalogs will not be affected, as the feature flags mechanism will continue to fall back to command-line flags.
* **Testing**: Automated tests were added to support the new behavior.
* **Reviewer**: @d-ronnqvist @patshaughnessy @mayaepps 