### PR TITLE
use unified overload data for initial overload variants

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -57,10 +57,10 @@
     {
       "identity" : "swift-docc-symbolkit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/QuietMisdreavus/swift-docc-symbolkit",
+      "location" : "https://github.com/apple/swift-docc-symbolkit",
       "state" : {
-        "branch" : "combine-overload-groups",
-        "revision" : "10801e704c1f9e703c8444c8967a4b168e47b880"
+        "branch" : "main",
+        "revision" : "a6ac00f3534293eeec73c37a396a1bac27816094"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -60,7 +60,7 @@
       "location" : "https://github.com/QuietMisdreavus/swift-docc-symbolkit",
       "state" : {
         "branch" : "combine-overload-groups",
-        "revision" : "e140c2ad63c26efb6ffe92757c8d702457abee52"
+        "revision" : "10801e704c1f9e703c8444c8967a4b168e47b880"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -60,7 +60,7 @@
       "location" : "https://github.com/QuietMisdreavus/swift-docc-symbolkit",
       "state" : {
         "branch" : "combine-overload-groups",
-        "revision" : "3a08be4efc1a3675177084a4c5b6055897d6e10d"
+        "revision" : "e140c2ad63c26efb6ffe92757c8d702457abee52"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -57,10 +57,10 @@
     {
       "identity" : "swift-docc-symbolkit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-docc-symbolkit",
+      "location" : "https://github.com/QuietMisdreavus/swift-docc-symbolkit",
       "state" : {
-        "branch" : "main",
-        "revision" : "8a740b5197ece51e4b597f8a467546da66324581"
+        "branch" : "combine-overload-groups",
+        "revision" : "3a08be4efc1a3675177084a4c5b6055897d6e10d"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -137,8 +137,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(url: "https://github.com/apple/swift-markdown.git", branch: "main"),
         .package(url: "https://github.com/apple/swift-lmdb.git", branch: "main"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.2"),
-//        .package(url: "https://github.com/apple/swift-docc-symbolkit", branch: "main"),
-        .package(url: "https://github.com/QuietMisdreavus/swift-docc-symbolkit", branch: "combine-overload-groups"),
+        .package(url: "https://github.com/apple/swift-docc-symbolkit", branch: "main"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "2.5.0"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.2.0"),
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -137,7 +137,8 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(url: "https://github.com/apple/swift-markdown.git", branch: "main"),
         .package(url: "https://github.com/apple/swift-lmdb.git", branch: "main"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.2"),
-        .package(url: "https://github.com/apple/swift-docc-symbolkit", branch: "main"),
+//        .package(url: "https://github.com/apple/swift-docc-symbolkit", branch: "main"),
+        .package(url: "https://github.com/QuietMisdreavus/swift-docc-symbolkit", branch: "combine-overload-groups"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "2.5.0"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.2.0"),
     ]

--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -1179,14 +1179,10 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
                     }
 
                     let overloadGroups: [String: Set<String>] =
-                    unifiedSymbolGraph.relationshipsByLanguage.values.joined().filter({
-                        $0.kind == .overloadOf
-                    }).map({
-                        (key: $0.target, value: $0.source)
-                    }).reduce([:], { acc, kv in
-                        var acc = acc
-                        acc[kv.key, default: []].insert(kv.value)
-                        return acc
+                    unifiedSymbolGraph.relationshipsByLanguage.values.flatMap({
+                        $0.filter { $0.kind == .overloadOf }
+                    }).reduce(into: [:], { acc, relationship in
+                        acc[relationship.target, default: []].insert(relationship.source)
                     })
                     addOverloadGroupReferences(overloadGroups: overloadGroups)
 

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
@@ -119,6 +119,17 @@ struct PathHierarchy {
                     existingNode.languages.insert(language!) // If we have symbols in this graph we have a language as well
                 } else {
                     assert(!symbol.pathComponents.isEmpty, "A symbol should have at least its own name in its path components.")
+
+                    if symbol.identifier.precise.hasSuffix(SymbolGraph.Symbol.overloadGroupIdentifierSuffix),
+                       loader.unifiedGraphs[moduleName]?.symbols.keys.contains(symbol.identifier.precise) != true {
+                        // Overload groups can be discarded in the unified symbol graph collector if
+                        // they don't reflect the default overload across all platforms. In this
+                        // case, we don't want to add these nodes to the path hierarchy since
+                        // they've been discarded from the unified graph that's used to generate
+                        // documentation nodes.
+                        continue
+                    }
+
                     let node = Node(symbol: symbol, name: symbol.pathComponents.last!)
                     // Disfavor synthesized symbols when they collide with other symbol with the same path.
                     // FIXME: Get information about synthesized symbols from SymbolKit https://github.com/apple/swift-docc-symbolkit/issues/58

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
@@ -121,7 +121,7 @@ struct PathHierarchy {
                     assert(!symbol.pathComponents.isEmpty, "A symbol should have at least its own name in its path components.")
 
                     if symbol.identifier.precise.hasSuffix(SymbolGraph.Symbol.overloadGroupIdentifierSuffix),
-                       loader.unifiedGraphs[moduleName]?.symbols.keys.contains(symbol.identifier.precise) != true {
+                       loader.unifiedGraphs[moduleNode.name]?.symbols.keys.contains(symbol.identifier.precise) != true {
                         // Overload groups can be discarded in the unified symbol graph collector if
                         // they don't reflect the default overload across all platforms. In this
                         // case, we don't want to add these nodes to the path hierarchy since

--- a/Sources/SwiftDocC/Model/DocumentationNode.swift
+++ b/Sources/SwiftDocC/Model/DocumentationNode.swift
@@ -226,14 +226,9 @@ public struct DocumentationNode {
         }
 
         let overloadVariants = DocumentationDataVariants(
-            symbolData: unifiedSymbol.mixins,
-            platformName: platformName
-        ) { mixins -> Symbol.Overloads? in
-            guard let overloadData = mixins[SymbolGraph.Symbol.OverloadData.mixinKey] as? SymbolGraph.Symbol.OverloadData else {
-                return nil
-            }
-            return .init(references: [], displayIndex: overloadData.overloadGroupIndex)
-        }
+            swiftVariant: unifiedSymbol.unifiedOverloadData.map { overloadData in
+                Symbol.Overloads(references: [], displayIndex: overloadData.overloadGroupIndex)
+            })
 
         var languages = Set([reference.sourceLanguage])
         var operatingSystemName = platformName.map({ Set([$0]) }) ?? []

--- a/Sources/SwiftDocCTestUtilities/SymbolGraphCreation.swift
+++ b/Sources/SwiftDocCTestUtilities/SymbolGraphCreation.swift
@@ -14,7 +14,12 @@ import XCTest
 import SymbolKit
 
 extension XCTestCase {
-    public func makeSymbolGraph(moduleName: String, symbols: [SymbolGraph.Symbol] = [], relationships: [SymbolGraph.Relationship] = []) -> SymbolGraph {
+    public func makeSymbolGraph(
+        moduleName: String,
+        platform: SymbolGraph.Platform = .init(),
+        symbols: [SymbolGraph.Symbol] = [],
+        relationships: [SymbolGraph.Relationship] = []
+    ) -> SymbolGraph {
         return SymbolGraph(
             metadata: SymbolGraph.Metadata(
                 formatVersion: SymbolGraph.SemanticVersion(major: 0, minor: 6, patch: 0),
@@ -22,7 +27,7 @@ extension XCTestCase {
             ),
             module: SymbolGraph.Module(
                 name: moduleName,
-                platform: SymbolGraph.Platform(architecture: nil, vendor: nil, operatingSystem: nil)
+                platform: platform
             ),
             symbols: symbols,
             relationships: relationships

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -5101,9 +5101,6 @@ let expected = """
         let overloadGroupSymbol: Symbol
         let overloadGroupReferences: Symbol.Overloads
 
-        // Even though the macOS symbol graph doesn't contain an overload group, one should still
-        // have been created from the iOS symbol graph, and that overload group should reference
-        // both symbols.
         switch context.resolve(.unresolved(.init(topicURL: .init(symbolPath: "SymbolName"))), in: moduleReference, fromSymbolLink: true) {
         case let .failure(_, errorMessage):
             XCTFail("Could not resolve overload group page. Error message: \(errorMessage)")


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://127130136

## Summary

When symbol graphs reflect overload groups that are different across different platforms, Swift-DocC runs into a situation where it can load inconsistent information based on which platform's mixins are loaded for the initial `overloadsVariants`. In some situations (where a symbol is only overloaded on one platform), this can even create a crash in debug builds since Swift-DocC trips an assertion about missing overload data from SymbolKit.

This PR builds on https://github.com/apple/swift-docc-symbolkit/pull/72 to use unified overload groups when calculating overload information. This allows Swift-DocC to present a unified view of overloads across every platform.

## Dependencies

https://github.com/apple/swift-docc-symbolkit/pull/72

## Testing

Use the following documentation catalog to test: [asdf.docc.zip](https://github.com/apple/swift-docc/files/15155647/asdf.docc.zip)

This catalog contains two symbol graphs, one for macOS and one for iOS. These symbol graphs describe the following structure:

```
APhoneOnlyClass // iOS only
MyClass
- myFunc(param: APhoneOnlyClass) // iOS only
- myFunc(param: Double) // macOS only
- myFunc(param: Int)
- myFunc(param: String)
```

Prior to this PR, this would have created two overload groups: One based on `myFunc(param: APhoneOnlyClass)`, and one based on `myFunc(param: Double)`.

Steps:
1. With a recent Swift-DocC-Render set in `$DOCC_HTML_DIR`, run `swift run docc preview /path/to/asdf.docc`
2. Navigate to `MyClass`.
3. Ensure that only one link to `myFunc(param:)` exists.
4. Navigate to `myFunc(param:)` and expand the overloaded declarations.
5. Verify that the overloaded declaration listing contains all four overloaded methods.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ n/a ] Updated documentation if necessary
