### PR TITLE
drop overload groups from curation if the overloads were manually curated

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Topic Graph/AutomaticCuration.swift
+++ b/Sources/SwiftDocC/Infrastructure/Topic Graph/AutomaticCuration.swift
@@ -96,7 +96,14 @@ public struct AutomaticCuration {
                 else {
                     return
                 }
-                
+
+                // If this symbol is an overload group and all its overloaded children were manually
+                // curated elsewhere, skip it so it doesn't clutter the curation hierarchy with a
+                // duplicate symbol.
+                if let overloads = context.topicGraph.overloads(of: reference), overloads.isEmpty {
+                    return
+                }
+
                 let childNode = try context.entity(with: reference)
                 guard let childSymbol = childNode.semantic as? Symbol else {
                     return


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://126273913

## Summary

To allow for a smoother transition when enabling the overloads feature for the first time, this PR avoids automatically curating an overload group if all its constituent overloads were manually curated. This way, if a documentation author had already tried to manually curate all the symbols in a package or framework, enabling the overloads feature doesn't spuriously add any new symbols that would disrupt that manual curation.

## Dependencies

None

## Testing

Use this doc bundle to test this feature: 

The symbol graph in the bundle was generated from the following code: [asdf.docc.zip](https://github.com/apple/swift-docc/files/15268536/asdf.docc.zip)

The symbol graph contained in this bundle was generated from the following code:

```swift
/// This is a cool class.
///
/// ## Topics
///
/// - ``myFunc(param:)-633ch``
/// - ``myFunc(param:)-3u65v``
public class MyClass {
    public func myFunc(param: Int) {}
    public func myFunc(param: String) {}
}
```

Steps:
1. `swift run docc preview /path/to/asdf.docc` (The bundle's Info.plist automatically enables the overloads feature, so the command-line flag is not required.)
2. Navigate to `MyClass`.
3. Ensure that there are two `myFunc(param:)` methods shown on the page, with specific type signatures in the curated title.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ n/a ] Updated documentation if necessary
