### PR TITLE
[6.0] drop overload groups from curation if the overloads were manually curated

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Topic Graph/AutomaticCuration.swift
+++ b/Sources/SwiftDocC/Infrastructure/Topic Graph/AutomaticCuration.swift
@@ -101,7 +101,14 @@ public struct AutomaticCuration {
                 else {
                     return
                 }
-                
+
+                // If this symbol is an overload group and all its overloaded children were manually
+                // curated elsewhere, skip it so it doesn't clutter the curation hierarchy with a
+                // duplicate symbol.
+                if let overloads = context.topicGraph.overloads(of: reference), overloads.isEmpty {
+                    return
+                }
+
                 let childNode = try context.entity(with: reference)
                 guard let childSymbol = childNode.semantic as? Symbol else {
                     return


### PR DESCRIPTION
- **Explanation**: Drops overload groups from automatic curation if all the constituent overloads are manually curated, to avoid creating unnecessary new pages in a curation hierarchy.
- **Scope**: UX improvement for an experimental feature
- **Issue**: rdar://126273913
- **Original PR**: https://github.com/apple/swift-docc/pull/913
- **Risk**: Low. The code path only affects the optional overloads feature, and the modification is minor.
- **Testing**: Automated testing has been added to verify the desired behavior.
- **Reviewer**: @d-ronnqvist 