### PR TITLE
Much faster navigator index creation for mixed Swift and Objective-C projects

### DIFF
--- a/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex+Ext.swift
+++ b/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex+Ext.swift
@@ -79,6 +79,6 @@ extension RenderNode {
     @_disfavoredOverload
     @available(*, deprecated, message: "This deprecated API will be removed after 6.1 is released")
     public func navigatorPageType() -> NavigatorIndex.PageType {
-        return (self as any NavigatorIndex.Builder.IndexableRenderNodeRepresentation).navigatorPageType()
+        return (self as any NavigatorIndexableRenderNodeRepresentation).navigatorPageType()
     }
 }

--- a/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex+Ext.swift
+++ b/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex+Ext.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -75,61 +75,10 @@ public class FileSystemRenderNodeProvider: RenderNodeProvider {
 }
 
 extension RenderNode {
-    private static let typesThatShouldNotUseNavigatorTitle: Set<NavigatorIndex.PageType> = [
-        .framework, .class, .structure, .enumeration, .protocol, .typeAlias, .associatedType, .extension
-    ]
-    
-    /// Returns a navigator title preferring the fragments inside the metadata, if applicable.
-    func navigatorTitle() -> String? {
-        let fragments: [DeclarationRenderSection.Token]?
-        
-        // FIXME: Use `metadata.navigatorTitle` for all Swift symbols (github.com/apple/swift-docc/issues/176).
-        if identifier.sourceLanguage == .swift || (metadata.navigatorTitle ?? []).isEmpty {
-            let pageType = navigatorPageType()
-            guard !Self.typesThatShouldNotUseNavigatorTitle.contains(pageType) else {
-                return metadata.title
-            }
-            fragments = metadata.fragments
-        } else {
-            fragments = metadata.navigatorTitle
-        }
-        
-        return fragments?.map(\.text).joined() ?? metadata.title
-    }
-    
     /// Returns the NavigatorIndex.PageType indicating the type of the page.
+    @_disfavoredOverload
+    @available(*, deprecated, message: "This deprecated API will be removed after 6.1 is released")
     public func navigatorPageType() -> NavigatorIndex.PageType {
-        
-        // This is a workaround to support plist keys.
-        if let roleHeading = metadata.roleHeading?.lowercased() {
-            if roleHeading == "property list key" {
-                return .propertyListKey
-            } else if roleHeading == "property list key reference" {
-                return .propertyListKeyReference
-            }
-        }
-        
-        switch self.kind {
-        case .article:
-            if let role = metadata.role {
-                return NavigatorIndex.PageType(role: role)
-            }
-            return NavigatorIndex.PageType.article
-        case .tutorial:
-            return NavigatorIndex.PageType.tutorial
-        case .section:
-            return NavigatorIndex.PageType.section
-        case .overview:
-            return NavigatorIndex.PageType.overview
-        case .symbol:
-            if let symbolKind = metadata.symbolKind {
-                return NavigatorIndex.PageType(symbolKind: symbolKind)
-            }
-            if let role = metadata.role {
-                return NavigatorIndex.PageType(role: role)
-            }
-            return NavigatorIndex.PageType.symbol
-        }
+        return (self as any NavigatorIndex.Builder.IndexableRenderNodeRepresentation).navigatorPageType()
     }
-    
 }

--- a/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
+++ b/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
@@ -636,7 +636,7 @@ extension NavigatorIndex {
                 return
             }
             
-            // A render node holds is structured differently depending on if it was created by "rendering" a documentation node 
+            // A render node is structured differently depending on if it was created by "rendering" a documentation node 
             // or if it was deserialized from a documentation archive.
             //
             // If it was created by rendering a documentation node, all variant information is stored in each individual variant collection and the variant overrides are nil.

--- a/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
+++ b/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
@@ -668,7 +668,7 @@ extension NavigatorIndex {
         }
         
         // The private index implementation which indexes a given render node representation
-        private func index(_ renderNode: any IndexableRenderNodeRepresentation, traits: [RenderNode.Variant.Trait]?) throws -> InterfaceLanguage? {
+        private func index(_ renderNode: any NavigatorIndexableRenderNodeRepresentation, traits: [RenderNode.Variant.Trait]?) throws -> InterfaceLanguage? {
             guard let navigatorIndex else {
                 throw Error.navigatorIndexIsNil
             }

--- a/Sources/SwiftDocC/Indexing/Navigator/RenderNode+NavigatorIndex.swift
+++ b/Sources/SwiftDocC/Indexing/Navigator/RenderNode+NavigatorIndex.swift
@@ -10,50 +10,48 @@
 
 import Foundation
 
-extension NavigatorIndex.Builder {
-    /// A language specific representation of a render node value for indexing.
-    protocol IndexableRenderNodeRepresentation<Metadata> {
-        associatedtype Metadata: IndexableRenderMetadataRepresentation
-        
-        // Information that's the same for all language variants
-        var identifier: ResolvedTopicReference { get }
-        var references: [String: RenderReference] { get }
-        var kind: RenderNode.Kind { get }
-        var sections: [RenderSection] { get }
-        
-        // Information that's different for each language variant
-        var metadata: Metadata { get }
-        var topicSections: [TaskGroupRenderSection] { get }
-        var defaultImplementationsSections: [TaskGroupRenderSection] { get }
-    }
+/// A language specific representation of a render node value for building a navigator index.
+protocol NavigatorIndexableRenderNodeRepresentation<Metadata> {
+    associatedtype Metadata: NavigatorIndexableRenderMetadataRepresentation
     
-    /// A language specific representation of a render metadata value for indexing.
-    protocol IndexableRenderMetadataRepresentation {
-        // Information that's the same for all language variants
-        var role: String? { get }
-        var images: [TopicImage] { get }
-        
-        // Information that's different for each language variant
-        var title: String? { get }
-        var navigatorTitle: [DeclarationRenderSection.Token]? { get }
-        var fragments: [DeclarationRenderSection.Token]? { get }
-        var externalID: String? { get }
-        var roleHeading: String? { get }
-        var symbolKind: String? { get }
-        var platforms: [AvailabilityRenderItem]? { get }
-    }
+    // Information that's the same for all language variants
+    var identifier: ResolvedTopicReference { get }
+    var references: [String: RenderReference] { get }
+    var kind: RenderNode.Kind { get }
+    var sections: [RenderSection] { get }
+    
+    // Information that's different for each language variant
+    var metadata: Metadata { get }
+    var topicSections: [TaskGroupRenderSection] { get }
+    var defaultImplementationsSections: [TaskGroupRenderSection] { get }
 }
 
-extension NavigatorIndex.Builder.IndexableRenderNodeRepresentation {
+/// A language specific representation of a render metadata value for building a navigator index.
+protocol NavigatorIndexableRenderMetadataRepresentation {
+    // Information that's the same for all language variants
+    var role: String? { get }
+    var images: [TopicImage] { get }
+    
+    // Information that's different for each language variant
+    var title: String? { get }
+    var navigatorTitle: [DeclarationRenderSection.Token]? { get }
+    var fragments: [DeclarationRenderSection.Token]? { get }
+    var externalID: String? { get }
+    var roleHeading: String? { get }
+    var symbolKind: String? { get }
+    var platforms: [AvailabilityRenderItem]? { get }
+}
+
+extension NavigatorIndexableRenderNodeRepresentation {
     var icon: RenderReferenceIdentifier? {
         metadata.images.first { $0.type == .icon }?.identifier
     }
 }
 
-extension RenderNode: NavigatorIndex.Builder.IndexableRenderNodeRepresentation {}
-extension RenderMetadata: NavigatorIndex.Builder.IndexableRenderMetadataRepresentation {}
+extension RenderNode: NavigatorIndexableRenderNodeRepresentation {}
+extension RenderMetadata: NavigatorIndexableRenderMetadataRepresentation {}
 
-struct RenderMetadataVariantView: NavigatorIndex.Builder.IndexableRenderMetadataRepresentation {
+struct RenderMetadataVariantView: NavigatorIndexableRenderMetadataRepresentation {
     var wrapped: RenderMetadata
     var traits: [RenderNode.Variant.Trait]
     
@@ -89,7 +87,7 @@ struct RenderMetadataVariantView: NavigatorIndex.Builder.IndexableRenderMetadata
     }
 }
 
-struct RenderNodeVariantView: NavigatorIndex.Builder.IndexableRenderNodeRepresentation {
+struct RenderNodeVariantView: NavigatorIndexableRenderNodeRepresentation {
     var wrapped: RenderNode
     var traits: [RenderNode.Variant.Trait]
     
@@ -128,7 +126,7 @@ private let typesThatShouldNotUseNavigatorTitle: Set<NavigatorIndex.PageType> = 
     .framework, .class, .structure, .enumeration, .protocol, .typeAlias, .associatedType, .extension
 ]
 
-extension NavigatorIndex.Builder.IndexableRenderNodeRepresentation {
+extension NavigatorIndexableRenderNodeRepresentation {
     /// Returns a navigator title preferring the fragments inside the metadata, if applicable.
     func navigatorTitle() -> String? {
         let tokens: [DeclarationRenderSection.Token]?
@@ -169,7 +167,7 @@ extension NavigatorIndex.Builder.IndexableRenderNodeRepresentation {
     }
 }
 
-extension NavigatorIndex.Builder.IndexableRenderNodeRepresentation {
+extension NavigatorIndexableRenderNodeRepresentation {
     func navigatorChildren(for traits: [RenderNode.Variant.Trait]?) -> [RenderRelationshipsGroup] {
         switch kind {
         case .overview:

--- a/Sources/SwiftDocC/Indexing/Navigator/RenderNode+NavigatorIndex.swift
+++ b/Sources/SwiftDocC/Indexing/Navigator/RenderNode+NavigatorIndex.swift
@@ -1,0 +1,214 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2024 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+
+extension NavigatorIndex.Builder {
+    /// A language specific representation of a render node value for indexing.
+    protocol IndexableRenderNodeRepresentation<Metadata> {
+        associatedtype Metadata: IndexableRenderMetadataRepresentation
+        
+        // Information that's the same for all language variants
+        var identifier: ResolvedTopicReference { get }
+        var references: [String: RenderReference] { get }
+        var kind: RenderNode.Kind { get }
+        var sections: [RenderSection] { get }
+        
+        // Information that's different for each language variant
+        var metadata: Metadata { get }
+        var topicSections: [TaskGroupRenderSection] { get }
+        var defaultImplementationsSections: [TaskGroupRenderSection] { get }
+    }
+    
+    /// A language specific representation of a render metadata value for indexing.
+    protocol IndexableRenderMetadataRepresentation {
+        // Information that's the same for all language variants
+        var role: String? { get }
+        var images: [TopicImage] { get }
+        
+        // Information that's different for each language variant
+        var title: String? { get }
+        var navigatorTitle: [DeclarationRenderSection.Token]? { get }
+        var fragments: [DeclarationRenderSection.Token]? { get }
+        var externalID: String? { get }
+        var roleHeading: String? { get }
+        var symbolKind: String? { get }
+        var platforms: [AvailabilityRenderItem]? { get }
+    }
+}
+
+extension NavigatorIndex.Builder.IndexableRenderNodeRepresentation {
+    var icon: RenderReferenceIdentifier? {
+        metadata.images.first { $0.type == .icon }?.identifier
+    }
+}
+
+extension RenderNode: NavigatorIndex.Builder.IndexableRenderNodeRepresentation {}
+extension RenderMetadata: NavigatorIndex.Builder.IndexableRenderMetadataRepresentation {}
+
+struct RenderMetadataVariantView: NavigatorIndex.Builder.IndexableRenderMetadataRepresentation {
+    var wrapped: RenderMetadata
+    var traits: [RenderNode.Variant.Trait]
+    
+    // The same for all language variants
+    var role: String? {
+        wrapped.role
+    }
+    var images: [TopicImage] {
+        wrapped.images
+    }
+    
+    // Different for each language variant
+    var title: String? {
+        wrapped.titleVariants.value(for: traits)
+    }
+    var navigatorTitle: [DeclarationRenderSection.Token]? {
+        wrapped.navigatorTitleVariants.value(for: traits)
+    }
+    var fragments: [DeclarationRenderSection.Token]? {
+        wrapped.fragmentsVariants.value(for: traits)
+    }
+    var externalID: String? {
+        wrapped.externalIDVariants.value(for: traits)
+    }
+    var roleHeading: String? {
+        wrapped.roleHeadingVariants.value(for: traits)
+    }
+    var symbolKind: String? {
+        wrapped.symbolKindVariants.value(for: traits)
+    }
+    var platforms: [AvailabilityRenderItem]? {
+        wrapped.platformsVariants.value(for: traits)
+    }
+}
+
+struct RenderNodeVariantView: NavigatorIndex.Builder.IndexableRenderNodeRepresentation {
+    var wrapped: RenderNode
+    var traits: [RenderNode.Variant.Trait]
+    
+    init(wrapped: RenderNode, traits: [RenderNode.Variant.Trait]) {
+        self.wrapped = wrapped
+        self.traits = traits
+        let traitLanguages = traits.map {
+            switch $0 {
+            case .interfaceLanguage(let id):
+                return SourceLanguage(id: id)
+            }
+        }
+        self.identifier = wrapped.identifier.withSourceLanguages(Set(traitLanguages))
+        self.metadata = RenderMetadataVariantView(wrapped: wrapped.metadata, traits: traits)
+    }
+    
+    // Computed during initialization
+    var identifier: ResolvedTopicReference
+    var metadata: RenderMetadataVariantView
+    
+    // The same for all language variants
+    var references: [String: any RenderReference] { wrapped.references }
+    var kind: RenderNode.Kind { wrapped.kind }
+    var sections: [any RenderSection] { wrapped.sections }
+    
+    // Different for each language variant
+    var topicSections: [TaskGroupRenderSection] {
+        wrapped.topicSectionsVariants.value(for: traits)
+    }
+    var defaultImplementationsSections: [TaskGroupRenderSection] {
+        wrapped.defaultImplementationsSectionsVariants.value(for: traits)
+    }
+}
+
+private let typesThatShouldNotUseNavigatorTitle: Set<NavigatorIndex.PageType> = [
+    .framework, .class, .structure, .enumeration, .protocol, .typeAlias, .associatedType, .extension
+]
+
+extension NavigatorIndex.Builder.IndexableRenderNodeRepresentation {
+    /// Returns a navigator title preferring the fragments inside the metadata, if applicable.
+    func navigatorTitle() -> String? {
+        let tokens: [DeclarationRenderSection.Token]?
+        
+        // FIXME: Use `metadata.navigatorTitle` for all Swift symbols (github.com/apple/swift-docc/issues/176).
+        if identifier.sourceLanguage == .swift || (metadata.navigatorTitle ?? []).isEmpty {
+            let pageType = navigatorPageType()
+            guard !typesThatShouldNotUseNavigatorTitle.contains(pageType) else {
+                return metadata.title
+            }
+            tokens = metadata.fragments
+        } else {
+            tokens = metadata.navigatorTitle
+        }
+        
+        return tokens?.map(\.text).joined() ?? metadata.title
+    }
+    
+    /// Returns the type of page for the render node.
+    func navigatorPageType() -> NavigatorIndex.PageType {
+        // This is a workaround to support plist keys.
+        switch metadata.roleHeading?.lowercased() {
+            case "property list key":           return .propertyListKey
+            case "property list key reference": return .propertyListKeyReference
+            default: break
+        }
+        
+        switch kind {
+            case .article:  return metadata.role.map { .init(role: $0) }
+                                ?? .article
+            case .tutorial: return .tutorial
+            case .section:  return .section
+            case .overview: return .overview
+            case .symbol:   return metadata.symbolKind.map { .init(symbolKind: $0) }
+                                ?? metadata.role.map { .init(role: $0) }
+                                ?? .symbol
+        }
+    }
+}
+
+extension NavigatorIndex.Builder.IndexableRenderNodeRepresentation {
+    func navigatorChildren(for traits: [RenderNode.Variant.Trait]?) -> [RenderRelationshipsGroup] {
+        switch kind {
+        case .overview:
+            var groups = [RenderRelationshipsGroup]()
+            for case let section as VolumeRenderSection in sections {
+                groups.append(contentsOf: section.chapters.map { chapter in
+                    RenderRelationshipsGroup(
+                        name: chapter.name,
+                        abstract: nil,
+                        references: chapter.tutorials.compactMap { self.references[$0.identifier] as? TopicRenderReference }
+                    )
+                })
+            }
+            return groups
+        default:
+            // Gather all topic references, transformed based on the traits, organizer by their identifier
+            let references: [String: TopicRenderReference] = references.values.reduce(into: [:]) { acc, renderReference in
+                guard var renderReference = renderReference as? TopicRenderReference else { return }
+                // Transform the topic reference to hold the variant title
+                if let traits {
+                    renderReference.title = renderReference.titleVariants.applied(to: renderReference.title, for: traits)
+                }
+                acc[renderReference.identifier.identifier] = renderReference
+            }
+            
+            func makeGroup(topicSection: TaskGroupRenderSection, isNestingReferences: Bool) -> RenderRelationshipsGroup {
+                RenderRelationshipsGroup(
+                    name: topicSection.title,
+                    abstract: nil, // The navigator index only needs the title and the references.
+                    references: topicSection.identifiers.map { references[$0]! },
+                    referencesAreNested: isNestingReferences
+                )
+            }
+            
+            return topicSections.map {
+                makeGroup(topicSection: $0, isNestingReferences: false)
+            } + defaultImplementationsSections.map {
+                makeGroup(topicSection: $0, isNestingReferences: true)
+            }
+        }
+    }
+}

--- a/Sources/SwiftDocC/Indexing/RenderNode+Relationships.swift
+++ b/Sources/SwiftDocC/Indexing/RenderNode+Relationships.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -17,47 +17,9 @@ extension RenderNode {
      
      - Returns: A list of `RenderRelationshipsGroup`.
      */
+    @available(*, deprecated, message: "This deprecated API will be removed after 6.1 is released")
     public func childrenRelationship(for language: String? = nil) -> [RenderRelationshipsGroup] {
-        var groups = [RenderRelationshipsGroup]()
-        
-        switch kind {
-        case .overview:
-            for case let section as VolumeRenderSection in sections {
-                let chapters = section.chapters
-                for chapter in chapters {
-                    let name = chapter.name
-                    
-                    // Extract the identifiers of linked chapters.
-                    let tutorials = chapter.tutorials.map { $0.identifier }
-                    // Get the references preserving the order.
-                    let references = tutorials.compactMap { self.references[$0] } as! [TopicRenderReference]
-
-                    groups.append(RenderRelationshipsGroup(name: name, abstract: nil, references: references))
-                }
-            }
-        default:
-            let topicReferences: [TopicRenderReference] = self.references.values.filter { $0 is TopicRenderReference } as! [TopicRenderReference]
-            let references: [String : TopicRenderReference] = Dictionary(uniqueKeysWithValues: topicReferences.map{ ($0.identifier.identifier, $0) })
-            
-            func processBlock(nestingReferences: Bool) -> ((TaskGroupRenderSection) -> ()) {
-                return { topicSection in
-                    // Get all the related identifiers
-                    let identifiers = topicSection.identifiers
-                    // Map the references preserving the order
-                    let relationships = identifiers.map { references[$0]! }
-                    // Get the abstract
-                    let abstract = topicSection.abstract?.map { $0.rawIndexableTextContent(references: self.references) }.joined(separator: " ")
-                    
-                    // Append the group to the result
-                    groups.append(RenderRelationshipsGroup(name: topicSection.title, abstract: abstract, references: relationships, referencesAreNested: nestingReferences))
-                }
-            }
-            
-            topicSections.forEach(processBlock(nestingReferences: false))
-            defaultImplementationsSections.forEach(processBlock(nestingReferences: true))
-        }
-        
-        return groups
+        return (self as any NavigatorIndex.Builder.IndexableRenderNodeRepresentation).navigatorChildren(for: nil)
     }
     
     /**

--- a/Sources/SwiftDocC/Indexing/RenderNode+Relationships.swift
+++ b/Sources/SwiftDocC/Indexing/RenderNode+Relationships.swift
@@ -19,7 +19,7 @@ extension RenderNode {
      */
     @available(*, deprecated, message: "This deprecated API will be removed after 6.1 is released")
     public func childrenRelationship(for language: String? = nil) -> [RenderRelationshipsGroup] {
-        return (self as any NavigatorIndex.Builder.IndexableRenderNodeRepresentation).navigatorChildren(for: nil)
+        return (self as any NavigatorIndexableRenderNodeRepresentation).navigatorChildren(for: nil)
     }
     
     /**

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+DisambiguatedPaths.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+DisambiguatedPaths.swift
@@ -192,8 +192,8 @@ extension PathHierarchy.DisambiguationContainer {
         let groupedByKind = [String?: [Element]](grouping: elements, by: \.kind)
         for (kind, elements) in groupedByKind where elements.count == 1 && kind != nil {
             let element = elements.first!
-            if includeLanguage, let symbol = element.node.symbol {
-                collisions.append((value: element.node, disambiguation: .kind("\(SourceLanguage(id: symbol.identifier.interfaceLanguage).linkDisambiguationID).\(kind!)")))
+            if includeLanguage, let language = element.node.languages.min() {
+                collisions.append((value: element.node, disambiguation: .kind("\(language.linkDisambiguationID).\(kind!)")))
             } else {
                 collisions.append((value: element.node, disambiguation: .kind(kind!)))
             }

--- a/Sources/SwiftDocC/LinkTargets/LinkDestinationSummary.swift
+++ b/Sources/SwiftDocC/LinkTargets/LinkDestinationSummary.swift
@@ -341,7 +341,7 @@ public extension DocumentationNode {
 
                 taskGroups = topicSectionGroups
                 for variant in renderNode.topicSectionsVariants.variants {
-                    taskGroupVariants[variant.traits] = variant.applyingPatchTo(renderNode.topicSections).map { group in .init(title: group.title, identifiers: group.identifiers) }
+                    taskGroupVariants[variant.traits] = renderNode.topicSectionsVariants.value(for: variant.traits).map { group in .init(title: group.title, identifiers: group.identifiers) }
                 }
             }
         } else {

--- a/Sources/SwiftDocC/Model/Rendering/References/TopicImage.swift
+++ b/Sources/SwiftDocC/Model/Rendering/References/TopicImage.swift
@@ -78,11 +78,3 @@ extension TopicImage {
     }
     
 }
-
-extension RenderNode {
-    var icon: RenderReferenceIdentifier? {
-        return metadata.images.first { image in
-            image.type == .icon
-        }?.identifier
-    }
-}

--- a/Sources/SwiftDocC/Model/Rendering/Variants/VariantPatchOperation.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Variants/VariantPatchOperation.swift
@@ -79,3 +79,85 @@ extension VariantCollection.Variant where Value: RangeReplaceableCollection {
 
 // The synthesized implementation is sufficient for this conformance.
 extension VariantPatchOperation: Equatable where Value: Equatable {}
+
+// MARK: Applying patches
+
+/// A type that can be transformed by incrementally applying variant patch operations.
+protocol VariantCollectionPatchable {
+    /// Apply an "add" patch operation to the value
+    mutating func add(_ other: Self)
+    /// Apply a "remove" patch operation to the value
+    mutating func remove()
+}
+
+extension Optional: VariantCollectionPatchable where Wrapped: VariantCollectionPatchable {
+    mutating func add(_ other: Wrapped?) {
+        guard var wrapped, let other else { return }
+        wrapped.add(other)
+        self = wrapped
+    }
+    
+    mutating func remove() {
+        self = nil
+    }
+}
+
+extension Array: VariantCollectionPatchable {
+    mutating func add(_ other: [Element]) {
+        append(contentsOf: other)
+    }
+    
+    mutating func remove() {
+        self.removeAll()
+    }
+}
+
+extension String: VariantCollectionPatchable {
+    mutating func add(_ other: String) {
+        append(contentsOf: other)
+    }
+    
+    mutating func remove() {
+        self.removeAll()
+    }
+}
+
+extension VariantCollection where Value: VariantCollectionPatchable {
+    /// Returns the transformed value after applying the patch operations for all variants that match the given source language to the default value.
+    /// - Parameters:
+    ///   - language: The source language that determine what variant's patches to apply to the default value.
+    /// - Returns: The transformed value, or the default value if no variants match the given source language.
+    func value(for language: SourceLanguage) -> Value {
+        applied(to: defaultValue, for: [.interfaceLanguage(language.id)])
+    } 
+    
+    /// Returns the transformed value after applying the patch operations for all variants that match the given traits to the default value.
+    /// - Parameters:
+    ///   - traits: The traits that determine what variant's patches to apply to the default value.
+    /// - Returns: The transformed value, or the default value if no variants match the given traits.
+    func value(for traits: [RenderNode.Variant.Trait]) -> Value {
+        applied(to: defaultValue, for: traits)
+    }
+    
+    /// Returns the transformed value after applying the patch operations for all variants that match the given traits to the original value.
+    /// - Parameters:
+    ///   - originalValue: The original value to transform.
+    ///   - traits: The traits that determine what variant's patches to apply to the original value.
+    /// - Returns: The transformed value, or the original value if no variants match the given traits.
+    func applied(to originalValue: Value, for traits: [RenderNode.Variant.Trait]) -> Value {
+        var patchedValue = originalValue
+        for variant in variants where variant.traits == traits {
+            for patch in variant.patch {
+                switch patch {
+                case .replace(let value):
+                    patchedValue = value
+                case .add(let value):
+                    patchedValue.add(value)
+                case .remove:
+                    patchedValue.remove()
+                }
+            }
+        }
+        return patchedValue
+    }
+}

--- a/Sources/SwiftDocC/Model/Rendering/Variants/VariantPatchOperation.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Variants/VariantPatchOperation.swift
@@ -56,27 +56,6 @@ public enum VariantPatchOperation<Value: Codable> {
     }
 }
 
-extension VariantCollection.Variant where Value: RangeReplaceableCollection {
-    /// Applies the variant's patch operations to a given value and returns the patched value.
-    ///
-    /// - Parameter originalValue: The value that the variant will apply the patch operations to.
-    /// - Returns: The value after applying all patch operations.
-    func applyingPatchTo(_ originalValue: Value) -> Value {
-        var result = originalValue
-        for operation in patch {
-            switch operation {
-            case .replace(let newValue):
-                result = newValue
-            case .add(let newValue):
-                result.append(contentsOf: newValue)
-            case .remove:
-                result.removeAll()
-            }
-        }
-        return result
-    }
-}
-
 // The synthesized implementation is sufficient for this conformance.
 extension VariantPatchOperation: Equatable where Value: Equatable {}
 

--- a/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
@@ -637,6 +637,79 @@ Root
         """)
     }
     
+    func testNavigatorWithDifferentSwiftAndObjectiveCHierarchies() throws {
+        let (_, bundle, context) = try testBundleAndContext(named: "GeometricalShapes")
+        let renderContext = RenderContext(documentationContext: context, bundle: bundle)
+        let converter = DocumentationContextConverter(bundle: bundle, context: context, renderContext: renderContext)
+        
+        let fromMemoryBuilder  = NavigatorIndex.Builder(outputURL: try createTemporaryDirectory(), bundleIdentifier: bundle.identifier, sortRootChildrenByName: true, groupByLanguage: true)
+        let fromDecodedBuilder = NavigatorIndex.Builder(outputURL: try createTemporaryDirectory(), bundleIdentifier: bundle.identifier, sortRootChildrenByName: true, groupByLanguage: true)
+        fromMemoryBuilder.setup()
+        fromDecodedBuilder.setup()
+        
+        for identifier in context.knownPages {
+            let source = context.documentURL(for: identifier)
+            let entity = try context.entity(with: identifier)
+            
+            let renderNode = try XCTUnwrap(converter.renderNode(for: entity, at: source))
+            XCTAssertNil(renderNode.variantOverrides)
+            try fromMemoryBuilder.index(renderNode: renderNode)
+            
+            let encoded = try RenderJSONEncoder.makeEncoder(emitVariantOverrides: true).encode(renderNode)
+            let decoded = try RenderJSONDecoder.makeDecoder().decode(RenderNode.self, from: encoded)
+            XCTAssertNotNil(decoded.variantOverrides)
+            try fromDecodedBuilder.index(renderNode: decoded)
+        }
+        
+        fromMemoryBuilder.finalize()
+        fromDecodedBuilder.finalize()
+        let fromMemoryNavigatorTree  = try XCTUnwrap(fromMemoryBuilder.navigatorIndex).navigatorTree.root
+        let fromDecodedNavigatorTree = try XCTUnwrap(fromDecodedBuilder.navigatorIndex).navigatorTree.root
+        
+        XCTAssertEqual(fromMemoryNavigatorTree.dumpTree(), fromDecodedNavigatorTree.dumpTree())
+        XCTAssertEqual(fromMemoryNavigatorTree.dumpTree(), """
+        [Root]
+        ┣╸Objective-C
+        ┃ ┗╸GeometricalShapes
+        ┃   ┣╸Structures
+        ┃   ┣╸TLACircle
+        ┃   ┃ ┣╸Instance Properties
+        ┃   ┃ ┣╸center
+        ┃   ┃ ┗╸radius
+        ┃   ┣╸Variables
+        ┃   ┣╸TLACircleDefaultRadius
+        ┃   ┣╸TLACircleNull
+        ┃   ┣╸TLACircleZero
+        ┃   ┣╸Functions
+        ┃   ┣╸TLACircleToString
+        ┃   ┣╸TLACircleFromString
+        ┃   ┣╸TLACircleIntersects
+        ┃   ┣╸TLACircleIsEmpty
+        ┃   ┣╸TLACircleIsNull
+        ┃   ┗╸TLACircleMake
+        ┗╸Swift
+          ┗╸GeometricalShapes
+            ┣╸Structures
+            ┗╸Circle
+              ┣╸Initializers
+              ┣╸init()
+              ┣╸init(center: CGPoint, radius: CGFloat)
+              ┣╸init(string: String)
+              ┣╸Instance Properties
+              ┣╸var center: CGPoint
+              ┣╸var debugDescription: String
+              ┣╸var isEmpty: Bool
+              ┣╸var isNull: Bool
+              ┣╸var radius: CGFloat
+              ┣╸Instance Methods
+              ┣╸func intersects(Circle) -> Bool
+              ┣╸Type Properties
+              ┣╸static let defaultRadius: CGFloat
+              ┣╸static let null: Circle
+              ┗╸static let zero: Circle
+        """)
+    }
+    
     func testNavigatorIndexGenerationVariantsPayload() throws {
         let jsonFile = Bundle.module.url(forResource: "Variant-render-node", withExtension: "json", subdirectory: "Test Resources")!
         let jsonData = try Data(contentsOf: jsonFile)

--- a/Tests/SwiftDocCTests/Model/RenderNodeSerializationTests.swift
+++ b/Tests/SwiftDocCTests/Model/RenderNodeSerializationTests.swift
@@ -165,7 +165,7 @@ class RenderNodeSerializationTests: XCTestCase {
         XCTAssertNotNil(renderNode.projectFiles())
         XCTAssertEqual(renderNode.projectFiles()?.url.lastPathComponent, "project.zip")
         
-        XCTAssertEqual(renderNode.childrenRelationship().count, 0)
+        XCTAssertEqual(renderNode.navigatorChildren(for: nil).count, 0)
         XCTAssertEqual(renderNode.downloadReferences().count, 1)
         
         // Check the output of the dictionary

--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
@@ -467,7 +467,7 @@ class SemaToRenderNodeTests: XCTestCase {
         
         XCTAssertEqual(renderNode.sections[2].kind, .callToAction)
         
-        XCTAssertEqual(renderNode.childrenRelationship().count, 0)
+        XCTAssertEqual(renderNode.navigatorChildren(for: nil).count, 0)
         
         XCTAssertNil(renderNode.metadata.roleHeading)
         XCTAssertEqual(renderNode.metadata.title, "Making an Augmented Reality App")
@@ -622,7 +622,7 @@ class SemaToRenderNodeTests: XCTestCase {
         
         XCTAssertEqual(renderNode.references.count, 13)
         
-        XCTAssertEqual(renderNode.childrenRelationship().count, 1)
+        XCTAssertEqual(renderNode.navigatorChildren(for: nil).count, 1)
         
         guard let introImageReference = renderNode.references["intro.png"] as? ImageReference else {
             XCTFail("Missing intro.png image reference")
@@ -878,7 +878,7 @@ class SemaToRenderNodeTests: XCTestCase {
         
         XCTAssertEqual(renderNode.references.count, 13)
         
-        XCTAssertEqual(renderNode.childrenRelationship().count, 3, "Expected three chapters as children.")
+        XCTAssertEqual(renderNode.navigatorChildren(for: nil).count, 3, "Expected three chapters as children.")
         
         guard let introImageReference = renderNode.references["intro.png"] as? ImageReference else {
             XCTFail("Missing intro.png image reference")
@@ -1060,7 +1060,7 @@ class SemaToRenderNodeTests: XCTestCase {
         XCTAssertEqual(discussion.kind, RenderSectionKind.content)
         
         // Test childrenRelationships are handled correctly
-        let children = renderNode.childrenRelationship()
+        let children = renderNode.navigatorChildren(for: nil)
         XCTAssertEqual(children.count, renderNode.topicSections.count)
         XCTAssertEqual(children.first?.name, "Task Group Exercising Symbol Links")
         XCTAssertEqual(children.first?.references.count, 3)

--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
@@ -3314,8 +3314,7 @@ Document
             "doc://org.swift.MixedFramework/documentation/MixedFramework/MyObjectiveCClassSwiftName/myMethodSwiftName()"
         ])
         
-        let objcTopicSectionVariant = try XCTUnwrap(topicSectionsVariants.variants.first { $0.traits[0] == .interfaceLanguage("occ") })
-        let objcTopicSection = objcTopicSectionVariant.applyingPatchTo(swiftTopicSection)
+        let objcTopicSection = topicSectionsVariants.value(for: [.interfaceLanguage("occ")])
         
         XCTAssertEqual(objcTopicSection.first?.title, "Something Objective-C only")
         XCTAssertEqual(objcTopicSection.first?.abstract?.plainText, "This link is only for Objective-C")
@@ -3392,8 +3391,7 @@ Document
                 "doc://GeometricalShapes/documentation/GeometricalShapes/Circle",
             ])
             
-            let objcTopicSectionsVariant = try XCTUnwrap(renderNode.topicSectionsVariants.variants.first(where: { $0.traits == [.interfaceLanguage(SourceLanguage.objectiveC.id) ]}))
-            let objcTopicSections = objcTopicSectionsVariant.applyingPatchTo(swiftTopicSections)
+            let objcTopicSections = renderNode.topicSectionsVariants.value(for: .objectiveC)
             XCTAssertEqual(objcTopicSections.flatMap { [$0.title!] + $0.identifiers }, [
                 "Structures",
                 "doc://GeometricalShapes/documentation/GeometricalShapes/Circle",
@@ -3443,8 +3441,7 @@ Document
                 "doc://GeometricalShapes/documentation/GeometricalShapes/Circle/zero"
             ])
             
-            let objcTopicSectionsVariant = try XCTUnwrap(renderNode.topicSectionsVariants.variants.first(where: { $0.traits == [.interfaceLanguage(SourceLanguage.objectiveC.id) ]}))
-            let objcTopicSections = objcTopicSectionsVariant.applyingPatchTo(swiftTopicSections)
+            let objcTopicSections = renderNode.topicSectionsVariants.value(for: .objectiveC)
             XCTAssertEqual(objcTopicSections.flatMap { [$0.title!] + $0.identifiers }, [
                 "Instance Properties",
                 "doc://GeometricalShapes/documentation/GeometricalShapes/Circle/center",

--- a/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorTests.swift
@@ -1303,24 +1303,6 @@ class RenderNodeTranslatorTests: XCTestCase {
     }
     
     func testExpectedRoleHeadingIsAssigned() throws {
-        func renderNodeArticleFromReferencePath(
-            referencePath: String
-        ) throws -> RenderNode {
-            let reference = ResolvedTopicReference(
-                bundleIdentifier: bundle.identifier,
-                path: referencePath,
-                sourceLanguage: .swift
-            )
-            let symbol = try XCTUnwrap(context.entity(with: reference).semantic as? Article)
-            var translator = RenderNodeTranslator(
-                context: context,
-                bundle: bundle,
-                identifier: reference,
-                source: nil
-            )
-            return try XCTUnwrap(translator.visitArticle(symbol) as? RenderNode)
-        }
-
         let exampleDocumentation = Folder(
             name: "unit-test.docc",
             content: [
@@ -1385,6 +1367,15 @@ class RenderNodeTranslatorTests: XCTestCase {
         let tempURL = try createTempFolder(content: [exampleDocumentation])
         let (_, bundle, context) = try loadBundle(from: tempURL)
 
+        func renderNodeArticleFromReferencePath(
+            referencePath: String
+        ) throws -> RenderNode {
+            let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: referencePath, sourceLanguage: .swift)
+            let symbol = try XCTUnwrap(context.entity(with: reference).semantic as? Article)
+            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference, source: nil)
+            return try XCTUnwrap(translator.visitArticle(symbol) as? RenderNode)
+        }
+        
         // Assert that articles that curates any symbol gets 'API Collection' assigned as the eyebrow title.
         var renderNode = try renderNodeArticleFromReferencePath(referencePath: "/documentation/unit-test/APICollection")
         XCTAssertEqual(renderNode.metadata.roleHeading, "API Collection")

--- a/Tests/SwiftDocCTests/Rendering/Variants/VariantPatchOperationTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/Variants/VariantPatchOperationTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -15,28 +15,28 @@ import XCTest
 class VariantPatchOperationTests: XCTestCase {
     func testApplyingPatch() {
         let original = [1, 2, 3]
-        let addVariant = VariantCollection<[Int]>.Variant(traits: [], patch: [
+        let addVariant = makeVariantCollection(original, patch: [
             .add(value: [4, 5, 6])
         ])
-        XCTAssertEqual(addVariant.applyingPatchTo(original), [1, 2, 3, 4, 5, 6])
+        XCTAssertEqual(addVariant.value(for: testTraits), [1, 2, 3, 4, 5, 6])
         
-        let removeVariant = VariantCollection<[Int]>.Variant(traits: [], patch: [
+        let removeVariant = makeVariantCollection(original, patch: [
             .remove
         ])
-        XCTAssertEqual(removeVariant.applyingPatchTo(original), [])
+        XCTAssertEqual(removeVariant.value(for: testTraits), [])
         
-        let replaceVariant = VariantCollection<[Int]>.Variant(traits: [], patch: [
+        let replaceVariant = makeVariantCollection(original, patch: [
             .replace(value: [4, 5, 6])
         ])
-        XCTAssertEqual(replaceVariant.applyingPatchTo(original), [4, 5, 6])
+        XCTAssertEqual(replaceVariant.value(for: testTraits), [4, 5, 6])
         
-        let mixVariant = VariantCollection<[Int]>.Variant(traits: [], patch: [
+        let mixVariant = makeVariantCollection(original, patch: [
             .replace(value: [4, 5, 6]),
             .remove,
             .add(value: [6, 7]),
             .add(value: [8, 9]),
         ])
-        XCTAssertEqual(mixVariant.applyingPatchTo(original), [6, 7, 8, 9])
+        XCTAssertEqual(mixVariant.value(for: testTraits), [6, 7, 8, 9])
     }
     
     func testApplyingSeriesOfPatchOperations() {
@@ -62,8 +62,8 @@ class VariantPatchOperationTests: XCTestCase {
             "MNOPQR",
         ]
         for (index, expectedValue) in expectedValues.enumerated() {
-            let stringVariant = VariantCollection<String>.Variant(traits: [], patch: Array(stringPatches.prefix(index)))
-            XCTAssertEqual(stringVariant.applyingPatchTo("A"), expectedValue)
+            let stringVariant = makeVariantCollection("A", patch: Array(stringPatches.prefix(index)))
+            XCTAssertEqual(stringVariant.value(for: testTraits), expectedValue)
         }
     }
     
@@ -90,5 +90,13 @@ class VariantPatchOperationTests: XCTestCase {
             XCTFail("Expected remove operation")
             return
         }
+    }
+    
+    private let testTraits = [RenderNode.Variant.Trait.interfaceLanguage("unit-test")]
+    
+    private func makeVariantCollection<Value>(_ original: Value, patch: [VariantPatchOperation<Value>]) -> VariantCollection<Value> {
+        VariantCollection(defaultValue: original, variants: [
+            .init(traits: testTraits, patch: patch)
+        ])
     }
 }

--- a/Tests/SwiftDocCUtilitiesTests/OutOfProcessReferenceResolverTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/OutOfProcessReferenceResolverTests.swift
@@ -124,12 +124,8 @@ class OutOfProcessReferenceResolverTests: XCTestCase {
         XCTAssertEqual(entity.topicRenderReference.fragments, [.init(text: "declaration fragment", kind: .text, preciseIdentifier: nil)])
 
         let variantTraits = [RenderNode.Variant.Trait.interfaceLanguage("com.test.another-language.id")]
-        
-        let titleVariant = try XCTUnwrap(entity.topicRenderReference.titleVariants.variants.first(where: { $0.traits == variantTraits }))
-        XCTAssertEqual(titleVariant.applyingPatchTo(entity.topicRenderReference.title), "Resolved Variant Title")
-        
-        let abstractVariant = try XCTUnwrap(entity.topicRenderReference.abstractVariants.variants.first(where: { $0.traits == variantTraits }))
-        XCTAssertEqual(abstractVariant.applyingPatchTo(entity.topicRenderReference.abstract), [.text("Resolved variant abstract for this topic.")])
+        XCTAssertEqual(entity.topicRenderReference.titleVariants.value(for: variantTraits), "Resolved Variant Title")
+        XCTAssertEqual(entity.topicRenderReference.abstractVariants.value(for: variantTraits), [.text("Resolved variant abstract for this topic.")])
         
         let fragmentVariant = try XCTUnwrap(entity.topicRenderReference.fragmentsVariants.variants.first(where: { $0.traits == variantTraits }))
         XCTAssertEqual(fragmentVariant.patch.map(\.operation), [.replace])
@@ -299,12 +295,8 @@ class OutOfProcessReferenceResolverTests: XCTestCase {
         XCTAssertEqual(entity.topicRenderReference.fragments, [.init(text: "declaration fragment", kind: .text, preciseIdentifier: nil)])
         
         let variantTraits = [RenderNode.Variant.Trait.interfaceLanguage("com.test.another-language.id")]
-        
-        let titleVariant = try XCTUnwrap(entity.topicRenderReference.titleVariants.variants.first(where: { $0.traits == variantTraits }))
-        XCTAssertEqual(titleVariant.applyingPatchTo(entity.topicRenderReference.title), "Resolved Variant Title")
-        
-        let abstractVariant = try XCTUnwrap(entity.topicRenderReference.abstractVariants.variants.first(where: { $0.traits == variantTraits }))
-        XCTAssertEqual(abstractVariant.applyingPatchTo(entity.topicRenderReference.abstract), [.text("Resolved variant abstract for this topic.")])
+        XCTAssertEqual(entity.topicRenderReference.titleVariants.value(for: variantTraits), "Resolved Variant Title")
+        XCTAssertEqual(entity.topicRenderReference.abstractVariants.value(for: variantTraits), [.text("Resolved variant abstract for this topic.")])
         
         let fragmentVariant = try XCTUnwrap(entity.topicRenderReference.fragmentsVariants.variants.first(where: { $0.traits == variantTraits }))
         XCTAssertEqual(fragmentVariant.patch.map(\.operation), [.replace])


### PR DESCRIPTION
<!--
If you're opening a PR to cherry-pick a change for a release branch, use this template instead:
https://github.com/apple/swift-docc/blob/main/.github/PULL_REQUEST_TEMPLATE/CHERRY_PICK.md
-->

Bug/issue #, if applicable: rdar://127759734

## Summary

This fixes a major inefficiency in the navigator index creation for large (10k+ symbols) mixed Swift and Objective-C projects. 

With these changes impacted projects will build about 5 times faster total `docc convert` time. Even larger projects may see even faster builds (the biggest improvement that I've seen was ~30 times faster in one project).

### Benchmarks

Below are two benchmarks from two large mixed Swift and Objective-C projects that show a 6 times improvement and a 5 time improvement compared to current main:

```
┌──────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ Metric                                   │ Change          │ main                 │ current              │
├──────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Duration for 'bundle-registration'       │ no change¹      │ 8.353 sec            │ 8.271 sec            │
│ Duration for 'convert-total-time'        │ -82.9%²         │ 89.014 sec           │ 15.223 sec           │
│ Duration for 'documentation-processing'  │ -93.41%³        │ 78.942 sec           │ 5.202 sec            │
│ Duration for 'finalize-navigation-index' │ no change⁴      │ 1.031 sec            │ 1.036 sec            │
│ Peak memory footprint                    │ no change⁵      │ 1.03 GB              │ 1.02 GB              │
│ Data subdirectory size                   │ no change⁶      │ 399.7 MB             │ 400.4 MB             │
│ Index subdirectory size                  │ no change⁷      │ 24.5 MB              │ 24.4 MB              │
│ Total DocC archive size                  │ no change⁸      │ 456.8 MB             │ 458.5 MB             │
│ Topic Anchor Checksum                    │ no change       │ 7da1d0d3ff251d8c2c0f │ 7da1d0d3ff251d8c2c0f │
│ Topic Graph Checksum                     │ change          │ 80f03eee58720209c93f │ 542c6795a3c9d1b555c3 │
└──────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```

```
┌──────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ Metric                                   │ Change          │ main                 │ current              │
├──────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Duration for 'bundle-registration'       │ no change¹,²    │ 3.052 sec            │ 2.954 sec            │
│ Duration for 'convert-total-time'        │ -80.11%³,⁴      │ 35.358 sec           │ 7.034 sec            │
│ Duration for 'documentation-processing'  │ -88.23%⁵,⁶      │ 31.986 sec           │ 3.765 sec            │
│ Duration for 'finalize-navigation-index' │ no change⁷,⁸    │ 0.169 sec            │ 0.163 sec            │
│ Peak memory footprint                    │ no change⁹      │ 577.3 MB             │ 575.6 MB             │
│ Data subdirectory size                   │ no change¹⁰     │ 108.6 MB             │ 108.6 MB             │
│ Index subdirectory size                  │ no change¹¹     │ 3.9 MB               │ 3.9 MB               │
│ Total DocC archive size                  │ no change¹²     │ 138.6 MB             │ 138.6 MB             │
│ Topic Anchor Checksum                    │ no change       │ d41d8cd98f00b204e980 │ d41d8cd98f00b204e980 │
│ Topic Graph Checksum                     │ change          │ d4e127bf2e5d126c1cb7 │ 3d1b0f2fcacafee063b6 │
└──────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```

If you look at these closely you may see that the output size and topic graph checksum aren't the same. At first I thought that I caused a regression but it turns out that the output isn't fully stable for mixed Swift and Objective-C projects. I tested this on "main", "release/6.0", and "release/5.10" and they all show similar differences when comparing the same commit of DocC to itself. For example, these 3 measurements are all gathered from the current main (`664acfd7`) and show similar changes in output size and topic graph checksum:
```
┌──────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ Metric                                   │ Change          │ main-1               │ main-2               │
├──────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Duration for 'bundle-registration'       │ no change¹,²    │ 8.242 sec            │ 8.41 sec             │
│ Duration for 'convert-total-time'        │ no change³,⁴    │ 96.103 sec           │ 96.014 sec           │
│ Duration for 'documentation-processing'  │ no change⁵,⁶    │ 84.831 sec           │ 84.838 sec           │
│ Duration for 'finalize-navigation-index' │ no change⁷,⁸    │ 1.104 sec            │ 1.09 sec             │
│ Peak memory footprint                    │ no change⁹      │ 1.03 GB              │ 1.05 GB              │
│ Data subdirectory size                   │ no change¹⁰     │ 403.9 MB             │ 399.9 MB             │
│ Index subdirectory size                  │ no change¹¹     │ 24.5 MB              │ 24.4 MB              │
│ Total DocC archive size                  │ no change¹²     │ 462 MB               │ 458 MB               │
│ Topic Anchor Checksum                    │ no change       │ 15bea17f1e7688a3fc2d │ 15bea17f1e7688a3fc2d │
│ Topic Graph Checksum                     │ change          │ 5b0bf590353b64a56db7 │ 477075a5259bee77ca9c │
└──────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```

```
┌──────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ Metric                                   │ Change          │ main-2               │ main-3               │
├──────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Duration for 'bundle-registration'       │ no change¹,²    │ 8.41 sec             │ 8.324 sec            │
│ Duration for 'convert-total-time'        │ no change³,⁴    │ 96.014 sec           │ 96.647 sec           │
│ Duration for 'documentation-processing'  │ no change⁵,⁶    │ 84.838 sec           │ 85.55 sec            │
│ Duration for 'finalize-navigation-index' │ no change⁷      │ 1.09 sec             │ 1.101 sec            │
│ Peak memory footprint                    │ no change⁸,⁹    │ 1.05 GB              │ 1.05 GB              │
│ Data subdirectory size                   │ no change¹⁰     │ 399.9 MB             │ 409 MB               │
│ Index subdirectory size                  │ no change¹¹     │ 24.4 MB              │ 24.4 MB              │
│ Total DocC archive size                  │ no change¹²     │ 458 MB               │ 467.1 MB             │
│ Topic Anchor Checksum                    │ no change       │ 15bea17f1e7688a3fc2d │ 15bea17f1e7688a3fc2d │
│ Topic Graph Checksum                     │ change          │ 477075a5259bee77ca9c │ eb532ce04afad3fdfcfd │
└──────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```

I've gone over my changes many times and since many previous releases have the same behavior, I'm reasonably certain that I didn't cause them now.

### Why this is faster

The added comment in NavigatorIndex.swift explain the specific changes in more detail, but long story short:

Using `RenderNodeVariantOverridesApplier()` to get the Objective-C variant of a `RenderNode` is very slow and involves repeatedly encoding and decoding the JSON into different formats to transform it.

By instead peeking into the different variant collections to give a "view" into the render node's Objective-C data we can avoid all that encoding and decoding.

Unfortunately the `docc process-archive index` command still needs to use the slow path.  I filed rdar://128050800 to track fixing that as a separate PR.

## Dependencies

None

## Testing

Build documentation for a large mixed Swift and Objective-C project with main and with this branch and measure the total build time. If the project is large enough the difference should be very noticeable. If you want rough estimate numbers to compare you can use `time` for each call, for example:
```sh
time .build/arm64-apple-macosx/release/docc convert /path/to/SomeCatalog.docc  --additional-symbol-graph-dir /path/to/some-symbol-graph-directory 
```

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] ~Updated documentation if necessary~ Not applicable
