### PR TITLE
Fix duplicated image missing diagnostic on extension file

### DIFF
--- a/Sources/SwiftDocC/Semantics/MarkupReferenceResolver.swift
+++ b/Sources/SwiftDocC/Semantics/MarkupReferenceResolver.swift
@@ -101,7 +101,14 @@ struct MarkupReferenceResolver: MarkupRewriter {
 
     mutating func visitImage(_ image: Image) -> Markup? {
         if let reference = image.reference(in: bundle), !context.resourceExists(with: reference) {
-            problems.append(unresolvedResourceProblem(resource: reference, source: source, range: image.range, severity: .warning))
+            if let rangeLowerBoundSource = image.range?.lowerBound.source,
+               let rangeUpperBoundSource = image.range?.upperBound.source,
+               let source = source,
+               source != rangeLowerBoundSource || source != rangeUpperBoundSource {
+                // Do not emit duplicated problem for extension file
+            } else {
+                problems.append(unresolvedResourceProblem(resource: reference, source: source, range: image.range, severity: .warning))
+            }
         }
 
         var image = image


### PR DESCRIPTION
<!--
If you're opening a PR to cherry-pick a change for a release branch, use this template instead:
https://github.com/apple/swift-docc/blob/main/.github/PULL_REQUEST_TEMPLATE/CHERRY_PICK.md
-->

Bug/issue #, if applicable: #729

## Summary

Fix duplicated image missing diagnostic on extension file

## Testing

None

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
