### PR TITLE
Rename `TitleStyle` to `PropertyListTitleStyle` to clarify its purpose

### DIFF
--- a/Sources/SwiftDocC/Indexing/RenderSection+TextIndexing.swift
+++ b/Sources/SwiftDocC/Indexing/RenderSection+TextIndexing.swift
@@ -328,15 +328,15 @@ extension AttributesRenderSection {
 
 extension PlistDetailsRenderSection {
     public var headings: [String] {
-        if let ideTitle = details.ideTitle {
-            return [details.name, ideTitle]
+        if let displayName = details.displayName {
+            return [details.rawKey, displayName]
         } else {
-            return [details.name]
+            return [details.rawKey]
         }
     }
     
     public func rawIndexableTextContent(references: [String : RenderReference]) -> String {
-        return [details.name, details.ideTitle ?? ""].joined(separator: " ")
+        return [details.rawKey, details.displayName ?? ""].joined(separator: " ")
     }
 }
 

--- a/Sources/SwiftDocC/Infrastructure/External Data/OutOfProcessReferenceResolver.swift
+++ b/Sources/SwiftDocC/Infrastructure/External Data/OutOfProcessReferenceResolver.swift
@@ -157,7 +157,6 @@ public class OutOfProcessReferenceResolver: ExternalDocumentationSource, GlobalE
             fragments: resolvedInformation.declarationFragments?.declarationFragments.map { DeclarationRenderSection.Token(fragment: $0, identifier: nil) },
             isBeta: (resolvedInformation.platforms ?? []).contains(where: { $0.isBeta == true }),
             isDeprecated: (resolvedInformation.platforms ?? []).contains(where: { $0.deprecated != nil }),
-            titleStyle: resolvedInformation.kind.isSymbol ? .symbol : .title,
             images: resolvedInformation.topicImages ?? []
         )
         for variant in resolvedInformation.variants ?? [] {

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/ExternalPathHierarchyResolver.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/ExternalPathHierarchyResolver.swift
@@ -218,9 +218,7 @@ private extension LinkDestinationSummary {
             isBeta: platforms?.contains(where: { $0.isBeta == true }) ?? false,
             isDeprecated: platforms?.contains(where: { $0.unconditionallyDeprecated == true }) ?? false,
             defaultImplementationCount: nil,
-            titleStyle: self.kind.isSymbol ? .symbol : .title,
-            name: title,
-            ideTitle: nil,
+            propertyListKeyNames: nil,
             tags: nil,
             images: topicImages ?? []
         )

--- a/Sources/SwiftDocC/Model/Rendering/References/TopicRenderReference.swift
+++ b/Sources/SwiftDocC/Model/Rendering/References/TopicRenderReference.swift
@@ -88,18 +88,18 @@ public struct TopicRenderReference: RenderReference, VariantContainer, Equatable
     /// This value is `false` if the referenced page is not a symbol.
     public var isDeprecated: Bool
     
-    /// Information about which title to use in links to this page.
-    ///
-    /// For symbols that have multiple possible titles (for example property list keys and entitlements) the title style decides which title to use in links.
-    public var titleStyle: TitleStyle?
-    /// Raw name of a symbol, e.g. "com.apple.enableDataAccess"
-    ///
-    /// This value is `nil` if the referenced page is not a symbol.
-    public var name: String?
-    /// The human friendly symbol name
-    ///
-    /// This value is `nil` if the referenced page is not a symbol.
-    public var ideTitle: String?
+    /// The names and style for a reference to a property list key or entitlement key.
+    public var propertyListKeyNames: PropertyListKeyNames?
+    
+    /// The display name and raw key name for a property list key or entitlement key and configuration about which "name" to use for links to this page.
+    public struct PropertyListKeyNames: Equatable {
+        /// A style for how to render links to a property list key or an entitlement key.
+        public var titleStyle: PropertyListTitleStyle?
+        /// The raw key name of a property list key or entitlement key, for example "com.apple.enableDataAccess".
+        public var rawKey: String?
+        /// The human friendly display name for a property list key or entitlement key, for example, "Enables Data Access".
+        public var displayName: String?
+    }
     
     /// An optional list of text-based tags.
     public var tags: [RenderNode.Tag]?
@@ -124,11 +124,272 @@ public struct TopicRenderReference: RenderReference, VariantContainer, Equatable
     ///   - isBeta: Whether this symbol is built for a beta platform, or `false` if the referenced page is not a symbol.
     ///   - isDeprecated: Whether this symbol is deprecated, or `false` if the referenced page is not a symbol.
     ///   - defaultImplementationCount: Number of default implementations for this symbol, or `nil` if the referenced page is not a symbol.
-    ///   - titleStyle: Information about which title to use in links to this page.
-    ///   - name: Raw name of a symbol, e.g. "com.apple.enableDataAccess", or `nil` if the referenced page is not a symbol.
-    ///   - ideTitle: The human friendly symbol name, or `nil` if the referenced page is not a symbol.
+    ///   - propertyListKeyNames: The names and style configuration for a property list key or entitlement key,  or `nil` if the referenced page is not a property list key or entitlement key.
     ///   - tags: An optional list of string tags.
     ///   - images: Author provided images that represent this page.
+    public init(
+        identifier: RenderReferenceIdentifier,
+        title: String,
+        abstract: [RenderInlineContent],
+        url: String,
+        kind: RenderNode.Kind,
+        required: Bool = false,
+        role: String? = nil,
+        fragments: [DeclarationRenderSection.Token]? = nil,
+        navigatorTitle: [DeclarationRenderSection.Token]? = nil,
+        estimatedTime: String? = nil,
+        conformance: ConformanceSection? = nil,
+        isBeta: Bool = false,
+        isDeprecated: Bool = false,
+        defaultImplementationCount: Int? = nil,
+        propertyListKeyNames: PropertyListKeyNames? = nil,
+        tags: [RenderNode.Tag]? = nil,
+        images: [TopicImage] = []
+    ) {
+        self.init(
+            identifier: identifier,
+            titleVariants: .init(defaultValue: title),
+            abstractVariants: .init(defaultValue: abstract),
+            url: url,
+            kind: kind,
+            required: required,
+            role: role,
+            fragmentsVariants: .init(defaultValue: fragments),
+            navigatorTitleVariants: .init(defaultValue: navigatorTitle),
+            estimatedTime: estimatedTime,
+            conformance: conformance,
+            isBeta: isBeta,
+            isDeprecated: isDeprecated,
+            defaultImplementationCount: defaultImplementationCount,
+            propertyListKeyNames: propertyListKeyNames,
+            tags: tags,
+            images: images
+        )
+    }
+    
+    /// Creates a new topic reference with all its initial values.
+    ///
+    /// - Parameters:
+    ///   - identifier: The identifier of this reference.
+    ///   - titleVariants: The variants for the title of the destination page.
+    ///   - abstractVariants: The abstract of the destination page.
+    ///   - url: The topic url of the destination page.
+    ///   - kind: The kind of page that's referenced.
+    ///   - required: Whether the reference is required in its parent context.
+    ///   - role: The additional "role" assigned to the symbol, if any.
+    ///   - fragmentsVariants: The abbreviated declaration of the symbol to display in links, or `nil` if the referenced page is not a symbol.
+    ///   - navigatorTitleVariants: The abbreviated declaration of the symbol to display in navigation, or `nil` if the referenced page is not a symbol.
+    ///   - estimatedTime: The estimated time to complete the topic.
+    ///   - conformance: Information about conditional conformance for the symbol, or `nil` if the referenced page is not a symbol.
+    ///   - isBeta: Whether this symbol is built for a beta platform, or `false` if the referenced page is not a symbol.
+    ///   - isDeprecated: Whether this symbol is deprecated, or `false` if the referenced page is not a symbol.
+    ///   - defaultImplementationCount: Number of default implementations for this symbol, or `nil` if the referenced page is not a symbol.
+    ///   - propertyListKeyNames: The names and style configuration for a property list key or entitlement key,  or `nil` if the referenced page is not a property list key or entitlement key.
+    ///   - tags: An optional list of string tags.
+    ///   - images: Author provided images that represent this page.
+    public init(
+        identifier: RenderReferenceIdentifier,
+        titleVariants: VariantCollection<String>,
+        abstractVariants: VariantCollection<[RenderInlineContent]>,
+        url: String,
+        kind: RenderNode.Kind,
+        required: Bool = false,
+        role: String? = nil,
+        fragmentsVariants: VariantCollection<[DeclarationRenderSection.Token]?> = .init(defaultValue: nil),
+        navigatorTitleVariants: VariantCollection<[DeclarationRenderSection.Token]?> = .init(defaultValue: nil),
+        estimatedTime: String? = nil,
+        conformance: ConformanceSection? = nil,
+        isBeta: Bool = false,
+        isDeprecated: Bool = false,
+        defaultImplementationCount: Int? = nil,
+        propertyListKeyNames: PropertyListKeyNames? = nil,
+        tags: [RenderNode.Tag]? = nil,
+        images: [TopicImage] = []
+    ) {
+        self.identifier = identifier
+        self.titleVariants = titleVariants
+        self.abstractVariants = abstractVariants
+        self.url = url
+        self.kind = kind
+        self.required = required
+        self.role = role
+        self.fragmentsVariants = fragmentsVariants
+        self.navigatorTitleVariants = navigatorTitleVariants
+        self.estimatedTime = estimatedTime
+        self.conformance = conformance
+        self.isBeta = isBeta
+        self.isDeprecated = isDeprecated
+        self.defaultImplementationCount = defaultImplementationCount
+        self.propertyListKeyNames = propertyListKeyNames
+        self.tags = tags
+        self.images = images
+    }
+    
+    enum CodingKeys: String, CodingKey {
+        case type
+        case identifier
+        case title
+        case url
+        case abstract
+        case kind
+        case required
+        case role
+        case fragments
+        case navigatorTitle
+        case estimatedTime
+        case conformance
+        case beta
+        case deprecated
+        case defaultImplementations
+        case propertyListTitleStyle = "titleStyle"
+        case propertyListRawKey = "name"
+        case propertyListDisplayName = "ideTitle"
+        case tags
+        case images
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        type = try values.decode(RenderReferenceType.self, forKey: .type)
+        identifier = try values.decode(RenderReferenceIdentifier.self, forKey: .identifier)
+        titleVariants = try values.decode(VariantCollection<String>.self, forKey: .title)
+        url = try values.decode(String.self, forKey: .url)
+        abstractVariants = try values.decodeIfPresent(VariantCollection<[RenderInlineContent]>.self, forKey: .abstract) ?? .init(defaultValue: [])
+        kind = try values.decodeIfPresent(RenderNode.Kind.self, forKey: .kind)
+            // Provide backwards-compatibility for TopicRenderReferences that don't have a `kind` key.
+            ?? .tutorial
+        required = try values.decodeIfPresent(Bool.self, forKey: .required) ?? false
+        role = try values.decodeIfPresent(String.self, forKey: .role)
+        fragmentsVariants = try values.decodeVariantCollectionIfPresent(ofValueType: [DeclarationRenderSection.Token]?.self, forKey: .fragments) ?? .init(defaultValue: nil)
+        navigatorTitleVariants = try values.decodeVariantCollectionIfPresent(ofValueType: [DeclarationRenderSection.Token]?.self, forKey: .navigatorTitle)
+        conformance = try values.decodeIfPresent(ConformanceSection.self, forKey: .conformance)
+        estimatedTime = try values.decodeIfPresent(String.self, forKey: .estimatedTime)
+        isBeta = try values.decodeIfPresent(Bool.self, forKey: .beta) ?? false
+        isDeprecated = try values.decodeIfPresent(Bool.self, forKey: .deprecated) ?? false
+        defaultImplementationCount = try values.decodeIfPresent(Int.self, forKey: .defaultImplementations)
+        let propertyListTitleStyle = try values.decodeIfPresent(PropertyListTitleStyle.self, forKey: .propertyListTitleStyle)
+        let propertyListRawKey = try values.decodeIfPresent(String.self, forKey: .propertyListRawKey)
+        let propertyListDisplayName = try values.decodeIfPresent(String.self, forKey: .propertyListDisplayName)
+        if propertyListRawKey != nil || propertyListRawKey != nil || propertyListDisplayName != nil {
+            propertyListKeyNames = PropertyListKeyNames(
+                titleStyle: propertyListTitleStyle,
+                rawKey: propertyListRawKey,
+                displayName: propertyListDisplayName
+            )
+        }
+        tags = try values.decodeIfPresent([RenderNode.Tag].self, forKey: .tags)
+        images = try values.decodeIfPresent([TopicImage].self, forKey: .images) ?? []
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        
+        try container.encode(type, forKey: .type)
+        try container.encode(identifier, forKey: .identifier)
+        try container.encodeVariantCollection(titleVariants, forKey: .title, encoder: encoder)
+        try container.encode(url, forKey: .url)
+        try container.encodeVariantCollection(abstractVariants, forKey: .abstract, encoder: encoder)
+        try container.encode(kind, forKey: .kind)
+        
+        if required {
+            try container.encode(required, forKey: .required)
+        }
+        try container.encodeIfPresent(role, forKey: .role)
+        try container.encodeVariantCollectionIfNotEmpty(fragmentsVariants, forKey: .fragments, encoder: encoder)
+        try container.encodeVariantCollectionIfNotEmpty(navigatorTitleVariants, forKey: .navigatorTitle, encoder: encoder)
+        try container.encodeIfPresent(conformance, forKey: .conformance)
+        try container.encodeIfPresent(estimatedTime, forKey: .estimatedTime)
+        try container.encodeIfPresent(defaultImplementationCount, forKey: .defaultImplementations)
+        
+        if isBeta {
+            try container.encode(isBeta, forKey: .beta)
+        }
+        if isDeprecated {
+            try container.encode(isDeprecated, forKey: .deprecated)
+        }
+        try container.encodeIfPresent(propertyListKeyNames?.titleStyle, forKey: .propertyListTitleStyle)
+        try container.encodeIfPresent(propertyListKeyNames?.rawKey, forKey: .propertyListRawKey)
+        try container.encodeIfPresent(propertyListKeyNames?.displayName, forKey: .propertyListDisplayName)
+        try container.encodeIfPresent(tags, forKey: .tags)
+        try container.encodeIfNotEmpty(images, forKey: .images)
+    }
+}
+
+// Diffable conformance
+extension TopicRenderReference: RenderJSONDiffable {
+    /// Returns the difference between two TopicRenderReferences.
+    func difference(from other: TopicRenderReference, at path: CodablePath) -> JSONPatchDifferences {
+        var diffBuilder = DifferenceBuilder(current: self, other: other, basePath: path)
+
+        diffBuilder.addDifferences(atKeyPath: \.type, forKey: CodingKeys.type)
+        diffBuilder.addDifferences(atKeyPath: \.identifier, forKey: CodingKeys.identifier)
+        diffBuilder.addDifferences(atKeyPath: \.title, forKey: CodingKeys.title)
+        diffBuilder.addDifferences(atKeyPath: \.url, forKey: CodingKeys.url)
+        diffBuilder.addDifferences(atKeyPath: \.abstract, forKey: CodingKeys.abstract)
+        diffBuilder.addDifferences(atKeyPath: \.kind, forKey: CodingKeys.kind)
+        diffBuilder.addDifferences(atKeyPath: \.required, forKey: CodingKeys.required)
+        diffBuilder.addDifferences(atKeyPath: \.role, forKey: CodingKeys.role)
+        diffBuilder.addDifferences(atKeyPath: \.fragments, forKey: CodingKeys.fragments)
+        diffBuilder.addDifferences(atKeyPath: \.navigatorTitle, forKey: CodingKeys.navigatorTitle)
+        diffBuilder.addDifferences(atKeyPath: \.conformance, forKey: CodingKeys.conformance)
+        diffBuilder.addDifferences(atKeyPath: \.estimatedTime, forKey: CodingKeys.estimatedTime)
+        diffBuilder.addDifferences(atKeyPath: \.defaultImplementationCount, forKey: CodingKeys.defaultImplementations)
+        diffBuilder.addDifferences(atKeyPath: \.isBeta, forKey: CodingKeys.beta)
+        diffBuilder.addDifferences(atKeyPath: \.isDeprecated, forKey: CodingKeys.deprecated)
+        diffBuilder.addDifferences(atKeyPath: \.propertyListKeyNames?.titleStyle, forKey: CodingKeys.propertyListTitleStyle)
+        diffBuilder.addDifferences(atKeyPath: \.propertyListKeyNames?.rawKey, forKey: CodingKeys.propertyListRawKey)
+        diffBuilder.addDifferences(atKeyPath: \.propertyListKeyNames?.displayName, forKey: CodingKeys.propertyListDisplayName)
+        diffBuilder.addDifferences(atKeyPath: \.tags, forKey: CodingKeys.tags)
+        diffBuilder.addDifferences(atKeyPath: \.images, forKey: CodingKeys.images)
+        
+        return diffBuilder.differences
+    }
+}
+
+// MARK: Deprecated
+
+extension TopicRenderReference {
+    @available(*, deprecated, renamed: "propertyListTitleStyle", message: "Use 'propertyListTitleStyle' instead. This deprecated API will be removed after 6.1 is released")
+    public var titleStyle: TitleStyle? {
+        get {
+            propertyListKeyNames?.titleStyle.map { $0.titleStyle }
+        }
+        set {
+            if propertyListKeyNames == nil {
+                propertyListKeyNames = PropertyListKeyNames()
+            }
+            propertyListKeyNames!.titleStyle = newValue.map { .init(titleStyle: $0) }
+        }
+    }
+    
+    @available(*, deprecated, renamed: "propertyListRawKey", message: "Use 'propertyListRawKey' instead. This deprecated API will be removed after 6.1 is released")
+    public var name: String? {
+        get { 
+            propertyListKeyNames?.rawKey
+        }
+        set {
+            if propertyListKeyNames == nil {
+                propertyListKeyNames = PropertyListKeyNames()
+            }
+            propertyListKeyNames!.rawKey = newValue
+        }
+    }
+    
+    @available(*, deprecated, renamed: "propertyListDisplayName", message: "Use 'propertyListDisplayName' instead. This deprecated API will be removed after 6.1 is released")
+    public var ideTitle: String? {
+        get { 
+            propertyListKeyNames?.displayName
+        }
+        set {
+            if propertyListKeyNames == nil {
+                propertyListKeyNames = PropertyListKeyNames()
+            }
+            propertyListKeyNames!.displayName = newValue
+        }
+    }
+    
+    @_disfavoredOverload
+    @available(*, deprecated, renamed: "init(identifier:title:abstract:url:kind:required:role:fragments:navigatorTitle:estimatedTime:conformance:isBeta:isDeprecated:defaultImplementationCount:propertyListKeyNames:tags:images:)", message: "Use 'init(identifier:title:abstract:url:kind:required:role:fragments:navigatorTitle:estimatedTime:conformance:isBeta:isDeprecated:defaultImplementationCount:propertyListKeyNames:tags:images:)' instead. This deprecated API will be removed after 6.1 is released")
     public init(
         identifier: RenderReferenceIdentifier,
         title: String,
@@ -165,36 +426,18 @@ public struct TopicRenderReference: RenderReference, VariantContainer, Equatable
             isBeta: isBeta,
             isDeprecated: isDeprecated,
             defaultImplementationCount: defaultImplementationCount,
-            titleStyle: titleStyle,
-            name: name,
-            ideTitle: ideTitle,
+            propertyListKeyNames: PropertyListKeyNames(
+                titleStyle: titleStyle.map { .init(titleStyle: $0) },
+                rawKey: name,
+                displayName: ideTitle
+            ),
             tags: tags,
             images: images
         )
     }
     
-    /// Creates a new topic reference with all its initial values.
-    /// 
-    /// - Parameters:
-    ///   - identifier: The identifier of this reference.
-    ///   - titleVariants: The variants for the title of the destination page.
-    ///   - abstractVariants: The abstract of the destination page.
-    ///   - url: The topic url of the destination page.
-    ///   - kind: The kind of page that's referenced.
-    ///   - required: Whether the reference is required in its parent context.
-    ///   - role: The additional "role" assigned to the symbol, if any.
-    ///   - fragmentsVariants: The abbreviated declaration of the symbol to display in links, or `nil` if the referenced page is not a symbol.
-    ///   - navigatorTitleVariants: The abbreviated declaration of the symbol to display in navigation, or `nil` if the referenced page is not a symbol.
-    ///   - estimatedTime: The estimated time to complete the topic.
-    ///   - conformance: Information about conditional conformance for the symbol, or `nil` if the referenced page is not a symbol.
-    ///   - isBeta: Whether this symbol is built for a beta platform, or `false` if the referenced page is not a symbol.
-    ///   - isDeprecated: Whether this symbol is deprecated, or `false` if the referenced page is not a symbol.
-    ///   - defaultImplementationCount: Number of default implementations for this symbol, or `nil` if the referenced page is not a symbol.
-    ///   - titleStyle: Information about which title to use in links to this page.
-    ///   - name: Raw name of a symbol, e.g. "com.apple.enableDataAccess", or `nil` if the referenced page is not a symbol.
-    ///   - ideTitle: The human friendly symbol name, or `nil` if the referenced page is not a symbol.
-    ///   - tags: An optional list of string tags.
-    ///   - images: Author provided images that represent this page.
+    @_disfavoredOverload
+    @available(*, deprecated, renamed: "init(identifier:titleVariants:abstractVariants:url:kind:required:role:fragmentsVariants:navigatorTitleVariants:estimatedTime:conformance:isBeta:isDeprecated:defaultImplementationCount:propertyListKeyNames:tags:images:)", message: "Use 'init(identifier:titleVariants:abstractVariants:url:kind:required:role:fragmentsVariants:navigatorTitleVariants:estimatedTime:conformance:isBeta:isDeprecated:defaultImplementationCount:propertyListKeyNames:tags:images:)' instead. This deprecated API will be removed after 6.1 is released")
     public init(
         identifier: RenderReferenceIdentifier,
         titleVariants: VariantCollection<String>,
@@ -230,123 +473,31 @@ public struct TopicRenderReference: RenderReference, VariantContainer, Equatable
         self.isBeta = isBeta
         self.isDeprecated = isDeprecated
         self.defaultImplementationCount = defaultImplementationCount
-        self.titleStyle = titleStyle
-        self.name = name
-        self.ideTitle = ideTitle
+        if titleStyle != nil || name != nil || ideTitle != nil {
+            self.propertyListKeyNames = PropertyListKeyNames(
+                titleStyle: titleStyle.map { .init(titleStyle: $0) },
+                rawKey: name,
+                displayName: ideTitle
+            )
+        }
         self.tags = tags
         self.images = images
     }
-    
-    enum CodingKeys: String, CodingKey {
-        case type
-        case identifier
-        case title
-        case url
-        case abstract
-        case kind
-        case required
-        case role
-        case fragments
-        case navigatorTitle
-        case estimatedTime
-        case conformance
-        case beta
-        case deprecated
-        case defaultImplementations
-        case titleStyle
-        case name
-        case ideTitle
-        case tags
-        case images
-    }
-    
-    public init(from decoder: Decoder) throws {
-        let values = try decoder.container(keyedBy: CodingKeys.self)
-        type = try values.decode(RenderReferenceType.self, forKey: .type)
-        identifier = try values.decode(RenderReferenceIdentifier.self, forKey: .identifier)
-        titleVariants = try values.decode(VariantCollection<String>.self, forKey: .title)
-        url = try values.decode(String.self, forKey: .url)
-        abstractVariants = try values.decodeIfPresent(VariantCollection<[RenderInlineContent]>.self, forKey: .abstract) ?? .init(defaultValue: [])
-        kind = try values.decodeIfPresent(RenderNode.Kind.self, forKey: .kind)
-            // Provide backwards-compatibility for TopicRenderReferences that don't have a `kind` key.
-            ?? .tutorial
-        required = try values.decodeIfPresent(Bool.self, forKey: .required) ?? false
-        role = try values.decodeIfPresent(String.self, forKey: .role)
-        fragmentsVariants = try values.decodeVariantCollectionIfPresent(ofValueType: [DeclarationRenderSection.Token]?.self, forKey: .fragments) ?? .init(defaultValue: nil)
-        navigatorTitleVariants = try values.decodeVariantCollectionIfPresent(ofValueType: [DeclarationRenderSection.Token]?.self, forKey: .navigatorTitle)
-        conformance = try values.decodeIfPresent(ConformanceSection.self, forKey: .conformance)
-        estimatedTime = try values.decodeIfPresent(String.self, forKey: .estimatedTime)
-        isBeta = try values.decodeIfPresent(Bool.self, forKey: .beta) ?? false
-        isDeprecated = try values.decodeIfPresent(Bool.self, forKey: .deprecated) ?? false
-        defaultImplementationCount = try values.decodeIfPresent(Int.self, forKey: .defaultImplementations)
-        titleStyle = try values.decodeIfPresent(TitleStyle.self, forKey: .titleStyle)
-        name = try values.decodeIfPresent(String.self, forKey: .name)
-        ideTitle = try values.decodeIfPresent(String.self, forKey: .ideTitle)
-        tags = try values.decodeIfPresent([RenderNode.Tag].self, forKey: .tags)
-        images = try values.decodeIfPresent([TopicImage].self, forKey: .images) ?? []
-    }
-    
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        
-        try container.encode(type, forKey: .type)
-        try container.encode(identifier, forKey: .identifier)
-        try container.encodeVariantCollection(titleVariants, forKey: .title, encoder: encoder)
-        try container.encode(url, forKey: .url)
-        try container.encodeVariantCollection(abstractVariants, forKey: .abstract, encoder: encoder)
-        try container.encode(kind, forKey: .kind)
-        
-        if required {
-            try container.encode(required, forKey: .required)
-        }
-        try container.encodeIfPresent(role, forKey: .role)
-        try container.encodeVariantCollectionIfNotEmpty(fragmentsVariants, forKey: .fragments, encoder: encoder)
-        try container.encodeVariantCollectionIfNotEmpty(navigatorTitleVariants, forKey: .navigatorTitle, encoder: encoder)
-        try container.encodeIfPresent(conformance, forKey: .conformance)
-        try container.encodeIfPresent(estimatedTime, forKey: .estimatedTime)
-        try container.encodeIfPresent(defaultImplementationCount, forKey: .defaultImplementations)
-        
-        if isBeta {
-            try container.encode(isBeta, forKey: .beta)
-        }
-        if isDeprecated {
-            try container.encode(isDeprecated, forKey: .deprecated)
-        }
-        try container.encodeIfPresent(titleStyle, forKey: .titleStyle)
-        try container.encodeIfPresent(name, forKey: .name)
-        try container.encodeIfPresent(ideTitle, forKey: .ideTitle)
-        try container.encodeIfPresent(tags, forKey: .tags)
-        try container.encodeIfNotEmpty(images, forKey: .images)
-    }
 }
 
-// Diffable conformance
-extension TopicRenderReference: RenderJSONDiffable {
-    /// Returns the difference between two TopicRenderReferences.
-    func difference(from other: TopicRenderReference, at path: CodablePath) -> JSONPatchDifferences {
-        var diffBuilder = DifferenceBuilder(current: self, other: other, basePath: path)
-
-        diffBuilder.addDifferences(atKeyPath: \.type, forKey: CodingKeys.type)
-        diffBuilder.addDifferences(atKeyPath: \.identifier, forKey: CodingKeys.identifier)
-        diffBuilder.addDifferences(atKeyPath: \.title, forKey: CodingKeys.title)
-        diffBuilder.addDifferences(atKeyPath: \.url, forKey: CodingKeys.url)
-        diffBuilder.addDifferences(atKeyPath: \.abstract, forKey: CodingKeys.abstract)
-        diffBuilder.addDifferences(atKeyPath: \.kind, forKey: CodingKeys.kind)
-        diffBuilder.addDifferences(atKeyPath: \.required, forKey: CodingKeys.required)
-        diffBuilder.addDifferences(atKeyPath: \.role, forKey: CodingKeys.role)
-        diffBuilder.addDifferences(atKeyPath: \.fragments, forKey: CodingKeys.fragments)
-        diffBuilder.addDifferences(atKeyPath: \.navigatorTitle, forKey: CodingKeys.navigatorTitle)
-        diffBuilder.addDifferences(atKeyPath: \.conformance, forKey: CodingKeys.conformance)
-        diffBuilder.addDifferences(atKeyPath: \.estimatedTime, forKey: CodingKeys.estimatedTime)
-        diffBuilder.addDifferences(atKeyPath: \.defaultImplementationCount, forKey: CodingKeys.defaultImplementations)
-        diffBuilder.addDifferences(atKeyPath: \.isBeta, forKey: CodingKeys.beta)
-        diffBuilder.addDifferences(atKeyPath: \.isDeprecated, forKey: CodingKeys.deprecated)
-        diffBuilder.addDifferences(atKeyPath: \.titleStyle, forKey: CodingKeys.titleStyle)
-        diffBuilder.addDifferences(atKeyPath: \.name, forKey: CodingKeys.name)
-        diffBuilder.addDifferences(atKeyPath: \.ideTitle, forKey: CodingKeys.ideTitle)
-        diffBuilder.addDifferences(atKeyPath: \.tags, forKey: CodingKeys.tags)
-        diffBuilder.addDifferences(atKeyPath: \.images, forKey: CodingKeys.images)
-
-        return diffBuilder.differences
+@available(*, deprecated, message: "This deprecated API will be removed after 6.1 is released")
+private extension PropertyListTitleStyle {
+    var titleStyle: TitleStyle {
+        switch self {
+        case .useDisplayName: return .title
+        case .useRawKey:      return .symbol
+        }
+    }
+    
+    init(titleStyle: TitleStyle) {
+        switch titleStyle {
+        case .title:  self = .useDisplayName
+        case .symbol: self = .useRawKey
+        }
     }
 }

--- a/Sources/SwiftDocC/Model/Rendering/Symbol/PlistDetailsRenderSection.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Symbol/PlistDetailsRenderSection.swift
@@ -12,12 +12,12 @@ import Foundation
 
 /// A style for how to render links to a property list key or an entitlement key.
 public enum PropertyListTitleStyle: String, Codable, Equatable {
-    /// Render links to the symbol using the raw key, for example, "com.apple.enableDataAccess".
+    /// Render links to the property list key using the raw key, for example "com.apple.enableDataAccess".
     ///
     /// ## See Also
     /// - ``TopicRenderReference/PropertyListKeyNames/rawKey``
     case useRawKey = "symbol"
-    /// Render links to the symbol using a special "IDE title" name, for example, "Enables Data Access".
+    /// Render links to the property list key using the display name, for example "Enables Data Access".
     ///
     /// ## See Also
     /// - ``TopicRenderReference/PropertyListKeyNames/displayName``

--- a/Sources/SwiftDocC/Model/Rendering/Symbol/PlistDetailsRenderSection.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Symbol/PlistDetailsRenderSection.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -10,55 +10,58 @@
 
 import Foundation
 
-/// A title style for a property list key or an entitlement key.
+/// A style for how to render links to a property list key or an entitlement key.
+public enum PropertyListTitleStyle: String, Codable, Equatable {
+    /// Render links to the symbol using the raw key, for example, "com.apple.enableDataAccess".
+    ///
+    /// ## See Also
+    /// - ``TopicRenderReference/PropertyListKeyNames/rawKey``
+    case useRawKey = "symbol"
+    /// Render links to the symbol using a special "IDE title" name, for example, "Enables Data Access".
+    ///
+    /// ## See Also
+    /// - ``TopicRenderReference/PropertyListKeyNames/displayName``
+    case useDisplayName = "title"
+}
+
+@available(*, deprecated, renamed: "PropertyListTitleStyle", message: "Use 'PropertyListTitleStyle' instead. This deprecated API will be removed after 6.1 is released")
 public enum TitleStyle: String, Codable, Equatable {
-    // Render links to the symbol using the "raw" name, for example, "com.apple.enableDataAccess".
+    @available(*, deprecated, renamed: "PropertyListTitleStyle.useRawKey", message: "Use 'PropertyListTitleStyle.useRawKey' instead. This deprecated API will be removed after 6.1 is released")
     case symbol
-    // Render links to the symbol using a special "IDE title" name, for example, "Enables Data Access".
+    @available(*, deprecated, renamed: "PropertyListTitleStyle.useDisplayName", message: "Use 'PropertyListTitleStyle.useDisplayName' instead. This deprecated API will be removed after 6.1 is released")
     case title
 }
 
 /// A section that contains details about a property list key.
 struct PlistDetailsRenderSection: RenderSection, Equatable {
-    public var kind: RenderSectionKind = .plistDetails
+    var kind: RenderSectionKind = .plistDetails
     /// A title for the section.
-    public var title = "Details"
+    var title = "Details"
     
     /// Details for a property list key.
     struct Details: Codable, Equatable {
         /// The name of the key.
-        let name: String
+        let rawKey: String
         /// A list of types acceptable for this key's value.
         let value: [TypeDetails]
         /// A list of platforms to which this key applies.
         let platforms: [String]
         /// An optional, human-friendly name of the key.
-        let ideTitle: String?
+        let displayName: String?
         /// A title rendering style.
-        let titleStyle: TitleStyle
+        let titleStyle: PropertyListTitleStyle
+        
+        enum CodingKeys: String, CodingKey {
+            case rawKey = "name"
+            case value
+            case platforms
+            case displayName = "ideTitle"
+            case titleStyle
+        }
     }
     
     /// The details of the property key.
-    public let details: Details
-    
-    // MARK: - Codable
-    
-    /// The list of keys you use to encode or decode this details section.
-    public enum CodingKeys: String, CodingKey {
-        case kind, title, details
-    }
-    
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        details = try container.decode(Details.self, forKey: .details)
-    }
-    
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(kind, forKey: .kind)
-        try container.encode(title, forKey: .title)
-        try container.encode(details, forKey: .details)
-    }
+    let details: Details
 }
 
 // Diffable conformance

--- a/Tests/SwiftDocCTests/Infrastructure/ExternalReferenceResolverTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/ExternalReferenceResolverTests.swift
@@ -49,9 +49,7 @@ class ExternalReferenceResolverTests: XCTestCase {
                     role: role,
                     fragments: resolvedEntityDeclarationFragments?.declarationFragments.map { fragment in
                         return DeclarationRenderSection.Token(fragment: fragment, identifier: nil)
-                    },
-                    estimatedTime: nil,
-                    titleStyle: resolvedEntityKind.isSymbol ? .symbol : .title
+                    }
                 ),
                 renderReferenceDependencies: RenderReferenceDependencies(),
                 sourceLanguages: [resolvedEntityLanguage]

--- a/Tests/SwiftDocCTests/Infrastructure/TestExternalReferenceResolvers.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/TestExternalReferenceResolvers.swift
@@ -105,7 +105,6 @@ class TestMultiResultExternalReferenceResolver: ExternalDocumentationSource {
                 fragments: entityInfo.declarationFragments?.declarationFragments.map { fragment in
                     return DeclarationRenderSection.Token(fragment: fragment, identifier: nil)
                 },
-                titleStyle: entityInfo.kind.isSymbol ? .symbol : .title,
                 images: entityInfo.topicImages?.map(\.0) ?? []
             ),
             renderReferenceDependencies: dependencies,

--- a/Tests/SwiftDocCTests/Rendering/PlistSymbolTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/PlistSymbolTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -33,9 +33,9 @@ class PlistSymbolTests: XCTestCase {
             return
         }
         
-        XCTAssertEqual(section.details.name, "com.apple.developer.networking.wifi")
-        XCTAssertEqual(section.details.ideTitle, "WiFi access")
-        XCTAssertEqual(section.details.titleStyle, .title)
+        XCTAssertEqual(section.details.rawKey, "com.apple.developer.networking.wifi")
+        XCTAssertEqual(section.details.displayName, "WiFi access")
+        XCTAssertEqual(section.details.titleStyle, .useDisplayName)
         guard section.details.value.count == 2 else {
             XCTFail("Invalid number of value types found")
             return
@@ -113,9 +113,9 @@ class PlistSymbolTests: XCTestCase {
             XCTFail("Did not find doc://org.swift.docc.example/plist/dataaccess reference")
             return
         }
-        XCTAssertEqual(reference.titleStyle, .title)
-        XCTAssertEqual(reference.name, "com.apple.enabledataaccess")
-        XCTAssertEqual(reference.ideTitle, "Enable Data Access")
+        XCTAssertEqual(reference.propertyListKeyNames?.titleStyle, .useDisplayName)
+        XCTAssertEqual(reference.propertyListKeyNames?.rawKey, "com.apple.enabledataaccess")
+        XCTAssertEqual(reference.propertyListKeyNames?.displayName, "Enable Data Access")
     
         // Test navigator information
         XCTAssertEqual(symbol.navigatorPageType(), .propertyListKey)
@@ -143,8 +143,8 @@ class PlistSymbolTests: XCTestCase {
             return
         }
         
-        XCTAssertEqual(section.details.name, "com.apple.developer.networking.wifi")
-        XCTAssertNil(section.details.ideTitle)
+        XCTAssertEqual(section.details.rawKey, "com.apple.developer.networking.wifi")
+        XCTAssertNil(section.details.displayName)
         
         AssertRoundtrip(for: symbol)
     }

--- a/Tests/SwiftDocCUtilitiesTests/OutOfProcessReferenceResolverTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/OutOfProcessReferenceResolverTests.swift
@@ -314,6 +314,14 @@ class OutOfProcessReferenceResolverTests: XCTestCase {
            XCTFail("Unexpected fragments variant patch")
         }
 
+        XCTAssertNil(entity.topicRenderReference.conformance)
+        XCTAssertNil(entity.topicRenderReference.estimatedTime)
+        XCTAssertNil(entity.topicRenderReference.defaultImplementationCount)
+        XCTAssertFalse(entity.topicRenderReference.isBeta)
+        XCTAssertFalse(entity.topicRenderReference.isDeprecated)
+        XCTAssertNil(entity.topicRenderReference.propertyListKeyNames)
+        XCTAssertNil(entity.topicRenderReference.tags)
+        
         XCTAssertEqual(entity.topicRenderReference.images.count, 1)
         let topicImage = try XCTUnwrap(entity.topicRenderReference.images.first)
         XCTAssertEqual(topicImage.type, .card)


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://126292460

## Summary

This renames the confusingly named `TitleStyle/title` and `TitleStyle/symbol` to `PropertyListTitleStyle/useDisplayName` and `PropertyListTitleStyle/useRawKey` to clarify what they are used for and fixes a fixes a call site that set the `titleStyle` of topic references because it wasn't clear that the API was only for property list keys. 

For the `TopicRenderReference` changes I started by renaming `titleStyle` to `propertyListTitleStyle`, `name` to `propertyListRawKey`, and `ideTitle` to `propertyListDisplayName`. Next, the common prefix led me to group these into a struct to make it even more clear that they are related.  

## Dependencies

None.

## Testing

In any documentation project
- Modify `/path/to/swift-docc-clone/bin/test-data-external-resolver` so that "kind/isSymbol" is "false"
- Add a documentation link to `<doc://com.test.bundle/something>` somewhere in the content
- Set `DOCC_LINK_RESOLVER_EXECUTABLE=/path/to/swift-docc-clone/bin/test-data-external-resolver`
- Preview documentation for the page with the link externally resolved link. 
   - The link text should not use a monospace font. 

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] ~Added~ Updated tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
