### PR TITLE
Fix bug where symbols would get the framework name show up twice in the availability badges.

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -1235,7 +1235,8 @@ public struct RenderNodeTranslator: SemanticVisitor {
             from: symbol.extendedModuleVariants,
             transform: { (_, value) in
                 let relatedModules: [String]?
-                if value != moduleName.displayName {
+                // Don't add the module name of extensions made in the compiled module.
+                if (value != moduleName.displayName) && (value != moduleName.symbolName) {
                     relatedModules = [value]
                 } else {
                     relatedModules = nil

--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
@@ -3045,6 +3045,7 @@ Document
          
         let moduleReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit", sourceLanguage: .swift)
         let protocolReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/MyProtocol", sourceLanguage: .swift)
+        let functionReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/MyClass/myFunction()", sourceLanguage: .swift)
         
         // Verify the MyKit module
         
@@ -3098,6 +3099,17 @@ Document
         for moduleVariant in protocolRenderNode.metadata.modulesVariants.variants {
             XCTAssertEqual(moduleVariant.patch.description, "My custom conceptual name")
         }
+        
+        // Verify the MyFunction node
+        
+        let functionNode = try context.entity(with: functionReference)
+        let functionSymbol = try XCTUnwrap(functionNode.semantic as? Symbol)
+        translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: functionNode.reference, source: nil)
+        let functionRenderNode = try XCTUnwrap(translator.visit(functionSymbol) as? RenderNode)
+        XCTAssertTrue(functionRenderNode.metadata.modulesVariants.variants.isEmpty)
+        // Test that the symbol name `MyKit` is not added as a related module.
+        XCTAssertNil((functionRenderNode.metadata.modulesVariants.defaultValue!.first!.relatedModules))
+        XCTAssertTrue(functionRenderNode.metadata.extendedModuleVariants.variants.isEmpty)
     }
     
     /// Tests that we correctly resolve links in automatic inherited API Collections.


### PR DESCRIPTION

<!--
If you're opening a PR to cherry-pick a change for a release branch, use this template instead:
https://github.com/apple/swift-docc/blob/main/.github/PULL_REQUEST_TEMPLATE/CHERRY_PICK.md
-->

Bug/issue #, if applicable: 126713717

## Summary

When a framework had a display name different to the top level symbol name both variations would appear as availability badges in the symbols that were declared in extensions of that same framework, resulting in  odd availability information.

Before the fix:
<img width="842" alt="Screenshot 2024-05-22 at 20 12 45" src="https://github.com/apple/swift-docc/assets/49292858/a71e0a78-7c9d-4caf-aaf9-433ef008225c">


After the fix:
<img width="834" alt="Screenshot 2024-05-22 at 20 14 38" src="https://github.com/apple/swift-docc/assets/49292858/d71f5dc7-1f12-49a1-8e3d-9cd14c3979be">

This was caused by the logic introduced here:
https://github.com/apple/swift-docc/pull/732/files#diff-68ec34e58e2102fa55684b18f310a856fd3220cf919e869bca4ad5f179ac1f14R1206

## Dependencies

N/A

## Testing

Steps:
1. Preview attached doc catalog.
2. Assert that the availabilities displayed in the `Foo` symbol does not show the framework name.


## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary (N/A)
[AvailabilityBug.docc.zip](https://github.com/apple/swift-docc/files/15407242/AvailabilityBug.docc.zip)


