### PR TITLE
[6.0] Add missing Apple supported platforms (#920)

### DIFF
--- a/Sources/SwiftDocC/Indexing/Navigator/AvailabilityIndex+Ext.swift
+++ b/Sources/SwiftDocC/Indexing/Navigator/AvailabilityIndex+Ext.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -259,6 +259,8 @@ public struct Platform: Hashable, CustomStringConvertible, Codable, Equatable {
         public static let watchOS = Platform.Name(name: "watchOS", mask: 1 << 3)
         public static let tvOS = Platform.Name(name: "tvOS", mask: 1 << 4)
         public static let macCatalyst = Platform.Name(name: "Mac Catalyst", mask: 1 << 5)
+        public static let iPadOS = Platform.Name(name: "iPadOS", mask: 1 << 6)
+        public static let visionOS = Platform.Name(name: "visionOS", mask: 1 << 7)
         
         // A mask including all the platforms
         public static let any = Platform.Name(name: "all", mask: ID.max)
@@ -284,6 +286,10 @@ public struct Platform: Hashable, CustomStringConvertible, Codable, Equatable {
                 return .tvOS
             case "mac catalyst":
                 return .macCatalyst
+            case "ipados":
+                return .iPadOS
+            case "visionos":
+                return .visionOS
             default:
                 return .undefined
             }

--- a/Sources/SwiftDocC/Infrastructure/Workspace/DefaultAvailability.swift
+++ b/Sources/SwiftDocC/Infrastructure/Workspace/DefaultAvailability.swift
@@ -131,7 +131,7 @@ public struct DefaultAvailability: Codable, Equatable {
     /// or have the same availability information as another platform.
     static let fallbackPlatforms: [PlatformName : PlatformName] = [
         .catalyst:.iOS,
-        PlatformName(operatingSystemName: "iPadOS"):.iOS
+        .iPadOS:.iOS
     ]
 
     /// Creates a default availability module.

--- a/Sources/SwiftDocC/Semantics/Symbol/PlatformName.swift
+++ b/Sources/SwiftDocC/Semantics/Symbol/PlatformName.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -66,13 +66,19 @@ public struct PlatformName: Codable, Hashable, Equatable {
     public static let catalystOSAppExtension = PlatformName(rawValue: "macCatalystAppExtension", displayName: "Mac Catalyst App Extension")
     /// The Swift toolchain platform.
     public static let swift = PlatformName(rawValue: "swift", displayName: "Swift")
+    /// The iPad platform.
+    public static let iPadOS = PlatformName(rawValue: "iPadOS")
+    /// Apple's visionOS operating system.
+    public static let visionOS = PlatformName(rawValue: "visionOS")
     
     /// All supported platforms sorted for presentation.
     public static let sortedPlatforms: [PlatformName] = [
         .iOS, .iOSAppExtension,
-        .macOS, .macOSAppExtension,
+        .iPadOS,
         .catalyst, .catalystOSAppExtension,
+        .macOS, .macOSAppExtension,
         .tvOS, .tvOSAppExtension,
+        .visionOS,
         .watchOS, .watchOSAppExtension,
         .swift
     ]

--- a/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
@@ -19,8 +19,6 @@ let testBundleIdentifier = "org.swift.docc.example"
 
 class NavigatorIndexingTests: XCTestCase {
     
-    let iPadOSPlatformName = Platform.Name("iPadOS", id: 6)
-    
     struct Language: OptionSet {
         let rawValue: UInt8
         
@@ -433,7 +431,7 @@ Root
             let navigatorIndex = builder.navigatorIndex!
             XCTAssertEqual(
                 navigatorIndex.availabilityIndex.platforms,
-                [.watchOS, .macCatalyst, .iOS, .tvOS, .macOS, iPadOSPlatformName]
+                [.watchOS, .macCatalyst, .iOS, .tvOS, .macOS, .iPadOS]
             )
             XCTAssertEqual(navigatorIndex.availabilityIndex.versions(for: .iOS), Set([
                 Platform.Version(string: "13.0")!,
@@ -817,7 +815,7 @@ Root
             
             let navigatorIndex = builder.navigatorIndex!
             
-            XCTAssertEqual(navigatorIndex.availabilityIndex.platforms, [.watchOS, .macCatalyst, .iOS, .tvOS, .macOS, iPadOSPlatformName])
+            XCTAssertEqual(navigatorIndex.availabilityIndex.platforms, [.watchOS, .macCatalyst, .iOS, .tvOS, .macOS, .iPadOS])
             XCTAssertEqual(navigatorIndex.availabilityIndex.versions(for: .iOS), Set([
                 Platform.Version(string: "13.0")!,
                 Platform.Version(string: "10.15")!,
@@ -867,7 +865,7 @@ Root
             // Read the index back from disk
             let navigatorIndex = try NavigatorIndex.readNavigatorIndex(url: targetURL)
             
-            XCTAssertEqual(navigatorIndex.availabilityIndex.platforms, [.watchOS, .macCatalyst, .iOS, .tvOS, .macOS, iPadOSPlatformName])
+            XCTAssertEqual(navigatorIndex.availabilityIndex.platforms, [.watchOS, .macCatalyst, .iOS, .tvOS, .macOS, .iPadOS])
             XCTAssertEqual(navigatorIndex.availabilityIndex.versions(for: .iOS), Set([
                 Platform.Version(string: "13.0")!,
                 Platform.Version(string: "10.15")!,
@@ -905,7 +903,7 @@ Root
     func testNavigatorIndexGenerationWithLanguageGrouping() throws {
         let navigatorIndex = try generatedNavigatorIndex(for: "TestBundle", bundleIdentifier: testBundleIdentifier)
         
-        XCTAssertEqual(navigatorIndex.availabilityIndex.platforms, [.watchOS, .macCatalyst, .iOS, .tvOS, .macOS, iPadOSPlatformName])
+        XCTAssertEqual(navigatorIndex.availabilityIndex.platforms, [.watchOS, .macCatalyst, .iOS, .tvOS, .macOS, .iPadOS])
         XCTAssertEqual(navigatorIndex.availabilityIndex.versions(for: .iOS), Set([
             Platform.Version(string: "13.0")!,
             Platform.Version(string: "10.15")!,
@@ -1008,7 +1006,7 @@ Root
         
         XCTAssertEqual(navigatorIndex.pathHasher, .md5)
         XCTAssertEqual(navigatorIndex.bundleIdentifier, testBundleIdentifier)
-        XCTAssertEqual(navigatorIndex.availabilityIndex.platforms, [.watchOS, .iOS, .macCatalyst, .tvOS, .macOS, iPadOSPlatformName])
+        XCTAssertEqual(navigatorIndex.availabilityIndex.platforms, [.watchOS, .iOS, .macCatalyst, .tvOS, .macOS, .iPadOS])
         XCTAssertEqual(navigatorIndex.availabilityIndex.versions(for: .macOS), Set([
             Platform.Version(string: "10.9")!,
             Platform.Version(string: "10.10")!,
@@ -1030,12 +1028,13 @@ Root
             Platform.Version(string: "13.0")!,
         ]))
         XCTAssertEqual(Set(navigatorIndex.languages), Set(["Swift"]))
-        XCTAssertEqual(Set(navigatorIndex.availabilityIndex.platforms(for: InterfaceLanguage.swift) ?? []), Set([.watchOS, .iOS, .macCatalyst, .tvOS, .macOS, iPadOSPlatformName]))
+        XCTAssertEqual(Set(navigatorIndex.availabilityIndex.platforms(for: InterfaceLanguage.swift) ?? []), Set([.watchOS, .iOS, .macCatalyst, .tvOS, .macOS, .iPadOS]))
         XCTAssertEqual(navigatorIndex.availabilityIndex.platform(named: "macOS"), .macOS)
         XCTAssertEqual(navigatorIndex.availabilityIndex.platform(named: "watchOS"), .watchOS)
         XCTAssertEqual(navigatorIndex.availabilityIndex.platform(named: "tvOS"), .tvOS)
         XCTAssertEqual(navigatorIndex.availabilityIndex.platform(named: "ios"), .undefined, "Incorrect capitalization")
         XCTAssertEqual(navigatorIndex.availabilityIndex.platform(named: "iOS"), .iOS)
+        XCTAssertEqual(navigatorIndex.availabilityIndex.platform(named: "iPadOS"), .iPadOS)
         
         // Check ID mapping
         XCTAssertNotNil(navigatorIndex.id(for:"/documentation/sidekit/sideclass", with: .swift))
@@ -1078,6 +1077,9 @@ Root
         XCTAssertFalse(availabilityInfo.isAvailable(on: Platform(name: .iOS, version: Platform.Version(string: "10.0")!)))
         availabilityInfo = availabilities[1]
         XCTAssertFalse(availabilityInfo.belongs(to: .macOS))
+        XCTAssertTrue(availabilityInfo.belongs(to: .iPadOS))
+        XCTAssertTrue(availabilityInfo.isAvailable(on: Platform(name: .iPadOS, version: Platform.Version(string: "10.15.0")!)))
+        availabilityInfo = availabilities[2]
         XCTAssertTrue(availabilityInfo.belongs(to: .macCatalyst))
         XCTAssertTrue(availabilityInfo.isAvailable(on: Platform(name: .macCatalyst, version: Platform.Version(string: "13.0")!)))
         

--- a/Tests/SwiftDocCTests/Rendering/AvailabilityRenderOrderTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/AvailabilityRenderOrderTests.swift
@@ -34,9 +34,11 @@ class AvailabilityRenderOrderTests: XCTestCase {
         // Additionally verify all the platforms have their correctly spelled name including spaces.
         XCTAssertEqual(renderNode.metadata.platforms?.map({ "\($0.name ?? "") \($0.introduced ?? "")" }), [
             "iOS 12.0", "iOS App Extension 12.0",
-            "macOS 10.12", "macOS App Extension 10.12",
+            "iPadOS 12.0",
             "Mac Catalyst 2.0", "Mac Catalyst App Extension 1.0",
+            "macOS 10.12", "macOS App Extension 10.12",
             "tvOS 12.0", "tvOS App Extension 12.0",
+            "visionOS 12.0",
             "watchOS 6.0", "watchOS App Extension 6.0",
             "Swift 4.2"
         ])
@@ -50,9 +52,11 @@ class AvailabilityRenderOrderTests: XCTestCase {
         let roundtripNode = try RenderNode.decode(fromJSON: roundtripData)
         XCTAssertEqual(roundtripNode.metadata.platforms?.map({ "\($0.name ?? "") \($0.introduced ?? "")" }), [
             "iOS 12.0", "iOS App Extension 12.0",
-            "macOS 10.12", "macOS App Extension 10.12",
+            "iPadOS 12.0",
             "Mac Catalyst 2.0", "Mac Catalyst App Extension 1.0",
+            "macOS 10.12", "macOS App Extension 10.12",
             "tvOS 12.0", "tvOS App Extension 12.0",
+            "visionOS 12.0",
             "watchOS 6.0", "watchOS App Extension 6.0",
             "Swift 4.2"
         ])

--- a/Tests/SwiftDocCTests/Test Resources/Availability.symbols.json
+++ b/Tests/SwiftDocCTests/Test Resources/Availability.symbols.json
@@ -10,10 +10,10 @@
   "module": {
     "name": "Availability",
     "platform": {
-      "architecture": "x86_64",
+      "architecture": "arm64",
       "vendor": "apple",
       "operatingSystem": {
-        "name": "macosx",
+        "name": "ios",
         "minimumVersion": {
           "major": 10,
           "minor": 10,
@@ -126,6 +126,13 @@
         },
         {
           "domain": "iOS",
+          "introduced": {
+            "major": 12,
+            "minor": 0
+          }
+        },
+        {
+          "domain": "visionOS",
           "introduced": {
             "major": 12,
             "minor": 0


### PR DESCRIPTION
* **Explanation:** This pr adds missing Apple supported platforms `iPadOS` and `visionOS`, and adds them into the list of sorted platforms for a correct presentation in the desired order.
* **Scope:** Symbol availability badges sorting.
* **Issue:** rdar://127384226
* **Risk:** Low.
* **Testing:** Manual testing was made and unit tests were added.
* **Reviewer:** @d-ronnqvist 
* **Original PR:** https://github.com/apple/swift-docc/pull/920
