### PR TITLE
Update navigator image references to the correct relative path

### DIFF
--- a/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
+++ b/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
@@ -1017,12 +1017,11 @@ extension NavigatorIndex {
             if emitJSONRepresentation {
                 let renderIndex = RenderIndex.fromNavigatorIndex(navigatorIndex, with: self)
                 
-                let jsonEncoder = JSONEncoder()
-                if shouldPrettyPrintOutputJSON {
-                    jsonEncoder.outputFormatting = [.sortedKeys, .prettyPrinted]
-                } else {
-                    jsonEncoder.outputFormatting = [.sortedKeys]
-                }
+                let jsonEncoder = RenderJSONEncoder.makeEncoder(
+                    prettyPrint: shouldPrettyPrintOutputJSON,
+                    assetPrefixComponent: bundleIdentifier.split(separator: "/").joined(separator: "-")
+                )
+                jsonEncoder.outputFormatting.insert(.sortedKeys)
                 
                 let jsonNavigatorIndexURL = outputURL.appendingPathComponent("index.json")
                 do {

--- a/Tests/SwiftDocCTests/Indexing/RenderIndexTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/RenderIndexTests.swift
@@ -704,7 +704,7 @@ final class RenderIndexTests: XCTestCase {
                       "identifier" : "plus.svg",
                       "variants" : [
                         {
-                          "url" : "\/images\/plus.svg",
+                          "url" : "\/images\/org.swift.docc.Book\/plus.svg",
                           "traits" : [
                             "1x",
                             "light"


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://128397787

## Summary

This fixes a bug in the navigator index where pages with custom `@PageImage` icons would use the wrong relative path to refer to that image within the .doccarchive.

## Dependencies

None.

## Testing

- In any project, add an article with a custom page image icon (and add an image to use as the icon). For example:
```
# Some article

@Metadata {
    @PageImage(purpose: icon, source: "my-icon")
}

An article with a custom page image.
```
- Build and preview documentation for the project.
   - The article's item in the navigator should display the custom icon

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] ~Updated documentation if necessary~ Not applicable
