### PR TITLE
[6.0] Update navigator image references to the correct relative path (#925)

### DIFF
--- a/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
+++ b/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
@@ -1017,12 +1017,11 @@ extension NavigatorIndex {
             if emitJSONRepresentation {
                 let renderIndex = RenderIndex.fromNavigatorIndex(navigatorIndex, with: self)
                 
-                let jsonEncoder = JSONEncoder()
-                if shouldPrettyPrintOutputJSON {
-                    jsonEncoder.outputFormatting = [.sortedKeys, .prettyPrinted]
-                } else {
-                    jsonEncoder.outputFormatting = [.sortedKeys]
-                }
+                let jsonEncoder = RenderJSONEncoder.makeEncoder(
+                    prettyPrint: shouldPrettyPrintOutputJSON,
+                    assetPrefixComponent: bundleIdentifier.split(separator: "/").joined(separator: "-")
+                )
+                jsonEncoder.outputFormatting.insert(.sortedKeys)
                 
                 let jsonNavigatorIndexURL = outputURL.appendingPathComponent("index.json")
                 do {

--- a/Tests/SwiftDocCTests/Indexing/RenderIndexTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/RenderIndexTests.swift
@@ -704,7 +704,7 @@ final class RenderIndexTests: XCTestCase {
                       "identifier" : "plus.svg",
                       "variants" : [
                         {
-                          "url" : "\/images\/plus.svg",
+                          "url" : "\/images\/org.swift.docc.Book\/plus.svg",
                           "traits" : [
                             "1x",
                             "light"


### PR DESCRIPTION
- **Explanation:** 
This fixes a bug in the navigator index where pages with custom `@PageImage` icons would use the wrong relative path to refer to that image within the .doccarchive.
- **Scope:** Custom `@PageImage` icons in the navigator index.
- **Issue:** rdar://128397787
- **Risk:** Low
- **Testing:** New tests verify that the encoded navigator index uses the correct relative asset path.
- **Reviewer:** @emilyychenn 
- **Original PR:** #925

