### PR TITLE
[6.0] Fix bug where symbols with display names would get the framework name show up twice in the availability badges. 

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -1235,7 +1235,8 @@ public struct RenderNodeTranslator: SemanticVisitor {
             from: symbol.extendedModuleVariants,
             transform: { (_, value) in
                 let relatedModules: [String]?
-                if value != moduleName.displayName {
+                // Don't add the module name of extensions made in the compiled module.
+                if (value != moduleName.displayName) && (value != moduleName.symbolName) {
                     relatedModules = [value]
                 } else {
                     relatedModules = nil

--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
@@ -3045,6 +3045,7 @@ Document
          
         let moduleReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit", sourceLanguage: .swift)
         let protocolReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/MyProtocol", sourceLanguage: .swift)
+        let functionReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/MyClass/myFunction()", sourceLanguage: .swift)
         
         // Verify the MyKit module
         
@@ -3098,6 +3099,17 @@ Document
         for moduleVariant in protocolRenderNode.metadata.modulesVariants.variants {
             XCTAssertEqual(moduleVariant.patch.description, "My custom conceptual name")
         }
+        
+        // Verify the MyFunction node
+        
+        let functionNode = try context.entity(with: functionReference)
+        let functionSymbol = try XCTUnwrap(functionNode.semantic as? Symbol)
+        translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: functionNode.reference, source: nil)
+        let functionRenderNode = try XCTUnwrap(translator.visit(functionSymbol) as? RenderNode)
+        XCTAssertTrue(functionRenderNode.metadata.modulesVariants.variants.isEmpty)
+        // Test that the symbol name `MyKit` is not added as a related module.
+        XCTAssertNil((functionRenderNode.metadata.modulesVariants.defaultValue!.first!.relatedModules))
+        XCTAssertTrue(functionRenderNode.metadata.extendedModuleVariants.variants.isEmpty)
     }
     
     /// Tests that we correctly resolve links in automatic inherited API Collections.


### PR DESCRIPTION
* **Explanation:** When a framework had a display name different to the top-level symbol name, both variations would appear as availability badges in the symbols that were declared in extensions of that same framework, resulting in odd availability information.
* **Scope:** Symbol availability badges.
* **Issue:** rdar://126713717
* **Risk:** Low.
* **Testing:** Manual and unit tests.
* **Reviewer:** @d-ronnqvist @patshaughnessy 
* **Original PR:** https://github.com/apple/swift-docc/pull/922
