### PR TITLE
Highlight declaration differences in overloaded symbol groups

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/DeclarationsSectionTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/DeclarationsSectionTranslator.swift
@@ -23,7 +23,7 @@ struct DeclarationsSectionTranslator: RenderSectionTranslator {
                 return nil
             }
 
-            func translateFragment(_ fragment: SymbolGraph.Symbol.DeclarationFragments.Fragment) -> DeclarationRenderSection.Token {
+            func translateFragment(_ fragment: SymbolGraph.Symbol.DeclarationFragments.Fragment, highlightDiff: Bool? = nil) -> DeclarationRenderSection.Token {
                 let reference: ResolvedTopicReference?
                 if let preciseIdentifier = fragment.preciseIdentifier,
                    let resolved = renderNodeTranslator.context.localOrExternalReference(symbolID: preciseIdentifier)
@@ -35,39 +35,98 @@ struct DeclarationsSectionTranslator: RenderSectionTranslator {
                 }
 
                 // Add the declaration token
-                return DeclarationRenderSection.Token(fragment: fragment, identifier: reference?.absoluteString)
+                return DeclarationRenderSection.Token(fragment: fragment, identifier: reference?.absoluteString, highlightDiff: highlightDiff)
             }
 
-            func renderOtherDeclarationsTokens(from overloads: Symbol.Overloads) -> DeclarationRenderSection.OtherDeclarations {
-                var otherDeclarations = [DeclarationRenderSection.OtherDeclarations.Declaration]()
-                for overloadReference in overloads.references {
-                    guard let overload = try? renderNodeTranslator.context.entity(with: overloadReference).semantic as? Symbol else {
-                        continue
+            func translateFragment(_ fragment: SymbolGraph.Symbol.DeclarationFragments.Fragment) -> DeclarationRenderSection.Token {
+                return translateFragment(fragment, highlightDiff: nil)
+            }
+
+            func translateDeclaration(
+                _ declaration: [SymbolGraph.Symbol.DeclarationFragments.Fragment],
+                commonFragments: [SymbolGraph.Symbol.DeclarationFragments.Fragment]
+            ) -> [DeclarationRenderSection.Token] {
+                var translatedDeclaration: [DeclarationRenderSection.Token] = []
+                var commonIndex = 0
+                for fragment in declaration {
+                    if commonIndex < commonFragments.count, fragment == commonFragments[commonIndex] {
+                        // fragment is common to all declarations, render plain
+                        translatedDeclaration.append(translateFragment(fragment))
+                        commonIndex += 1
+                    } else {
+                        // fragment is unique to this declaration, render highlighted
+                        translatedDeclaration.append(translateFragment(fragment, highlightDiff: true))
                     }
+                }
 
-                    let declarationFragments = overload.declarationVariants[trait]?.values.first?.declarationFragments
-                    assert(declarationFragments != nil, "Overloaded symbols must have declaration fragments.")
-                    guard let declarationFragments else { continue }
+                return translatedDeclaration
+            }
 
-                    let declarationTokens = declarationFragments.map(translateFragment)
-                    otherDeclarations.append(
-                        .init(
-                            tokens: declarationTokens,
-                            identifier: overloadReference.absoluteString
-                        )
-                    )
+            typealias OverloadDeclaration = (declaration: [SymbolGraph.Symbol.DeclarationFragments.Fragment], reference: ResolvedTopicReference)
+
+            func renderOtherDeclarationsTokens(
+                from overloadDeclarations: [OverloadDeclaration],
+                displayIndex: Int,
+                commonFragments: [SymbolGraph.Symbol.DeclarationFragments.Fragment]
+            ) -> DeclarationRenderSection.OtherDeclarations {
+                var otherDeclarations = [DeclarationRenderSection.OtherDeclarations.Declaration]()
+
+                for overloadDeclaration in overloadDeclarations {
+                    var commonIndex = 0
+                    var translatedDeclaration: [DeclarationRenderSection.Token] = []
+                    for fragment in overloadDeclaration.declaration {
+                        if commonIndex < commonFragments.count && fragment == commonFragments[commonIndex] {
+                            // fragment is common to all declarations, render plain
+                            translatedDeclaration.append(translateFragment(fragment))
+                            commonIndex += 1
+                        } else {
+                            // fragment is unique to this declaration, render highlighted
+                            translatedDeclaration.append(translateFragment(fragment, highlightDiff: true))
+                        }
+                    }
+                    otherDeclarations.append(.init(
+                        tokens: translatedDeclaration,
+                        identifier: overloadDeclaration.reference.absoluteString))
 
                     // Add a topic reference to the overload
-                    renderNodeTranslator.collectedTopicReferences.append(overloadReference)
+                    renderNodeTranslator.collectedTopicReferences.append(overloadDeclaration.reference)
                 }
-                return .init(declarations: otherDeclarations, displayIndex: overloads.displayIndex)
+
+                return .init(declarations: otherDeclarations, displayIndex: displayIndex)
             }
 
             var declarations = [DeclarationRenderSection]()
             for pair in declaration {
                 let (platforms, declaration) = pair
 
-                let renderedTokens = declaration.declarationFragments.map(translateFragment)
+                let renderedTokens: [DeclarationRenderSection.Token]
+                let otherDeclarations: DeclarationRenderSection.OtherDeclarations?
+
+                // If this symbol has overloads, render their declarations as well.
+                if let overloads = symbol.overloadsVariants[trait],
+                   let overloadDeclarations = symbol.overloadsVariants[trait]?.references.compactMap({ overloadReference -> OverloadDeclaration? in
+                    guard let overload = try? renderNodeTranslator.context.entity(with: overloadReference).semantic as? Symbol else {
+                        return nil
+                    }
+
+                    let declarationFragments = overload.declarationVariants[trait]?.values.first?.declarationFragments
+                    assert(declarationFragments != nil, "Overloaded symbols must have declaration fragments.")
+                    return declarationFragments.map({ (declaration: $0, reference: overloadReference )})
+                }), !overloadDeclarations.isEmpty {
+                    // Collect the "common fragments" so we can highlight the ones that are different
+                    // in each declaration
+                    // FIXME: Pre-process declarations to break up text fragments for better visual output
+                    let commonFragments = longestCommonSubsequence([declaration.declarationFragments] + overloadDeclarations.map(\.declaration))
+
+                    renderedTokens = translateDeclaration(declaration.declarationFragments, commonFragments: commonFragments)
+                    otherDeclarations = renderOtherDeclarationsTokens(
+                        from: overloadDeclarations,
+                        displayIndex: overloads.displayIndex,
+                        commonFragments: commonFragments)
+                } else {
+                    renderedTokens = declaration.declarationFragments.map(translateFragment)
+                    otherDeclarations = nil
+                }
 
                 let platformNames = platforms.sorted { (lhs, rhs) -> Bool in
                     guard let lhsValue = lhs, let rhsValue = rhs else {
@@ -75,9 +134,6 @@ struct DeclarationsSectionTranslator: RenderSectionTranslator {
                     }
                     return lhsValue.rawValue < rhsValue.rawValue
                 }
-
-                // If this symbol has overloads, render their declarations as well.
-                let otherDeclarations = symbol.overloadsVariants[trait].map({ renderOtherDeclarationsTokens(from: $0) })
 
                 declarations.append(
                     DeclarationRenderSection(
@@ -113,4 +169,125 @@ struct DeclarationsSectionTranslator: RenderSectionTranslator {
             return DeclarationsRenderSection(declarations: declarations)
         }
     }
+}
+
+/// Calculate the "longest common subsequence" of two sequences.
+///
+/// The longest common subsequence (LCS) of a set of sequences is the sequence of items that
+/// appears in all the input sequences in the same order. For example given the sequences `ABAC`
+/// and `CAACB`, the letters `AAC` appear in the same order in both of them, even though the letter
+/// `B` interrupts the sequence in the first one.
+fileprivate func longestCommonSubsequence<Element>(_ inputLHS: [Element], _ inputRHS: [Element]) -> [Element] where Element: Equatable {
+    // Optimization: Trim out the elements that are common to both sequences so we can reduce the
+    // number of required comparisons
+    let commonPrefix = zip(inputLHS, inputRHS).prefix(while: { $0 == $1 }).map(\.0)
+    let lhs = inputLHS.dropFirst(commonPrefix.count)
+    let rhs = inputRHS.dropFirst(commonPrefix.count)
+
+    if lhs.isEmpty || rhs.isEmpty {
+        return commonPrefix
+    }
+
+    // "Longest common subsequence" is the underlying problem behind `diff` and other kinds of
+    // sequence comparisons. The fundamental issue with trying a naive "running comparison" solution
+    // is knowing how long a subsequence of differing tokens is, i.e. when to "rejoin" the sequences
+    // together. The well-understood solution for two sequences follows a "dynamic programming"
+    // style, creating a matrix of element-to-element comparisons and building the resulting
+    // answer(s) from that.
+    //
+    // Here's an example, using the inputs from this function's doc comment. The built-up matrix
+    // compares each element of one sequence with each element of the other sequence, marking which
+    // pairs of elements are equal:
+    //
+    //   | A | B | A | C
+    // -----------------
+    // C |   |   |   | X
+    // A | X |   | X |
+    // A | X |   | X |
+    // C |   |   |   | X
+    // B |   | X |   |
+    //
+    // To construct the answer, the algorithm then walks the matrix row-wise from top to bottom,
+    // following two rules:
+    //
+    // 1. If the two elements were not equal, take the longest sequence from either the cell above
+    //    or the cell to the left. (Reading "off the edge" of the matrix yields an empty sequence.)
+    //    If both sequences were the same length, take both of them.
+    // 2. If the two elements were equal, take the sequence(s) from the cell diagonally up-left and
+    //    append the element to them.
+    //
+    // When you have finished walking the matrix, the sequence(s) from the bottom-right cell are the
+    // longest common subsequence(s) of the pair.
+    //
+    // When this algorithm is used to calculate an edit sequence from the left-column sequence to
+    // the top-row sequence (e.g. using `diff`), "taking the sequence from the row above" represents
+    // a deletion, and "taking the sequence from the cell to the left" represents an insertion. To
+    // better reflect the output from a proper diff when deduplicating multiple result sequences,
+    // this implementation proactively selects the "row above" sequence, which corresponds to
+    // preferentially printing deletions before insertions.
+
+    // In lieu of keeping the complete matrix of equal comparisons, store the intermediate sequences
+    // and only save the "previous row" so we don't have to walk it back later.
+    var previousRow: [[Element]] = .init(repeating: [], count: rhs.count)
+
+    /// Fetches the element in the index before the given one, or an empty array if that would read out of bounds.
+    func getPreviousOrDefault(_ array: [[Element]], index: Int) -> [Element] {
+        if index == 0 {
+            return []
+        } else {
+            return array[index - 1]
+        }
+    }
+
+    /// Returns the longer sequence, or `lhs` if they are of equal length.
+    func maxLength(_ lhs: [Element], _ rhs: [Element]) -> [Element] {
+        if rhs.count > lhs.count {
+            return rhs
+        } else {
+            return lhs
+        }
+    }
+
+    // Iterate row-wise: compare all the elements in the first sequence.
+    for lhsValue in lhs {
+        var currentRow: [[Element]] = .init(repeating: [], count: rhs.count)
+        // Iterate column-wise: with the indices and values from the second sequence, perform the comparison.
+        for (rhsIndex, rhsValue) in rhs.enumerated() {
+            if lhsValue == rhsValue {
+                // If the values are equal, pull the sequence "diagonally up-left" from this coordinate,
+                // and append the current element to it.
+                currentRow[rhsIndex] = getPreviousOrDefault(previousRow, index: rhsIndex) + [lhsValue]
+            } else {
+                // If the values are not equal, pull the longer sequence from either the row above or
+                // the column to the left. Short-circuit by preferring the "row-above" value in case
+                // they're equal.
+                currentRow[rhsIndex] = maxLength(previousRow[rhsIndex], getPreviousOrDefault(currentRow, index: rhsIndex))
+            }
+        }
+        // Now that we've computed this comparison row, save it for the next iteration.
+        previousRow = currentRow
+    }
+
+    return commonPrefix + previousRow.last!
+}
+
+/// Computes the "longest common subsequence" of a list of sequences.
+fileprivate func longestCommonSubsequence<Element>(_ sequences: [[Element]]) -> [Element] where Element: Equatable {
+    var resultSequence: [Element]? = nil
+
+    // This function relies on the two-sequence LCS to expand to an arbitrary set of sequences. The
+    // idea is effectively a `reduce1` without a default case. This does expand the worst-case time
+    // complexity to nearly `L^N` comparisons, with `L` being the average length of the sequences,
+    // and `N` being the number of sequences. In practice, since overloaded declarations tend to
+    // share a common prefix (which is trimmed in the underlying implementation), and because this
+    // is a rolling comparison against the calculated LCS, the actual number of comparisons is
+    // likely to be less than that in the average case.
+    for sequence in sequences {
+        if let currentResult = resultSequence {
+            resultSequence = longestCommonSubsequence(currentResult, sequence)
+        } else {
+            resultSequence = sequence
+        }
+    }
+    return resultSequence ?? []
 }

--- a/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/DeclarationsSectionTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/DeclarationsSectionTranslator.swift
@@ -135,6 +135,9 @@ struct DeclarationsSectionTranslator: RenderSectionTranslator {
             }
 
             var declarations: [DeclarationRenderSection] = []
+            let languages = [
+                trait.interfaceLanguage ?? renderNodeTranslator.identifier.sourceLanguage.id
+            ]
             for pair in declaration {
                 let (platforms, declaration) = pair
 
@@ -178,9 +181,7 @@ struct DeclarationsSectionTranslator: RenderSectionTranslator {
 
                 declarations.append(
                     DeclarationRenderSection(
-                        languages: [
-                            trait.interfaceLanguage ?? renderNodeTranslator.identifier.sourceLanguage.id
-                        ],
+                        languages: languages,
                         platforms: platformNames,
                         tokens: renderedTokens,
                         otherDeclarations: otherDeclarations
@@ -191,19 +192,16 @@ struct DeclarationsSectionTranslator: RenderSectionTranslator {
             if let alternateDeclarations = symbol.alternateDeclarationVariants[trait] {
                 for pair in alternateDeclarations {
                     let (platforms, decls) = pair
+                    let platformNames =
+                        platforms
+                        .compactMap { $0 }
+                        .sorted(by: \.rawValue)
                     for alternateDeclaration in decls {
                         let renderedTokens = alternateDeclaration.declarationFragments.map(translateFragment)
 
-                        let platformNames =
-                            platforms
-                            .compactMap { $0 }
-                            .sorted(by: \.rawValue)
-
                         declarations.append(
                             DeclarationRenderSection(
-                                languages: [
-                                    trait.interfaceLanguage ?? renderNodeTranslator.identifier.sourceLanguage.id
-                                ],
+                                languages: languages,
                                 platforms: platformNames,
                                 tokens: renderedTokens
                             )

--- a/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/DeclarationsSectionTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/DeclarationsSectionTranslator.swift
@@ -140,9 +140,9 @@ struct DeclarationsSectionTranslator: RenderSectionTranslator {
                     // Pre-process the declarations by splitting text fragments apart to increase legibility
                     let mainDeclaration = declaration.declarationFragments.flatMap(preProcessFragment(_:))
                     let processedOverloadDeclarations = overloadDeclarations.map({
-                        ($0.declaration.flatMap(preProcessFragment(_:)), $0.reference)
+                        OverloadDeclaration($0.declaration.flatMap(preProcessFragment(_:)), $0.reference)
                     })
-                    let preProcessedDeclarations = [mainDeclaration] + processedOverloadDeclarations.map(\.0)
+                    let preProcessedDeclarations = [mainDeclaration] + processedOverloadDeclarations.map(\.declaration)
 
                     // Collect the "common fragments" so we can highlight the ones that are different
                     // in each declaration

--- a/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/DeclarationsSectionTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/DeclarationsSectionTranslator.swift
@@ -388,7 +388,7 @@ fileprivate func preProcessFragment(
     guard fragment.kind == .text, !fragment.spelling.isEmpty else {
         return [fragment]
     }
-    var textPartitions: [String] = []
+    var textPartitions: [Substring] = []
     var substringIndex = fragment.spelling.startIndex
     var currentElement = fragment.spelling[substringIndex]
 
@@ -412,17 +412,17 @@ fileprivate func preProcessFragment(
     // FIXME: replace this with `chunked(by:)` if we add swift-algorithms as a dependency
     for (nextIndex, nextElement) in fragment.spelling.indexed().dropFirst() {
         if !areInSameChunk(currentElement, nextElement) {
-            textPartitions.append(String(fragment.spelling[substringIndex..<nextIndex]))
+            textPartitions.append(fragment.spelling[substringIndex..<nextIndex])
             substringIndex = nextIndex
         }
         currentElement = nextElement
     }
 
     if substringIndex != fragment.spelling.endIndex {
-        textPartitions.append(String(fragment.spelling[substringIndex...]))
+        textPartitions.append(fragment.spelling[substringIndex...])
     }
 
-    return textPartitions.map({ .init(kind: .text, spelling: $0, preciseIdentifier: nil) })
+    return textPartitions.map({ .init(kind: .text, spelling: String($0), preciseIdentifier: nil) })
 }
 
 /// Calculate the "longest common subsequence" of a list of sequences.

--- a/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/DeclarationsSectionTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/DeclarationsSectionTranslator.swift
@@ -359,123 +359,25 @@ struct DeclarationsSectionTranslator: RenderSectionTranslator {
     }
 }
 
-/// Calculate the "longest common subsequence" of two sequences.
+/// Calculate the "longest common subsequence" of a list of sequences.
 ///
 /// The longest common subsequence (LCS) of a set of sequences is the sequence of items that
 /// appears in all the input sequences in the same order. For example given the sequences `ABAC`
 /// and `CAACB`, the letters `AAC` appear in the same order in both of them, even though the letter
 /// `B` interrupts the sequence in the first one.
-fileprivate func longestCommonSubsequence<Element>(_ inputLHS: [Element], _ inputRHS: [Element]) -> [Element] where Element: Equatable {
-    // Optimization: Trim out the elements that are common to both sequences so we can reduce the
-    // number of required comparisons
-    let commonPrefix = zip(inputLHS, inputRHS).prefix(while: { $0 == $1 }).map(\.0)
-    let lhs = inputLHS.dropFirst(commonPrefix.count)
-    let rhs = inputRHS.dropFirst(commonPrefix.count)
+fileprivate func longestCommonSubsequence<Element: Equatable>(_ sequences: [[Element]]) -> [Element] {
+    guard var result = sequences.first else { return [] }
 
-    if lhs.isEmpty || rhs.isEmpty {
-        return commonPrefix
-    }
-
-    // "Longest common subsequence" is the underlying problem behind `diff` and other kinds of
-    // sequence comparisons. The fundamental issue with trying a naive "running comparison" solution
-    // is knowing how long a subsequence of differing tokens is, i.e. when to "rejoin" the sequences
-    // together. The well-understood solution for two sequences follows a "dynamic programming"
-    // style, creating a matrix of element-to-element comparisons and building the resulting
-    // answer(s) from that.
-    //
-    // Here's an example, using the inputs from this function's doc comment. The built-up matrix
-    // compares each element of one sequence with each element of the other sequence, marking which
-    // pairs of elements are equal:
-    //
-    //   | A | B | A | C
-    // -----------------
-    // C |   |   |   | X
-    // A | X |   | X |
-    // A | X |   | X |
-    // C |   |   |   | X
-    // B |   | X |   |
-    //
-    // To construct the answer, the algorithm then walks the matrix row-wise from top to bottom,
-    // following two rules:
-    //
-    // 1. If the two elements were not equal, take the longest sequence from either the cell above
-    //    or the cell to the left. (Reading "off the edge" of the matrix yields an empty sequence.)
-    //    If both sequences were the same length, take both of them.
-    // 2. If the two elements were equal, take the sequence(s) from the cell diagonally up-left and
-    //    append the element to them.
-    //
-    // When you have finished walking the matrix, the sequence(s) from the bottom-right cell are the
-    // longest common subsequence(s) of the pair.
-    //
-    // When this algorithm is used to calculate an edit sequence from the left-column sequence to
-    // the top-row sequence (e.g. using `diff`), "taking the sequence from the row above" represents
-    // a deletion, and "taking the sequence from the cell to the left" represents an insertion. To
-    // better reflect the output from a proper diff when deduplicating multiple result sequences,
-    // this implementation proactively selects the "row above" sequence, which corresponds to
-    // preferentially printing deletions before insertions.
-
-    // In lieu of keeping the complete matrix of equal comparisons, store the intermediate sequences
-    // and only save the "previous row" so we don't have to walk it back later.
-    var previousRow: [[Element]] = .init(repeating: [], count: rhs.count)
-
-    /// Fetches the element in the index before the given one, or an empty array if that would read out of bounds.
-    func getPreviousOrDefault(_ array: [[Element]], index: Int) -> [Element] {
-        if index == 0 {
-            return []
-        } else {
-            return array[index - 1]
+    for other in sequences.dropFirst() {
+        // This implementation uses the Swift standard library's `CollectionDifference` API to
+        // calculate the difference between two sequences, then back-computes the LCS by applying
+        // just the calculated "removals" to the first sequence. Then, in the next loop iteration,
+        // recalculate the LCS between the result and the next input sequence. By the time all the
+        // input sequences have been iterated, we have a common subsequence from all the inputs.
+        for case .remove(let offset, _, _) in other.difference(from: result).removals.reversed() {
+            result.remove(at: result.startIndex + offset)
         }
     }
 
-    /// Returns the longer sequence, or `lhs` if they are of equal length.
-    func maxLength(_ lhs: [Element], _ rhs: [Element]) -> [Element] {
-        if rhs.count > lhs.count {
-            return rhs
-        } else {
-            return lhs
-        }
-    }
-
-    // Iterate row-wise: compare all the elements in the first sequence.
-    for lhsValue in lhs {
-        var currentRow: [[Element]] = .init(repeating: [], count: rhs.count)
-        // Iterate column-wise: with the indices and values from the second sequence, perform the comparison.
-        for (rhsIndex, rhsValue) in rhs.enumerated() {
-            if lhsValue == rhsValue {
-                // If the values are equal, pull the sequence "diagonally up-left" from this coordinate,
-                // and append the current element to it.
-                currentRow[rhsIndex] = getPreviousOrDefault(previousRow, index: rhsIndex) + [lhsValue]
-            } else {
-                // If the values are not equal, pull the longer sequence from either the row above or
-                // the column to the left. Short-circuit by preferring the "row-above" value in case
-                // they're equal.
-                currentRow[rhsIndex] = maxLength(previousRow[rhsIndex], getPreviousOrDefault(currentRow, index: rhsIndex))
-            }
-        }
-        // Now that we've computed this comparison row, save it for the next iteration.
-        previousRow = currentRow
-    }
-
-    return commonPrefix + previousRow.last!
-}
-
-/// Computes the "longest common subsequence" of a list of sequences.
-fileprivate func longestCommonSubsequence<Element>(_ sequences: [[Element]]) -> [Element] where Element: Equatable {
-    var resultSequence: [Element]? = nil
-
-    // This function relies on the two-sequence LCS to expand to an arbitrary set of sequences. The
-    // idea is effectively a `reduce1` without a default case. This does expand the worst-case time
-    // complexity to nearly `L^N` comparisons, with `L` being the average length of the sequences,
-    // and `N` being the number of sequences. In practice, since overloaded declarations tend to
-    // share a common prefix (which is trimmed in the underlying implementation), and because this
-    // is a rolling comparison against the calculated LCS, the actual number of comparisons is
-    // likely to be less than that in the average case.
-    for sequence in sequences {
-        if let currentResult = resultSequence {
-            resultSequence = longestCommonSubsequence(currentResult, sequence)
-        } else {
-            resultSequence = sequence
-        }
-    }
-    return resultSequence ?? []
+    return result
 }

--- a/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/DeclarationsSectionTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/DeclarationsSectionTranslator.swift
@@ -128,7 +128,7 @@ struct DeclarationsSectionTranslator: RenderSectionTranslator {
                             let declarationFragments = overload.declarationVariants[trait]?.values
                                 .first?
                                 .declarationFragments
-                            assert(
+                            precondition(
                                 declarationFragments != nil,
                                 "Overloaded symbols must have declaration fragments."
                             )

--- a/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/DeclarationsSectionTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/DeclarationsSectionTranslator.swift
@@ -215,6 +215,11 @@ fileprivate extension DeclarationRenderSection.Token {
         self.highlight == .changed && self.kind == .text
     }
 
+    /// Whether this token has any highlight applied to it.
+    var isHighlighted: Bool {
+        self.highlight != nil
+    }
+
     /// Create a new ``Kind/text`` token with the given text and highlight.
     init(plainText text: String, highlight: Highlight? = nil) {
         self.init(text: text, kind: .text, highlight: highlight)
@@ -274,7 +279,7 @@ fileprivate func postProcessTokens(
             // and the current token is not highlighted, then remove the highlighting for the
             // whitespace.
             if previousToken.isHighlightedText,
-                currentToken.highlight == nil,
+                !currentToken.isHighlighted,
                 previousToken.text.last?.isWhitespace == true
             {
                 if previousToken.text.allSatisfy(\.isWhitespace) {
@@ -291,7 +296,7 @@ fileprivate func postProcessTokens(
 
                     previousToken = .init(plainText: String(trailingWhitespace))
                 }
-            } else if previousToken.highlight == nil,
+            } else if !previousToken.isHighlighted,
                 currentToken.isHighlightedText,
                 currentToken.text.first?.isWhitespace == true
             {

--- a/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/DeclarationsSectionTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/DeclarationsSectionTranslator.swift
@@ -25,7 +25,7 @@ struct DeclarationsSectionTranslator: RenderSectionTranslator {
 
             /// Convert a ``SymbolGraph`` declaration fragment into a ``DeclarationRenderSection/Token``
             /// by resolving any symbol USRs to the appropriate reference link.
-            func translateFragment(_ fragment: SymbolGraph.Symbol.DeclarationFragments.Fragment, highlightDiff: Bool = false) -> DeclarationRenderSection.Token {
+            func translateFragment(_ fragment: SymbolGraph.Symbol.DeclarationFragments.Fragment, highlightDiff: Bool? = nil) -> DeclarationRenderSection.Token {
                 let reference: ResolvedTopicReference?
                 if let preciseIdentifier = fragment.preciseIdentifier,
                    let resolved = renderNodeTranslator.context.localOrExternalReference(symbolID: preciseIdentifier)
@@ -37,16 +37,13 @@ struct DeclarationsSectionTranslator: RenderSectionTranslator {
                 }
 
                 // Add the declaration token
-                return DeclarationRenderSection.Token(
-                    fragment: fragment,
-                    identifier: reference?.absoluteString,
-                    highlightDiff: highlightDiff)
+                return DeclarationRenderSection.Token(fragment: fragment, identifier: reference?.absoluteString, highlightDiff: highlightDiff)
             }
 
             /// Convenience overload for `translateFragment(_:highlightDiff:)` that can be used in
             /// an iterator mapping.
             func translateFragment(_ fragment: SymbolGraph.Symbol.DeclarationFragments.Fragment) -> DeclarationRenderSection.Token {
-                return translateFragment(fragment, highlightDiff: false)
+                return translateFragment(fragment, highlightDiff: nil)
             }
 
             /// Translate a whole ``SymbolGraph`` declaration to a ``DeclarationRenderSection``
@@ -73,111 +70,86 @@ struct DeclarationsSectionTranslator: RenderSectionTranslator {
                 var currentToken: DeclarationRenderSection.Token? = nil
                 for var token in translatedDeclaration {
                     if var previousToken = currentToken {
-                        if previousToken.kind == .highlightDiff,
-                           token.kind != .highlightDiff,
-                           let previousInnerToken = previousToken.tokens?.last,
-                           previousInnerToken.kind == .text,
-                           previousInnerToken.text.last?.isWhitespace == true
+                        if previousToken.kind == .text,
+                           previousToken.highlightDiff == true,
+                           token.highlightDiff != true,
+                           previousToken.text.last?.isWhitespace == true
                         {
-                            var newTokens: [DeclarationRenderSection.Token] = previousToken.tokens!.dropLast()
                             // if we've ended a span of highlighted tokens with trailing whitespace,
                             // trim the space out of the highlighted section before continuing
-                            if previousInnerToken.text.allSatisfy(\.isWhitespace) {
+                            if previousToken.text.allSatisfy(\.isWhitespace) {
                                 // if the last token was all whitespace, just convert it to be unhighlighted
-                                // and save off the remaining highlighted tokens
-                                processedDeclaration.append(.init(
-                                    text: previousToken.text,
-                                    kind: previousToken.kind,
-                                    tokens: newTokens))
                                 previousToken = .init(
-                                    text: previousInnerToken.text,
-                                    kind: .text)
+                                    text: previousToken.text,
+                                    kind: .text,
+                                    highlightDiff: nil)
                             } else {
                                 // otherwise, split off the trailing whitespace into a new token and
                                 // save off the rest of the highlighted text
-                                let trimmedText = previousInnerToken.text.removingTrailingWhitespace()
-                                newTokens.append(.init(text: trimmedText, kind: .text))
+                                let trimmedText = previousToken.text.removingTrailingWhitespace()
+                                let trailingWhitespace = previousToken.text.suffix(previousToken.text.count - trimmedText.count)
                                 processedDeclaration.append(.init(
-                                    text: previousToken.text,
-                                    kind: previousToken.kind,
-                                    tokens: newTokens))
-                                let trailingWhitespace = previousInnerToken.text.suffix(previousInnerToken.text.count - trimmedText.count)
+                                    text: trimmedText,
+                                    kind: .text,
+                                    highlightDiff: previousToken.highlightDiff))
 
-                                // save the trailing whitespace into `previousToken` as a plain-text
-                                // token so we can potentially combine it with the next token below
+                                // save the trailing whitespace into `previousToken` so we can
+                                // potentially combine it with the next token below
                                 previousToken = .init(
                                     text: String(trailingWhitespace),
-                                    kind: .text)
+                                    kind: .text,
+                                    highlightDiff: nil)
                             }
-                        } else if previousToken.kind != .highlightDiff,
-                                  token.kind == .highlightDiff,
-                                  token.tokens?.count == 1,
-                                  let innerToken = token.tokens?.first,
-                                  innerToken.kind == .text,
-                                  innerToken.text.first?.isWhitespace == true
+                        } else if previousToken.highlightDiff != true,
+                                  token.highlightDiff == true,
+                                  token.kind == .text,
+                                  token.text.first?.isWhitespace == true
                         {
                             // if we're about to start a span of highlighted tokens with leading
                             // whitespace, trim the space out of the highlighted section before
                             // continuing
-                            if innerToken.text.allSatisfy(\.isWhitespace) {
-                                // if this token is all whitespace, just extract it so it renders
-                                // without highlighting
-                                token = innerToken
+                            if token.text.allSatisfy(\.isWhitespace) {
+                                // if this token is all whitespace, just convert it to be unhighlighted
+                                token = .init(
+                                    text: token.text,
+                                    kind: .text,
+                                    highlightDiff: nil)
                             } else {
                                 // otherwise, split the whitespace into a new token and save the
                                 // remainder back into the token being processed
-                                let trimmedText = innerToken.text.removingLeadingWhitespace()
-                                let leadingWhitespace = innerToken.text.prefix(innerToken.text.count - trimmedText.count)
+                                let trimmedText = token.text.removingLeadingWhitespace()
+                                let leadingWhitespace = token.text.prefix(token.text.count - trimmedText.count)
                                 token = .init(
-                                    text: token.text,
-                                    kind: token.kind,
-                                    tokens: [.init(text: trimmedText, kind: .text)])
+                                    text: trimmedText,
+                                    kind: .text,
+                                    highlightDiff: token.highlightDiff)
                                 // if we can combine the whitespace with the previous token, do that
                                 if previousToken.kind == .text {
                                     previousToken = .init(
                                         text: previousToken.text + leadingWhitespace,
-                                        kind: .text)
+                                        kind: .text,
+                                        highlightDiff: previousToken.highlightDiff)
                                 } else {
                                     // otherwise, save off the previous token and create a new token
                                     // with just the whitespace in it
                                     processedDeclaration.append(previousToken)
                                     previousToken = .init(
                                         text: String(leadingWhitespace),
-                                        kind: .text)
+                                        kind: .text,
+                                        highlightDiff: nil)
                                 }
                             }
                         }
 
                         if previousToken.kind == .text,
-                            token.kind == .text
+                            token.kind == .text,
+                            previousToken.highlightDiff == token.highlightDiff
                         {
-                            // combine adjacent text tokens if they're both plain
+                            // combine adjacent text tokens if they're both highlighted or plain
                             token = .init(
                                 text: previousToken.text + token.text,
-                                kind: .text)
-                        } else if previousToken.kind == .highlightDiff, token.kind == .highlightDiff {
-                            if let previousInnerTokens = previousToken.tokens,
-                               let previousInnerToken = previousInnerTokens.last,
-                               let nextInnerTokens = token.tokens, nextInnerTokens.count == 1,
-                               let nextInnerToken = nextInnerTokens.first,
-                               previousInnerToken.kind == .text, nextInnerToken.kind == .text
-                            {
-                                // combine adjacent text tokens if they're both highlighted
-                                var newTokens: [DeclarationRenderSection.Token] = previousInnerTokens.dropLast()
-                                newTokens.append(.init(
-                                    text: previousInnerToken.text + nextInnerToken.text,
-                                    kind: .text))
-                                token = .init(
-                                    text: "",
-                                    kind: .highlightDiff,
-                                    tokens: newTokens)
-                            } else {
-                                // fold adjacent highlighted tokens into the same token list
-                                token = .init(
-                                    text: previousToken.text,
-                                    kind: previousToken.kind,
-                                    tokens: (previousToken.tokens ?? []) + (token.tokens ?? []))
-                            }
+                                kind: .text,
+                                highlightDiff: previousToken.highlightDiff)
                         } else {
                             // otherwise, just save off the previous token so we can store the next
                             // one for the next iteration

--- a/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/DeclarationsSectionTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/DeclarationsSectionTranslator.swift
@@ -134,6 +134,15 @@ struct DeclarationsSectionTranslator: RenderSectionTranslator {
                 return declarations
             }
 
+            func sortPlatformNames(_ platforms: [PlatformName?]) -> [PlatformName?] {
+                platforms.sorted { (lhs, rhs) -> Bool in
+                    guard let lhsValue = lhs, let rhsValue = rhs else {
+                        return lhs == nil
+                    }
+                    return lhsValue.rawValue < rhsValue.rawValue
+                }
+            }
+
             var declarations: [DeclarationRenderSection] = []
             let languages = [
                 trait.interfaceLanguage ?? renderNodeTranslator.identifier.sourceLanguage.id
@@ -172,17 +181,10 @@ struct DeclarationsSectionTranslator: RenderSectionTranslator {
                     otherDeclarations = nil
                 }
 
-                let platformNames = platforms.sorted { (lhs, rhs) -> Bool in
-                    guard let lhsValue = lhs, let rhsValue = rhs else {
-                        return lhs == nil
-                    }
-                    return lhsValue.rawValue < rhsValue.rawValue
-                }
-
                 declarations.append(
                     DeclarationRenderSection(
                         languages: languages,
-                        platforms: platformNames,
+                        platforms: sortPlatformNames(platforms),
                         tokens: renderedTokens,
                         otherDeclarations: otherDeclarations
                     )
@@ -192,10 +194,7 @@ struct DeclarationsSectionTranslator: RenderSectionTranslator {
             if let alternateDeclarations = symbol.alternateDeclarationVariants[trait] {
                 for pair in alternateDeclarations {
                     let (platforms, decls) = pair
-                    let platformNames =
-                        platforms
-                        .compactMap { $0 }
-                        .sorted(by: \.rawValue)
+                    let platformNames = sortPlatformNames(platforms)
                     for alternateDeclaration in decls {
                         let renderedTokens = alternateDeclaration.declarationFragments.map(translateFragment)
 

--- a/Sources/SwiftDocC/Model/Rendering/Symbol/DeclarationRenderSection+SymbolGraph.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Symbol/DeclarationRenderSection+SymbolGraph.swift
@@ -19,12 +19,19 @@ extension DeclarationRenderSection.Token {
     init(
         fragment: SymbolKit.SymbolGraph.Symbol.DeclarationFragments.Fragment,
         identifier: String?,
-        highlightDiff: Bool? = nil
+        highlightDiff: Bool = false
     ) {
-        self.text = fragment.spelling
-        self.kind = Kind(rawValue: fragment.kind.rawValue) ?? .text
-        self.identifier = identifier
-        self.preciseIdentifier = fragment.preciseIdentifier
-        self.highlightDiff = highlightDiff
+        let token = Self.init(
+            text: fragment.spelling,
+            kind: Kind(rawValue: fragment.kind.rawValue) ?? .text,
+            tokens: nil,
+            identifier: identifier,
+            preciseIdentifier: fragment.preciseIdentifier)
+
+        if highlightDiff {
+            self.init(text: "", kind: .highlightDiff, tokens: [token])
+        } else {
+            self = token
+        }
     }
 }

--- a/Sources/SwiftDocC/Model/Rendering/Symbol/DeclarationRenderSection+SymbolGraph.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Symbol/DeclarationRenderSection+SymbolGraph.swift
@@ -16,10 +16,15 @@ extension DeclarationRenderSection.Token {
     /// - Parameters:
     ///   - fragment: The symbol-graph declaration fragment to render.
     ///   - identifier: An optional reference to a symbol.
-    init(fragment: SymbolKit.SymbolGraph.Symbol.DeclarationFragments.Fragment, identifier: String?) {
+    init(
+        fragment: SymbolKit.SymbolGraph.Symbol.DeclarationFragments.Fragment,
+        identifier: String?,
+        highlightDiff: Bool? = nil
+    ) {
         self.text = fragment.spelling
         self.kind = Kind(rawValue: fragment.kind.rawValue) ?? .text
         self.identifier = identifier
         self.preciseIdentifier = fragment.preciseIdentifier
+        self.highlightDiff = highlightDiff
     }
 }

--- a/Sources/SwiftDocC/Model/Rendering/Symbol/DeclarationRenderSection+SymbolGraph.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Symbol/DeclarationRenderSection+SymbolGraph.swift
@@ -19,12 +19,16 @@ extension DeclarationRenderSection.Token {
     init(
         fragment: SymbolKit.SymbolGraph.Symbol.DeclarationFragments.Fragment,
         identifier: String?,
-        highlightDiff: Bool? = nil
+        highlight: Bool = false
     ) {
         self.text = fragment.spelling
         self.kind = Kind(rawValue: fragment.kind.rawValue) ?? .text
         self.identifier = identifier
         self.preciseIdentifier = fragment.preciseIdentifier
-        self.highlightDiff = highlightDiff
+        if highlight {
+            self.highlight = .changed
+        } else {
+            self.highlight = nil
+        }
     }
 }

--- a/Sources/SwiftDocC/Model/Rendering/Symbol/DeclarationRenderSection+SymbolGraph.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Symbol/DeclarationRenderSection+SymbolGraph.swift
@@ -19,19 +19,12 @@ extension DeclarationRenderSection.Token {
     init(
         fragment: SymbolKit.SymbolGraph.Symbol.DeclarationFragments.Fragment,
         identifier: String?,
-        highlightDiff: Bool = false
+        highlightDiff: Bool? = nil
     ) {
-        let token = Self.init(
-            text: fragment.spelling,
-            kind: Kind(rawValue: fragment.kind.rawValue) ?? .text,
-            tokens: nil,
-            identifier: identifier,
-            preciseIdentifier: fragment.preciseIdentifier)
-
-        if highlightDiff {
-            self.init(text: "", kind: .highlightDiff, tokens: [token])
-        } else {
-            self = token
-        }
+        self.text = fragment.spelling
+        self.kind = Kind(rawValue: fragment.kind.rawValue) ?? .text
+        self.identifier = identifier
+        self.preciseIdentifier = fragment.preciseIdentifier
+        self.highlightDiff = highlightDiff
     }
 }

--- a/Sources/SwiftDocC/Model/Rendering/Symbol/DeclarationsRenderSection.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Symbol/DeclarationsRenderSection.swift
@@ -80,9 +80,7 @@ public struct DeclarationRenderSection: Codable, Equatable {
         public let text: String
         /// The token programming kind.
         public let kind: Kind
-        /// Any child tokens, used for `highlightDiff`-type tokens.
-        public let tokens: [Token]?
-
+        
         /// The list of all expected tokens in a declaration.
         public enum Kind: String, Codable, RawRepresentable {
             /// A known keyword, like "class" or "var".
@@ -107,8 +105,6 @@ public struct DeclarationRenderSection: Codable, Equatable {
             case externalParam
             /// A label that precedes an identifier.
             case label
-            /// A container for tokens that should be highlighted as distinct from sibling declarations.
-            case highlightDiff
         }
         
         /// If the token is a known symbol, its identifier.
@@ -119,6 +115,8 @@ public struct DeclarationRenderSection: Codable, Equatable {
         /// If the token is a known symbol, its precise identifier as vended in the symbol graph.
         public let preciseIdentifier: String?
 
+        public let highlightDiff: Bool?
+
         /// Creates a new declaration token with optional identifier and precise identifier.
         /// - Parameters:
         ///   - text: The text content of the token.
@@ -128,21 +126,21 @@ public struct DeclarationRenderSection: Codable, Equatable {
         public init(
             text: String,
             kind: Kind,
-            tokens: [Token]? = nil,
             identifier: String? = nil,
-            preciseIdentifier: String? = nil
+            preciseIdentifier: String? = nil,
+            highlightDiff: Bool? = nil
         ) {
             self.text = text
             self.kind = kind
-            self.tokens = tokens
             self.identifier = identifier
             self.preciseIdentifier = preciseIdentifier
+            self.highlightDiff = highlightDiff
         }
         
         // MARK: - Codable
         
         private enum CodingKeys: CodingKey {
-            case text, kind, tokens, identifier, preciseIdentifier, otherDeclarations
+            case text, kind, identifier, preciseIdentifier, highlightDiff, otherDeclarations
         }
         
         public func encode(to encoder: Encoder) throws {
@@ -150,9 +148,9 @@ public struct DeclarationRenderSection: Codable, Equatable {
             
             try container.encode(text, forKey: .text)
             try container.encode(kind, forKey: .kind)
-            try container.encodeIfPresent(tokens, forKey: .tokens)
             try container.encodeIfPresent(identifier, forKey: .identifier)
             try container.encodeIfPresent(preciseIdentifier, forKey: .preciseIdentifier)
+            try container.encodeIfPresent(highlightDiff, forKey: .highlightDiff)
         }
         
         public init(from decoder: Decoder) throws {
@@ -160,9 +158,9 @@ public struct DeclarationRenderSection: Codable, Equatable {
             
             text = try container.decode(String.self, forKey: .text)
             kind = try container.decode(Kind.self, forKey: .kind)
-            tokens = try container.decodeIfPresent([Token].self, forKey: .tokens)
             preciseIdentifier = try container.decodeIfPresent(String.self, forKey: .preciseIdentifier)
             identifier = try container.decodeIfPresent(String.self, forKey: .identifier)
+            highlightDiff = try container.decodeIfPresent(Bool.self, forKey: .highlightDiff)
 
             if let reference = identifier {
                 decoder.registerReferences([reference])
@@ -276,7 +274,6 @@ extension DeclarationRenderSection.Token: RenderJSONDiffable {
 
         diffBuilder.addDifferences(atKeyPath: \.text, forKey: CodingKeys.text)
         diffBuilder.addDifferences(atKeyPath: \.kind, forKey: CodingKeys.kind)
-        diffBuilder.addDifferences(atKeyPath: \.tokens, forKey: CodingKeys.tokens)
 
         return diffBuilder.differences
     }

--- a/Sources/SwiftDocC/Model/Rendering/Symbol/DeclarationsRenderSection.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Symbol/DeclarationsRenderSection.swift
@@ -276,6 +276,7 @@ extension DeclarationRenderSection.Token: RenderJSONDiffable {
 
         diffBuilder.addDifferences(atKeyPath: \.text, forKey: CodingKeys.text)
         diffBuilder.addDifferences(atKeyPath: \.kind, forKey: CodingKeys.kind)
+        diffBuilder.addDifferences(atKeyPath: \.tokens, forKey: CodingKeys.tokens)
 
         return diffBuilder.differences
     }

--- a/Sources/SwiftDocC/Model/Rendering/Symbol/DeclarationsRenderSection.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Symbol/DeclarationsRenderSection.swift
@@ -115,7 +115,14 @@ public struct DeclarationRenderSection: Codable, Equatable {
         /// If the token is a known symbol, its precise identifier as vended in the symbol graph.
         public let preciseIdentifier: String?
 
-        public let highlightDiff: Bool?
+        /// The kind of highlight the token should be rendered with.
+        public let highlight: Highlight?
+
+        /// The kinds of highlights that can be applied to a token.
+        public enum Highlight: String, Codable, RawRepresentable {
+            /// A highlight representing generalized change, not specifically added or removed.
+            case changed
+        }
 
         /// Creates a new declaration token with optional identifier and precise identifier.
         /// - Parameters:
@@ -128,19 +135,19 @@ public struct DeclarationRenderSection: Codable, Equatable {
             kind: Kind,
             identifier: String? = nil,
             preciseIdentifier: String? = nil,
-            highlightDiff: Bool? = nil
+            highlight: Highlight? = nil
         ) {
             self.text = text
             self.kind = kind
             self.identifier = identifier
             self.preciseIdentifier = preciseIdentifier
-            self.highlightDiff = highlightDiff
+            self.highlight = highlight
         }
         
         // MARK: - Codable
         
         private enum CodingKeys: CodingKey {
-            case text, kind, identifier, preciseIdentifier, highlightDiff, otherDeclarations
+            case text, kind, identifier, preciseIdentifier, highlight, otherDeclarations
         }
         
         public func encode(to encoder: Encoder) throws {
@@ -150,7 +157,7 @@ public struct DeclarationRenderSection: Codable, Equatable {
             try container.encode(kind, forKey: .kind)
             try container.encodeIfPresent(identifier, forKey: .identifier)
             try container.encodeIfPresent(preciseIdentifier, forKey: .preciseIdentifier)
-            try container.encodeIfPresent(highlightDiff, forKey: .highlightDiff)
+            try container.encodeIfPresent(highlight, forKey: .highlight)
         }
         
         public init(from decoder: Decoder) throws {
@@ -160,7 +167,7 @@ public struct DeclarationRenderSection: Codable, Equatable {
             kind = try container.decode(Kind.self, forKey: .kind)
             preciseIdentifier = try container.decodeIfPresent(String.self, forKey: .preciseIdentifier)
             identifier = try container.decodeIfPresent(String.self, forKey: .identifier)
-            highlightDiff = try container.decodeIfPresent(Bool.self, forKey: .highlightDiff)
+            highlight = try container.decodeIfPresent(Highlight.self, forKey: .highlight)
 
             if let reference = identifier {
                 decoder.registerReferences([reference])

--- a/Sources/SwiftDocC/Model/Rendering/Symbol/DeclarationsRenderSection.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Symbol/DeclarationsRenderSection.swift
@@ -114,24 +114,33 @@ public struct DeclarationRenderSection: Codable, Equatable {
         
         /// If the token is a known symbol, its precise identifier as vended in the symbol graph.
         public let preciseIdentifier: String?
-        
+
+        public let highlightDiff: Bool?
+
         /// Creates a new declaration token with optional identifier and precise identifier.
         /// - Parameters:
         ///   - text: The text content of the token.
         ///   - kind: The kind of the token.
         ///   - identifier: If the token refers to a known symbol, its identifier.
         ///   - preciseIdentifier: If the refers to a symbol, its precise identifier.
-        public init(text: String, kind: Kind, identifier: String? = nil, preciseIdentifier: String? = nil) {
+        public init(
+            text: String,
+            kind: Kind,
+            identifier: String? = nil,
+            preciseIdentifier: String? = nil,
+            highlightDiff: Bool? = nil
+        ) {
             self.text = text
             self.kind = kind
             self.identifier = identifier
             self.preciseIdentifier = preciseIdentifier
+            self.highlightDiff = highlightDiff
         }
         
         // MARK: - Codable
         
         private enum CodingKeys: CodingKey {
-            case text, kind, identifier, preciseIdentifier, otherDeclarations
+            case text, kind, identifier, preciseIdentifier, highlightDiff, otherDeclarations
         }
         
         public func encode(to encoder: Encoder) throws {
@@ -141,6 +150,7 @@ public struct DeclarationRenderSection: Codable, Equatable {
             try container.encode(kind, forKey: .kind)
             try container.encodeIfPresent(identifier, forKey: .identifier)
             try container.encodeIfPresent(preciseIdentifier, forKey: .preciseIdentifier)
+            try container.encodeIfPresent(highlightDiff, forKey: .highlightDiff)
         }
         
         public init(from decoder: Decoder) throws {
@@ -150,6 +160,7 @@ public struct DeclarationRenderSection: Codable, Equatable {
             kind = try container.decode(Kind.self, forKey: .kind)
             preciseIdentifier = try container.decodeIfPresent(String.self, forKey: .preciseIdentifier)
             identifier = try container.decodeIfPresent(String.self, forKey: .identifier)
+            highlightDiff = try container.decodeIfPresent(Bool.self, forKey: .highlightDiff)
 
             if let reference = identifier {
                 decoder.registerReferences([reference])

--- a/Sources/SwiftDocC/Model/Rendering/Symbol/DeclarationsRenderSection.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Symbol/DeclarationsRenderSection.swift
@@ -80,7 +80,9 @@ public struct DeclarationRenderSection: Codable, Equatable {
         public let text: String
         /// The token programming kind.
         public let kind: Kind
-        
+        /// Any child tokens, used for `highlightDiff`-type tokens.
+        public let tokens: [Token]?
+
         /// The list of all expected tokens in a declaration.
         public enum Kind: String, Codable, RawRepresentable {
             /// A known keyword, like "class" or "var".
@@ -105,6 +107,8 @@ public struct DeclarationRenderSection: Codable, Equatable {
             case externalParam
             /// A label that precedes an identifier.
             case label
+            /// A container for tokens that should be highlighted as distinct from sibling declarations.
+            case highlightDiff
         }
         
         /// If the token is a known symbol, its identifier.
@@ -115,8 +119,6 @@ public struct DeclarationRenderSection: Codable, Equatable {
         /// If the token is a known symbol, its precise identifier as vended in the symbol graph.
         public let preciseIdentifier: String?
 
-        public let highlightDiff: Bool?
-
         /// Creates a new declaration token with optional identifier and precise identifier.
         /// - Parameters:
         ///   - text: The text content of the token.
@@ -126,21 +128,21 @@ public struct DeclarationRenderSection: Codable, Equatable {
         public init(
             text: String,
             kind: Kind,
+            tokens: [Token]? = nil,
             identifier: String? = nil,
-            preciseIdentifier: String? = nil,
-            highlightDiff: Bool? = nil
+            preciseIdentifier: String? = nil
         ) {
             self.text = text
             self.kind = kind
+            self.tokens = tokens
             self.identifier = identifier
             self.preciseIdentifier = preciseIdentifier
-            self.highlightDiff = highlightDiff
         }
         
         // MARK: - Codable
         
         private enum CodingKeys: CodingKey {
-            case text, kind, identifier, preciseIdentifier, highlightDiff, otherDeclarations
+            case text, kind, tokens, identifier, preciseIdentifier, otherDeclarations
         }
         
         public func encode(to encoder: Encoder) throws {
@@ -148,9 +150,9 @@ public struct DeclarationRenderSection: Codable, Equatable {
             
             try container.encode(text, forKey: .text)
             try container.encode(kind, forKey: .kind)
+            try container.encodeIfPresent(tokens, forKey: .tokens)
             try container.encodeIfPresent(identifier, forKey: .identifier)
             try container.encodeIfPresent(preciseIdentifier, forKey: .preciseIdentifier)
-            try container.encodeIfPresent(highlightDiff, forKey: .highlightDiff)
         }
         
         public init(from decoder: Decoder) throws {
@@ -158,9 +160,9 @@ public struct DeclarationRenderSection: Codable, Equatable {
             
             text = try container.decode(String.self, forKey: .text)
             kind = try container.decode(Kind.self, forKey: .kind)
+            tokens = try container.decodeIfPresent([Token].self, forKey: .tokens)
             preciseIdentifier = try container.decodeIfPresent(String.self, forKey: .preciseIdentifier)
             identifier = try container.decodeIfPresent(String.self, forKey: .identifier)
-            highlightDiff = try container.decodeIfPresent(Bool.self, forKey: .highlightDiff)
 
             if let reference = identifier {
                 decoder.registerReferences([reference])

--- a/Sources/SwiftDocC/Model/Rendering/Symbol/DeclarationsRenderSection.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Symbol/DeclarationsRenderSection.swift
@@ -77,7 +77,7 @@ public struct DeclarationRenderSection: Codable, Equatable {
     /// For example, `123` is represented as a single token of kind "number".
     public struct Token: Codable, Hashable, Equatable {
         /// The token text content.
-        public let text: String
+        public var text: String
         /// The token programming kind.
         public let kind: Kind
         
@@ -116,7 +116,7 @@ public struct DeclarationRenderSection: Codable, Equatable {
         public let preciseIdentifier: String?
 
         /// The kind of highlight the token should be rendered with.
-        public let highlight: Highlight?
+        public var highlight: Highlight?
 
         /// The kinds of highlights that can be applied to a token.
         public enum Highlight: String, Codable, RawRepresentable {

--- a/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderNode.spec.json
+++ b/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderNode.spec.json
@@ -2617,8 +2617,11 @@
                     "preciseIdentifier": {
                         "type": "string"
                     },
-                    "highlightDiff": {
-                        "type": "boolean"
+                    "highlight": {
+                        "type": "string",
+                        "enum": [
+                            "changed"
+                        ]
                     }
                 }
             },

--- a/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderNode.spec.json
+++ b/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderNode.spec.json
@@ -2607,7 +2607,7 @@
                     "kind": {
                         "type": "string",
                         "enum": [
-                            "keyword", "attribute", "number", "string", "identifier", "typeIdentifier", "genericParameter", "text", "internalParam", "externalParam", "label", "highlightDiff"
+                            "keyword", "attribute", "number", "string", "identifier", "typeIdentifier", "genericParameter", "text", "internalParam", "externalParam", "label"
                         ]
                     },
                     "identifier": {
@@ -2617,11 +2617,8 @@
                     "preciseIdentifier": {
                         "type": "string"
                     },
-                    "tokens": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/DeclarationToken"
-                        }
+                    "highlightDiff": {
+                        "type": "boolean"
                     }
                 }
             },

--- a/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderNode.spec.json
+++ b/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderNode.spec.json
@@ -2616,6 +2616,9 @@
                     },
                     "preciseIdentifier": {
                         "type": "string"
+                    },
+                    "highlightDiff": {
+                        "type": "boolean"
                     }
                 }
             },

--- a/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderNode.spec.json
+++ b/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderNode.spec.json
@@ -2607,7 +2607,7 @@
                     "kind": {
                         "type": "string",
                         "enum": [
-                            "keyword", "attribute", "number", "string", "identifier", "typeIdentifier", "genericParameter", "text", "internalParam", "externalParam", "label"
+                            "keyword", "attribute", "number", "string", "identifier", "typeIdentifier", "genericParameter", "text", "internalParam", "externalParam", "label", "highlightDiff"
                         ]
                     },
                     "identifier": {
@@ -2617,8 +2617,11 @@
                     "preciseIdentifier": {
                         "type": "string"
                     },
-                    "highlightDiff": {
-                        "type": "boolean"
+                    "tokens": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/DeclarationToken"
+                        }
                     }
                 }
             },

--- a/Tests/SwiftDocCTests/Rendering/DeclarationsRenderSectionTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/DeclarationsRenderSectionTests.swift
@@ -27,7 +27,6 @@ class DeclarationsRenderSectionTests: XCTestCase {
             (.internalParam, "internalParam"),
             (.externalParam, "externalParam"),
             (.label, "label"),
-            (.highlightDiff, "highlightDiff"),
         ]
 
         for (token, string) in values {
@@ -75,46 +74,6 @@ class DeclarationsRenderSectionTests: XCTestCase {
                         )
                     ),
                 ])
-            )
-        }
-    }
-
-    func testDecodingTokensWithTokenArray() throws {
-        let values: [(DeclarationRenderSection.Token.Kind, String)] = [
-            (.keyword, "keyword"),
-            (.attribute, "attribute"),
-            (.number, "number"),
-            (.string, "string"),
-            (.identifier, "identifier"),
-            (.typeIdentifier, "typeIdentifier"),
-            (.genericParameter, "genericParameter"),
-            (.text, "text"),
-            (.internalParam, "internalParam"),
-            (.externalParam, "externalParam"),
-            (.label, "label"),
-            (.highlightDiff, "highlightDiff"),
-        ]
-
-        for (token, string) in values {
-            let jsonData = """
-            {
-                "text": "",
-                "kind": "\(string)",
-                "tokens": [
-                    {
-                        "text": "",
-                        "kind": "\(string)"
-                    }
-                ]
-            }
-            """.data(using: .utf8)!
-
-            XCTAssertEqual(
-                try JSONDecoder().decode(DeclarationRenderSection.Token.self, from: jsonData),
-                DeclarationRenderSection.Token(
-                    text: "",
-                    kind: token,
-                    tokens: [.init(text: "", kind: token)])
             )
         }
     }
@@ -236,9 +195,7 @@ class DeclarationsRenderSectionTests: XCTestCase {
             .init(text: "(", kind: .text),
             .init(text: "param", kind: .externalParam),
             .init(text: ": ", kind: .text),
-            .init(text: "", kind: .highlightDiff, tokens: [
-                .init(text: "Int", kind: .typeIdentifier, preciseIdentifier: "s:Si"),
-            ]),
+            .init(text: "Int", kind: .typeIdentifier, preciseIdentifier: "s:Si", highlight: .changed),
             .init(text: ")", kind: .text),
         ])
 
@@ -247,28 +204,23 @@ class DeclarationsRenderSectionTests: XCTestCase {
                 .init(text: "func", kind: .keyword),
                 .init(text: " ", kind: .text),
                 .init(text: "myFunc", kind: .identifier),
-                .init(text: "", kind: .highlightDiff, tokens: [
-                    .init(text: "<", kind: .text),
-                    .init(text: "S", kind: .genericParameter),
-                    .init(text: ">", kind: .text),
-                ]),
+                .init(text: "<", kind: .text, highlight: .changed),
+                .init(text: "S", kind: .genericParameter, highlight: .changed),
+                .init(text: ">", kind: .text, highlight: .changed),
                 .init(text: "(", kind: .text),
                 .init(text: "param", kind: .externalParam),
                 .init(text: ": ", kind: .text),
-                .init(text: "", kind: .highlightDiff, tokens: [
-                    .init(
-                        text: "S",
-                        kind: .typeIdentifier,
-                        preciseIdentifier: "s:9FancyOverloads7MyClassC6myFunc5paramyx_tSyRzlF1SL_xmfp"),
-                ]),
+                .init(
+                    text: "S",
+                    kind: .typeIdentifier,
+                    preciseIdentifier: "s:9FancyOverloads7MyClassC6myFunc5paramyx_tSyRzlF1SL_xmfp",
+                    highlight: .changed),
                 .init(text: ") ", kind: .text),
-                .init(text: "", kind: .highlightDiff, tokens: [
-                    .init(text: "where", kind: .keyword),
-                    .init(text: " ", kind: .text),
-                    .init(text: "S", kind: .typeIdentifier),
-                    .init(text: " : ", kind: .text),
-                    .init(text: "StringProtocol", kind: .typeIdentifier, preciseIdentifier: "s:Sy"),
-                ])
+                .init(text: "where", kind: .keyword, highlight: .changed),
+                .init(text: " ", kind: .text, highlight: .changed),
+                .init(text: "S", kind: .typeIdentifier, highlight: .changed),
+                .init(text: " : ", kind: .text, highlight: .changed),
+                .init(text: "StringProtocol", kind: .typeIdentifier, preciseIdentifier: "s:Sy", highlight: .changed),
             ],
         ])
     }

--- a/Tests/SwiftDocCTests/Rendering/DeclarationsRenderSectionTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/DeclarationsRenderSectionTests.swift
@@ -11,6 +11,7 @@
 import Foundation
 import XCTest
 @testable import SwiftDocC
+import SwiftDocCTestUtilities
 
 class DeclarationsRenderSectionTests: XCTestCase {
     func testDecodingTokens() throws {
@@ -26,6 +27,7 @@ class DeclarationsRenderSectionTests: XCTestCase {
             (.internalParam, "internalParam"),
             (.externalParam, "externalParam"),
             (.label, "label"),
+            (.highlightDiff, "highlightDiff"),
         ]
 
         for (token, string) in values {
@@ -76,7 +78,47 @@ class DeclarationsRenderSectionTests: XCTestCase {
             )
         }
     }
-    
+
+    func testDecodingTokensWithTokenArray() throws {
+        let values: [(DeclarationRenderSection.Token.Kind, String)] = [
+            (.keyword, "keyword"),
+            (.attribute, "attribute"),
+            (.number, "number"),
+            (.string, "string"),
+            (.identifier, "identifier"),
+            (.typeIdentifier, "typeIdentifier"),
+            (.genericParameter, "genericParameter"),
+            (.text, "text"),
+            (.internalParam, "internalParam"),
+            (.externalParam, "externalParam"),
+            (.label, "label"),
+            (.highlightDiff, "highlightDiff"),
+        ]
+
+        for (token, string) in values {
+            let jsonData = """
+            {
+                "text": "",
+                "kind": "\(string)",
+                "tokens": [
+                    {
+                        "text": "",
+                        "kind": "\(string)"
+                    }
+                ]
+            }
+            """.data(using: .utf8)!
+
+            XCTAssertEqual(
+                try JSONDecoder().decode(DeclarationRenderSection.Token.self, from: jsonData),
+                DeclarationRenderSection.Token(
+                    text: "",
+                    kind: token,
+                    tokens: [.init(text: "", kind: token)])
+            )
+        }
+    }
+
     func testDoNotEmitOtherDeclarationsIfEmpty() throws {
 
         let encoder = RenderJSONEncoder.makeEncoder(prettyPrint: true)
@@ -150,5 +192,84 @@ class DeclarationsRenderSectionTests: XCTestCase {
 
         XCTAssertEqual(declarationsSection.declarations.count, 2)
         XCTAssert(declarationsSection.declarations.allSatisfy({ $0.platforms == [.iOS, .macOS] }))
+    }
+
+    func testHighlightDiff() throws {
+        enableFeatureFlag(\.isExperimentalOverloadedSymbolPresentationEnabled)
+
+        let symbolGraphFile = Bundle.module.url(
+            forResource: "FancyOverloads",
+            withExtension: "symbols.json",
+            subdirectory: "Test Resources"
+        )!
+
+        let tempURL = try createTempFolder(content: [
+            Folder(name: "unit-test.docc", content: [
+                InfoPlist(displayName: "FancyOverloads", identifier: "com.test.example"),
+                CopyOfFile(original: symbolGraphFile),
+            ])
+        ])
+
+        let (_, bundle, context) = try loadBundle(from: tempURL)
+
+        let reference = ResolvedTopicReference(
+            bundleIdentifier: bundle.identifier,
+            path: "/documentation/FancyOverloads/MyClass/myFunc(param:)-2rd6z",
+            sourceLanguage: .swift
+        )
+        let symbol = try XCTUnwrap(context.entity(with: reference).semantic as? Symbol)
+        var translator = RenderNodeTranslator(
+            context: context,
+            bundle: bundle,
+            identifier: reference,
+            source: nil
+        )
+        let renderNode = try XCTUnwrap(translator.visitSymbol(symbol) as? RenderNode)
+        let declarationsSection = try XCTUnwrap(renderNode.primaryContentSections.compactMap({ $0 as? DeclarationsRenderSection }).first)
+        XCTAssertEqual(declarationsSection.declarations.count, 1)
+        let declarations = try XCTUnwrap(declarationsSection.declarations.first)
+
+        XCTAssertEqual(declarations.tokens, [
+            .init(text: "func", kind: .keyword),
+            .init(text: " ", kind: .text),
+            .init(text: "myFunc", kind: .identifier),
+            .init(text: "(", kind: .text),
+            .init(text: "param", kind: .externalParam),
+            .init(text: ": ", kind: .text),
+            .init(text: "", kind: .highlightDiff, tokens: [
+                .init(text: "Int", kind: .typeIdentifier, preciseIdentifier: "s:Si"),
+            ]),
+            .init(text: ")", kind: .text),
+        ])
+
+        XCTAssertEqual(declarations.otherDeclarations?.declarations.map(\.tokens), [
+            [
+                .init(text: "func", kind: .keyword),
+                .init(text: " ", kind: .text),
+                .init(text: "myFunc", kind: .identifier),
+                .init(text: "", kind: .highlightDiff, tokens: [
+                    .init(text: "<", kind: .text),
+                    .init(text: "S", kind: .genericParameter),
+                    .init(text: ">", kind: .text),
+                ]),
+                .init(text: "(", kind: .text),
+                .init(text: "param", kind: .externalParam),
+                .init(text: ": ", kind: .text),
+                .init(text: "", kind: .highlightDiff, tokens: [
+                    .init(
+                        text: "S",
+                        kind: .typeIdentifier,
+                        preciseIdentifier: "s:9FancyOverloads7MyClassC6myFunc5paramyx_tSyRzlF1SL_xmfp"),
+                ]),
+                .init(text: ") ", kind: .text),
+                .init(text: "", kind: .highlightDiff, tokens: [
+                    .init(text: "where", kind: .keyword),
+                    .init(text: " ", kind: .text),
+                    .init(text: "S", kind: .typeIdentifier),
+                    .init(text: " : ", kind: .text),
+                    .init(text: "StringProtocol", kind: .typeIdentifier, preciseIdentifier: "s:Sy"),
+                ])
+            ],
+        ])
     }
 }

--- a/Tests/SwiftDocCTests/Test Resources/FancyOverloads.symbols.json
+++ b/Tests/SwiftDocCTests/Test Resources/FancyOverloads.symbols.json
@@ -5,7 +5,7 @@
       "minor": 6,
       "patch": 0
     },
-    "generator": "Apple Swift version 5.10 (swiftlang-5.10.0.13 clang-1500.3.9.4)"
+    "generator": "Apple Swift version 6.0 (swiftlang-6.0.0.3.300 clang-1600.0.20.10)"
   },
   "module": {
     "name": "FancyOverloads",
@@ -24,88 +24,18 @@
   "symbols": [
     {
       "kind": {
-        "identifier": "swift.class",
-        "displayName": "Class"
+        "identifier": "swift.func",
+        "displayName": "Function"
       },
       "identifier": {
-        "precise": "s:9FancyOverloads7MyClassC",
+        "precise": "s:9FancyOverloads9overload3yySDyS2iGF",
         "interfaceLanguage": "swift"
       },
       "pathComponents": [
-        "MyClass"
+        "overload3(_:)"
       ],
       "names": {
-        "title": "MyClass",
-        "navigator": [
-          {
-            "kind": "identifier",
-            "spelling": "MyClass"
-          }
-        ],
-        "subHeading": [
-          {
-            "kind": "keyword",
-            "spelling": "class"
-          },
-          {
-            "kind": "text",
-            "spelling": " "
-          },
-          {
-            "kind": "identifier",
-            "spelling": "MyClass"
-          }
-        ]
-      },
-      "docComment": {
-        "module": "FancyOverloads",
-        "lines": [
-          {
-            "range": {
-              "start": {
-                "line": 9,
-                "character": 4
-              },
-              "end": {
-                "line": 9,
-                "character": 25
-              }
-            },
-            "text": "This is a cool class."
-          }
-        ]
-      },
-      "declarationFragments": [
-        {
-          "kind": "keyword",
-          "spelling": "class"
-        },
-        {
-          "kind": "text",
-          "spelling": " "
-        },
-        {
-          "kind": "identifier",
-          "spelling": "MyClass"
-        }
-      ],
-      "accessLevel": "public"
-    },
-    {
-      "kind": {
-        "identifier": "swift.method",
-        "displayName": "Instance Method"
-      },
-      "identifier": {
-        "precise": "s:9FancyOverloads7MyClassC6myFunc5paramyx_tSyRzlF",
-        "interfaceLanguage": "swift"
-      },
-      "pathComponents": [
-        "MyClass",
-        "myFunc(param:)"
-      ],
-      "names": {
-        "title": "myFunc(param:)",
+        "title": "overload3(_:)",
         "subHeading": [
           {
             "kind": "keyword",
@@ -117,7 +47,351 @@
           },
           {
             "kind": "identifier",
-            "spelling": "myFunc"
+            "spelling": "overload3"
+          },
+          {
+            "kind": "text",
+            "spelling": "(["
+          },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "Int",
+            "preciseIdentifier": "s:Si"
+          },
+          {
+            "kind": "text",
+            "spelling": " : "
+          },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "Int",
+            "preciseIdentifier": "s:Si"
+          },
+          {
+            "kind": "text",
+            "spelling": "])"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "name": "p",
+            "declarationFragments": [
+              {
+                "kind": "identifier",
+                "spelling": "p"
+              },
+              {
+                "kind": "text",
+                "spelling": ": ["
+              },
+              {
+                "kind": "typeIdentifier",
+                "spelling": "Int",
+                "preciseIdentifier": "s:Si"
+              },
+              {
+                "kind": "text",
+                "spelling": " : "
+              },
+              {
+                "kind": "typeIdentifier",
+                "spelling": "Int",
+                "preciseIdentifier": "s:Si"
+              },
+              {
+                "kind": "text",
+                "spelling": "]"
+              }
+            ]
+          }
+        ],
+        "returns": [
+          {
+            "kind": "text",
+            "spelling": "()"
+          }
+        ]
+      },
+      "declarationFragments": [
+        {
+          "kind": "keyword",
+          "spelling": "func"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "overload3"
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "externalParam",
+          "spelling": "_"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "p"
+        },
+        {
+          "kind": "text",
+          "spelling": ": ["
+        },
+        {
+          "kind": "typeIdentifier",
+          "spelling": "Int",
+          "preciseIdentifier": "s:Si"
+        },
+        {
+          "kind": "text",
+          "spelling": " : "
+        },
+        {
+          "kind": "typeIdentifier",
+          "spelling": "Int",
+          "preciseIdentifier": "s:Si"
+        },
+        {
+          "kind": "text",
+          "spelling": "])"
+        }
+      ],
+      "accessLevel": "public"
+    },
+    {
+      "kind": {
+        "identifier": "swift.func",
+        "displayName": "Function"
+      },
+      "identifier": {
+        "precise": "s:9FancyOverloads9overload22p12p2ySi_Sit_SitF",
+        "interfaceLanguage": "swift"
+      },
+      "pathComponents": [
+        "overload2(p1:p2:)"
+      ],
+      "names": {
+        "title": "overload2(p1:p2:)",
+        "subHeading": [
+          {
+            "kind": "keyword",
+            "spelling": "func"
+          },
+          {
+            "kind": "text",
+            "spelling": " "
+          },
+          {
+            "kind": "identifier",
+            "spelling": "overload2"
+          },
+          {
+            "kind": "text",
+            "spelling": "("
+          },
+          {
+            "kind": "externalParam",
+            "spelling": "p1"
+          },
+          {
+            "kind": "text",
+            "spelling": ": ("
+          },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "Int",
+            "preciseIdentifier": "s:Si"
+          },
+          {
+            "kind": "text",
+            "spelling": ", "
+          },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "Int",
+            "preciseIdentifier": "s:Si"
+          },
+          {
+            "kind": "text",
+            "spelling": "), "
+          },
+          {
+            "kind": "externalParam",
+            "spelling": "p2"
+          },
+          {
+            "kind": "text",
+            "spelling": ": "
+          },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "Int",
+            "preciseIdentifier": "s:Si"
+          },
+          {
+            "kind": "text",
+            "spelling": ")"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "name": "p1",
+            "declarationFragments": [
+              {
+                "kind": "identifier",
+                "spelling": "p1"
+              },
+              {
+                "kind": "text",
+                "spelling": ": ("
+              },
+              {
+                "kind": "typeIdentifier",
+                "spelling": "Int",
+                "preciseIdentifier": "s:Si"
+              },
+              {
+                "kind": "text",
+                "spelling": ", "
+              },
+              {
+                "kind": "typeIdentifier",
+                "spelling": "Int",
+                "preciseIdentifier": "s:Si"
+              },
+              {
+                "kind": "text",
+                "spelling": ")"
+              }
+            ]
+          },
+          {
+            "name": "p2",
+            "declarationFragments": [
+              {
+                "kind": "identifier",
+                "spelling": "p2"
+              },
+              {
+                "kind": "text",
+                "spelling": ": "
+              },
+              {
+                "kind": "typeIdentifier",
+                "spelling": "Int",
+                "preciseIdentifier": "s:Si"
+              }
+            ]
+          }
+        ],
+        "returns": [
+          {
+            "kind": "text",
+            "spelling": "()"
+          }
+        ]
+      },
+      "declarationFragments": [
+        {
+          "kind": "keyword",
+          "spelling": "func"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "overload2"
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "externalParam",
+          "spelling": "p1"
+        },
+        {
+          "kind": "text",
+          "spelling": ": ("
+        },
+        {
+          "kind": "typeIdentifier",
+          "spelling": "Int",
+          "preciseIdentifier": "s:Si"
+        },
+        {
+          "kind": "text",
+          "spelling": ", "
+        },
+        {
+          "kind": "typeIdentifier",
+          "spelling": "Int",
+          "preciseIdentifier": "s:Si"
+        },
+        {
+          "kind": "text",
+          "spelling": "), "
+        },
+        {
+          "kind": "externalParam",
+          "spelling": "p2"
+        },
+        {
+          "kind": "text",
+          "spelling": ": "
+        },
+        {
+          "kind": "typeIdentifier",
+          "spelling": "Int",
+          "preciseIdentifier": "s:Si"
+        },
+        {
+          "kind": "text",
+          "spelling": ")"
+        }
+      ],
+      "accessLevel": "public"
+    },
+    {
+      "kind": {
+        "identifier": "swift.func",
+        "displayName": "Function"
+      },
+      "identifier": {
+        "precise": "s:9FancyOverloads9overload3yySDyxxGSHRzlF",
+        "interfaceLanguage": "swift"
+      },
+      "pathComponents": [
+        "overload3(_:)"
+      ],
+      "names": {
+        "title": "overload3(_:)",
+        "subHeading": [
+          {
+            "kind": "keyword",
+            "spelling": "func"
+          },
+          {
+            "kind": "text",
+            "spelling": " "
+          },
+          {
+            "kind": "identifier",
+            "spelling": "overload3"
           },
           {
             "kind": "text",
@@ -125,11 +399,856 @@
           },
           {
             "kind": "genericParameter",
-            "spelling": "S"
+            "spelling": "T"
           },
           {
             "kind": "text",
-            "spelling": ">("
+            "spelling": ">(["
+          },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "T",
+            "preciseIdentifier": "s:9FancyOverloads9overload3yySDyxxGSHRzlF1TL_xmfp"
+          },
+          {
+            "kind": "text",
+            "spelling": " : "
+          },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "T",
+            "preciseIdentifier": "s:9FancyOverloads9overload3yySDyxxGSHRzlF1TL_xmfp"
+          },
+          {
+            "kind": "text",
+            "spelling": "])"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "name": "p",
+            "declarationFragments": [
+              {
+                "kind": "identifier",
+                "spelling": "p"
+              },
+              {
+                "kind": "text",
+                "spelling": ": ["
+              },
+              {
+                "kind": "typeIdentifier",
+                "spelling": "T",
+                "preciseIdentifier": "s:9FancyOverloads9overload3yySDyxxGSHRzlF1TL_xmfp"
+              },
+              {
+                "kind": "text",
+                "spelling": " : "
+              },
+              {
+                "kind": "typeIdentifier",
+                "spelling": "T",
+                "preciseIdentifier": "s:9FancyOverloads9overload3yySDyxxGSHRzlF1TL_xmfp"
+              },
+              {
+                "kind": "text",
+                "spelling": "]"
+              }
+            ]
+          }
+        ],
+        "returns": [
+          {
+            "kind": "text",
+            "spelling": "()"
+          }
+        ]
+      },
+      "swiftGenerics": {
+        "parameters": [
+          {
+            "name": "T",
+            "index": 0,
+            "depth": 0
+          }
+        ],
+        "constraints": [
+          {
+            "kind": "conformance",
+            "lhs": "T",
+            "rhs": "Hashable",
+            "rhsPrecise": "s:SH"
+          }
+        ]
+      },
+      "declarationFragments": [
+        {
+          "kind": "keyword",
+          "spelling": "func"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "overload3"
+        },
+        {
+          "kind": "text",
+          "spelling": "<"
+        },
+        {
+          "kind": "genericParameter",
+          "spelling": "T"
+        },
+        {
+          "kind": "text",
+          "spelling": ">("
+        },
+        {
+          "kind": "externalParam",
+          "spelling": "_"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "p"
+        },
+        {
+          "kind": "text",
+          "spelling": ": ["
+        },
+        {
+          "kind": "typeIdentifier",
+          "spelling": "T",
+          "preciseIdentifier": "s:9FancyOverloads9overload3yySDyxxGSHRzlF1TL_xmfp"
+        },
+        {
+          "kind": "text",
+          "spelling": " : "
+        },
+        {
+          "kind": "typeIdentifier",
+          "spelling": "T",
+          "preciseIdentifier": "s:9FancyOverloads9overload3yySDyxxGSHRzlF1TL_xmfp"
+        },
+        {
+          "kind": "text",
+          "spelling": "]) "
+        },
+        {
+          "kind": "keyword",
+          "spelling": "where"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "typeIdentifier",
+          "spelling": "T"
+        },
+        {
+          "kind": "text",
+          "spelling": " : "
+        },
+        {
+          "kind": "typeIdentifier",
+          "spelling": "Hashable",
+          "preciseIdentifier": "s:SH"
+        }
+      ],
+      "accessLevel": "public"
+    },
+    {
+      "kind": {
+        "identifier": "swift.func",
+        "displayName": "Function"
+      },
+      "identifier": {
+        "precise": "s:9FancyOverloads9overload3yySDyxq_GSHRzr0_lF",
+        "interfaceLanguage": "swift"
+      },
+      "pathComponents": [
+        "overload3(_:)"
+      ],
+      "names": {
+        "title": "overload3(_:)",
+        "subHeading": [
+          {
+            "kind": "keyword",
+            "spelling": "func"
+          },
+          {
+            "kind": "text",
+            "spelling": " "
+          },
+          {
+            "kind": "identifier",
+            "spelling": "overload3"
+          },
+          {
+            "kind": "text",
+            "spelling": "<"
+          },
+          {
+            "kind": "genericParameter",
+            "spelling": "K"
+          },
+          {
+            "kind": "text",
+            "spelling": ", "
+          },
+          {
+            "kind": "genericParameter",
+            "spelling": "V"
+          },
+          {
+            "kind": "text",
+            "spelling": ">(["
+          },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "K",
+            "preciseIdentifier": "s:9FancyOverloads9overload3yySDyxq_GSHRzr0_lF1KL_xmfp"
+          },
+          {
+            "kind": "text",
+            "spelling": " : "
+          },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "V",
+            "preciseIdentifier": "s:9FancyOverloads9overload3yySDyxq_GSHRzr0_lF1VL_q_mfp"
+          },
+          {
+            "kind": "text",
+            "spelling": "])"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "name": "p",
+            "declarationFragments": [
+              {
+                "kind": "identifier",
+                "spelling": "p"
+              },
+              {
+                "kind": "text",
+                "spelling": ": ["
+              },
+              {
+                "kind": "typeIdentifier",
+                "spelling": "K",
+                "preciseIdentifier": "s:9FancyOverloads9overload3yySDyxq_GSHRzr0_lF1KL_xmfp"
+              },
+              {
+                "kind": "text",
+                "spelling": " : "
+              },
+              {
+                "kind": "typeIdentifier",
+                "spelling": "V",
+                "preciseIdentifier": "s:9FancyOverloads9overload3yySDyxq_GSHRzr0_lF1VL_q_mfp"
+              },
+              {
+                "kind": "text",
+                "spelling": "]"
+              }
+            ]
+          }
+        ],
+        "returns": [
+          {
+            "kind": "text",
+            "spelling": "()"
+          }
+        ]
+      },
+      "swiftGenerics": {
+        "parameters": [
+          {
+            "name": "K",
+            "index": 0,
+            "depth": 0
+          },
+          {
+            "name": "V",
+            "index": 1,
+            "depth": 0
+          }
+        ],
+        "constraints": [
+          {
+            "kind": "conformance",
+            "lhs": "K",
+            "rhs": "Hashable",
+            "rhsPrecise": "s:SH"
+          }
+        ]
+      },
+      "declarationFragments": [
+        {
+          "kind": "keyword",
+          "spelling": "func"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "overload3"
+        },
+        {
+          "kind": "text",
+          "spelling": "<"
+        },
+        {
+          "kind": "genericParameter",
+          "spelling": "K"
+        },
+        {
+          "kind": "text",
+          "spelling": ", "
+        },
+        {
+          "kind": "genericParameter",
+          "spelling": "V"
+        },
+        {
+          "kind": "text",
+          "spelling": ">("
+        },
+        {
+          "kind": "externalParam",
+          "spelling": "_"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "p"
+        },
+        {
+          "kind": "text",
+          "spelling": ": ["
+        },
+        {
+          "kind": "typeIdentifier",
+          "spelling": "K",
+          "preciseIdentifier": "s:9FancyOverloads9overload3yySDyxq_GSHRzr0_lF1KL_xmfp"
+        },
+        {
+          "kind": "text",
+          "spelling": " : "
+        },
+        {
+          "kind": "typeIdentifier",
+          "spelling": "V",
+          "preciseIdentifier": "s:9FancyOverloads9overload3yySDyxq_GSHRzr0_lF1VL_q_mfp"
+        },
+        {
+          "kind": "text",
+          "spelling": "]) "
+        },
+        {
+          "kind": "keyword",
+          "spelling": "where"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "typeIdentifier",
+          "spelling": "K"
+        },
+        {
+          "kind": "text",
+          "spelling": " : "
+        },
+        {
+          "kind": "typeIdentifier",
+          "spelling": "Hashable",
+          "preciseIdentifier": "s:SH"
+        }
+      ],
+      "accessLevel": "public"
+    },
+    {
+      "kind": {
+        "identifier": "swift.func",
+        "displayName": "Function"
+      },
+      "identifier": {
+        "precise": "s:9FancyOverloads9overload22p12p2ySi_SitF",
+        "interfaceLanguage": "swift"
+      },
+      "pathComponents": [
+        "overload2(p1:p2:)"
+      ],
+      "names": {
+        "title": "overload2(p1:p2:)",
+        "subHeading": [
+          {
+            "kind": "keyword",
+            "spelling": "func"
+          },
+          {
+            "kind": "text",
+            "spelling": " "
+          },
+          {
+            "kind": "identifier",
+            "spelling": "overload2"
+          },
+          {
+            "kind": "text",
+            "spelling": "("
+          },
+          {
+            "kind": "externalParam",
+            "spelling": "p1"
+          },
+          {
+            "kind": "text",
+            "spelling": ": "
+          },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "Int",
+            "preciseIdentifier": "s:Si"
+          },
+          {
+            "kind": "text",
+            "spelling": ", "
+          },
+          {
+            "kind": "externalParam",
+            "spelling": "p2"
+          },
+          {
+            "kind": "text",
+            "spelling": ": "
+          },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "Int",
+            "preciseIdentifier": "s:Si"
+          },
+          {
+            "kind": "text",
+            "spelling": ")"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "name": "p1",
+            "declarationFragments": [
+              {
+                "kind": "identifier",
+                "spelling": "p1"
+              },
+              {
+                "kind": "text",
+                "spelling": ": "
+              },
+              {
+                "kind": "typeIdentifier",
+                "spelling": "Int",
+                "preciseIdentifier": "s:Si"
+              }
+            ]
+          },
+          {
+            "name": "p2",
+            "declarationFragments": [
+              {
+                "kind": "identifier",
+                "spelling": "p2"
+              },
+              {
+                "kind": "text",
+                "spelling": ": "
+              },
+              {
+                "kind": "typeIdentifier",
+                "spelling": "Int",
+                "preciseIdentifier": "s:Si"
+              }
+            ]
+          }
+        ],
+        "returns": [
+          {
+            "kind": "text",
+            "spelling": "()"
+          }
+        ]
+      },
+      "declarationFragments": [
+        {
+          "kind": "keyword",
+          "spelling": "func"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "overload2"
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "externalParam",
+          "spelling": "p1"
+        },
+        {
+          "kind": "text",
+          "spelling": ": "
+        },
+        {
+          "kind": "typeIdentifier",
+          "spelling": "Int",
+          "preciseIdentifier": "s:Si"
+        },
+        {
+          "kind": "text",
+          "spelling": ", "
+        },
+        {
+          "kind": "externalParam",
+          "spelling": "p2"
+        },
+        {
+          "kind": "text",
+          "spelling": ": "
+        },
+        {
+          "kind": "typeIdentifier",
+          "spelling": "Int",
+          "preciseIdentifier": "s:Si"
+        },
+        {
+          "kind": "text",
+          "spelling": ")"
+        }
+      ],
+      "accessLevel": "public"
+    },
+    {
+      "kind": {
+        "identifier": "swift.func",
+        "displayName": "Function"
+      },
+      "identifier": {
+        "precise": "s:9FancyOverloads9overload15paramySDyS2iG_tF",
+        "interfaceLanguage": "swift"
+      },
+      "pathComponents": [
+        "overload1(param:)"
+      ],
+      "names": {
+        "title": "overload1(param:)",
+        "subHeading": [
+          {
+            "kind": "keyword",
+            "spelling": "func"
+          },
+          {
+            "kind": "text",
+            "spelling": " "
+          },
+          {
+            "kind": "identifier",
+            "spelling": "overload1"
+          },
+          {
+            "kind": "text",
+            "spelling": "("
+          },
+          {
+            "kind": "externalParam",
+            "spelling": "param"
+          },
+          {
+            "kind": "text",
+            "spelling": ": ["
+          },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "Int",
+            "preciseIdentifier": "s:Si"
+          },
+          {
+            "kind": "text",
+            "spelling": " : "
+          },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "Int",
+            "preciseIdentifier": "s:Si"
+          },
+          {
+            "kind": "text",
+            "spelling": "])"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "name": "param",
+            "declarationFragments": [
+              {
+                "kind": "identifier",
+                "spelling": "param"
+              },
+              {
+                "kind": "text",
+                "spelling": ": ["
+              },
+              {
+                "kind": "typeIdentifier",
+                "spelling": "Int",
+                "preciseIdentifier": "s:Si"
+              },
+              {
+                "kind": "text",
+                "spelling": " : "
+              },
+              {
+                "kind": "typeIdentifier",
+                "spelling": "Int",
+                "preciseIdentifier": "s:Si"
+              },
+              {
+                "kind": "text",
+                "spelling": "]"
+              }
+            ]
+          }
+        ],
+        "returns": [
+          {
+            "kind": "text",
+            "spelling": "()"
+          }
+        ]
+      },
+      "declarationFragments": [
+        {
+          "kind": "keyword",
+          "spelling": "func"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "overload1"
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "externalParam",
+          "spelling": "param"
+        },
+        {
+          "kind": "text",
+          "spelling": ": ["
+        },
+        {
+          "kind": "typeIdentifier",
+          "spelling": "Int",
+          "preciseIdentifier": "s:Si"
+        },
+        {
+          "kind": "text",
+          "spelling": " : "
+        },
+        {
+          "kind": "typeIdentifier",
+          "spelling": "Int",
+          "preciseIdentifier": "s:Si"
+        },
+        {
+          "kind": "text",
+          "spelling": "])"
+        }
+      ],
+      "accessLevel": "public"
+    },
+    {
+      "kind": {
+        "identifier": "swift.func",
+        "displayName": "Function"
+      },
+      "identifier": {
+        "precise": "s:9FancyOverloads9overload15paramySaySiGSg_tF",
+        "interfaceLanguage": "swift"
+      },
+      "pathComponents": [
+        "overload1(param:)"
+      ],
+      "names": {
+        "title": "overload1(param:)",
+        "subHeading": [
+          {
+            "kind": "keyword",
+            "spelling": "func"
+          },
+          {
+            "kind": "text",
+            "spelling": " "
+          },
+          {
+            "kind": "identifier",
+            "spelling": "overload1"
+          },
+          {
+            "kind": "text",
+            "spelling": "("
+          },
+          {
+            "kind": "externalParam",
+            "spelling": "param"
+          },
+          {
+            "kind": "text",
+            "spelling": ": ["
+          },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "Int",
+            "preciseIdentifier": "s:Si"
+          },
+          {
+            "kind": "text",
+            "spelling": "]?)"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "name": "param",
+            "declarationFragments": [
+              {
+                "kind": "identifier",
+                "spelling": "param"
+              },
+              {
+                "kind": "text",
+                "spelling": ": ["
+              },
+              {
+                "kind": "typeIdentifier",
+                "spelling": "Int",
+                "preciseIdentifier": "s:Si"
+              },
+              {
+                "kind": "text",
+                "spelling": "]?"
+              }
+            ]
+          }
+        ],
+        "returns": [
+          {
+            "kind": "text",
+            "spelling": "()"
+          }
+        ]
+      },
+      "declarationFragments": [
+        {
+          "kind": "keyword",
+          "spelling": "func"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "overload1"
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "externalParam",
+          "spelling": "param"
+        },
+        {
+          "kind": "text",
+          "spelling": ": ["
+        },
+        {
+          "kind": "typeIdentifier",
+          "spelling": "Int",
+          "preciseIdentifier": "s:Si"
+        },
+        {
+          "kind": "text",
+          "spelling": "]?)"
+        }
+      ],
+      "accessLevel": "public"
+    },
+    {
+      "kind": {
+        "identifier": "swift.func",
+        "displayName": "Function"
+      },
+      "identifier": {
+        "precise": "s:9FancyOverloads9overload15paramySiSg_tF",
+        "interfaceLanguage": "swift"
+      },
+      "pathComponents": [
+        "overload1(param:)"
+      ],
+      "names": {
+        "title": "overload1(param:)",
+        "subHeading": [
+          {
+            "kind": "keyword",
+            "spelling": "func"
+          },
+          {
+            "kind": "text",
+            "spelling": " "
+          },
+          {
+            "kind": "identifier",
+            "spelling": "overload1"
+          },
+          {
+            "kind": "text",
+            "spelling": "("
           },
           {
             "kind": "externalParam",
@@ -141,12 +1260,12 @@
           },
           {
             "kind": "typeIdentifier",
-            "spelling": "S",
-            "preciseIdentifier": "s:9FancyOverloads7MyClassC6myFunc5paramyx_tSyRzlF1SL_xmfp"
+            "spelling": "Int",
+            "preciseIdentifier": "s:Si"
           },
           {
             "kind": "text",
-            "spelling": ")"
+            "spelling": "?)"
           }
         ]
       },
@@ -165,8 +1284,12 @@
               },
               {
                 "kind": "typeIdentifier",
-                "spelling": "S",
-                "preciseIdentifier": "s:9FancyOverloads7MyClassC6myFunc5paramyx_tSyRzlF1SL_xmfp"
+                "spelling": "Int",
+                "preciseIdentifier": "s:Si"
+              },
+              {
+                "kind": "text",
+                "spelling": "?"
               }
             ]
           }
@@ -175,23 +1298,6 @@
           {
             "kind": "text",
             "spelling": "()"
-          }
-        ]
-      },
-      "swiftGenerics": {
-        "parameters": [
-          {
-            "name": "S",
-            "index": 0,
-            "depth": 0
-          }
-        ],
-        "constraints": [
-          {
-            "kind": "conformance",
-            "lhs": "S",
-            "rhs": "StringProtocol",
-            "rhsPrecise": "s:Sy"
           }
         ]
       },
@@ -206,19 +1312,11 @@
         },
         {
           "kind": "identifier",
-          "spelling": "myFunc"
+          "spelling": "overload1"
         },
         {
           "kind": "text",
-          "spelling": "<"
-        },
-        {
-          "kind": "genericParameter",
-          "spelling": "S"
-        },
-        {
-          "kind": "text",
-          "spelling": ">("
+          "spelling": "("
         },
         {
           "kind": "externalParam",
@@ -230,52 +1328,30 @@
         },
         {
           "kind": "typeIdentifier",
-          "spelling": "S",
-          "preciseIdentifier": "s:9FancyOverloads7MyClassC6myFunc5paramyx_tSyRzlF1SL_xmfp"
+          "spelling": "Int",
+          "preciseIdentifier": "s:Si"
         },
         {
           "kind": "text",
-          "spelling": ") "
-        },
-        {
-          "kind": "keyword",
-          "spelling": "where"
-        },
-        {
-          "kind": "text",
-          "spelling": " "
-        },
-        {
-          "kind": "typeIdentifier",
-          "spelling": "S"
-        },
-        {
-          "kind": "text",
-          "spelling": " : "
-        },
-        {
-          "kind": "typeIdentifier",
-          "spelling": "StringProtocol",
-          "preciseIdentifier": "s:Sy"
+          "spelling": "?)"
         }
       ],
       "accessLevel": "public"
     },
     {
       "kind": {
-        "identifier": "swift.method",
-        "displayName": "Instance Method"
+        "identifier": "swift.func",
+        "displayName": "Function"
       },
       "identifier": {
-        "precise": "s:9FancyOverloads7MyClassC6myFunc5paramySi_tF",
+        "precise": "s:9FancyOverloads9overload22p12p2yS2icSg_SitF",
         "interfaceLanguage": "swift"
       },
       "pathComponents": [
-        "MyClass",
-        "myFunc(param:)"
+        "overload2(p1:p2:)"
       ],
       "names": {
-        "title": "myFunc(param:)",
+        "title": "overload2(p1:p2:)",
         "subHeading": [
           {
             "kind": "keyword",
@@ -287,7 +1363,597 @@
           },
           {
             "kind": "identifier",
-            "spelling": "myFunc"
+            "spelling": "overload2"
+          },
+          {
+            "kind": "text",
+            "spelling": "("
+          },
+          {
+            "kind": "externalParam",
+            "spelling": "p1"
+          },
+          {
+            "kind": "text",
+            "spelling": ": (("
+          },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "Int",
+            "preciseIdentifier": "s:Si"
+          },
+          {
+            "kind": "text",
+            "spelling": ") -> "
+          },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "Int",
+            "preciseIdentifier": "s:Si"
+          },
+          {
+            "kind": "text",
+            "spelling": ")?, "
+          },
+          {
+            "kind": "externalParam",
+            "spelling": "p2"
+          },
+          {
+            "kind": "text",
+            "spelling": ": "
+          },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "Int",
+            "preciseIdentifier": "s:Si"
+          },
+          {
+            "kind": "text",
+            "spelling": ")"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "name": "p1",
+            "declarationFragments": [
+              {
+                "kind": "identifier",
+                "spelling": "p1"
+              },
+              {
+                "kind": "text",
+                "spelling": ": (("
+              },
+              {
+                "kind": "typeIdentifier",
+                "spelling": "Int",
+                "preciseIdentifier": "s:Si"
+              },
+              {
+                "kind": "text",
+                "spelling": ") -> "
+              },
+              {
+                "kind": "typeIdentifier",
+                "spelling": "Int",
+                "preciseIdentifier": "s:Si"
+              },
+              {
+                "kind": "text",
+                "spelling": ")?"
+              }
+            ]
+          },
+          {
+            "name": "p2",
+            "declarationFragments": [
+              {
+                "kind": "identifier",
+                "spelling": "p2"
+              },
+              {
+                "kind": "text",
+                "spelling": ": "
+              },
+              {
+                "kind": "typeIdentifier",
+                "spelling": "Int",
+                "preciseIdentifier": "s:Si"
+              }
+            ]
+          }
+        ],
+        "returns": [
+          {
+            "kind": "text",
+            "spelling": "()"
+          }
+        ]
+      },
+      "declarationFragments": [
+        {
+          "kind": "keyword",
+          "spelling": "func"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "overload2"
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "externalParam",
+          "spelling": "p1"
+        },
+        {
+          "kind": "text",
+          "spelling": ": (("
+        },
+        {
+          "kind": "typeIdentifier",
+          "spelling": "Int",
+          "preciseIdentifier": "s:Si"
+        },
+        {
+          "kind": "text",
+          "spelling": ") -> "
+        },
+        {
+          "kind": "typeIdentifier",
+          "spelling": "Int",
+          "preciseIdentifier": "s:Si"
+        },
+        {
+          "kind": "text",
+          "spelling": ")?, "
+        },
+        {
+          "kind": "externalParam",
+          "spelling": "p2"
+        },
+        {
+          "kind": "text",
+          "spelling": ": "
+        },
+        {
+          "kind": "typeIdentifier",
+          "spelling": "Int",
+          "preciseIdentifier": "s:Si"
+        },
+        {
+          "kind": "text",
+          "spelling": ")"
+        }
+      ],
+      "accessLevel": "public"
+    },
+    {
+      "kind": {
+        "identifier": "swift.func",
+        "displayName": "Function"
+      },
+      "identifier": {
+        "precise": "s:9FancyOverloads9overload22p12p2yS2iXE_SitF",
+        "interfaceLanguage": "swift"
+      },
+      "pathComponents": [
+        "overload2(p1:p2:)"
+      ],
+      "names": {
+        "title": "overload2(p1:p2:)",
+        "subHeading": [
+          {
+            "kind": "keyword",
+            "spelling": "func"
+          },
+          {
+            "kind": "text",
+            "spelling": " "
+          },
+          {
+            "kind": "identifier",
+            "spelling": "overload2"
+          },
+          {
+            "kind": "text",
+            "spelling": "("
+          },
+          {
+            "kind": "externalParam",
+            "spelling": "p1"
+          },
+          {
+            "kind": "text",
+            "spelling": ": ("
+          },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "Int",
+            "preciseIdentifier": "s:Si"
+          },
+          {
+            "kind": "text",
+            "spelling": ") -> "
+          },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "Int",
+            "preciseIdentifier": "s:Si"
+          },
+          {
+            "kind": "text",
+            "spelling": ", "
+          },
+          {
+            "kind": "externalParam",
+            "spelling": "p2"
+          },
+          {
+            "kind": "text",
+            "spelling": ": "
+          },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "Int",
+            "preciseIdentifier": "s:Si"
+          },
+          {
+            "kind": "text",
+            "spelling": ")"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "name": "p1",
+            "declarationFragments": [
+              {
+                "kind": "identifier",
+                "spelling": "p1"
+              },
+              {
+                "kind": "text",
+                "spelling": ": ("
+              },
+              {
+                "kind": "typeIdentifier",
+                "spelling": "Int",
+                "preciseIdentifier": "s:Si"
+              },
+              {
+                "kind": "text",
+                "spelling": ") -> "
+              },
+              {
+                "kind": "typeIdentifier",
+                "spelling": "Int",
+                "preciseIdentifier": "s:Si"
+              }
+            ]
+          },
+          {
+            "name": "p2",
+            "declarationFragments": [
+              {
+                "kind": "identifier",
+                "spelling": "p2"
+              },
+              {
+                "kind": "text",
+                "spelling": ": "
+              },
+              {
+                "kind": "typeIdentifier",
+                "spelling": "Int",
+                "preciseIdentifier": "s:Si"
+              }
+            ]
+          }
+        ],
+        "returns": [
+          {
+            "kind": "text",
+            "spelling": "()"
+          }
+        ]
+      },
+      "declarationFragments": [
+        {
+          "kind": "keyword",
+          "spelling": "func"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "overload2"
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "externalParam",
+          "spelling": "p1"
+        },
+        {
+          "kind": "text",
+          "spelling": ": ("
+        },
+        {
+          "kind": "typeIdentifier",
+          "spelling": "Int",
+          "preciseIdentifier": "s:Si"
+        },
+        {
+          "kind": "text",
+          "spelling": ") -> "
+        },
+        {
+          "kind": "typeIdentifier",
+          "spelling": "Int",
+          "preciseIdentifier": "s:Si"
+        },
+        {
+          "kind": "text",
+          "spelling": ", "
+        },
+        {
+          "kind": "externalParam",
+          "spelling": "p2"
+        },
+        {
+          "kind": "text",
+          "spelling": ": "
+        },
+        {
+          "kind": "typeIdentifier",
+          "spelling": "Int",
+          "preciseIdentifier": "s:Si"
+        },
+        {
+          "kind": "text",
+          "spelling": ")"
+        }
+      ],
+      "accessLevel": "public"
+    },
+    {
+      "kind": {
+        "identifier": "swift.func",
+        "displayName": "Function"
+      },
+      "identifier": {
+        "precise": "s:9FancyOverloads9overload22p12p2ySiSgSiXE_SitF",
+        "interfaceLanguage": "swift"
+      },
+      "pathComponents": [
+        "overload2(p1:p2:)"
+      ],
+      "names": {
+        "title": "overload2(p1:p2:)",
+        "subHeading": [
+          {
+            "kind": "keyword",
+            "spelling": "func"
+          },
+          {
+            "kind": "text",
+            "spelling": " "
+          },
+          {
+            "kind": "identifier",
+            "spelling": "overload2"
+          },
+          {
+            "kind": "text",
+            "spelling": "("
+          },
+          {
+            "kind": "externalParam",
+            "spelling": "p1"
+          },
+          {
+            "kind": "text",
+            "spelling": ": ("
+          },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "Int",
+            "preciseIdentifier": "s:Si"
+          },
+          {
+            "kind": "text",
+            "spelling": ") -> "
+          },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "Int",
+            "preciseIdentifier": "s:Si"
+          },
+          {
+            "kind": "text",
+            "spelling": "?, "
+          },
+          {
+            "kind": "externalParam",
+            "spelling": "p2"
+          },
+          {
+            "kind": "text",
+            "spelling": ": "
+          },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "Int",
+            "preciseIdentifier": "s:Si"
+          },
+          {
+            "kind": "text",
+            "spelling": ")"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "name": "p1",
+            "declarationFragments": [
+              {
+                "kind": "identifier",
+                "spelling": "p1"
+              },
+              {
+                "kind": "text",
+                "spelling": ": ("
+              },
+              {
+                "kind": "typeIdentifier",
+                "spelling": "Int",
+                "preciseIdentifier": "s:Si"
+              },
+              {
+                "kind": "text",
+                "spelling": ") -> "
+              },
+              {
+                "kind": "typeIdentifier",
+                "spelling": "Int",
+                "preciseIdentifier": "s:Si"
+              },
+              {
+                "kind": "text",
+                "spelling": "?"
+              }
+            ]
+          },
+          {
+            "name": "p2",
+            "declarationFragments": [
+              {
+                "kind": "identifier",
+                "spelling": "p2"
+              },
+              {
+                "kind": "text",
+                "spelling": ": "
+              },
+              {
+                "kind": "typeIdentifier",
+                "spelling": "Int",
+                "preciseIdentifier": "s:Si"
+              }
+            ]
+          }
+        ],
+        "returns": [
+          {
+            "kind": "text",
+            "spelling": "()"
+          }
+        ]
+      },
+      "declarationFragments": [
+        {
+          "kind": "keyword",
+          "spelling": "func"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "overload2"
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "externalParam",
+          "spelling": "p1"
+        },
+        {
+          "kind": "text",
+          "spelling": ": ("
+        },
+        {
+          "kind": "typeIdentifier",
+          "spelling": "Int",
+          "preciseIdentifier": "s:Si"
+        },
+        {
+          "kind": "text",
+          "spelling": ") -> "
+        },
+        {
+          "kind": "typeIdentifier",
+          "spelling": "Int",
+          "preciseIdentifier": "s:Si"
+        },
+        {
+          "kind": "text",
+          "spelling": "?, "
+        },
+        {
+          "kind": "externalParam",
+          "spelling": "p2"
+        },
+        {
+          "kind": "text",
+          "spelling": ": "
+        },
+        {
+          "kind": "typeIdentifier",
+          "spelling": "Int",
+          "preciseIdentifier": "s:Si"
+        },
+        {
+          "kind": "text",
+          "spelling": ")"
+        }
+      ],
+      "accessLevel": "public"
+    },
+    {
+      "kind": {
+        "identifier": "swift.func",
+        "displayName": "Function"
+      },
+      "identifier": {
+        "precise": "s:9FancyOverloads9overload15paramySi_tF",
+        "interfaceLanguage": "swift"
+      },
+      "pathComponents": [
+        "overload1(param:)"
+      ],
+      "names": {
+        "title": "overload1(param:)",
+        "subHeading": [
+          {
+            "kind": "keyword",
+            "spelling": "func"
+          },
+          {
+            "kind": "text",
+            "spelling": " "
+          },
+          {
+            "kind": "identifier",
+            "spelling": "overload1"
           },
           {
             "kind": "text",
@@ -351,7 +2017,7 @@
         },
         {
           "kind": "identifier",
-          "spelling": "myFunc"
+          "spelling": "overload1"
         },
         {
           "kind": "text",
@@ -376,18 +2042,641 @@
         }
       ],
       "accessLevel": "public"
-    }
-  ],
-  "relationships": [
-    {
-      "kind": "memberOf",
-      "source": "s:9FancyOverloads7MyClassC6myFunc5paramySi_tF",
-      "target": "s:9FancyOverloads7MyClassC"
     },
     {
-      "kind": "memberOf",
-      "source": "s:9FancyOverloads7MyClassC6myFunc5paramyx_tSyRzlF",
-      "target": "s:9FancyOverloads7MyClassC"
+      "kind": {
+        "identifier": "swift.func",
+        "displayName": "Function"
+      },
+      "identifier": {
+        "precise": "s:9FancyOverloads9overload15paramyShySiG_tF",
+        "interfaceLanguage": "swift"
+      },
+      "pathComponents": [
+        "overload1(param:)"
+      ],
+      "names": {
+        "title": "overload1(param:)",
+        "subHeading": [
+          {
+            "kind": "keyword",
+            "spelling": "func"
+          },
+          {
+            "kind": "text",
+            "spelling": " "
+          },
+          {
+            "kind": "identifier",
+            "spelling": "overload1"
+          },
+          {
+            "kind": "text",
+            "spelling": "("
+          },
+          {
+            "kind": "externalParam",
+            "spelling": "param"
+          },
+          {
+            "kind": "text",
+            "spelling": ": "
+          },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "Set",
+            "preciseIdentifier": "s:Sh"
+          },
+          {
+            "kind": "text",
+            "spelling": "<"
+          },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "Int",
+            "preciseIdentifier": "s:Si"
+          },
+          {
+            "kind": "text",
+            "spelling": ">)"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "name": "param",
+            "declarationFragments": [
+              {
+                "kind": "identifier",
+                "spelling": "param"
+              },
+              {
+                "kind": "text",
+                "spelling": ": "
+              },
+              {
+                "kind": "typeIdentifier",
+                "spelling": "Set",
+                "preciseIdentifier": "s:Sh"
+              },
+              {
+                "kind": "text",
+                "spelling": "<"
+              },
+              {
+                "kind": "typeIdentifier",
+                "spelling": "Int",
+                "preciseIdentifier": "s:Si"
+              },
+              {
+                "kind": "text",
+                "spelling": ">"
+              }
+            ]
+          }
+        ],
+        "returns": [
+          {
+            "kind": "text",
+            "spelling": "()"
+          }
+        ]
+      },
+      "declarationFragments": [
+        {
+          "kind": "keyword",
+          "spelling": "func"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "overload1"
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "externalParam",
+          "spelling": "param"
+        },
+        {
+          "kind": "text",
+          "spelling": ": "
+        },
+        {
+          "kind": "typeIdentifier",
+          "spelling": "Set",
+          "preciseIdentifier": "s:Sh"
+        },
+        {
+          "kind": "text",
+          "spelling": "<"
+        },
+        {
+          "kind": "typeIdentifier",
+          "spelling": "Int",
+          "preciseIdentifier": "s:Si"
+        },
+        {
+          "kind": "text",
+          "spelling": ">)"
+        }
+      ],
+      "accessLevel": "public"
+    },
+    {
+      "kind": {
+        "identifier": "swift.func",
+        "displayName": "Function"
+      },
+      "identifier": {
+        "precise": "s:9FancyOverloads9overload22p12p2yySiXE_SitF",
+        "interfaceLanguage": "swift"
+      },
+      "pathComponents": [
+        "overload2(p1:p2:)"
+      ],
+      "names": {
+        "title": "overload2(p1:p2:)",
+        "subHeading": [
+          {
+            "kind": "keyword",
+            "spelling": "func"
+          },
+          {
+            "kind": "text",
+            "spelling": " "
+          },
+          {
+            "kind": "identifier",
+            "spelling": "overload2"
+          },
+          {
+            "kind": "text",
+            "spelling": "("
+          },
+          {
+            "kind": "externalParam",
+            "spelling": "p1"
+          },
+          {
+            "kind": "text",
+            "spelling": ": ("
+          },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "Int",
+            "preciseIdentifier": "s:Si"
+          },
+          {
+            "kind": "text",
+            "spelling": ") -> (), "
+          },
+          {
+            "kind": "externalParam",
+            "spelling": "p2"
+          },
+          {
+            "kind": "text",
+            "spelling": ": "
+          },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "Int",
+            "preciseIdentifier": "s:Si"
+          },
+          {
+            "kind": "text",
+            "spelling": ")"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "name": "p1",
+            "declarationFragments": [
+              {
+                "kind": "identifier",
+                "spelling": "p1"
+              },
+              {
+                "kind": "text",
+                "spelling": ": ("
+              },
+              {
+                "kind": "typeIdentifier",
+                "spelling": "Int",
+                "preciseIdentifier": "s:Si"
+              },
+              {
+                "kind": "text",
+                "spelling": ") -> ()"
+              }
+            ]
+          },
+          {
+            "name": "p2",
+            "declarationFragments": [
+              {
+                "kind": "identifier",
+                "spelling": "p2"
+              },
+              {
+                "kind": "text",
+                "spelling": ": "
+              },
+              {
+                "kind": "typeIdentifier",
+                "spelling": "Int",
+                "preciseIdentifier": "s:Si"
+              }
+            ]
+          }
+        ],
+        "returns": [
+          {
+            "kind": "text",
+            "spelling": "()"
+          }
+        ]
+      },
+      "declarationFragments": [
+        {
+          "kind": "keyword",
+          "spelling": "func"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "overload2"
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "externalParam",
+          "spelling": "p1"
+        },
+        {
+          "kind": "text",
+          "spelling": ": ("
+        },
+        {
+          "kind": "typeIdentifier",
+          "spelling": "Int",
+          "preciseIdentifier": "s:Si"
+        },
+        {
+          "kind": "text",
+          "spelling": ") -> (), "
+        },
+        {
+          "kind": "externalParam",
+          "spelling": "p2"
+        },
+        {
+          "kind": "text",
+          "spelling": ": "
+        },
+        {
+          "kind": "typeIdentifier",
+          "spelling": "Int",
+          "preciseIdentifier": "s:Si"
+        },
+        {
+          "kind": "text",
+          "spelling": ")"
+        }
+      ],
+      "accessLevel": "public"
+    },
+    {
+      "kind": {
+        "identifier": "swift.func",
+        "displayName": "Function"
+      },
+      "identifier": {
+        "precise": "s:9FancyOverloads9overload22p12p2ySi_Si_SittF",
+        "interfaceLanguage": "swift"
+      },
+      "pathComponents": [
+        "overload2(p1:p2:)"
+      ],
+      "names": {
+        "title": "overload2(p1:p2:)",
+        "subHeading": [
+          {
+            "kind": "keyword",
+            "spelling": "func"
+          },
+          {
+            "kind": "text",
+            "spelling": " "
+          },
+          {
+            "kind": "identifier",
+            "spelling": "overload2"
+          },
+          {
+            "kind": "text",
+            "spelling": "("
+          },
+          {
+            "kind": "externalParam",
+            "spelling": "p1"
+          },
+          {
+            "kind": "text",
+            "spelling": ": "
+          },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "Int",
+            "preciseIdentifier": "s:Si"
+          },
+          {
+            "kind": "text",
+            "spelling": ", "
+          },
+          {
+            "kind": "externalParam",
+            "spelling": "p2"
+          },
+          {
+            "kind": "text",
+            "spelling": ": ("
+          },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "Int",
+            "preciseIdentifier": "s:Si"
+          },
+          {
+            "kind": "text",
+            "spelling": ", "
+          },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "Int",
+            "preciseIdentifier": "s:Si"
+          },
+          {
+            "kind": "text",
+            "spelling": "))"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "name": "p1",
+            "declarationFragments": [
+              {
+                "kind": "identifier",
+                "spelling": "p1"
+              },
+              {
+                "kind": "text",
+                "spelling": ": "
+              },
+              {
+                "kind": "typeIdentifier",
+                "spelling": "Int",
+                "preciseIdentifier": "s:Si"
+              }
+            ]
+          },
+          {
+            "name": "p2",
+            "declarationFragments": [
+              {
+                "kind": "identifier",
+                "spelling": "p2"
+              },
+              {
+                "kind": "text",
+                "spelling": ": ("
+              },
+              {
+                "kind": "typeIdentifier",
+                "spelling": "Int",
+                "preciseIdentifier": "s:Si"
+              },
+              {
+                "kind": "text",
+                "spelling": ", "
+              },
+              {
+                "kind": "typeIdentifier",
+                "spelling": "Int",
+                "preciseIdentifier": "s:Si"
+              },
+              {
+                "kind": "text",
+                "spelling": ")"
+              }
+            ]
+          }
+        ],
+        "returns": [
+          {
+            "kind": "text",
+            "spelling": "()"
+          }
+        ]
+      },
+      "declarationFragments": [
+        {
+          "kind": "keyword",
+          "spelling": "func"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "overload2"
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "externalParam",
+          "spelling": "p1"
+        },
+        {
+          "kind": "text",
+          "spelling": ": "
+        },
+        {
+          "kind": "typeIdentifier",
+          "spelling": "Int",
+          "preciseIdentifier": "s:Si"
+        },
+        {
+          "kind": "text",
+          "spelling": ", "
+        },
+        {
+          "kind": "externalParam",
+          "spelling": "p2"
+        },
+        {
+          "kind": "text",
+          "spelling": ": ("
+        },
+        {
+          "kind": "typeIdentifier",
+          "spelling": "Int",
+          "preciseIdentifier": "s:Si"
+        },
+        {
+          "kind": "text",
+          "spelling": ", "
+        },
+        {
+          "kind": "typeIdentifier",
+          "spelling": "Int",
+          "preciseIdentifier": "s:Si"
+        },
+        {
+          "kind": "text",
+          "spelling": "))"
+        }
+      ],
+      "accessLevel": "public"
+    },
+    {
+      "kind": {
+        "identifier": "swift.func",
+        "displayName": "Function"
+      },
+      "identifier": {
+        "precise": "s:9FancyOverloads9overload15paramySaySiG_tF",
+        "interfaceLanguage": "swift"
+      },
+      "pathComponents": [
+        "overload1(param:)"
+      ],
+      "names": {
+        "title": "overload1(param:)",
+        "subHeading": [
+          {
+            "kind": "keyword",
+            "spelling": "func"
+          },
+          {
+            "kind": "text",
+            "spelling": " "
+          },
+          {
+            "kind": "identifier",
+            "spelling": "overload1"
+          },
+          {
+            "kind": "text",
+            "spelling": "("
+          },
+          {
+            "kind": "externalParam",
+            "spelling": "param"
+          },
+          {
+            "kind": "text",
+            "spelling": ": ["
+          },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "Int",
+            "preciseIdentifier": "s:Si"
+          },
+          {
+            "kind": "text",
+            "spelling": "])"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "name": "param",
+            "declarationFragments": [
+              {
+                "kind": "identifier",
+                "spelling": "param"
+              },
+              {
+                "kind": "text",
+                "spelling": ": ["
+              },
+              {
+                "kind": "typeIdentifier",
+                "spelling": "Int",
+                "preciseIdentifier": "s:Si"
+              },
+              {
+                "kind": "text",
+                "spelling": "]"
+              }
+            ]
+          }
+        ],
+        "returns": [
+          {
+            "kind": "text",
+            "spelling": "()"
+          }
+        ]
+      },
+      "declarationFragments": [
+        {
+          "kind": "keyword",
+          "spelling": "func"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "overload1"
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "externalParam",
+          "spelling": "param"
+        },
+        {
+          "kind": "text",
+          "spelling": ": ["
+        },
+        {
+          "kind": "typeIdentifier",
+          "spelling": "Int",
+          "preciseIdentifier": "s:Si"
+        },
+        {
+          "kind": "text",
+          "spelling": "])"
+        }
+      ],
+      "accessLevel": "public"
     }
-  ]
+  ],
+  "relationships": []
 }

--- a/Tests/SwiftDocCTests/Test Resources/FancyOverloads.symbols.json
+++ b/Tests/SwiftDocCTests/Test Resources/FancyOverloads.symbols.json
@@ -1,0 +1,393 @@
+{
+  "metadata": {
+    "formatVersion": {
+      "major": 0,
+      "minor": 6,
+      "patch": 0
+    },
+    "generator": "Apple Swift version 5.10 (swiftlang-5.10.0.13 clang-1500.3.9.4)"
+  },
+  "module": {
+    "name": "FancyOverloads",
+    "platform": {
+      "architecture": "arm64",
+      "vendor": "apple",
+      "operatingSystem": {
+        "name": "macosx",
+        "minimumVersion": {
+          "major": 12,
+          "minor": 4
+        }
+      }
+    }
+  },
+  "symbols": [
+    {
+      "kind": {
+        "identifier": "swift.class",
+        "displayName": "Class"
+      },
+      "identifier": {
+        "precise": "s:9FancyOverloads7MyClassC",
+        "interfaceLanguage": "swift"
+      },
+      "pathComponents": [
+        "MyClass"
+      ],
+      "names": {
+        "title": "MyClass",
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "MyClass"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "keyword",
+            "spelling": "class"
+          },
+          {
+            "kind": "text",
+            "spelling": " "
+          },
+          {
+            "kind": "identifier",
+            "spelling": "MyClass"
+          }
+        ]
+      },
+      "docComment": {
+        "module": "FancyOverloads",
+        "lines": [
+          {
+            "range": {
+              "start": {
+                "line": 9,
+                "character": 4
+              },
+              "end": {
+                "line": 9,
+                "character": 25
+              }
+            },
+            "text": "This is a cool class."
+          }
+        ]
+      },
+      "declarationFragments": [
+        {
+          "kind": "keyword",
+          "spelling": "class"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "MyClass"
+        }
+      ],
+      "accessLevel": "public"
+    },
+    {
+      "kind": {
+        "identifier": "swift.method",
+        "displayName": "Instance Method"
+      },
+      "identifier": {
+        "precise": "s:9FancyOverloads7MyClassC6myFunc5paramyx_tSyRzlF",
+        "interfaceLanguage": "swift"
+      },
+      "pathComponents": [
+        "MyClass",
+        "myFunc(param:)"
+      ],
+      "names": {
+        "title": "myFunc(param:)",
+        "subHeading": [
+          {
+            "kind": "keyword",
+            "spelling": "func"
+          },
+          {
+            "kind": "text",
+            "spelling": " "
+          },
+          {
+            "kind": "identifier",
+            "spelling": "myFunc"
+          },
+          {
+            "kind": "text",
+            "spelling": "<"
+          },
+          {
+            "kind": "genericParameter",
+            "spelling": "S"
+          },
+          {
+            "kind": "text",
+            "spelling": ">("
+          },
+          {
+            "kind": "externalParam",
+            "spelling": "param"
+          },
+          {
+            "kind": "text",
+            "spelling": ": "
+          },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "S",
+            "preciseIdentifier": "s:9FancyOverloads7MyClassC6myFunc5paramyx_tSyRzlF1SL_xmfp"
+          },
+          {
+            "kind": "text",
+            "spelling": ")"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "name": "param",
+            "declarationFragments": [
+              {
+                "kind": "identifier",
+                "spelling": "param"
+              },
+              {
+                "kind": "text",
+                "spelling": ": "
+              },
+              {
+                "kind": "typeIdentifier",
+                "spelling": "S",
+                "preciseIdentifier": "s:9FancyOverloads7MyClassC6myFunc5paramyx_tSyRzlF1SL_xmfp"
+              }
+            ]
+          }
+        ],
+        "returns": [
+          {
+            "kind": "text",
+            "spelling": "()"
+          }
+        ]
+      },
+      "swiftGenerics": {
+        "parameters": [
+          {
+            "name": "S",
+            "index": 0,
+            "depth": 0
+          }
+        ],
+        "constraints": [
+          {
+            "kind": "conformance",
+            "lhs": "S",
+            "rhs": "StringProtocol",
+            "rhsPrecise": "s:Sy"
+          }
+        ]
+      },
+      "declarationFragments": [
+        {
+          "kind": "keyword",
+          "spelling": "func"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "myFunc"
+        },
+        {
+          "kind": "text",
+          "spelling": "<"
+        },
+        {
+          "kind": "genericParameter",
+          "spelling": "S"
+        },
+        {
+          "kind": "text",
+          "spelling": ">("
+        },
+        {
+          "kind": "externalParam",
+          "spelling": "param"
+        },
+        {
+          "kind": "text",
+          "spelling": ": "
+        },
+        {
+          "kind": "typeIdentifier",
+          "spelling": "S",
+          "preciseIdentifier": "s:9FancyOverloads7MyClassC6myFunc5paramyx_tSyRzlF1SL_xmfp"
+        },
+        {
+          "kind": "text",
+          "spelling": ") "
+        },
+        {
+          "kind": "keyword",
+          "spelling": "where"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "typeIdentifier",
+          "spelling": "S"
+        },
+        {
+          "kind": "text",
+          "spelling": " : "
+        },
+        {
+          "kind": "typeIdentifier",
+          "spelling": "StringProtocol",
+          "preciseIdentifier": "s:Sy"
+        }
+      ],
+      "accessLevel": "public"
+    },
+    {
+      "kind": {
+        "identifier": "swift.method",
+        "displayName": "Instance Method"
+      },
+      "identifier": {
+        "precise": "s:9FancyOverloads7MyClassC6myFunc5paramySi_tF",
+        "interfaceLanguage": "swift"
+      },
+      "pathComponents": [
+        "MyClass",
+        "myFunc(param:)"
+      ],
+      "names": {
+        "title": "myFunc(param:)",
+        "subHeading": [
+          {
+            "kind": "keyword",
+            "spelling": "func"
+          },
+          {
+            "kind": "text",
+            "spelling": " "
+          },
+          {
+            "kind": "identifier",
+            "spelling": "myFunc"
+          },
+          {
+            "kind": "text",
+            "spelling": "("
+          },
+          {
+            "kind": "externalParam",
+            "spelling": "param"
+          },
+          {
+            "kind": "text",
+            "spelling": ": "
+          },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "Int",
+            "preciseIdentifier": "s:Si"
+          },
+          {
+            "kind": "text",
+            "spelling": ")"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "name": "param",
+            "declarationFragments": [
+              {
+                "kind": "identifier",
+                "spelling": "param"
+              },
+              {
+                "kind": "text",
+                "spelling": ": "
+              },
+              {
+                "kind": "typeIdentifier",
+                "spelling": "Int",
+                "preciseIdentifier": "s:Si"
+              }
+            ]
+          }
+        ],
+        "returns": [
+          {
+            "kind": "text",
+            "spelling": "()"
+          }
+        ]
+      },
+      "declarationFragments": [
+        {
+          "kind": "keyword",
+          "spelling": "func"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "myFunc"
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "externalParam",
+          "spelling": "param"
+        },
+        {
+          "kind": "text",
+          "spelling": ": "
+        },
+        {
+          "kind": "typeIdentifier",
+          "spelling": "Int",
+          "preciseIdentifier": "s:Si"
+        },
+        {
+          "kind": "text",
+          "spelling": ")"
+        }
+      ],
+      "accessLevel": "public"
+    }
+  ],
+  "relationships": [
+    {
+      "kind": "memberOf",
+      "source": "s:9FancyOverloads7MyClassC6myFunc5paramySi_tF",
+      "target": "s:9FancyOverloads7MyClassC"
+    },
+    {
+      "kind": "memberOf",
+      "source": "s:9FancyOverloads7MyClassC6myFunc5paramyx_tSyRzlF",
+      "target": "s:9FancyOverloads7MyClassC"
+    }
+  ]
+}


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://116409531

## Summary

This PR introduces a new field to declaration tokens in Render JSON: `highlight`. This field indicates that the token is distinct among a set of overloads and should be indicated with a highlight or other style. It also performs a difference comparison of overloaded symbols' declarations so that the fields are populated for Swift-DocC-Render.

When combined with the related Swift-DocC-Render PR (linked below), the rendered page appears like this:

<img width="916" alt="image" src="https://github.com/apple/swift-docc/assets/5217170/c48d1cf2-fe7e-45ef-936d-a307bcdc3e82">

Because the differencing works directly on the declaration fragments received from the symbol graph, this PR also takes some care to break up `.text` tokens to prevent false-positive differences and create a cleaner output. For example, the below overloads correctly only highlight the `<S>` in the second overload, even though it originally contains a text token of `>(`. Also visible in this example is some proactive whitespace-trimming from highlighted sections; there is a unique text token containing a single space before the `where` clause in the second overload, but it's not highlighted to reduce clutter:

<img width="913" alt="image" src="https://github.com/apple/swift-docc/assets/5217170/4883dced-5c73-4a6e-9246-a22b54b989d7">

### Performance

This PR uses the standard library's `CollectionDifference` API to generate the [Longest Common Subsequence](https://en.wikipedia.org/wiki/Longest_common_subsequence) of the overload declarations. The diff algorithm can have a heavy time complexity, especially when run repeatedly like here. The standard library's implementation is well-optimized, but there is still a necessary performance hit to calculate the diffs. This following is a benchmark run on a large framework with many overloaded symbols:

```
┌──────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ Metric                                   │ Change          │ main                 │ current              │
├──────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Duration for 'bundle-registration'       │ +1.913%¹,²      │ 10.351 sec           │ 10.549 sec           │
│ Duration for 'convert-total-time'        │ +3.857%³,⁴      │ 15.477 sec           │ 16.074 sec           │
│ Duration for 'documentation-processing'  │ +7.959%⁵,⁶      │ 5.003 sec            │ 5.401 sec            │
│ Duration for 'finalize-navigation-index' │ no change⁷      │ 0.046 sec            │ 0.046 sec            │
│ Peak memory footprint                    │ no change⁸      │ 811 MB               │ 835.4 MB             │
│ Data subdirectory size                   │ +2.028%⁹        │ 127.4 MB             │ 130 MB               │
│ Index subdirectory size                  │ -0.02829%¹⁰     │ 1.1 MB               │ 1.1 MB               │
│ Total DocC archive size                  │ +1.092%¹¹       │ 236.6 MB             │ 239.2 MB             │
│ Topic Anchor Checksum                    │ no change       │ 53074b40863239b7a00d │ 53074b40863239b7a00d │
│ Topic Graph Checksum                     │ change          │ 5bdfe323b77baec3d5cd │ f4af046ddef9eab49ba8 │
└──────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```

## Dependencies

https://github.com/apple/swift-docc-render/pull/847 is required to render the tokens with a highlight.

## Testing

Steps:
1. Build the Swift-DocC-Render PR and link the resulting `dist` directory into the `DOCC_HTML_DIR` environment variable.
2. `swift run docc preview --enable-experimental-overloaded-symbol-presentation 'Tests/SwiftDocCTests/Test Bundles/OverloadedSymbols.docc'
3. Navigate to the `OverloadedEnum/firstTestMemberName(_:)` overload group and expand the declaration list.
4. Ensure that the declarations correctly highlight the parameter type in each overloaded declaration.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ n/a ] Updated documentation if necessary
