### PR TITLE
Merge automatically curated task groups

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -1555,6 +1555,8 @@ public struct RenderNodeTranslator: SemanticVisitor {
                 // If the section has been manually curated, merge the references of both the automatic curation and the manual curation into one section (rdar://61899214).
                 if let duplicateSectionIndex = sections.firstIndex(where: { $0.title == group.title }) {
                     let originalSection = sections[duplicateSectionIndex]
+                    // Combining all references here without checking for duplicates should be safe,
+                    // because the automatic curation of topics only returns symbols that haven't already been manually curated.
                     let combinedReferences = originalSection.identifiers + newReferences.map { $0.absoluteString }
                     sections[duplicateSectionIndex] = TaskGroupRenderSection(title: originalSection.title, abstract: originalSection.abstract, discussion: originalSection.discussion, identifiers: combinedReferences)
                 } else {


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://61899214

## Summary

Currently, when a developer writes a symbol extension markdown file, and creates a topic section which is named the same as one of the titles which are used for automatic curation ("Initializers", "Instance Properties", "Instance Methods", "Type Aliases", etc.), the result is duplicated sections:
![3cf36344-f5ab-466f-832f-1ffc8c738ac7](https://github.com/apple/swift-docc/assets/15234535/67cd2d8a-4096-4003-8b2f-5439487b1352)

This PR changes this behaviour so that automatically curated section contents are merged with existing sections, if they have the same title:
![c0df4dbb-3317-4bf6-a517-ccb8e48dcdff](https://github.com/apple/swift-docc/assets/15234535/159f928f-b69d-4d79-b565-8bb20b79aaca)

### Implementation

in `RenderNodeTranslator.visitSymbol(_:)`, after the list of automatically curated task groups has been created, we now check whether there is an existing manually curated section with the same title. 

If it exists, we extend this section in place with the symbol references from the automatically curated task group. Otherwise, we create a new section same as before.

## Dependencies

No dependencies.

## Testing

You can use the following test package to test locally:
[TestPackage.zip](https://github.com/apple/swift-docc/files/15486030/TestPackage.zip)

Steps:
1. Generate rendered documentation for the test package using `docc`
2. View rendered documentation for `ExampleClass` (at http://localhost:8080/documentation/testpackage/exampleclass) and validate that there is only one "Initializers" section under "Topics".

More generally, this can be reproduced by:
1. Creating an extension markdown file for a package's symbol.
2. Creating a section under topics which is titled same as one of the titles which are used for automatic curation ("Initializers", "Instance Properties", "Instance Methods", "Type Aliases", etc.).
3. Render the documentation.
4. View the extended symbol's documentation, and verify that the contents from the manually curated section have been merged with the automatically curated symbols.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary

### Verification

**Unit tests**

Added test `testAutomaticallyCuratedSymbolTopicsAreMergedWithManuallyCuratedTopics()`, which passes. This test explicitly tests the new merging functionality. I'm relying on the existing tests for testing that previous automatic curation functionality still works as expected.

Ran `./bin/test`:
```
=> Checking for unacceptable language… okay.
=> Checking license headers… okay.
=> Validating scripts in bin subdirectory… okay.
```

**Site rendering**

Verified manually by creating a test package with an extension markdown file which defines a topic section "Initializers". Before this change, the result would be two separate sections, both titled "Initializers". After this change, there is only one section named "Initializer" with the merged contents.

Input markdown:
```md
# ``ExampleClass``


This is a summary.

## Overview

This is an overview.

## Topics

### Other group

- <doc:ExampleArticle>

### Initializers

- <doc:ExampleArticle>

## See Also

- ``TestPackage``
```

Before                                  |  After
:-------------------------:|:-------------------------:
![c60e266d-74e0-49a9-8305-e1846d2bc789](https://github.com/apple/swift-docc/assets/15234535/f961783d-8ebc-4877-89cc-3e0fbbce1989) | ![c664cdff-cc81-41bc-bab4-4f8e56ff0cbe](https://github.com/apple/swift-docc/assets/15234535/0337886f-172c-442d-a573-a99eab4085b1)

**Documentation**

As far as I can tell, no changes to the documentation are needed.
