### PR TITLE
Improve test hygiene in ConvertSubcommandTests

### DIFF
--- a/Tests/SwiftDocCUtilitiesTests/ArgumentParsing/ConvertSubcommandTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ArgumentParsing/ConvertSubcommandTests.swift
@@ -31,7 +31,7 @@ class ConvertSubcommandTests: XCTestCase {
         // by the machine environment.
         let priorWorkingDirectory = FileManager.default.currentDirectoryPath
         let temporaryDirectory = try createTemporaryDirectory()
-        FileManager.default.changeCurrentDirectoryPath(temporaryDirectory.path())
+        FileManager.default.changeCurrentDirectoryPath(temporaryDirectory.path)
         addTeardownBlock {
             FileManager.default.changeCurrentDirectoryPath(priorWorkingDirectory)
         }

--- a/Tests/SwiftDocCUtilitiesTests/ArgumentParsing/ConvertSubcommandTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ArgumentParsing/ConvertSubcommandTests.swift
@@ -26,6 +26,17 @@ class ConvertSubcommandTests: XCTestCase {
         Docc.Convert._errorLogHandle = .none
     }
 
+    override func setUpWithError() throws {
+        // By default, run all tests in a temporary directory to ensure that they are not affected
+        // by the machine environment.
+        let priorWorkingDirectory = FileManager.default.currentDirectoryPath
+        let temporaryDirectory = try createTemporaryDirectory()
+        FileManager.default.changeCurrentDirectoryPath(temporaryDirectory.path())
+        addTeardownBlock {
+            FileManager.default.changeCurrentDirectoryPath(priorWorkingDirectory)
+        }
+    }
+
     /// Saves the current value of the documentation template environment variable, and adds a test teardown block to restore it.
     func saveCurrentTemplateEnvironmentVariable() {
         let existingTemplate = ProcessInfo.processInfo.environment[TemplateOption.environmentVariableKey]

--- a/Tests/SwiftDocCUtilitiesTests/ArgumentParsing/ConvertSubcommandTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ArgumentParsing/ConvertSubcommandTests.swift
@@ -34,7 +34,17 @@ class ConvertSubcommandTests: XCTestCase {
         // create template dir
         let rendererTemplateDirectory = try createTemporaryDirectory()
         try "".write(to: rendererTemplateDirectory.appendingPathComponent("index.html"), atomically: true, encoding: .utf8)
-        
+
+        // store the template environment if it exists, and restore it after we mess with it
+        let existingTemplate = ProcessInfo.processInfo.environment[TemplateOption.environmentVariableKey]
+        defer {
+            if let existingTemplate = existingTemplate {
+                SetEnvironmentVariable(TemplateOption.environmentVariableKey, existingTemplate)
+            } else {
+                UnsetEnvironmentVariable(TemplateOption.environmentVariableKey)
+            }
+        }
+
         // Tests a single input.
         do {
             SetEnvironmentVariable(TemplateOption.environmentVariableKey, rendererTemplateDirectory.path)

--- a/Tests/SwiftDocCUtilitiesTests/ArgumentParsing/ConvertSubcommandTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ArgumentParsing/ConvertSubcommandTests.swift
@@ -19,8 +19,17 @@ class ConvertSubcommandTests: XCTestCase {
     
     private let testTemplateURL = Bundle.module.url(
         forResource: "Test Template", withExtension: nil, subdirectory: "Test Resources")!
-    
-    override func setUp() {
+
+    override func setUpWithError() throws {
+        // By default, run all tests in a temporary directory to ensure that they are not affected
+        // by the machine environment.
+        let priorWorkingDirectory = FileManager.default.currentDirectoryPath
+        let temporaryDirectory = try createTemporaryDirectory()
+        FileManager.default.changeCurrentDirectoryPath(temporaryDirectory.path)
+        addTeardownBlock {
+            FileManager.default.changeCurrentDirectoryPath(priorWorkingDirectory)
+        }
+
         // By default, send all warnings to `.none` instead of filling the
         // test console output with unrelated messages.
         Docc.Convert._errorLogHandle = .none
@@ -35,17 +44,6 @@ class ConvertSubcommandTests: XCTestCase {
             } else {
                 UnsetEnvironmentVariable(TemplateOption.environmentVariableKey)
             }
-        }
-    }
-
-    override func setUpWithError() throws {
-        // By default, run all tests in a temporary directory to ensure that they are not affected
-        // by the machine environment.
-        let priorWorkingDirectory = FileManager.default.currentDirectoryPath
-        let temporaryDirectory = try createTemporaryDirectory()
-        FileManager.default.changeCurrentDirectoryPath(temporaryDirectory.path)
-        addTeardownBlock {
-            FileManager.default.changeCurrentDirectoryPath(priorWorkingDirectory)
         }
     }
 


### PR DESCRIPTION
Bug/issue #, if applicable: None

## Summary

This PR adds some setup and teardown for the tests in `SwiftDocCUtilitiesTests.ConvertSubcommandTests` to clean up the process environment and working directory before and after each test. This resolves some test flakiness that depended on specific environmental conditions. In particular, it resolves `testParameterValidationFeatureFlag` failing when tests are run sequentially, and resolves `testTreatWarningAsError` failing when a symlink is present in the Swift-DocC directory tree.

## Dependencies

None

## Testing

Steps:
1. `touch test && ln -s test test2`
2. `swift test` (Important: **not** `bin/test`, as the test only failed when run sequentially due to unclean environment)
3. Ensure that all tests pass.
4. `rm test test2` (to clean up your repo state)

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ n/a ] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ n/a ] Updated documentation if necessary
