### PR TITLE
Micro optimization for whitespace trimming of strings

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/Content/Extensions/RenderTermLists.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Content/Extensions/RenderTermLists.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -286,22 +286,20 @@ extension RenderInlineContent {
 }
 
 extension String {
-    
-    /// The result of removing whitespace from the beginning of the string.
+    /// Returns a new string made by removing whitespace from the beginning of the string.
     func removingLeadingWhitespace() -> String {
-        var trimmedString = self
-        while trimmedString.first?.isWhitespace == true {
-            trimmedString = String(trimmedString.dropFirst())
+        guard let index = self.firstIndex(where: { !$0.isWhitespace }) else { return "" }
+        if index == startIndex {
+            // Avoid a potential copy if the string doesn't have any leading whitespace.
+            return self
         }
-        return trimmedString
+        return String(self[index...])
     }
     
-    /// The result of removing whitespace from the end of the string.
+    /// Returns a new string made by removing whitespace from the end of the string.
     func removingTrailingWhitespace() -> String {
-        var trimmedString = self
-        while trimmedString.last?.isWhitespace == true {
-            trimmedString = String(trimmedString.dropLast())
-        }
-        return trimmedString
+        guard let index = self.lastIndex(where: { !$0.isWhitespace }) else { return "" }
+        // It's not worth checking if the index is at the end because `index(before: endIndex)` is slower than not checking.
+        return String(self[...index])
     }
 }

--- a/Tests/SwiftDocCTests/Utility/String+WhitespaceTests.swift
+++ b/Tests/SwiftDocCTests/Utility/String+WhitespaceTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -36,6 +36,26 @@ class String_WhitespaceTests: XCTestCase {
         
         XCTAssertEqual("Words: with, various. punctuation! as - separators".replacingWhitespaceAndPunctuation(with: "-"),
                        "Words-with-various-punctuation-as-separators")
+    }
+    
+    func testTrimmingWhitespace() {
+        XCTAssertEqual("".removingLeadingWhitespace(), "")
+        XCTAssertEqual("".removingTrailingWhitespace(), "")
+        
+        XCTAssertEqual("ABC".removingLeadingWhitespace(), "ABC")
+        XCTAssertEqual("ABC".removingTrailingWhitespace(), "ABC")
+        
+        XCTAssertEqual("\t ABC\t ".removingLeadingWhitespace(), "ABC\t ", "Removing leading whitespace doesn't remove trailing whitespace")
+        XCTAssertEqual("\t ABC\t ".removingTrailingWhitespace(), "\t ABC", "Removing trailing whitespace doesn't remove leading whitespace")
+        
+        XCTAssertEqual("\t ".removingLeadingWhitespace(), "", "All characters are whitespace")
+        XCTAssertEqual("\t ".removingTrailingWhitespace(), "", "All characters are whitespace")
+        
+        XCTAssertEqual("\n ABC \n".removingLeadingWhitespace(), "ABC \n", "Newline is considered a whitespace character")
+        XCTAssertEqual("\n ABC \n".removingTrailingWhitespace(), "\n ABC", "Newline is considered a whitespace character")
+        
+        XCTAssertEqual("start ABC end".removingLeadingWhitespace(), "start ABC end", "Only removes whitespace at the start and end of the string")
+        XCTAssertEqual("start ABC end".removingTrailingWhitespace(), "start ABC end", "Only removes whitespace at the start and end of the string")
     }
 }
 


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

This is a micro optimization to make `String/removingLeadingWhitespace()` and `String/removingTrailingWhitespace()` faster. This difference is only measurable in micro benchmarks.

---

I stumbled upon this code while reviewing something else and the repeated String copying irked me. 

Using micro benchmarks I could confirm that using `firstIndex(where:)`/ `lastIndex(where:)` is faster for all amounts of leading and trailing whitespace. In the graphs below, all measurements are divided by the string length.

### 1 leading and 1 trailing space
```swift
" \(String(repeating: "A", count: n)) "
```
<img width="1280" alt="chart-1-space" src="https://github.com/apple/swift-docc/assets/1228143/aeebb1e5-13d5-4b45-b83e-ac9b5fc1543c">

### _n_ leading and _n_ trailing spaces
```swift
"\(String(repeating: " ", count: n))A\(String(repeating: " ", count: n))"
```
<img width="1280" alt="chart-n-spaces" src="https://github.com/apple/swift-docc/assets/1228143/edcf74bf-425e-45ae-8311-7d84c8d2cfb0">

### 0 leading and 0 trailing spaces
```swift
String(repeating: "A", count: n)
```
Note that green compares to red and yellow compares to blue.
<img width="1280" alt="chart-no-spaces" src="https://github.com/apple/swift-docc/assets/1228143/0d2711e0-ba79-40f1-a8a7-f8cf03e81e97">


## Dependencies

None

## Testing

None. This isn't a change in behavior.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
