### PR TITLE
Avoid visiting symbol markup twice when there's a documentation extension file

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -566,14 +566,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
                 // Diagnostics for in-source documentation comments need to be offset based on the start location of the comment in the source file.
                 
                 // Get the source location
-                var inSourceDocumentationCommentSource: URL?
-                var inSourceDocumentationCommentOffset: SymbolGraph.LineList.SourceRange?
-                for docChunk in documentationNode.docChunks {
-                    guard case .sourceCode(let location, let offset) = docChunk.source else { continue }
-                    inSourceDocumentationCommentSource = location?.url
-                    inSourceDocumentationCommentOffset = offset
-                    break
-                }
+                let inSourceDocumentationCommentInfo = documentationNode.inSourceDocumentationChunk
                 
                 // Post-process and filter out unwanted diagnostics (for example from inherited documentation comments)
                 problems = resolver.problems.compactMap { problem in
@@ -582,10 +575,10 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
                         return nil
                     }
                     
-                    if source == inSourceDocumentationCommentSource, let inSourceDocumentationCommentOffset {
+                    if source == inSourceDocumentationCommentInfo?.url, let offset = inSourceDocumentationCommentInfo?.offset {
                         // Diagnostics from an in-source documentation comment need to be offset based on the location of that documentation comment.
                         var modifiedProblem = problem
-                        modifiedProblem.offsetWithRange(inSourceDocumentationCommentOffset)
+                        modifiedProblem.offsetWithRange(offset)
                         return modifiedProblem
                     } 
                     

--- a/Sources/SwiftDocC/Model/DocumentationNode.swift
+++ b/Sources/SwiftDocC/Model/DocumentationNode.swift
@@ -94,6 +94,16 @@ public struct DocumentationNode {
     /// property.
     var docChunks: [DocumentationChunk]
     
+    /// Returns information about the node's in-source documentation comment chunk, or `nil` if the node doesn't have an in-source documentation chunk.
+    var inSourceDocumentationChunk: (url: URL?, offset: SymbolGraph.LineList.SourceRange?)? {
+        for docChunk in docChunks {
+            guard case .sourceCode(let location, let offset) = docChunk.source else { continue }
+            
+            return (url: location?.url, offset: offset)
+        }
+        return nil
+    }
+    
     /// Linkable in-content sections.
     var anchorSections = [AnchorSection]()
     

--- a/Sources/SwiftDocC/Semantics/ReferenceResolver.swift
+++ b/Sources/SwiftDocC/Semantics/ReferenceResolver.swift
@@ -226,6 +226,7 @@ struct ReferenceResolver: SemanticVisitor {
                             summary: "This documentation block is inherited by other symbols where \(unresolved.topicURL.absoluteString.singleQuoted) fails to resolve."),
                             possibleSolutions: [
                                 Solution(summary: "Use an absolute link path.", replacements: [
+                                    // FIXME: The resolved reference path isn't the same as the authorable link.
                                     Replacement(range: range, replacement: "<doc:\(resolved.path)>")
                                 ])
                             ])

--- a/Sources/SwiftDocC/Semantics/ReferenceResolver.swift
+++ b/Sources/SwiftDocC/Semantics/ReferenceResolver.swift
@@ -213,14 +213,14 @@ struct ReferenceResolver: SemanticVisitor {
         let parent = inheritanceParentReference
         let context = self.context
         
-        markupResolver.problemForUnresolvedReference = { unresolved, source, range, fromSymbolLink, underlyingErrorMessage -> Problem? in
+        markupResolver.problemForUnresolvedReference = { unresolved, range, fromSymbolLink, underlyingErrorMessage -> Problem? in
             // Verify we have all the information about the location of the source comment
             // and the symbol that the comment is inherited from.
             if let parent, let range {
                 switch context.resolve(.unresolved(unresolved), in: parent, fromSymbolLink: fromSymbolLink) {
                     case .success(let resolved):
                         // Return a warning with a suggested change that replaces the relative link with an absolute one.
-                        return Problem(diagnostic: Diagnostic(source: source,
+                        return Problem(diagnostic: Diagnostic(source: range.source,
                             severity: .warning, range: range,
                             identifier: "org.swift.docc.UnresolvableLinkWhenInherited",
                             summary: "This documentation block is inherited by other symbols where \(unresolved.topicURL.absoluteString.singleQuoted) fails to resolve."),

--- a/Sources/SwiftDocC/Semantics/ReferenceResolver.swift
+++ b/Sources/SwiftDocC/Semantics/ReferenceResolver.swift
@@ -92,9 +92,6 @@ struct ReferenceResolver: SemanticVisitor {
     /// The bundle in which visited documents reside.
     var bundle: DocumentationBundle
     
-    /// The source document being analyzed.
-    var source: URL?
-    
     /// Problems found while trying to resolve references.
     var problems = [Problem]()
     
@@ -103,10 +100,9 @@ struct ReferenceResolver: SemanticVisitor {
     /// If the documentation is inherited, the reference of the parent symbol.
     var inheritanceParentReference: ResolvedTopicReference?
     
-    init(context: DocumentationContext, bundle: DocumentationBundle, source: URL?, rootReference: ResolvedTopicReference? = nil, inheritanceParentReference: ResolvedTopicReference? = nil) {
+    init(context: DocumentationContext, bundle: DocumentationBundle, rootReference: ResolvedTopicReference? = nil, inheritanceParentReference: ResolvedTopicReference? = nil) {
         self.context = context
         self.bundle = bundle
-        self.source = source
         self.rootReference = rootReference ?? bundle.rootReference
         self.inheritanceParentReference = inheritanceParentReference
     }
@@ -118,7 +114,7 @@ struct ReferenceResolver: SemanticVisitor {
             
         case let .failure(unresolved, error):
             let uncuratedArticleMatch = context.uncuratedArticles[bundle.documentationRootReference.appendingPathOfReference(unresolved)]?.source
-            problems.append(unresolvedReferenceProblem(source: source, range: range, severity: severity, uncuratedArticleMatch: uncuratedArticleMatch, errorInfo: error, fromSymbolLink: false))
+            problems.append(unresolvedReferenceProblem(source: range?.source, range: range, severity: severity, uncuratedArticleMatch: uncuratedArticleMatch, errorInfo: error, fromSymbolLink: false))
             return .failure(unresolved, error)
         }
     }
@@ -128,7 +124,7 @@ struct ReferenceResolver: SemanticVisitor {
     */
     func resolve(resource: ResourceReference, range: SourceRange?, severity: DiagnosticSeverity) -> Problem? {
         if !context.resourceExists(with: resource) {
-            return unresolvedResourceProblem(resource: resource, source: source, range: range, severity: severity)
+            return unresolvedResourceProblem(resource: resource, source: range?.source, range: range, severity: severity)
         } else {
             return nil
         }
@@ -213,7 +209,7 @@ struct ReferenceResolver: SemanticVisitor {
     }
     
     mutating func visitMarkupContainer(_ markupContainer: MarkupContainer) -> Semantic {
-        var markupResolver = MarkupReferenceResolver(context: context, bundle: bundle, source: source, rootReference: rootReference)
+        var markupResolver = MarkupReferenceResolver(context: context, bundle: bundle, rootReference: rootReference)
         let parent = inheritanceParentReference
         let context = self.context
         
@@ -291,7 +287,7 @@ struct ReferenceResolver: SemanticVisitor {
         var uniqueReferences = Set<TopicReference>()
         let newTutorialReferencesWithoutDupes = newTutorialReferences.filter { newTutorialReference in
             guard !uniqueReferences.contains(newTutorialReference.topic) else {
-                let diagnostic = Diagnostic(source: source, severity: .warning, range: newTutorialReference.originalMarkup.range, identifier: "org.swift.docc.\(Chapter.self).Duplicate\(TutorialReference.self)", summary: "Duplicate \(TutorialReference.directiveName.singleQuoted) directive refers to \(newTutorialReference.topic.description.singleQuoted)")
+                let diagnostic = Diagnostic(source: chapter.originalMarkup.range?.source, severity: .warning, range: newTutorialReference.originalMarkup.range, identifier: "org.swift.docc.\(Chapter.self).Duplicate\(TutorialReference.self)", summary: "Duplicate \(TutorialReference.directiveName.singleQuoted) directive refers to \(newTutorialReference.topic.description.singleQuoted)")
                 let solutions = newTutorialReference.originalMarkup.range.map {
                     return [Solution(summary: "Remove duplicate \(TutorialReference.directiveName.singleQuoted) directive", replacements: [
                         Replacement(range: $0, replacement: "")

--- a/Tests/SwiftDocCTests/Diagnostics/DiagnosticTests.swift
+++ b/Tests/SwiftDocCTests/Diagnostics/DiagnosticTests.swift
@@ -81,10 +81,10 @@ class DiagnosticTests: XCTestCase {
     func testOffsetDiagnostics() throws {
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
 
-        let source = "Test a ``Reference`` in a sentence."
-        let markup = Document(parsing: source, options: .parseSymbolLinks)
+        let content = "Test a ``Reference`` in a sentence."
+        let markup = Document(parsing: content, source: URL(string: "/tmp/foo.symbols.json"), options: .parseSymbolLinks)
         
-        var resolver = ReferenceResolver(context: context, bundle: bundle, source: URL(string: "/tmp/foo.symbols.json"), rootReference: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit", sourceLanguage: .swift))
+        var resolver = ReferenceResolver(context: context, bundle: bundle, rootReference: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit", sourceLanguage: .swift))
         
         // Resolve references
         _ = resolver.visitMarkup(markup)

--- a/Tests/SwiftDocCTests/Infrastructure/ReferenceResolverTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/ReferenceResolverTests.swift
@@ -814,11 +814,21 @@ class ReferenceResolverTests: XCTestCase {
             let problem = try XCTUnwrap(problems.first)
             XCTAssertEqual(problem.diagnostic.summary, "Can't resolve 'NotFoundArticle'")
             XCTAssertEqual(problem.diagnostic.source?.path, "/Users/username/path/to/Something.swift")
+            // Note: `ReferenceResolver` doesn't offset diagnostics. That happens in `DocumentationContext/resolveLinks(curatedReferences:bundle:)`
+            XCTAssertEqual(problem.diagnostic.range?.lowerBound.line, 3)
+            XCTAssertEqual(problem.diagnostic.range?.upperBound.line, 3)
+            XCTAssertEqual(problem.diagnostic.range?.lowerBound.column, 44)
+            XCTAssertEqual(problem.diagnostic.range?.upperBound.column, 59)
         }
         do {
             let problem = try XCTUnwrap(problems.dropFirst().first)
             XCTAssertEqual(problem.diagnostic.summary, "Can't resolve 'NotFoundSymbol'")
             XCTAssertEqual(problem.diagnostic.source?.path, "/Users/username/path/to/Something.swift")
+            // Note: `ReferenceResolver` doesn't offset diagnostics. That happens in `DocumentationContext/resolveLinks(curatedReferences:bundle:)`
+            XCTAssertEqual(problem.diagnostic.range?.lowerBound.line, 3)
+            XCTAssertEqual(problem.diagnostic.range?.upperBound.line, 3)
+            XCTAssertEqual(problem.diagnostic.range?.lowerBound.column, 18)
+            XCTAssertEqual(problem.diagnostic.range?.upperBound.column, 32)
         }
         
         // These other links to ``OtherNotFoundSymbol`` and <doc:OtherNotFoundArticle> also won't resolve.
@@ -826,11 +836,19 @@ class ReferenceResolverTests: XCTestCase {
             let problem = try XCTUnwrap(problems.dropFirst(2).first)
             XCTAssertEqual(problem.diagnostic.summary, "Can't resolve 'OtherNotFoundArticle'")
             XCTAssertEqual(problem.diagnostic.source?.path, "/Users/username/path/to/SomeCatalog.docc/Something.md")
+            XCTAssertEqual(problem.diagnostic.range?.lowerBound.line, 5)
+            XCTAssertEqual(problem.diagnostic.range?.upperBound.line, 5)
+            XCTAssertEqual(problem.diagnostic.range?.lowerBound.column, 55)
+            XCTAssertEqual(problem.diagnostic.range?.upperBound.column, 75)
         }
         do {
             let problem = try XCTUnwrap(problems.dropFirst(3).first)
             XCTAssertEqual(problem.diagnostic.summary, "Can't resolve 'OtherNotFoundSymbol'")
             XCTAssertEqual(problem.diagnostic.source?.path, "/Users/username/path/to/SomeCatalog.docc/Something.md")
+            XCTAssertEqual(problem.diagnostic.range?.lowerBound.line, 5)
+            XCTAssertEqual(problem.diagnostic.range?.upperBound.line, 5)
+            XCTAssertEqual(problem.diagnostic.range?.lowerBound.column, 24)
+            XCTAssertEqual(problem.diagnostic.range?.upperBound.column, 43)
         }
         
         // This image name won't resolve: ![Some image that's not found](some-not-found-image)
@@ -838,6 +856,11 @@ class ReferenceResolverTests: XCTestCase {
             let problem = try XCTUnwrap(problems.dropFirst(4).first)
             XCTAssertEqual(problem.diagnostic.summary, "Resource 'not-found-image' couldn't be found")
             XCTAssertEqual(problem.diagnostic.source?.path, "/Users/username/path/to/Something.swift")
+            // Note: `ReferenceResolver` doesn't offset diagnostics. That happens in `DocumentationContext/resolveLinks(curatedReferences:bundle:)`
+            XCTAssertEqual(problem.diagnostic.range?.lowerBound.line, 5)
+            XCTAssertEqual(problem.diagnostic.range?.upperBound.line, 5)
+            XCTAssertEqual(problem.diagnostic.range?.lowerBound.column, 32)
+            XCTAssertEqual(problem.diagnostic.range?.upperBound.column, 79)
         }
         
         // This other image name also won't resolve: ![Some other image that's not found](other-not-found-image)
@@ -845,6 +868,10 @@ class ReferenceResolverTests: XCTestCase {
             let problem = try XCTUnwrap(problems.dropFirst(5).first)
             XCTAssertEqual(problem.diagnostic.summary, "Resource 'other-not-found-image' couldn't be found")
             XCTAssertEqual(problem.diagnostic.source?.path, "/Users/username/path/to/SomeCatalog.docc/Something.md")
+            XCTAssertEqual(problem.diagnostic.range?.lowerBound.line, 7)
+            XCTAssertEqual(problem.diagnostic.range?.upperBound.line, 7)
+            XCTAssertEqual(problem.diagnostic.range?.lowerBound.column, 43)
+            XCTAssertEqual(problem.diagnostic.range?.upperBound.column, 102)
         }
     }
 }

--- a/Tests/SwiftDocCTests/Infrastructure/ReferenceResolverTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/ReferenceResolverTests.swift
@@ -11,6 +11,7 @@
 import XCTest
 @_spi(ExternalLinks) @testable import SwiftDocC
 import Markdown
+import SymbolKit
 
 class ReferenceResolverTests: XCTestCase {
     func testResolvesMediaForIntro() throws {
@@ -27,7 +28,7 @@ class ReferenceResolverTests: XCTestCase {
         var problems = [Problem]()
         let intro = Intro(from: directive, source: nil, for: bundle, in: context, problems: &problems)!
         
-        var resolver = ReferenceResolver(context: context, bundle: bundle, source: nil)
+        var resolver = ReferenceResolver(context: context, bundle: bundle)
         _ = resolver.visitIntro(intro)
         XCTAssertEqual(resolver.problems.count, 1)
     }
@@ -46,7 +47,7 @@ class ReferenceResolverTests: XCTestCase {
         var problems = [Problem]()
         let contentAndMedia = ContentAndMedia(from: directive, source: nil, for: bundle, in: context, problems: &problems)!
         
-        var resolver = ReferenceResolver(context: context, bundle: bundle, source: nil)
+        var resolver = ReferenceResolver(context: context, bundle: bundle)
         _ = resolver.visit(contentAndMedia)
         XCTAssertEqual(resolver.problems.count, 1)
     }
@@ -63,7 +64,7 @@ class ReferenceResolverTests: XCTestCase {
         var problems = [Problem]()
         let intro = Intro(from: directive, source: nil, for: bundle, in: context, problems: &problems)!
         
-        var resolver = ReferenceResolver(context: context, bundle: bundle, source: nil)
+        var resolver = ReferenceResolver(context: context, bundle: bundle)
         
         guard let container = resolver.visit(intro).children.first as? MarkupContainer,
               let firstElement = container.elements.first,
@@ -563,7 +564,7 @@ class ReferenceResolverTests: XCTestCase {
         var problems = [Problem]()
 
         let chapter = try XCTUnwrap(Chapter(from: directive, source: nil, for: bundle, in: context, problems: &problems))
-        var resolver = ReferenceResolver(context: context, bundle: bundle, source: nil)
+        var resolver = ReferenceResolver(context: context, bundle: bundle)
         _ = resolver.visitChapter(chapter)
         XCTAssertFalse(resolver.problems.containsErrors)
         XCTAssertEqual(resolver.problems.count, 1)
@@ -583,7 +584,7 @@ class ReferenceResolverTests: XCTestCase {
         let document = Document(parsing: source, options: [.parseBlockDirectives, .parseSymbolLinks])
         let article = try XCTUnwrap(Article(markup: document, metadata: nil, redirects: nil, options: [:]))
         
-        var resolver = ReferenceResolver(context: context, bundle: bundle, source: nil)
+        var resolver = ReferenceResolver(context: context, bundle: bundle)
         let resolvedArticle = try XCTUnwrap(resolver.visitArticle(article) as? Article)
         let abstractSection = try XCTUnwrap(resolvedArticle.abstractSection)
         
@@ -613,7 +614,7 @@ class ReferenceResolverTests: XCTestCase {
     func testForwardsSymbolPropertiesThatAreUnmodifiedDuringLinkResolution() throws {
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
         
-        var resolver = ReferenceResolver(context: context, bundle: bundle, source: nil)
+        var resolver = ReferenceResolver(context: context, bundle: bundle)
         
         let symbol = try XCTUnwrap(context.documentationCache["s:5MyKit0A5ClassC"]?.semantic as? Symbol)
         
@@ -733,6 +734,117 @@ class ReferenceResolverTests: XCTestCase {
         // Assert symbol variant values that are Equatable.
         for assertion in assertions {
             assertion(resolvedSymbol)
+        }
+    }
+    
+    func testEmitsDiagnosticsForEachDocumentationChunk() throws {
+        let moduleReference = ResolvedTopicReference(bundleIdentifier: "com.example.test", path: "/documentation/ModuleName", sourceLanguage: .swift)
+        let reference = ResolvedTopicReference(bundleIdentifier: "com.example.test", path: "/documentation/ModuleName/Something", sourceLanguage: .swift)
+        
+        let inSourceComment = """
+        Some description of this class
+        
+        These links to ``NotFoundSymbol`` and <doc:NotFoundArticle> won't resolve.
+        
+        This image name won't resolve: ![Some image that's not found](not-found-image)
+        """
+        let start = (line: 7, character: 4) // arbitrary non-zero values
+        let sourceCodeURL = URL(fileURLWithPath: "/Users/username/path/to/Something.swift")
+        
+        let symbol = SymbolGraph.Symbol(
+            identifier: .init(precise: "some-symbol-id", interfaceLanguage: SourceLanguage.swift.id),
+            names: .init(title: "Something", navigator: nil, subHeading: nil, prose: nil),
+            pathComponents: ["Something"],
+            docComment: SymbolGraph.LineList(
+                inSourceComment.splitByNewlines.enumerated().map { lineOffset, line in
+                    SymbolGraph.LineList.Line(text: line, range: .init(
+                        start: .init(line: start.line + lineOffset, character: start.character),
+                        end: .init(line: start.line + lineOffset, character: start.character + line.count)
+                    ))
+                },
+                uri: sourceCodeURL.absoluteString // We want the "file://" prefix
+            ),
+            accessLevel: .public,
+            kind: .init(parsedIdentifier: .class, displayName: "Kind Display Name"),
+            mixins: [:]
+        )
+        
+        let (bundle, context) = try testBundleAndContext()
+        
+        let documentationExtensionContent = """
+        # ``Something``
+        
+        Continue the documentation for the "something" class.
+        
+        These other links to ``OtherNotFoundSymbol`` and <doc:OtherNotFoundArticle> also won't resolve.
+        
+        This other image name also won't resolve: ![Some other image that's not found](other-not-found-image)
+        """
+        let documentationExtensionURL = URL(fileURLWithPath: "/Users/username/path/to/SomeCatalog.docc/Something.md")
+        
+        var ignoredProblems = [Problem]()
+        let article = Article(
+            from: Document(parsing: documentationExtensionContent, source: documentationExtensionURL, options: [.parseSymbolLinks, .parseBlockDirectives]),
+            source: documentationExtensionURL,
+            for: bundle,
+            in: context,
+            problems: &ignoredProblems
+        )
+        XCTAssert(ignoredProblems.isEmpty, "Unexpected problems creating article")
+        
+        let node = DocumentationNode(
+            reference: reference,
+            symbol: symbol,
+            platformName: nil,
+            moduleReference: moduleReference,
+            article: article,
+            engine: context.diagnosticEngine
+        )
+        
+        XCTAssertEqual(node.docChunks.count, 2, "This node has content from both the in-source comment and the documentation extension file.")
+        
+        var resolver = ReferenceResolver(context: context, bundle: bundle)
+        _ = resolver.visitSymbol(node.semantic as! Symbol)
+        
+        let problems = resolver.problems.sorted(by: \.diagnostic.summary)
+        XCTAssertEqual(problems.count, 6)
+        
+        // These links to ``NotFoundSymbol`` and <doc:NotFoundArticle> won't resolve.
+        do {
+            let problem = try XCTUnwrap(problems.first)
+            XCTAssertEqual(problem.diagnostic.summary, "Can't resolve 'NotFoundArticle'")
+            XCTAssertEqual(problem.diagnostic.source?.path, "/Users/username/path/to/Something.swift")
+        }
+        do {
+            let problem = try XCTUnwrap(problems.dropFirst().first)
+            XCTAssertEqual(problem.diagnostic.summary, "Can't resolve 'NotFoundSymbol'")
+            XCTAssertEqual(problem.diagnostic.source?.path, "/Users/username/path/to/Something.swift")
+        }
+        
+        // These other links to ``OtherNotFoundSymbol`` and <doc:OtherNotFoundArticle> also won't resolve.
+        do {
+            let problem = try XCTUnwrap(problems.dropFirst(2).first)
+            XCTAssertEqual(problem.diagnostic.summary, "Can't resolve 'OtherNotFoundArticle'")
+            XCTAssertEqual(problem.diagnostic.source?.path, "/Users/username/path/to/SomeCatalog.docc/Something.md")
+        }
+        do {
+            let problem = try XCTUnwrap(problems.dropFirst(3).first)
+            XCTAssertEqual(problem.diagnostic.summary, "Can't resolve 'OtherNotFoundSymbol'")
+            XCTAssertEqual(problem.diagnostic.source?.path, "/Users/username/path/to/SomeCatalog.docc/Something.md")
+        }
+        
+        // This image name won't resolve: ![Some image that's not found](some-not-found-image)
+        do {
+            let problem = try XCTUnwrap(problems.dropFirst(4).first)
+            XCTAssertEqual(problem.diagnostic.summary, "Resource 'not-found-image' couldn't be found")
+            XCTAssertEqual(problem.diagnostic.source?.path, "/Users/username/path/to/Something.swift")
+        }
+        
+        // This other image name also won't resolve: ![Some other image that's not found](other-not-found-image)
+        do {
+            let problem = try XCTUnwrap(problems.dropFirst(5).first)
+            XCTAssertEqual(problem.diagnostic.summary, "Resource 'other-not-found-image' couldn't be found")
+            XCTAssertEqual(problem.diagnostic.source?.path, "/Users/username/path/to/SomeCatalog.docc/Something.md")
         }
     }
 }

--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
@@ -2856,7 +2856,7 @@ Document
         let node = try context.entity(with: myFuncReference)
         let symbol = try XCTUnwrap(node.semantic as? Symbol)
         
-        // Verify that by default we don't inherit docs and we gernerate default abstract.
+        // Verify that by default we don't inherit docs and we generate default abstract.
         do {
             var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
             let renderNode = try XCTUnwrap(translator.visit(symbol) as? RenderNode)

--- a/Tests/SwiftDocCTests/Semantics/MarkupReferenceResolverTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/MarkupReferenceResolverTests.swift
@@ -23,7 +23,7 @@ class MarkupReferenceResolverTests: XCTestCase {
         }
         """
         let document = Document(parsing: source, options: [.parseBlockDirectives, .parseSymbolLinks])
-        var resolver = MarkupReferenceResolver(context: context, bundle: bundle, source: nil, rootReference: context.rootModules[0])
+        var resolver = MarkupReferenceResolver(context: context, bundle: bundle, rootReference: context.rootModules[0])
         _ = resolver.visit(document)
         XCTAssertEqual(0, resolver.problems.count)
     }

--- a/Tests/SwiftDocCTests/Semantics/SnippetTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/SnippetTests.swift
@@ -65,7 +65,7 @@ class SnippetTests: XCTestCase {
         @Snippet(path: "Test/Snippets/DoesntExist")
         """
         let document = Document(parsing: source, options: .parseBlockDirectives)
-        var resolver = MarkupReferenceResolver(context: context, bundle: bundle, source: nil, rootReference: context.rootModules[0])
+        var resolver = MarkupReferenceResolver(context: context, bundle: bundle, rootReference: context.rootModules[0])
         _ = resolver.visit(document)
         XCTAssertEqual(1, resolver.problems.count)
         resolver.problems.first.map {

--- a/Tests/SwiftDocCTests/Semantics/SymbolTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/SymbolTests.swift
@@ -965,9 +965,11 @@ class SymbolTests: XCTestCase {
 
             // SymbolKit.SymbolGraph.LineList.SourceRange.Position is indexed from 0, whereas
             // (absolute) Markdown.SourceLocations are indexed from 1
-            let newDocComment = SymbolGraph.LineList(docComment.components(separatedBy: .newlines).enumerated().map { lineNumber, lineText in
-                .init(text: lineText, range: .init(start: .init(line: lineNumber, character: 0), end: .init(line: lineNumber, character: lineText.count)))
-            })
+            let newDocComment = SymbolGraph.LineList(
+                docComment.components(separatedBy: .newlines).enumerated().map { lineNumber, lineText in
+                        .init(text: lineText, range: .init(start: .init(line: lineNumber, character: 0), end: .init(line: lineNumber, character: lineText.count)))
+                },
+                uri: "file:///Users/username/path/to/Something.swift")
             graph.symbols[myFunctionUSR]?.docComment = newDocComment
             
             let newGraphData = try JSONEncoder().encode(graph)

--- a/Tests/SwiftDocCTests/XCTestCase+LoadingTestData.swift
+++ b/Tests/SwiftDocCTests/XCTestCase+LoadingTestData.swift
@@ -238,7 +238,6 @@ extension XCTestCase {
         var referenceResolver = MarkupReferenceResolver(
             context: context,
             bundle: bundle,
-            source: source,
             rootReference: bundle.rootReference
         )
         


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://129677496

## Summary

This implements a change that @patshaughnessy suggested to me a couple of weeks ago; leveraging the markup's source information to avoid visiting a symbol's markup twice if that symbol's documentation is a mix of in-source comments and documentation extension file content.

Before this change, when a symbol had documentation content from both an in-source documentation comment and a documentation extension file, the context would visit the symbol's full markup twice passing different source URLs to the reference resolver which would filter out any diagnostics that didn't match the markup's source information. 

Now, the reference resolver doesn't have a separate source property and instead relies solely on the source information from the markup. This means that a single pass is enough, no matter how many "doc chunks" the documentation node may have.

This also removes the need to filter out the duplicated diagnostics which have been a source of user facing bugs and also crashes (although the crashes should be resolved by #947 🤞).

## Dependencies

None

## Testing

This is a non-functional change. Everything should continue to work the same.

The relevant functionality to test for regression would be link resolution diagnostics (symbol links, documentation links, and image references) in in-source doc comments and documentation extension files. For example:

```swift
/// Some description of this class
///
/// Can link to ``doSomething()`` but not to ``NotFoundSymbol`` or <doc:NotFoundArticle>.
///
/// ![This image isn't found](some-not-found-image)
public class Something {
    public func doSomething() {}
}
```
```md
# ``Something``

Line 3 in the doc comment have two unresolvable links. Those should't appear here.

Here's two more unresolvable links to ``SomeOtherNotFoundSymbol`` and <doc:SomeOtherNotFoundArticle>. 

Links to ``Something`` and ``doSomething()`` should resolve.

![This image isn't found](another-not-found-image)
```

or 

```objc
/// Some description of my class
///
/// Can link to ``doSomething`` but not to ``NotFoundSymbol`` or <doc:NotFoundArticle>.
///
/// ![This image isn't found](other-not-found-image)
@interface MyClass : NSObject
- (void)doSomething;
@end
```

```md
# ``MyClass``

A link to ``Something`` should work but not ``NotFoundSymbolName`` or <doc:NotFoundArticleName>.

![This image isn't found](some-other-not-found-image)

## Topics

- ``Something``
- ``SomethingNotFound``
```
## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] ~Updated documentation if necessary~ Not applicable 