### PR TITLE
[6.0] [external-links] Display frameworks as beta only if all platforms are beta

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/External Data/OutOfProcessReferenceResolver.swift
+++ b/Sources/SwiftDocC/Infrastructure/External Data/OutOfProcessReferenceResolver.swift
@@ -155,7 +155,7 @@ public class OutOfProcessReferenceResolver: ExternalDocumentationSource, GlobalE
             kind: kind,
             role: role,
             fragments: resolvedInformation.declarationFragments?.declarationFragments.map { DeclarationRenderSection.Token(fragment: $0, identifier: nil) },
-            isBeta: (resolvedInformation.platforms ?? []).contains(where: { $0.isBeta == true }),
+            isBeta: resolvedInformation.isBeta,
             isDeprecated: (resolvedInformation.platforms ?? []).contains(where: { $0.deprecated != nil }),
             images: resolvedInformation.topicImages ?? []
         )
@@ -587,6 +587,15 @@ extension OutOfProcessReferenceResolver {
         
         /// The variants of content (kind, url, title, abstract, language, declaration) for this resolver information.
         public var variants: [Variant]?
+       
+        /// A value that indicates whether this symbol is under development and likely to change.
+        var isBeta: Bool {
+            guard let platforms, !platforms.isEmpty else {
+                return false
+            }
+            
+            return platforms.allSatisfy { $0.isBeta == true }
+        }
         
         /// Creates a new resolved information value with all its values.
         ///

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/ExternalPathHierarchyResolver.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/ExternalPathHierarchyResolver.swift
@@ -182,6 +182,15 @@ private extension Sequence<DeclarationRenderSection.Token> {
 // MARK: ExternalEntity
 
 private extension LinkDestinationSummary {
+    /// A value that indicates whether this symbol is under development and likely to change.
+    var isBeta: Bool {
+        guard let platforms, !platforms.isEmpty else {
+            return false
+        }
+        
+        return platforms.allSatisfy { $0.isBeta == true }
+    }
+    
     /// Create a topic render render reference for this link summary and its content variants.
     func topicRenderReference() -> TopicRenderReference {
         let (kind, role) = DocumentationContentRenderer.renderKindAndRole(kind, semantic: nil)
@@ -215,7 +224,7 @@ private extension LinkDestinationSummary {
             navigatorTitleVariants: .init(defaultValue: nil),
             estimatedTime: nil,
             conformance: nil,
-            isBeta: platforms?.contains(where: { $0.isBeta == true }) ?? false,
+            isBeta: isBeta,
             isDeprecated: platforms?.contains(where: { $0.unconditionallyDeprecated == true }) ?? false,
             defaultImplementationCount: nil,
             propertyListKeyNames: nil,

--- a/Tests/SwiftDocCTests/Test Bundles/AvailabilityBetaBundle.docc/mykit.symbols.json
+++ b/Tests/SwiftDocCTests/Test Bundles/AvailabilityBetaBundle.docc/mykit.symbols.json
@@ -1,0 +1,241 @@
+{
+  "metadata": {
+      "formatVersion" : {
+          "major" : 1
+      },
+      "generator" : "app/1.0"
+  },
+  "module" : {
+    "name" : "MyKit",
+    "platform" : {
+      "architecture" : "x86_64",
+      "vendor" : "apple",
+      "operatingSystem" : {
+        "name" : "macosx",
+        "minimumVersion" : {
+          "major" : 1,
+          "minor" : 0,
+          "patch" : 0
+        }
+      }
+    }
+  },
+  "symbols" : [
+    {
+      "accessLevel" : "public",
+      "kind" : {
+        "identifier" : "swift.class",
+        "displayName" : "Class"
+      },
+      "names" : {
+        "title" : "MyClass",
+        "subHeading" : [
+            {
+              "kind" : "keyword",
+              "spelling" : "class"
+            },
+            {
+              "kind" : "text",
+              "spelling" : " "
+            },
+            {
+              "kind" : "identifier",
+              "spelling" : "MyClass"
+            }
+        ],
+        "navigator" : [
+            {
+              "kind" : "identifier",
+              "spelling" : "MyClassNavigator"
+            }
+        ]
+      },
+      "availability" : [
+        {
+          "domain": "macOS",
+          "introduced": {
+            "major": 1,
+            "minor": 0
+          }
+        },
+        {
+          "domain": "watchOS",
+          "introduced": {
+            "major": 2,
+            "minor": 0
+          }
+        },
+        {
+          "domain": "tvOS",
+          "introduced": {
+            "major": 3,
+            "minor": 0
+          }
+        },
+        {
+          "domain": "iOS",
+          "introduced": {
+            "major": 4,
+            "minor": 0
+          }
+        }
+      ],
+      "pathComponents" : [
+        "MyClass"
+      ],
+      "identifier" : {
+        "precise" : "s:5MyKit0A5ClassC",
+        "interfaceLanguage": "swift"
+      },
+      "declarationFragments" : [
+        {
+          "kind" : "keyword",
+          "spelling" : "class"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " "
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "MyClass"
+        }
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "kind" : {
+        "identifier" : "swift.class",
+        "displayName" : "Class"
+      },
+      "names" : {
+        "title" : "MyOtherClass",
+        "subHeading" : [
+            {
+              "kind" : "keyword",
+              "spelling" : "class"
+            },
+            {
+              "kind" : "text",
+              "spelling" : " "
+            },
+            {
+              "kind" : "identifier",
+              "spelling" : "MyOtherClass"
+            }
+        ],
+        "navigator" : [
+            {
+              "kind" : "identifier",
+              "spelling" : "MyOtherClassNavigator"
+            }
+        ]
+      },
+      "availability" : [
+        {
+          "domain": "macOS",
+          "introduced": {
+            "major": 1,
+            "minor": 0
+          }
+        },
+        {
+          "domain": "watchOS",
+          "introduced": {
+            "major": 2,
+            "minor": 0
+          }
+        },
+        {
+          "domain": "tvOS",
+          "introduced": {
+            "major": 3,
+            "minor": 0
+          }
+        },
+        {
+          "domain": "iOS",
+          "introduced": {
+            "major": 3,
+            "minor": 0
+          }
+        }
+      ],
+      "pathComponents" : [
+        "MyOtherClass"
+      ],
+      "identifier" : {
+        "precise" : "s:5MyKit0A5MyOtherClassC",
+        "interfaceLanguage": "swift"
+      },
+      "declarationFragments" : [
+        {
+          "kind" : "keyword",
+          "spelling" : "class"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " "
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "MyOtherClass"
+        }
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "kind" : {
+        "identifier" : "swift.class",
+        "displayName" : "Class"
+      },
+      "names" : {
+        "title" : "MyThirdClass",
+        "subHeading" : [
+            {
+              "kind" : "keyword",
+              "spelling" : "class"
+            },
+            {
+              "kind" : "text",
+              "spelling" : " "
+            },
+            {
+              "kind" : "identifier",
+              "spelling" : "MyThirdClass"
+            }
+        ],
+        "navigator" : [
+            {
+              "kind" : "identifier",
+              "spelling" : "MyThirdClassNavigator"
+            }
+        ]
+      },
+      "availability" : [],
+      "pathComponents" : [
+        "MyThirdClass"
+      ],
+      "identifier" : {
+        "precise" : "s:5MyKit0A5MyThirdClassC",
+        "interfaceLanguage": "swift"
+      },
+      "declarationFragments" : [
+        {
+          "kind" : "keyword",
+          "spelling" : "class"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " "
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "MyThirdClass"
+        }
+      ]
+    },
+
+  ],
+  "relationships" : []
+}

--- a/Tests/SwiftDocCUtilitiesTests/OutOfProcessReferenceResolverTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/OutOfProcessReferenceResolverTests.swift
@@ -51,10 +51,7 @@ class OutOfProcessReferenceResolverTests: XCTestCase {
         #endif
     }
     
-    func assertResolvesTopicLink(
-        makeResolver: (OutOfProcessReferenceResolver.ResolvedInformation) throws
-            -> OutOfProcessReferenceResolver
-    ) throws {
+    func assertResolvesTopicLink(makeResolver: (OutOfProcessReferenceResolver.ResolvedInformation) throws -> OutOfProcessReferenceResolver) throws {
         let testMetadata = OutOfProcessReferenceResolver.ResolvedInformation(
             kind: .init(name: "Kind Name", id: "com.test.kind.id", isSymbol: true),
             url: URL(string: "doc://com.test.bundle/something")!,
@@ -112,6 +109,8 @@ class OutOfProcessReferenceResolverTests: XCTestCase {
         XCTAssertEqual(entity.topicRenderReference.title, "Resolved Title")
         XCTAssertEqual(entity.topicRenderReference.abstract, [.text("Resolved abstract for this topic.")])
 
+        XCTAssertFalse(entity.topicRenderReference.isBeta)
+        
         XCTAssertEqual(entity.sourceLanguages.count, 3)
 
         let availableSourceLanguages = entity.sourceLanguages.sorted(by: { lhs, rhs in lhs.id < rhs.id })
@@ -132,7 +131,7 @@ class OutOfProcessReferenceResolverTests: XCTestCase {
         if case .replace(let variantFragment) = fragmentVariant.patch.first {
             XCTAssertEqual(variantFragment, [.init(text: "variant declaration fragment", kind: .text, preciseIdentifier: nil)])
         } else {
-           XCTFail("Unexpected fragments variant patch")
+            XCTFail("Unexpected fragments variant patch")
         }
     }
     
@@ -205,10 +204,7 @@ class OutOfProcessReferenceResolverTests: XCTestCase {
         })
     }
     
-    func assertResolvesSymbol(
-        makeResolver: (OutOfProcessReferenceResolver.ResolvedInformation) throws
-            -> OutOfProcessReferenceResolver
-    ) throws {
+    func assertResolvesSymbol(makeResolver: (OutOfProcessReferenceResolver.ResolvedInformation) throws -> OutOfProcessReferenceResolver) throws {
         let lightCardImageURL = try XCTUnwrap(URL(string: "https://com.test.example/some-image-name.jpg"))
         let darkCardImageURL = try XCTUnwrap(URL(string: "https://com.test.example/some-image-name-dark.jpg"))
         
@@ -702,5 +698,156 @@ class OutOfProcessReferenceResolverTests: XCTestCase {
                 completion(response)
             }
         }
+    }
+    
+    func assertSymbolBetaStatus(
+        platforms: [OutOfProcessReferenceResolver.ResolvedInformation.PlatformAvailability], expectedStatus isBeta: Bool,
+        file: StaticString = #file, line: UInt = #line,
+        makeResolver: (OutOfProcessReferenceResolver.ResolvedInformation) throws -> OutOfProcessReferenceResolver
+    ) throws {
+        let testMetadata = OutOfProcessReferenceResolver.ResolvedInformation(
+            kind: .init(name: "Kind Name", id: "com.test.kind.id", isSymbol: true),
+            url: URL(string: "doc://com.test.bundle/something")!,
+            title: "Resolved Title",
+            abstract: "Resolved abstract for this topic.",
+            language: .swift, // This is Swift to account for what is considered a symbol's "first" variant value (rdar://86580516)
+            availableLanguages: [],
+            platforms: platforms,
+            declarationFragments: nil,
+            topicImages: nil,
+            references: nil,
+            variants: []
+        )
+                
+        let resolver = try makeResolver(testMetadata)
+        XCTAssertEqual(resolver.bundleIdentifier, "com.test.bundle", file: file, line: line)
+
+        // Resolve the reference
+        let unresolved = TopicReference.unresolved(
+            UnresolvedTopicReference(topicURL: ValidatedURL(parsingExact: "doc://com.test.bundle/something")!))
+        guard case .success(let resolvedReference) = resolver.resolve(unresolved) else {
+            XCTFail("Unexpectedly failed to resolve reference")
+            return
+        }
+        
+        // Resolve the symbol
+        let topicLinkEntity = resolver.entity(with: resolvedReference)
+
+        XCTAssertEqual(topicLinkEntity.topicRenderReference.isBeta, isBeta, file: file, line: line)
+        
+        // Resolve the symbol
+        let (_, symbolEntity) = try XCTUnwrap(resolver.symbolReferenceAndEntity(withPreciseIdentifier: "abc123"), "Unexpectedly failed to resolve symbol")
+        
+        XCTAssertEqual(symbolEntity.topicRenderReference.isBeta, isBeta, file: file, line: line)
+
+    }
+    
+    func testResolvingSymbolBetaStatusProcess() throws {
+        #if os(macOS)
+        func makeResolver(testMetadata: OutOfProcessReferenceResolver.ResolvedInformation) throws -> OutOfProcessReferenceResolver {
+            let temporaryFolder = try createTemporaryDirectory()
+            let executableLocation = temporaryFolder.appendingPathComponent("link-resolver-executable")
+            
+            let encodedMetadata = try String(data: JSONEncoder().encode(testMetadata), encoding: .utf8)!
+            
+            try """
+        #!/bin/bash
+        echo '{"bundleIdentifier":"com.test.bundle"}'           # Write this resolver's bundle identifier
+        read                                                    # Wait for docc to send a symbol USR
+        echo '{"resolvedInformation":\(encodedMetadata)}'       # Respond with the test metadata (above)
+        read                                                    # Wait for docc to send a symbol USR
+        echo '{"resolvedInformation":\(encodedMetadata)}'       # Respond with the test metadata (above)
+        """.write(to: executableLocation, atomically: true, encoding: .utf8)
+            
+            // `0o0700` is `-rwx------` (read, write, & execute only for owner)
+            try FileManager.default.setAttributes([.posixPermissions: 0o0700], ofItemAtPath: executableLocation.path)
+            XCTAssert(FileManager.default.isExecutableFile(atPath: executableLocation.path))
+            
+            return try OutOfProcessReferenceResolver(processLocation: executableLocation, errorOutputHandler: { _ in })
+        }
+        
+        // All platforms are in beta
+        try assertSymbolBetaStatus(platforms: [
+            .init(name: "fooOS", introduced: "1.2.3", isBeta: true),
+            .init(name: "barOS", introduced: "1.2.3", isBeta: true),
+            .init(name: "bazOS", introduced: "1.2.3", isBeta: true),
+        ], expectedStatus: true, makeResolver: makeResolver)
+        
+        // One platform is stable, the other two are in beta
+        try assertSymbolBetaStatus(platforms: [
+            .init(name: "fooOS", introduced: "1.2.3", isBeta: false),
+            .init(name: "barOS", introduced: "1.2.3", isBeta: true),
+            .init(name: "bazOS", introduced: "1.2.3", isBeta: true),
+        ], expectedStatus: false, makeResolver: makeResolver)
+        
+        // No platforms explicitly supported
+        try assertSymbolBetaStatus(platforms: [
+        ], expectedStatus: false, makeResolver: makeResolver)
+
+        #endif
+    }
+    
+    func testResolvingSymbolBetaStatusService() throws {
+        func makeResolver(testMetadata: OutOfProcessReferenceResolver.ResolvedInformation) throws -> OutOfProcessReferenceResolver {
+            let server = DocumentationServer()
+            server.register(service: MockService { message in
+                XCTAssertEqual(message.type, "resolve-reference")
+                XCTAssert(message.identifier.hasPrefix("SwiftDocC"))
+                do {
+                    let payload = try XCTUnwrap(message.payload)
+                    let request = try JSONDecoder()
+                        .decode(
+                            ConvertRequestContextWrapper<OutOfProcessReferenceResolver.Request>.self,
+                            from: payload
+                        )
+                    
+                    XCTAssertEqual(request.convertRequestIdentifier, "convert-id")
+                    
+                    switch request.payload {
+                    case .symbol(let preciseIdentifier):
+                        XCTAssertEqual(preciseIdentifier, "abc123")
+                    case .topic(let url):
+                        XCTAssertEqual(url, URL(string: "doc://com.test.bundle/something")!)
+                    default:
+                        XCTFail("Unexpected request")
+                        return nil
+                    }
+
+                    let response = DocumentationServer.Message(
+                        type: "resolve-reference-response",
+                        payload: try JSONEncoder().encode(
+                            OutOfProcessReferenceResolver.Response.resolvedInformation(testMetadata))
+                    )
+                    return response
+                } catch {
+                    XCTFail(error.localizedDescription)
+                    return nil
+                }
+            })
+
+            return try OutOfProcessReferenceResolver(
+                bundleIdentifier: "com.test.bundle",
+                server: server,
+                convertRequestIdentifier: "convert-id"
+            )
+        }
+        
+        // All platforms are in beta
+        try assertSymbolBetaStatus(platforms: [
+            .init(name: "fooOS", introduced: "1.2.3", isBeta: true),
+            .init(name: "barOS", introduced: "1.2.3", isBeta: true),
+            .init(name: "bazOS", introduced: "1.2.3", isBeta: true),
+        ], expectedStatus: true, makeResolver: makeResolver)
+        
+        // One platform is stable, the other two are in beta
+        try assertSymbolBetaStatus(platforms: [
+            .init(name: "fooOS", introduced: "1.2.3", isBeta: false),
+            .init(name: "barOS", introduced: "1.2.3", isBeta: true),
+            .init(name: "bazOS", introduced: "1.2.3", isBeta: true),
+        ], expectedStatus: false, makeResolver: makeResolver)
+        
+        // No platforms explicitly supported
+        try assertSymbolBetaStatus(platforms: [
+        ], expectedStatus: false, makeResolver: makeResolver)
     }
 }


### PR DESCRIPTION
- **Explanation**: Fixes a bug where beta status resolution was inconsistent across external and internal links. Unifies the behaviour so that a symbol is only in beta if all its platforms are in beta.
- **Scope**: Affects beta status resolution for all external links to symbols.
- **Issue**: rdar://128997995
- **Risk**: Low/Medium
- **Testing**: Validated by rendering example external symbols locally, and by unit testing (see original PR).
- **Reviewer**: @d-ronnqvist 
- **Original PR**: https://github.com/apple/swift-docc/pull/938