### PR TITLE
[6.0] Avoid visiting symbol markup twice when there's a documentation extension file (#951)

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -518,78 +518,91 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
         let results = Synchronized<[LinkResolveResult]>([])
         results.sync({ $0.reserveCapacity(references.count) })
 
+        func inheritsDocumentationFromOtherModule(_ documentationNode: DocumentationNode, symbolOriginReference: ResolvedTopicReference) -> Bool {
+            // Check that this symbol only has documentation from an in-source documentation comment
+            guard documentationNode.docChunks.count == 1,
+                  case .sourceCode = documentationNode.docChunks.first?.source
+            else {
+                return false
+            }
+            
+            // Check that that documentation comment is inherited from a symbol belonging to another module
+            guard let symbolSemantic = documentationNode.semantic as? Symbol,
+                  let originSymbolSemantic = documentationCache[symbolOriginReference]?.semantic as? Symbol
+            else {
+                return false
+            }
+            return symbolSemantic.moduleReference != originSymbolSemantic.moduleReference
+        }
+        
         let resolveNodeWithReference: (ResolvedTopicReference) -> Void = { [unowned self] reference in
-            if var documentationNode = try? entity(with: reference), documentationNode.semantic is Article || documentationNode.semantic is Symbol {
-                for doc in documentationNode.docChunks {
-                    let source: URL?
-                    switch doc.source {
-                    case _ where documentationNode.semantic is Article,
-                            .documentationExtension:
-                        source = documentLocationMap[reference]
-                    case .sourceCode(let location, _):
-                        // For symbols, first check if we should reference resolve
-                        // inherited docs or not. If we don't inherit the docs
-                        // we should also skip reference resolving the chunk.
-                        if let semantic = documentationNode.semantic as? Symbol,
-                           let origin = semantic.origin, !externalMetadata.inheritDocs
-                        {
-                            // If the two symbols are coming from different modules,
-                            // regardless if they are in the same bundle
-                            // (for example Foundation and SwiftUI), skip link resolving.
-                            if let originSymbol = documentationCache[origin.identifier]?.semantic as? Symbol,
-                               originSymbol.moduleReference != semantic.moduleReference {
-                                continue
-                            }
-                        }
-
-                        source = location?.url()
-                    }
-
-                    // Find the inheritance parent, if the docs are inherited.
-                    let inheritanceParentReference: ResolvedTopicReference?
-                    if let origin = (documentationNode.semantic as? Symbol)?.origin,
-                       let originReference = documentationCache.reference(symbolID: origin.identifier)
-                    {
-                        inheritanceParentReference = originReference
-                    } else {
-                        inheritanceParentReference = nil
-                    }
-
-                    var resolver = ReferenceResolver(context: self, bundle: bundle, source: source, rootReference: reference, inheritanceParentReference: inheritanceParentReference)
+            guard var documentationNode = try? entity(with: reference),
+                  documentationNode.semantic is Article || documentationNode.semantic is Symbol
+            else {
+                return
+            }
                     
-                    // Update the cache with the resolved node.
-                    // We aggressively release used memory, since we're copying all semantic objects
-                    // on the line below while rewriting nodes with the resolved content.
-                    documentationNode.semantic = autoreleasepool { resolver.visit(documentationNode.semantic) }
-                    
-                    let pageImageProblems = documentationNode.metadata?.pageImages.compactMap { pageImage in
-                        return resolver.resolve(
-                            resource: pageImage.source,
-                            range: pageImage.originalMarkup.range,
-                            severity: .warning
-                        )
-                    } ?? []
-                    
-                    resolver.problems.append(contentsOf: pageImageProblems)
-
-                    var problems = resolver.problems
-
-                    if case .sourceCode(_, let offset) = doc.source, documentationNode.kind.isSymbol {
-                        // Offset all problem ranges by the start location of the
-                        // source comment in the context of the complete file.
-                        if let docRange = offset {
-                            for i in problems.indices {
-                                problems[i].offsetWithRange(docRange)
-                            }
-                        } else {
-                            problems.removeAll()
-                        }
+            let symbolOriginReference = (documentationNode.semantic as? Symbol)?.origin.flatMap { origin in
+                documentationCache.reference(symbolID: origin.identifier)
+            }
+            // Check if we should skip resolving links for inherited documentation from other modules.
+            if !externalMetadata.inheritDocs,
+                let symbolOriginReference,
+                inheritsDocumentationFromOtherModule(documentationNode, symbolOriginReference: symbolOriginReference)
+            {
+                // Don't resolve any links for this symbol.
+                return
+            }
+            
+            var resolver = ReferenceResolver(context: self, bundle: bundle, rootReference: reference, inheritanceParentReference: symbolOriginReference)
+            
+            // Update the node with the markup that contains resolved references instead of authored links.
+            documentationNode.semantic = autoreleasepool { 
+                // We use an autorelease pool to release used memory as soon as possible, since the resolver will copy each semantic value
+                // to rewrite it and replace the authored links with resolved reference strings instead.
+                resolver.visit(documentationNode.semantic)
+            }
+            
+            let problems: [Problem]
+            if documentationNode.semantic is Article {
+                // Diagnostics for articles have correct source ranges and don't need to be modified.
+                problems = resolver.problems
+            } else {
+                // Diagnostics for in-source documentation comments need to be offset based on the start location of the comment in the source file.
+                
+                // Get the source location
+                let inSourceDocumentationCommentInfo = documentationNode.inSourceDocumentationChunk
+                
+                // Post-process and filter out unwanted diagnostics (for example from inherited documentation comments)
+                problems = resolver.problems.compactMap { problem in
+                    guard let source = problem.diagnostic.source else {
+                        // Ignore any diagnostic without a source location. These can't be meaningfully presented to the user.
+                        return nil
                     }
-
-                    let result: LinkResolveResult = (reference: reference, node: documentationNode, problems: problems)
-                    results.sync({ $0.append(result) })
+                    
+                    if source == inSourceDocumentationCommentInfo?.url, let offset = inSourceDocumentationCommentInfo?.offset {
+                        // Diagnostics from an in-source documentation comment need to be offset based on the location of that documentation comment.
+                        var modifiedProblem = problem
+                        modifiedProblem.offsetWithRange(offset)
+                        return modifiedProblem
+                    } 
+                    
+                    // Diagnostics from documentation extension files have correct source ranges and don't need to be modified.
+                    return problem
                 }
             }
+            
+            // Also resolve the node's page images. This isn't part of the node's 'semantic' value (resolved above).
+            let pageImageProblems = documentationNode.metadata?.pageImages.compactMap { pageImage in
+                return resolver.resolve(
+                    resource: pageImage.source,
+                    range: pageImage.originalMarkup.range,
+                    severity: .warning
+                )
+            } ?? []
+            
+            let result: LinkResolveResult = (reference: reference, node: documentationNode, problems: problems + pageImageProblems)
+            results.sync({ $0.append(result) })
         }
 
         // Resolve links concurrently if there are no external resolvers.
@@ -604,7 +617,8 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
                 // Record symbol links as symbol "mentions" for automatic cross references
                 // on rendered symbol documentation.
                 if let article = result.node.semantic as? Article,
-                   case .article = DocumentationContentRenderer.roleForArticle(article, nodeKind: result.node.kind) {
+                   case .article = DocumentationContentRenderer.roleForArticle(article, nodeKind: result.node.kind) 
+                {
                     for markup in article.abstractSection?.content ?? [] {
                         var mentions = SymbolLinkCollector(context: self, article: result.node.reference, baseWeight: 2)
                         mentions.visit(markup)
@@ -652,7 +666,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
             autoreleasepool {
                 let url = technologyResult.source
                 let unresolvedTechnology = technologyResult.value
-                var resolver = ReferenceResolver(context: self, bundle: bundle, source: url)
+                var resolver = ReferenceResolver(context: self, bundle: bundle)
                 let technology = resolver.visit(unresolvedTechnology) as! Technology
                 diagnosticEngine.emit(resolver.problems)
                 
@@ -724,7 +738,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
             autoreleasepool {
                 let url = tutorialResult.source
                 let unresolvedTutorial = tutorialResult.value
-                var resolver = ReferenceResolver(context: self, bundle: bundle, source: url)
+                var resolver = ReferenceResolver(context: self, bundle: bundle)
                 let tutorial = resolver.visit(unresolvedTutorial) as! Tutorial
                 diagnosticEngine.emit(resolver.problems)
                 
@@ -758,7 +772,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
             autoreleasepool {
                 let url = articleResult.source
                 let unresolvedTutorialArticle = articleResult.value
-                var resolver = ReferenceResolver(context: self, bundle: bundle, source: url)
+                var resolver = ReferenceResolver(context: self, bundle: bundle)
                 let article = resolver.visit(unresolvedTutorialArticle) as! TutorialArticle
                 diagnosticEngine.emit(resolver.problems)
                             

--- a/Sources/SwiftDocC/Model/DocumentationNode.swift
+++ b/Sources/SwiftDocC/Model/DocumentationNode.swift
@@ -94,6 +94,16 @@ public struct DocumentationNode {
     /// property.
     var docChunks: [DocumentationChunk]
     
+    /// Returns information about the node's in-source documentation comment chunk, or `nil` if the node doesn't have an in-source documentation chunk.
+    var inSourceDocumentationChunk: (url: URL?, offset: SymbolGraph.LineList.SourceRange?)? {
+        for docChunk in docChunks {
+            guard case .sourceCode(let location, let offset) = docChunk.source else { continue }
+            
+            return (url: location?.url, offset: offset)
+        }
+        return nil
+    }
+    
     /// Linkable in-content sections.
     var anchorSections = [AnchorSection]()
     

--- a/Sources/SwiftDocC/Semantics/MarkupReferenceResolver.swift
+++ b/Sources/SwiftDocC/Semantics/MarkupReferenceResolver.swift
@@ -12,21 +12,21 @@ import Foundation
 import Markdown
 import SymbolKit
 
-fileprivate func invalidLinkDestinationProblem(destination: String, source: URL?, range: SourceRange?, severity: DiagnosticSeverity) -> Problem {
-    let diagnostic = Diagnostic(source: source, severity: severity, range: range, identifier: "org.swift.docc.invalidLinkDestination", summary: "Link destination \(destination.singleQuoted) is not a valid URL")
+private func invalidLinkDestinationProblem(destination: String, range: SourceRange?, severity: DiagnosticSeverity) -> Problem {
+    let diagnostic = Diagnostic(source: range?.source, severity: severity, range: range, identifier: "org.swift.docc.invalidLinkDestination", summary: "Link destination \(destination.singleQuoted) is not a valid URL")
     return Problem(diagnostic: diagnostic, possibleSolutions: [])
 }
 
-fileprivate func disabledLinkDestinationProblem(reference: ResolvedTopicReference, source: URL?, range: SourceRange?, severity: DiagnosticSeverity) -> Problem {
-    return Problem(diagnostic: Diagnostic(source: source, severity: severity, range: range, identifier: "org.swift.docc.disabledLinkDestination", summary: "The topic \(reference.path.singleQuoted) cannot be linked to."), possibleSolutions: [])
+private func disabledLinkDestinationProblem(reference: ResolvedTopicReference, range: SourceRange?, severity: DiagnosticSeverity) -> Problem {
+    return Problem(diagnostic: Diagnostic(source: range?.source, severity: severity, range: range, identifier: "org.swift.docc.disabledLinkDestination", summary: "The topic \(reference.path.singleQuoted) cannot be linked to."), possibleSolutions: [])
 }
 
-fileprivate func unknownSnippetSliceProblem(snippetPath: String, slice: String, source: URL?, range: SourceRange?) -> Problem {
-    let diagnostic = Diagnostic(source: source, severity: .warning, range: range, identifier: "org.swift.docc.unknownSnippetSlice", summary: "Snippet slice \(slice.singleQuoted) does not exist in snippet \(snippetPath.singleQuoted); this directive will be ignored")
+private func unknownSnippetSliceProblem(snippetPath: String, slice: String, range: SourceRange?) -> Problem {
+    let diagnostic = Diagnostic(source: range?.source, severity: .warning, range: range, identifier: "org.swift.docc.unknownSnippetSlice", summary: "Snippet slice \(slice.singleQuoted) does not exist in snippet \(snippetPath.singleQuoted); this directive will be ignored")
     return Problem(diagnostic: diagnostic, possibleSolutions: [])
 }
 
-fileprivate func removedLinkDestinationProblem(reference: ResolvedTopicReference, source: URL?, range: SourceRange?, severity: DiagnosticSeverity) -> Problem {
+private func removedLinkDestinationProblem(reference: ResolvedTopicReference, range: SourceRange?, severity: DiagnosticSeverity) -> Problem {
     var solutions = [Solution]()
     if let range, reference.pathComponents.count > 3 {
         // The first three path components are "/", "documentation", and the module name, so drop those
@@ -35,7 +35,7 @@ fileprivate func removedLinkDestinationProblem(reference: ResolvedTopicReference
             .init(range: range, replacement: "`\(pathRemainder.joined(separator: "/"))`")
         ]))
     }
-    let diagnostic = Diagnostic(source: source, severity: severity, range: range, identifier: "org.swift.docc.removedExtensionLinkDestination", summary: "The topic \(reference.path.singleQuoted) is an empty extension page and cannot be linked to.", explanation: "This extension symbol has had all its children curated and has been removed.")
+    let diagnostic = Diagnostic(source: range?.source, severity: severity, range: range, identifier: "org.swift.docc.removedExtensionLinkDestination", summary: "The topic \(reference.path.singleQuoted) is an empty extension page and cannot be linked to.", explanation: "This extension symbol has had all its children curated and has been removed.")
     return Problem(diagnostic: diagnostic, possibleSolutions: solutions)
 }
 
@@ -45,14 +45,12 @@ fileprivate func removedLinkDestinationProblem(reference: ResolvedTopicReference
 struct MarkupReferenceResolver: MarkupRewriter {
     var context: DocumentationContext
     var bundle: DocumentationBundle
-    var source: URL?
     var problems = [Problem]()
     var rootReference: ResolvedTopicReference
     
-    init(context: DocumentationContext, bundle: DocumentationBundle, source: URL?, rootReference: ResolvedTopicReference) {
+    init(context: DocumentationContext, bundle: DocumentationBundle, rootReference: ResolvedTopicReference) {
         self.context = context
         self.bundle = bundle
-        self.source = source
         self.rootReference = rootReference
     }
 
@@ -61,7 +59,7 @@ struct MarkupReferenceResolver: MarkupRewriter {
     // This property offers a customization point for when we need to try
     // resolving links in other contexts than the current one to provide more
     // precise diagnostics.
-    var problemForUnresolvedReference: ((_ unresolvedReference: UnresolvedTopicReference, _ source: URL?, _ range: SourceRange?, _ fromSymbolLink: Bool, _ underlyingErrorMessage: String) -> Problem?)? = nil
+    var problemForUnresolvedReference: ((_ unresolvedReference: UnresolvedTopicReference, _ range: SourceRange?, _ fromSymbolLink: Bool, _ underlyingErrorMessage: String) -> Problem?)? = nil
 
     private mutating func resolve(reference: TopicReference, range: SourceRange?, severity: DiagnosticSeverity, fromSymbolLink: Bool = false) -> ResolvedTopicReference? {
         switch context.resolve(reference, in: rootReference, fromSymbolLink: fromSymbolLink) {
@@ -70,38 +68,31 @@ struct MarkupReferenceResolver: MarkupRewriter {
             // verify that linking to it is enabled, else return `nil`.
             if let node = context.topicGraph.nodeWithReference(resolved) {
                 if node.isEmptyExtension {
-                    problems.append(removedLinkDestinationProblem(reference: resolved, source: source, range: range, severity: severity))
+                    problems.append(removedLinkDestinationProblem(reference: resolved, range: range, severity: severity))
                     return nil
                 } else if !context.topicGraph.isLinkable(node.reference) {
-                    problems.append(disabledLinkDestinationProblem(reference: resolved, source: source, range: range, severity: severity))
+                    problems.append(disabledLinkDestinationProblem(reference: resolved, range: range, severity: severity))
                     return nil
                 }
             }
             return resolved
             
         case .failure(let unresolved, let error):
-            if let rangeLowerBoundSource = range?.lowerBound.source,
-               let rangeUpperBoundSource = range?.upperBound.source,
-               let source,
-               source != rangeLowerBoundSource || source != rangeUpperBoundSource {
-                return nil
-            }
-
             if let callback = problemForUnresolvedReference,
-               let problem = callback(unresolved, source, range, fromSymbolLink, error.message) {
+               let problem = callback(unresolved, range, fromSymbolLink, error.message) {
                 problems.append(problem)
                 return nil
             }
             
             let uncuratedArticleMatch = context.uncuratedArticles[bundle.articlesDocumentationRootReference.appendingPathOfReference(unresolved)]?.source
-            problems.append(unresolvedReferenceProblem(source: source, range: range, severity: severity, uncuratedArticleMatch: uncuratedArticleMatch, errorInfo: error, fromSymbolLink: fromSymbolLink))
+            problems.append(unresolvedReferenceProblem(source: range?.source, range: range, severity: severity, uncuratedArticleMatch: uncuratedArticleMatch, errorInfo: error, fromSymbolLink: fromSymbolLink))
             return nil
         }
     }
 
     mutating func visitImage(_ image: Image) -> Markup? {
         if let reference = image.reference(in: bundle), !context.resourceExists(with: reference) {
-            problems.append(unresolvedResourceProblem(resource: reference, source: source, range: image.range, severity: .warning))
+            problems.append(unresolvedResourceProblem(resource: reference, source: image.range?.source, range: image.range, severity: .warning))
         }
 
         var image = image
@@ -125,7 +116,7 @@ struct MarkupReferenceResolver: MarkupRewriter {
             return link
         }
         guard let url = ValidatedURL(parsingAuthoredLink: destination) else {
-            problems.append(invalidLinkDestinationProblem(destination: destination, source: source, range: link.range, severity: .warning))
+            problems.append(invalidLinkDestinationProblem(destination: destination, range: link.range, severity: .warning))
             return link
         }
         guard url.components.scheme == ResolvedTopicReference.urlScheme else {
@@ -148,7 +139,7 @@ struct MarkupReferenceResolver: MarkupRewriter {
     mutating func resolveAbsoluteSymbolLink(unresolvedDestination: String, elementRange range: SourceRange?) -> ResolvedTopicReference? {
         if let cached = context.referenceIndex[unresolvedDestination] {
             guard context.topicGraph.isLinkable(cached) == true else {
-                problems.append(disabledLinkDestinationProblem(reference: cached, source: source, range: range, severity: .warning))
+                problems.append(disabledLinkDestinationProblem(reference: cached, range: range, severity: .warning))
                 return nil
             }
             return cached
@@ -177,6 +168,7 @@ struct MarkupReferenceResolver: MarkupRewriter {
     }
 
     mutating func visitBlockDirective(_ blockDirective: BlockDirective) -> Markup? {
+        let source = blockDirective.range?.source
         switch blockDirective.name {
         case Snippet.directiveName:
             var problems = [Problem]()
@@ -190,7 +182,7 @@ struct MarkupReferenceResolver: MarkupRewriter {
                    let snippetMixin = try? context.entity(with: resolved).symbol?
                     .mixins[SymbolGraph.Symbol.Snippet.mixinKey] as? SymbolGraph.Symbol.Snippet {
                     guard snippetMixin.slices[requestedSlice] != nil else {
-                        problems.append(unknownSnippetSliceProblem(snippetPath: snippet.path, slice: requestedSlice, source: blockDirective.nameLocation?.source, range: blockDirective.nameRange))
+                        problems.append(unknownSnippetSliceProblem(snippetPath: snippet.path, slice: requestedSlice, range: blockDirective.nameRange))
                         return blockDirective
                     }
                     argumentText.append(", slice: \"\(requestedSlice)\"")
@@ -209,7 +201,7 @@ struct MarkupReferenceResolver: MarkupRewriter {
                     unresolvedResourceProblem(
                         resource: imageMedia.source,
                         expectedType: .image,
-                        source: source,
+                        source: blockDirective.range?.source,
                         range: imageMedia.originalMarkup.range,
                         severity: .warning
                     )

--- a/Sources/SwiftDocC/Semantics/ReferenceResolver.swift
+++ b/Sources/SwiftDocC/Semantics/ReferenceResolver.swift
@@ -92,9 +92,6 @@ struct ReferenceResolver: SemanticVisitor {
     /// The bundle in which visited documents reside.
     var bundle: DocumentationBundle
     
-    /// The source document being analyzed.
-    var source: URL?
-    
     /// Problems found while trying to resolve references.
     var problems = [Problem]()
     
@@ -103,10 +100,9 @@ struct ReferenceResolver: SemanticVisitor {
     /// If the documentation is inherited, the reference of the parent symbol.
     var inheritanceParentReference: ResolvedTopicReference?
     
-    init(context: DocumentationContext, bundle: DocumentationBundle, source: URL?, rootReference: ResolvedTopicReference? = nil, inheritanceParentReference: ResolvedTopicReference? = nil) {
+    init(context: DocumentationContext, bundle: DocumentationBundle, rootReference: ResolvedTopicReference? = nil, inheritanceParentReference: ResolvedTopicReference? = nil) {
         self.context = context
         self.bundle = bundle
-        self.source = source
         self.rootReference = rootReference ?? bundle.rootReference
         self.inheritanceParentReference = inheritanceParentReference
     }
@@ -118,7 +114,7 @@ struct ReferenceResolver: SemanticVisitor {
             
         case let .failure(unresolved, error):
             let uncuratedArticleMatch = context.uncuratedArticles[bundle.documentationRootReference.appendingPathOfReference(unresolved)]?.source
-            problems.append(unresolvedReferenceProblem(source: source, range: range, severity: severity, uncuratedArticleMatch: uncuratedArticleMatch, errorInfo: error, fromSymbolLink: false))
+            problems.append(unresolvedReferenceProblem(source: range?.source, range: range, severity: severity, uncuratedArticleMatch: uncuratedArticleMatch, errorInfo: error, fromSymbolLink: false))
             return .failure(unresolved, error)
         }
     }
@@ -128,7 +124,7 @@ struct ReferenceResolver: SemanticVisitor {
     */
     func resolve(resource: ResourceReference, range: SourceRange?, severity: DiagnosticSeverity) -> Problem? {
         if !context.resourceExists(with: resource) {
-            return unresolvedResourceProblem(resource: resource, source: source, range: range, severity: severity)
+            return unresolvedResourceProblem(resource: resource, source: range?.source, range: range, severity: severity)
         } else {
             return nil
         }
@@ -213,23 +209,24 @@ struct ReferenceResolver: SemanticVisitor {
     }
     
     mutating func visitMarkupContainer(_ markupContainer: MarkupContainer) -> Semantic {
-        var markupResolver = MarkupReferenceResolver(context: context, bundle: bundle, source: source, rootReference: rootReference)
+        var markupResolver = MarkupReferenceResolver(context: context, bundle: bundle, rootReference: rootReference)
         let parent = inheritanceParentReference
         let context = self.context
         
-        markupResolver.problemForUnresolvedReference = { unresolved, source, range, fromSymbolLink, underlyingErrorMessage -> Problem? in
+        markupResolver.problemForUnresolvedReference = { unresolved, range, fromSymbolLink, underlyingErrorMessage -> Problem? in
             // Verify we have all the information about the location of the source comment
             // and the symbol that the comment is inherited from.
             if let parent, let range {
                 switch context.resolve(.unresolved(unresolved), in: parent, fromSymbolLink: fromSymbolLink) {
                     case .success(let resolved):
                         // Return a warning with a suggested change that replaces the relative link with an absolute one.
-                        return Problem(diagnostic: Diagnostic(source: source,
+                        return Problem(diagnostic: Diagnostic(source: range.source,
                             severity: .warning, range: range,
                             identifier: "org.swift.docc.UnresolvableLinkWhenInherited",
                             summary: "This documentation block is inherited by other symbols where \(unresolved.topicURL.absoluteString.singleQuoted) fails to resolve."),
                             possibleSolutions: [
                                 Solution(summary: "Use an absolute link path.", replacements: [
+                                    // FIXME: The resolved reference path isn't the same as the authorable link.
                                     Replacement(range: range, replacement: "<doc:\(resolved.path)>")
                                 ])
                             ])
@@ -291,7 +288,7 @@ struct ReferenceResolver: SemanticVisitor {
         var uniqueReferences = Set<TopicReference>()
         let newTutorialReferencesWithoutDupes = newTutorialReferences.filter { newTutorialReference in
             guard !uniqueReferences.contains(newTutorialReference.topic) else {
-                let diagnostic = Diagnostic(source: source, severity: .warning, range: newTutorialReference.originalMarkup.range, identifier: "org.swift.docc.\(Chapter.self).Duplicate\(TutorialReference.self)", summary: "Duplicate \(TutorialReference.directiveName.singleQuoted) directive refers to \(newTutorialReference.topic.description.singleQuoted)")
+                let diagnostic = Diagnostic(source: chapter.originalMarkup.range?.source, severity: .warning, range: newTutorialReference.originalMarkup.range, identifier: "org.swift.docc.\(Chapter.self).Duplicate\(TutorialReference.self)", summary: "Duplicate \(TutorialReference.directiveName.singleQuoted) directive refers to \(newTutorialReference.topic.description.singleQuoted)")
                 let solutions = newTutorialReference.originalMarkup.range.map {
                     return [Solution(summary: "Remove duplicate \(TutorialReference.directiveName.singleQuoted) directive", replacements: [
                         Replacement(range: $0, replacement: "")

--- a/Tests/SwiftDocCTests/Diagnostics/DiagnosticTests.swift
+++ b/Tests/SwiftDocCTests/Diagnostics/DiagnosticTests.swift
@@ -81,10 +81,10 @@ class DiagnosticTests: XCTestCase {
     func testOffsetDiagnostics() throws {
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
 
-        let source = "Test a ``Reference`` in a sentence."
-        let markup = Document(parsing: source, options: .parseSymbolLinks)
+        let content = "Test a ``Reference`` in a sentence."
+        let markup = Document(parsing: content, source: URL(string: "/tmp/foo.symbols.json"), options: .parseSymbolLinks)
         
-        var resolver = ReferenceResolver(context: context, bundle: bundle, source: URL(string: "/tmp/foo.symbols.json"), rootReference: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit", sourceLanguage: .swift))
+        var resolver = ReferenceResolver(context: context, bundle: bundle, rootReference: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit", sourceLanguage: .swift))
         
         // Resolve references
         _ = resolver.visitMarkup(markup)

--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
@@ -2856,7 +2856,7 @@ Document
         let node = try context.entity(with: myFuncReference)
         let symbol = try XCTUnwrap(node.semantic as? Symbol)
         
-        // Verify that by default we don't inherit docs and we gernerate default abstract.
+        // Verify that by default we don't inherit docs and we generate default abstract.
         do {
             var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
             let renderNode = try XCTUnwrap(translator.visit(symbol) as? RenderNode)

--- a/Tests/SwiftDocCTests/Semantics/MarkupReferenceResolverTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/MarkupReferenceResolverTests.swift
@@ -23,7 +23,7 @@ class MarkupReferenceResolverTests: XCTestCase {
         }
         """
         let document = Document(parsing: source, options: [.parseBlockDirectives, .parseSymbolLinks])
-        var resolver = MarkupReferenceResolver(context: context, bundle: bundle, source: nil, rootReference: context.rootModules[0])
+        var resolver = MarkupReferenceResolver(context: context, bundle: bundle, rootReference: context.rootModules[0])
         _ = resolver.visit(document)
         XCTAssertEqual(0, resolver.problems.count)
     }

--- a/Tests/SwiftDocCTests/Semantics/SnippetTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/SnippetTests.swift
@@ -65,7 +65,7 @@ class SnippetTests: XCTestCase {
         @Snippet(path: "Test/Snippets/DoesntExist")
         """
         let document = Document(parsing: source, options: .parseBlockDirectives)
-        var resolver = MarkupReferenceResolver(context: context, bundle: bundle, source: nil, rootReference: context.rootModules[0])
+        var resolver = MarkupReferenceResolver(context: context, bundle: bundle, rootReference: context.rootModules[0])
         _ = resolver.visit(document)
         XCTAssertEqual(1, resolver.problems.count)
         resolver.problems.first.map {

--- a/Tests/SwiftDocCTests/Semantics/SymbolTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/SymbolTests.swift
@@ -965,9 +965,11 @@ class SymbolTests: XCTestCase {
 
             // SymbolKit.SymbolGraph.LineList.SourceRange.Position is indexed from 0, whereas
             // (absolute) Markdown.SourceLocations are indexed from 1
-            let newDocComment = SymbolGraph.LineList(docComment.components(separatedBy: .newlines).enumerated().map { lineNumber, lineText in
-                .init(text: lineText, range: .init(start: .init(line: lineNumber, character: 0), end: .init(line: lineNumber, character: lineText.count)))
-            })
+            let newDocComment = SymbolGraph.LineList(
+                docComment.components(separatedBy: .newlines).enumerated().map { lineNumber, lineText in
+                        .init(text: lineText, range: .init(start: .init(line: lineNumber, character: 0), end: .init(line: lineNumber, character: lineText.count)))
+                },
+                uri: "file:///Users/username/path/to/Something.swift")
             graph.symbols[myFunctionUSR]?.docComment = newDocComment
             
             let newGraphData = try JSONEncoder().encode(graph)

--- a/Tests/SwiftDocCTests/XCTestCase+LoadingTestData.swift
+++ b/Tests/SwiftDocCTests/XCTestCase+LoadingTestData.swift
@@ -238,7 +238,6 @@ extension XCTestCase {
         var referenceResolver = MarkupReferenceResolver(
             context: context,
             bundle: bundle,
-            source: source,
             rootReference: bundle.rootReference
         )
         


### PR DESCRIPTION

- **Explanation:** This addresses the source of duplicate diagnostics by not visiting a symbol's markup twice when a symbol has documentation from both an in-source doc comment and from a documentation extension file.
This was a source of crashes before https://github.com/apple/swift-docc/pull/948 
- **Scope:** Potential duplicated diagnostics.
- **Issue:** rdar://129677496 
- **Risk:** Low
- **Testing:** New tests verify a single pass updates and produces diagnostics for both sources of documentation (in-source doc comment and a documentation extension file). Existing tests and manual testing verifies that no expected diagnostics are missing.
- **Reviewer:** @patshaughnessy 
- **Original PR:** #951

