### PR TITLE
Deprecate the unused AttributedCodeListing type

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/DocumentationBundle.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationBundle.swift
@@ -68,7 +68,8 @@ public struct DocumentationBundle {
     }
     
     /// Code listings extracted from the documented modules' source, indexed by their identifier.
-    public var attributedCodeListings: [String: AttributedCodeListing]
+    @available(*, deprecated, message: "This deprecated API will be removed after 6.1 is released")
+    public var attributedCodeListings: [String: AttributedCodeListing] = [:]
     
     /// Symbol Graph JSON files for the modules documented by this bundle.
     public let symbolGraphURLs: [URL]
@@ -100,7 +101,6 @@ public struct DocumentationBundle {
     /// - Parameters:
     ///   - info: Information about the bundle.
     ///   - baseURL: A URL prefix to be appended to the relative presentation URL.
-    ///   - attributedCodeListings: Code listings extracted from the documented modules' source, indexed by their identifier.
     ///   - symbolGraphURLs: Symbol Graph JSON files for the modules documented by the bundle.
     ///   - markupURLs: DocC Markup files of the bundle.
     ///   - miscResourceURLs: Miscellaneous resources of the bundle.
@@ -110,7 +110,6 @@ public struct DocumentationBundle {
     public init(
         info: Info,
         baseURL: URL = URL(string: "/")!,
-        attributedCodeListings: [String: AttributedCodeListing] = [:],
         symbolGraphURLs: [URL],
         markupURLs: [URL],
         miscResourceURLs: [URL],
@@ -120,7 +119,6 @@ public struct DocumentationBundle {
     ) {
         self.info = info
         self.baseURL = baseURL
-        self.attributedCodeListings = attributedCodeListings
         self.symbolGraphURLs = symbolGraphURLs
         self.markupURLs = markupURLs
         self.miscResourceURLs = miscResourceURLs
@@ -132,6 +130,22 @@ public struct DocumentationBundle {
         self.tutorialsRootReference = ResolvedTopicReference(bundleIdentifier: info.identifier, path: NodeURLGenerator.Path.tutorialsFolder, sourceLanguage: .swift)
         self.technologyTutorialsRootReference = tutorialsRootReference.appendingPath(urlReadablePath(info.displayName))
         self.articlesDocumentationRootReference = documentationRootReference.appendingPath(urlReadablePath(info.displayName))
+    }
+    
+    @available(*, deprecated, renamed: "init(info:baseURL:attributedCodeListings:symbolGraphURLs:markupURLs:miscResourceURLs:customHeader:customFooter:themeSettings:)", message: "Use 'init(info:baseURL:attributedCodeListings:symbolGraphURLs:markupURLs:miscResourceURLs:customHeader:customFooter:themeSettings:)' instead. This deprecated API will be removed after 6.1 is released")
+    public init(
+        info: Info,
+        baseURL: URL = URL(string: "/")!,
+        attributedCodeListings: [String: AttributedCodeListing] = [:],
+        symbolGraphURLs: [URL],
+        markupURLs: [URL],
+        miscResourceURLs: [URL],
+        customHeader: URL? = nil,
+        customFooter: URL? = nil,
+        themeSettings: URL? = nil
+    ) {
+        self.init(info: info, baseURL: baseURL, symbolGraphURLs: symbolGraphURLs, markupURLs: markupURLs, miscResourceURLs: miscResourceURLs, customHeader: customHeader, customFooter: customFooter, themeSettings: themeSettings)
+        self.attributedCodeListings = attributedCodeListings
     }
     
     public private(set) var rootReference: ResolvedTopicReference

--- a/Sources/SwiftDocC/Infrastructure/DocumentationBundle.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationBundle.swift
@@ -132,7 +132,7 @@ public struct DocumentationBundle {
         self.articlesDocumentationRootReference = documentationRootReference.appendingPath(urlReadablePath(info.displayName))
     }
     
-    @available(*, deprecated, renamed: "init(info:baseURL:attributedCodeListings:symbolGraphURLs:markupURLs:miscResourceURLs:customHeader:customFooter:themeSettings:)", message: "Use 'init(info:baseURL:attributedCodeListings:symbolGraphURLs:markupURLs:miscResourceURLs:customHeader:customFooter:themeSettings:)' instead. This deprecated API will be removed after 6.1 is released")
+    @available(*, deprecated, renamed: "init(info:baseURL:symbolGraphURLs:markupURLs:miscResourceURLs:customHeader:customFooter:themeSettings:)", message: "Use 'init(info:baseURL:symbolGraphURLs:markupURLs:miscResourceURLs:customHeader:customFooter:themeSettings:)' instead. This deprecated API will be removed after 6.1 is released")
     public init(
         info: Info,
         baseURL: URL = URL(string: "/")!,

--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -413,16 +413,9 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
     func preResolveModuleNames() {
         for reference in rootModules {
             if let node = try? entity(with: reference) {
-                let displayName: String
-                switch node.name {
-                case .conceptual(let title):
-                    displayName = title
-                case .symbol(let declaration):
-                    displayName = declaration.tokens.map { $0.description }.joined()
-                }
                 // A module node should always have a symbol.
                 // Remove the fallback value and force unwrap `node.symbol` on the main branch: https://github.com/apple/swift-docc/issues/249
-                moduleNameCache[reference] = (displayName, node.symbol?.names.title ?? reference.lastPathComponent)
+                moduleNameCache[reference] = (node.name.plainText, node.symbol?.names.title ?? reference.lastPathComponent)
             }
         }
     }
@@ -2877,6 +2870,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
     /// - Parameters:
     ///   - unresolvedCodeListingReference: The code listing reference to resolve.
     ///   - parent: The topic the code listing reference appears in.
+    @available(*, deprecated, message: "This deprecated API will be removed after 6.1 is released")
     public func resolveCodeListing(_ unresolvedCodeListingReference: UnresolvedCodeListingReference, in parent: ResolvedTopicReference) -> AttributedCodeListing? {
         return dataProvider.bundles[parent.bundleIdentifier]?.attributedCodeListings[unresolvedCodeListingReference.identifier]
     }

--- a/Sources/SwiftDocC/Infrastructure/Workspace/GeneratedDataProvider.swift
+++ b/Sources/SwiftDocC/Infrastructure/Workspace/GeneratedDataProvider.swift
@@ -76,7 +76,6 @@ public class GeneratedDataProvider: DocumentationWorkspaceDataProvider {
         return [
             DocumentationBundle(
                 info: info,
-                attributedCodeListings: [:],
                 symbolGraphURLs: options.additionalSymbolGraphFiles,
                 markupURLs: topLevelPages,
                 miscResourceURLs: []

--- a/Sources/SwiftDocC/Model/Content/AttributedCodeListing.swift
+++ b/Sources/SwiftDocC/Model/Content/AttributedCodeListing.swift
@@ -11,6 +11,7 @@
 /// A code block represented as lines of lexical tokens.
 ///
 /// Use attributed code listings to represent code written in a specific programming language.
+@available(*, deprecated, message: "This deprecated API will be removed after 6.1 is released")
 public struct AttributedCodeListing: Hashable {
     /// The source-code language for this code listing.
     public let sourceLanguage: SourceLanguage?
@@ -30,6 +31,7 @@ public struct AttributedCodeListing: Hashable {
     }
 }
 
+@available(*, deprecated, message: "This deprecated API will be removed after 6.1 is released")
 extension AttributedCodeListing {
     /// A single line of tokenized code in an attributed code listing.
     public struct Line: Hashable {
@@ -66,6 +68,7 @@ extension AttributedCodeListing {
     }
 }
 
+@available(*, deprecated, message: "This deprecated API will be removed after 6.1 is released")
 extension AttributedCodeListing.Line {
     /// An element in a line of code.
     public enum Token: Hashable, CustomStringConvertible {

--- a/Sources/SwiftDocC/Model/DocumentationNode.swift
+++ b/Sources/SwiftDocC/Model/DocumentationNode.swift
@@ -207,7 +207,7 @@ public struct DocumentationNode {
         
         self.kind = Self.kind(for: defaultSymbol)
         self.sourceLanguage = reference.sourceLanguage
-        self.name = .symbol(declaration: .init([.plain(defaultSymbol.names.title)]))
+        self.name = .symbol(name: defaultSymbol.names.title)
         self.symbol = defaultSymbol
         self.unifiedSymbol = unifiedSymbol
         self.isVirtual = moduleData.isVirtual
@@ -364,7 +364,7 @@ public struct DocumentationNode {
             case .conceptual:
                 self.name = .conceptual(title: displayName.name)
             case .symbol:
-                self.name = .symbol(declaration: .init([.plain(displayName.name)]))
+                self.name = .symbol(name: displayName.name)
             }
             semantic.titleVariants = semantic.titleVariants.map { _ in
                 displayName.name
@@ -610,10 +610,10 @@ public struct DocumentationNode {
             case .conceptual:
                 self.name = .conceptual(title: displayName.name)
             case .symbol:
-                self.name = .symbol(declaration: .init([.plain(displayName.name)]))
+                self.name = .symbol(name: displayName.name)
             }
         } else {
-            self.name = .symbol(declaration: .init([.plain(symbol.names.title)]))
+            self.name = .symbol(name: symbol.names.title)
         }
         self.symbol = symbol
         

--- a/Sources/SwiftDocC/Model/Name.swift
+++ b/Sources/SwiftDocC/Model/Name.swift
@@ -19,9 +19,6 @@ extension DocumentationNode {
     public enum Name: Hashable, CustomStringConvertible {
         /// The name of a conceptual document is its title.
         case conceptual(title: String)
-        /// The name of the symbol is derived from its declaration.
-        @available(*, deprecated, message: "This deprecated API will be removed after 6.1 is released")
-        case _symbol(declaration: AttributedCodeListing.Line)
         /// The name of the symbol.
         case symbol(name: String)
         
@@ -31,9 +28,6 @@ extension DocumentationNode {
                 hasher.combine(text)
             case .symbol(let name):
                 hasher.combine(name)
-                
-            case ._symbol(let declaration):
-                hasher.combine(declaration)
             }
         }
         
@@ -43,9 +37,6 @@ extension DocumentationNode {
                 return title
             case .symbol(let name):
                 return name
-                
-            case ._symbol(let declaration):
-                return declaration.tokens.map { $0.description }.joined(separator: " ")
             }
         }
         
@@ -57,7 +48,7 @@ extension DocumentationNode {
         static func symbol(declaration: AttributedCodeListing.Line) -> Name {
             // This static function exists so that `Name.symbol(declaration:)` is available while 
             // still allowing switching over the two "symbol" name cases.
-            Name._symbol(declaration: declaration)
+            Name.symbol(name: declaration.tokens.first?.description ?? "")
         }
     }
 }

--- a/Sources/SwiftDocC/Model/Name.swift
+++ b/Sources/SwiftDocC/Model/Name.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -20,13 +20,19 @@ extension DocumentationNode {
         /// The name of a conceptual document is its title.
         case conceptual(title: String)
         /// The name of the symbol is derived from its declaration.
-        case symbol(declaration: AttributedCodeListing.Line)
+        @available(*, deprecated, message: "This deprecated API will be removed after 6.1 is released")
+        case _symbol(declaration: AttributedCodeListing.Line)
+        /// The name of the symbol.
+        case symbol(name: String)
         
         public func hash(into hasher: inout Hasher) {
             switch self {
             case .conceptual(let text):
                 hasher.combine(text)
-            case .symbol(let declaration):
+            case .symbol(let name):
+                hasher.combine(name)
+                
+            case ._symbol(let declaration):
                 hasher.combine(declaration)
             }
         }
@@ -35,9 +41,23 @@ extension DocumentationNode {
             switch self {
             case .conceptual(let title):
                 return title
-            case .symbol(let declaration):
+            case .symbol(let name):
+                return name
+                
+            case ._symbol(let declaration):
                 return declaration.tokens.map { $0.description }.joined(separator: " ")
             }
+        }
+        
+        var plainText: String {
+            description
+        }
+        
+        @available(*, deprecated, message: "This deprecated API will be removed after 6.1 is released")
+        static func symbol(declaration: AttributedCodeListing.Line) -> Name {
+            // This static function exists so that `Name.symbol(declaration:)` is available while 
+            // still allowing switching over the two "symbol" name cases.
+            Name._symbol(declaration: declaration)
         }
     }
 }

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -613,12 +613,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
         
         let moduleNames = modules.compactMap { reference -> String? in
             guard let node = try? context.entity(with: reference) else { return nil }
-            switch node.name {
-            case .conceptual(let title):
-                return title
-            case .symbol(let declaration):
-                return declaration.tokens.map { $0.description }.joined(separator: " ")
-            }
+            return node.name.plainText
         }
         if !moduleNames.isEmpty {
             node.metadata.modules = moduleNames.map({

--- a/Sources/SwiftDocC/Semantics/ReferenceResolver.swift
+++ b/Sources/SwiftDocC/Semantics/ReferenceResolver.swift
@@ -408,7 +408,9 @@ struct ReferenceResolver: SemanticVisitor {
         switch node.name {
         case .conceptual(let documentTitle):
             return documentTitle
-        case .symbol(let declaration):
+        case .symbol(let name):
+            return node.symbol?.names.title ?? name
+        case ._symbol(let declaration):
             return node.symbol?.names.title ?? declaration.tokens.map { $0.description }.joined(separator: " ")
         }
     }

--- a/Sources/SwiftDocC/Semantics/ReferenceResolver.swift
+++ b/Sources/SwiftDocC/Semantics/ReferenceResolver.swift
@@ -410,8 +410,6 @@ struct ReferenceResolver: SemanticVisitor {
             return documentTitle
         case .symbol(let name):
             return node.symbol?.names.title ?? name
-        case ._symbol(let declaration):
-            return node.symbol?.names.title ?? declaration.tokens.map { $0.description }.joined(separator: " ")
         }
     }
     

--- a/Tests/SwiftDocCTests/Checker/Checkers/NonInclusiveLanguageCheckerTests.swift
+++ b/Tests/SwiftDocCTests/Checker/Checkers/NonInclusiveLanguageCheckerTests.swift
@@ -178,12 +178,12 @@ func aBlackListedFunc() {
 
     func testDisabledByDefault() throws {
         // Create a test bundle with some non-inclusive content.
-        let (bundleURL, _, _) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], codeListings: [:], externalResolvers: [:], externalSymbolResolver: nil, configureBundle: { url in
+        let (bundleURL, _, _) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], externalResolvers: [:], externalSymbolResolver: nil, configureBundle: { url in
             try self.nonInclusiveContent.write(to: url.appendingPathComponent("documentation").appendingPathComponent("sidekit.md"), atomically: true, encoding: .utf8)
         })
         
         // Load the bundle
-        let (_, _, context) = try loadBundle(from: bundleURL, codeListings: [:], externalResolvers: [:], externalSymbolResolver: nil, diagnosticFilterLevel: .error, configureContext: nil)
+        let (_, _, context) = try loadBundle(from: bundleURL, externalResolvers: [:], externalSymbolResolver: nil, diagnosticFilterLevel: .error, configureContext: nil)
         XCTAssertEqual(context.problems.count, 0)
     }
 
@@ -198,7 +198,7 @@ func aBlackListedFunc() {
         ]
         
         // Create a test bundle with some non-inclusive content.
-        let (bundleURL, _, _) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], codeListings: [:], externalResolvers: [:], externalSymbolResolver: nil, configureBundle: { url in
+        let (bundleURL, _, _) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], externalResolvers: [:], externalSymbolResolver: nil, configureBundle: { url in
             try self.nonInclusiveContent.write(to: url.appendingPathComponent("documentation").appendingPathComponent("sidekit.md"), atomically: true, encoding: .utf8)
         })
 
@@ -206,7 +206,7 @@ func aBlackListedFunc() {
             let (severity, enabled) = expectation
             
             // Load the bundle
-            let (_, _, context) = try loadBundle(from: bundleURL, codeListings: [:], externalResolvers: [:], externalSymbolResolver: nil, diagnosticFilterLevel: severity, configureContext: nil)
+            let (_, _, context) = try loadBundle(from: bundleURL, externalResolvers: [:], externalSymbolResolver: nil, diagnosticFilterLevel: severity, configureContext: nil)
             // Verify that checker diagnostics were emitted or not, depending on the diagnostic level set.
             XCTAssertEqual(context.problems.contains(where: { $0.diagnostic.identifier == "org.swift.docc.NonInclusiveLanguage" }), enabled)
         }

--- a/Tests/SwiftDocCTests/Infrastructure/AutomaticCurationTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/AutomaticCurationTests.swift
@@ -115,7 +115,7 @@ class AutomaticCurationTests: XCTestCase {
     }
     
     func testAutomaticTopicsSkippingCustomCuratedSymbols() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], codeListings: [:], configureBundle: { url in
+        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], configureBundle: { url in
             // Curate some of `SideClass`'s children under SideKit.
             let sideKit = """
             # ``SideKit``
@@ -413,7 +413,7 @@ class AutomaticCurationTests: XCTestCase {
             forResource: "TopLevelCuration.symbols", withExtension: "json", subdirectory: "Test Resources")!
         
         // Create a test bundle copy with the symbol graph from above
-        let (bundleURL, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], codeListings: [:]) { url in
+        let (bundleURL, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: []) { url in
             try? FileManager.default.copyItem(at: topLevelCurationSGFURL, to: url.appendingPathComponent("TopLevelCuration.symbols.json"))
         }
         defer {

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -2642,7 +2642,7 @@ let expected = """
             try text.write(to: referencesURL, atomically: true, encoding: .utf8)
             
             // Load the bundle & reference resolve symbol graph docs
-            let (_, _, context) = try loadBundle(from: targetURL, codeListings: [:])
+            let (_, _, context) = try loadBundle(from: targetURL)
             
             guard context.problems.count == 5 else {
                 XCTFail("Expected 5 problems during reference resolving; got \(context.problems.count)")
@@ -2779,7 +2779,7 @@ let expected = """
         // Verify there is no pool bucket for the bundle we're about to test
         XCTAssertNil(ResolvedTopicReference._numberOfCachedReferences(bundleID: bundleID))
         
-        let (_, _, _) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], codeListings: [:], configureBundle: { rootURL in
+        let (_, _, _) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], configureBundle: { rootURL in
             let infoPlistURL = rootURL.appendingPathComponent("Info.plist", isDirectory: false)
             try! String(contentsOf: infoPlistURL)
                 .replacingOccurrences(of: "org.swift.docc.example", with: bundleID)
@@ -3949,7 +3949,7 @@ let expected = """
     // Verifies if the context fails to resolve non-resolvable nodes.
     func testNonLinkableNodes() throws {
         // Create a bundle with variety absolute and relative links and symbol links to a non linkable node.
-        let (_, _, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], codeListings: [:], externalResolvers: [:], externalSymbolResolver: nil, configureBundle: { url in
+        let (_, _, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], externalResolvers: [:], externalSymbolResolver: nil, configureBundle: { url in
             try """
             # ``SideKit/SideClass``
             Abstract.

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationCuratorTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationCuratorTests.swift
@@ -341,7 +341,7 @@ class DocumentationCuratorTests: XCTestCase {
     }
     
     func testGroupLinkValidation() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], codeListings: [:]) { root in
+        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: []) { root in
             // Create a sidecar with invalid group links
             try! """
             # ``SideKit``

--- a/Tests/SwiftDocCTests/Infrastructure/Symbol Link Resolution/AbsoluteSymbolLinkTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/Symbol Link Resolution/AbsoluteSymbolLinkTests.swift
@@ -223,11 +223,7 @@ class AbsoluteSymbolLinkTests: XCTestCase {
     }
     
     func testCompileSymbolGraphAndValidateLinks() throws {
-        let (_, _, context) = try testBundleAndContext(
-            copying: "TestBundle",
-            excludingPaths: [],
-            codeListings: [:]
-        )
+        let (_, _, context) = try testBundleAndContext(named: "TestBundle")
         let expectedDescriptions = [
             // doc://org.swift.docc.example/documentation/FillIntroduced:
             """
@@ -535,11 +531,7 @@ class AbsoluteSymbolLinkTests: XCTestCase {
     }
     
     func testCompileOverloadedSymbolGraphAndValidateLinks() throws {
-        let (_, _, context) = try testBundleAndContext(
-            copying: "OverloadedSymbols",
-            excludingPaths: [],
-            codeListings: [:]
-        )
+        let (_, _, context) = try testBundleAndContext(named: "OverloadedSymbols")
         
         let expectedDescriptions = [
             // doc://com.shapes.ShapeKit/documentation/ShapeKit:
@@ -859,11 +851,7 @@ class AbsoluteSymbolLinkTests: XCTestCase {
     }
     
     func testLinkComponentStringConversion() throws {
-        let (_, _, context) = try testBundleAndContext(
-            copying: "OverloadedSymbols",
-            excludingPaths: [],
-            codeListings: [:]
-        )
+        let (_, _, context) = try testBundleAndContext(named: "OverloadedSymbols")
         
         let bundlePathComponents = context.documentationCache.allReferences
             .flatMap(\.pathComponents)

--- a/Tests/SwiftDocCTests/Infrastructure/Symbol Link Resolution/DocCSymbolRepresentableTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/Symbol Link Resolution/DocCSymbolRepresentableTests.swift
@@ -113,11 +113,7 @@ class DocCSymbolRepresentableTests: XCTestCase {
         expectedNumberOfAmbiguousSymbols: Int
     ) throws {
         // Build a bundle with an unusual number of overloaded symbols
-        let (_, _, context) = try testBundleAndContext(
-            copying: "OverloadedSymbols",
-            excludingPaths: [],
-            codeListings: [:]
-        )
+        let (_, _, context) = try testBundleAndContext(named: "OverloadedSymbols")
         
         // Collect the overloaded symbols nodes from the built bundle
         let ambiguousSymbols = context.documentationCache
@@ -171,11 +167,7 @@ class DocCSymbolRepresentableTests: XCTestCase {
     }
     
     func testLinkComponentInitialization() throws {
-        let (_, _, context) = try testBundleAndContext(
-            copying: "OverloadedSymbols",
-            excludingPaths: [],
-            codeListings: [:]
-        )
+        let (_, _, context) = try testBundleAndContext(named: "OverloadedSymbols")
         
         var count = 0
         for (reference, documentationNode) in context.documentationCache {

--- a/Tests/SwiftDocCTests/Infrastructure/SymbolGraph/SymbolGraphLoaderTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/SymbolGraph/SymbolGraphLoaderTests.swift
@@ -459,7 +459,7 @@ class SymbolGraphLoaderTests: XCTestCase {
         let infoPlistURL = targetURL.appendingPathComponent("Info.plist")
         try infoPlist.write(to: infoPlistURL, atomically: true, encoding: .utf8)
         // Load the bundle & reference resolve symbol graph docs
-        var (_, _, context) = try loadBundle(from: targetURL, codeListings: [:])
+        var (_, _, context) = try loadBundle(from: targetURL)
         guard let availability = (context.documentationCache["c:@F@A"]?.semantic as? Symbol)?.availability?.availability else {
             XCTFail("Did not find availability for symbol 'c:@F@A'")
             return
@@ -490,7 +490,7 @@ class SymbolGraphLoaderTests: XCTestCase {
         """
         try infoPlist.write(to: infoPlistURL, atomically: true, encoding: .utf8)
         // Load the bundle & reference resolve symbol graph docs
-        (_, _, context) = try loadBundle(from: targetURL, codeListings: [:])
+        (_, _, context) = try loadBundle(from: targetURL)
         guard let availability = (context.documentationCache["c:@F@A"]?.semantic as? Symbol)?.availability?.availability else {
             XCTFail("Did not find availability for symbol 'c:@F@A'")
             return
@@ -533,7 +533,7 @@ class SymbolGraphLoaderTests: XCTestCase {
         """
         try infoPlist.write(to: infoPlistURL, atomically: true, encoding: .utf8)
         // Load the bundle & reference resolve symbol graph docs
-        (_, _, context) = try loadBundle(from: targetURL, codeListings: [:])
+        (_, _, context) = try loadBundle(from: targetURL)
         guard let availability = (context.documentationCache["c:@F@A"]?.semantic as? Symbol)?.availability?.availability else {
             XCTFail("Did not find availability for symbol 'c:@F@A'")
             return
@@ -596,7 +596,7 @@ class SymbolGraphLoaderTests: XCTestCase {
         let symbolGraphURL = targetURL.appendingPathComponent("MyModule.symbols.json")
         try symbolGraphString.write(to: symbolGraphURL, atomically: true, encoding: .utf8)
         // Load the bundle & reference resolve symbol graph docs
-        let (_, _, context) = try loadBundle(from: targetURL, codeListings: [:])
+        let (_, _, context) = try loadBundle(from: targetURL)
         guard let availability = (context.documentationCache["c:@F@A"]?.semantic as? Symbol)?.availability?.availability else {
             XCTFail("Did not find availability for symbol 'c:@F@A'")
             return
@@ -701,7 +701,7 @@ class SymbolGraphLoaderTests: XCTestCase {
         try symbolGraphStringiOS.write(to: targetURL.appendingPathComponent("MyModule-ios.symbols.json"), atomically: true, encoding: .utf8)
         try symbolGraphStringCatalyst.write(to: targetURL.appendingPathComponent("MyModule-catalyst.symbols.json"), atomically: true, encoding: .utf8)
         // Load the bundle & reference resolve symbol graph docs
-        let (_, _, context) = try loadBundle(from: targetURL, codeListings: [:])
+        let (_, _, context) = try loadBundle(from: targetURL)
         guard let availability = (context.documentationCache["c:@F@A"]?.semantic as? Symbol)?.availability?.availability else {
             XCTFail("Did not find availability for symbol 'c:@F@A'")
             return
@@ -844,7 +844,7 @@ class SymbolGraphLoaderTests: XCTestCase {
         let infoPlistURL = targetURL.appendingPathComponent("Info.plist")
         try infoPlist.write(to: infoPlistURL, atomically: true, encoding: .utf8)
         // Load the bundle & reference resolve symbol graph docs
-        let (_, _, context) = try loadBundle(from: targetURL, codeListings: [:])
+        let (_, _, context) = try loadBundle(from: targetURL)
         guard let availability = (context.documentationCache["c:@F@A"]?.semantic as? Symbol)?.availability?.availability else {
             XCTFail("Did not find availability for symbol 'c:@F@A'")
             return
@@ -947,7 +947,7 @@ class SymbolGraphLoaderTests: XCTestCase {
         let infoPlistURL = targetURL.appendingPathComponent("Info.plist")
         try infoPlist.write(to: infoPlistURL, atomically: true, encoding: .utf8)
         // Load the bundle & reference resolve symbol graph docs
-        let (_, _, context) = try loadBundle(from: targetURL, codeListings: [:])
+        let (_, _, context) = try loadBundle(from: targetURL)
         guard let availability = (context.documentationCache["c:@F@A"]?.semantic as? Symbol)?.availability?.availability else {
             XCTFail("Did not find availability for symbol 'c:@F@A'")
             return
@@ -1082,7 +1082,7 @@ class SymbolGraphLoaderTests: XCTestCase {
         let infoPlistURL = targetURL.appendingPathComponent("Info.plist")
         try infoPlist.write(to: infoPlistURL, atomically: true, encoding: .utf8)
         // Load the bundle & reference resolve symbol graph docs
-        var (_, _, context) = try loadBundle(from: targetURL, codeListings: [:])
+        var (_, _, context) = try loadBundle(from: targetURL)
         guard let availability = (context.documentationCache["c:@F@A"]?.semantic as? Symbol)?.availability?.availability else {
             XCTFail("Did not find availability for symbol 'c:@F@A'")
             return
@@ -1102,7 +1102,7 @@ class SymbolGraphLoaderTests: XCTestCase {
             platform: """
             """
         ).write(to: targetURL.appendingPathComponent("MyModule-catalyst.symbols.json"), atomically: true, encoding: .utf8)
-        (_, _, context) = try loadBundle(from: targetURL, codeListings: [:])
+        (_, _, context) = try loadBundle(from: targetURL)
         guard let availability = (context.documentationCache["c:@F@A"]?.semantic as? Symbol)?.availability?.availability else {
             XCTFail("Did not find availability for symbol 'c:@F@A'")
             return
@@ -1224,7 +1224,7 @@ class SymbolGraphLoaderTests: XCTestCase {
             """
         ).write(to: targetURL.appendingPathComponent("MyModule-catalyst.symbols.json"), atomically: true, encoding: .utf8)
         // Load the bundle & reference resolve symbol graph docs
-        var (_, _, context) = try loadBundle(from: targetURL, codeListings: [:])
+        var (_, _, context) = try loadBundle(from: targetURL)
         guard let availabilityFoo = (context.documentationCache["c:@F@A"]?.semantic as? Symbol)?.availability?.availability else {
             XCTFail("Did not find availability for symbol 'c:@F@A'")
             return
@@ -1283,7 +1283,7 @@ class SymbolGraphLoaderTests: XCTestCase {
         // Create info list
         let infoPlistURL = targetURL.appendingPathComponent("Info.plist")
         try infoPlist.write(to: infoPlistURL, atomically: true, encoding: .utf8)
-        (_, _, context) = try loadBundle(from: targetURL, codeListings: [:])
+        (_, _, context) = try loadBundle(from: targetURL)
         guard let availabilityFoo = (context.documentationCache["c:@F@A"]?.semantic as? Symbol)?.availability?.availability else {
             XCTFail("Did not find availability for symbol 'c:@F@A'")
             return
@@ -1363,7 +1363,7 @@ class SymbolGraphLoaderTests: XCTestCase {
         """
         let infoPlistURL = targetURL.appendingPathComponent("Info.plist")
         try infoPlist.write(to: infoPlistURL, atomically: true, encoding: .utf8)
-        let (_, _, context) = try loadBundle(from: targetURL, codeListings: [:])
+        let (_, _, context) = try loadBundle(from: targetURL)
         guard let availability = (context.documentationCache["c:@F@A"]?.semantic as? Symbol)?.availability?.availability else {
             XCTFail("Did not find availability for symbol 'c:@F@A'")
             return

--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
@@ -1528,7 +1528,7 @@ class SemaToRenderNodeTests: XCTestCase {
         
         // Override with both a low and a high value
         for version in [SymbolGraph.SemanticVersion(major: 1, minor: 1, patch: 1), SymbolGraph.SemanticVersion(major: 99, minor: 99, patch: 99)] {
-            let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], codeListings: [:], configureBundle: { url in
+            let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], configureBundle: { url in
                 // Duplicate the symbol graph
                 let myKitURL = url.appendingPathComponent("mykit-iOS.symbols.json")
                 let myClassUSR = "s:5MyKit0A5ClassC"
@@ -1823,7 +1823,7 @@ Document
 
         try content.write(to: targetURL.appendingPathComponent("article2.md"), atomically: true, encoding: .utf8)
 
-        let (_, bundle, context) = try loadBundle(from: targetURL, codeListings: [:])
+        let (_, bundle, context) = try loadBundle(from: targetURL)
         let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/Test-Bundle/article2", sourceLanguage: .swift))
         let article = node.semantic as! Article
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
@@ -1906,7 +1906,7 @@ Document
     }
     
     func testRendersBetaViolators() throws {
-        let (bundle, context) = try testBundleAndContext(named: "TestBundle", codeListings: [:])
+        let (bundle, context) = try testBundleAndContext(named: "TestBundle")
         
         let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/MyClass", sourceLanguage: .swift)
         let node = try context.entity(with: reference)
@@ -2041,7 +2041,7 @@ Document
     }
     
     func testRendersDeprecatedViolator() throws {
-        let (bundle, context) = try testBundleAndContext(named: "TestBundle", codeListings: [:])
+        let (bundle, context) = try testBundleAndContext(named: "TestBundle")
 
         // Make the referenced symbol deprecated
         do {
@@ -2064,7 +2064,7 @@ Document
     }
 
     func testDoesNotRenderDeprecatedViolator() throws {
-        let (bundle, context) = try testBundleAndContext(named: "TestBundle", codeListings: [:])
+        let (bundle, context) = try testBundleAndContext(named: "TestBundle")
 
         // Make the referenced symbol deprecated
         do {
@@ -2088,7 +2088,7 @@ Document
     }
     
     func testRendersDeprecatedViolatorForUnconditionallyDeprecatedReference() throws {
-        let (bundle, context) = try testBundleAndContext(named: "TestBundle", codeListings: [:])
+        let (bundle, context) = try testBundleAndContext(named: "TestBundle")
 
         // Make the referenced symbol deprecated
         do {
@@ -2544,7 +2544,7 @@ Document
     func testRenderAsides() throws {
         let asidesSGFURL = Bundle.module.url(
             forResource: "Asides.symbols", withExtension: "json", subdirectory: "Test Resources")!
-        let (bundleURL, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], codeListings: [:]) { url in
+        let (bundleURL, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: []) { url in
             try? FileManager.default.copyItem(at: asidesSGFURL, to: url.appendingPathComponent("Asides.symbols.json"))
         }
         defer {
@@ -2589,7 +2589,7 @@ Document
         let sgURL = Bundle.module.url(
             forResource: "TestBundle.docc/sidekit.symbols", withExtension: "json", subdirectory: "Test Bundles")!
 
-        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], codeListings: [:], externalResolvers: [:], externalSymbolResolver: nil, configureBundle: { url in
+        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], externalResolvers: [:], externalSymbolResolver: nil, configureBundle: { url in
             // Replace the out-of-bundle origin with a symbol from the same bundle.
             try String(contentsOf: sgURL)
                 .replacingOccurrences(of: #"identifier" : "s:OriginalUSR"#, with: #"identifier" : "s:5MyKit0A5MyProtocol0Afunc()"#)
@@ -2615,7 +2615,7 @@ Document
         let sgURL = Bundle.module.url(
             forResource: "TestBundle.docc/sidekit.symbols", withExtension: "json", subdirectory: "Test Bundles")!
 
-        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], codeListings: [:], externalResolvers: [:], externalSymbolResolver: nil, configureBundle: { url in
+        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], externalResolvers: [:], externalSymbolResolver: nil, configureBundle: { url in
             // Replace the out-of-bundle origin with a symbol from the same bundle but
             // from the MyKit module.
             try String(contentsOf: sgURL)
@@ -2669,7 +2669,7 @@ Document
 
     /// Tests doc extensions are matched to inherited symbols
     func testInheritedSymbolDocExtension() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], codeListings: [:], externalResolvers: [:], externalSymbolResolver: nil, configureBundle: { url in
+        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], externalResolvers: [:], externalSymbolResolver: nil, configureBundle: { url in
             try? """
             # ``SideKit/SideClass/Element/inherited()``
             Doc extension abstract.
@@ -2812,7 +2812,7 @@ Document
         for testData in testData {
             let sgURL = Bundle.module.url(forResource: "TestBundle.docc/sidekit.symbols", withExtension: "json", subdirectory: "Test Bundles")!
          
-            let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], codeListings: [:], externalResolvers: [:], externalSymbolResolver: nil, configureBundle: { url in
+            let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], externalResolvers: [:], externalSymbolResolver: nil, configureBundle: { url in
                 // Replace the out-of-bundle origin with a symbol from the same bundle but
                 // from the MyKit module.
                 var graph = try JSONDecoder().decode(SymbolGraph.self, from: Data(contentsOf: sgURL))
@@ -2993,7 +2993,7 @@ Document
 
     /// Tests links to symbols that have deprecation summary in markdown appear deprecated.
     func testLinkToDeprecatedSymbolViaDirectiveIsDeprecated() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], codeListings: [:], externalResolvers: [:], externalSymbolResolver: nil, configureBundle: { url in
+        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], externalResolvers: [:], externalSymbolResolver: nil, configureBundle: { url in
             try """
             # ``MyKit/MyProtocol``
             @DeprecationSummary {
@@ -3013,7 +3013,7 @@ Document
     }
     
     func testCustomSymbolDisplayNames() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], codeListings: [:], externalResolvers: [:], externalSymbolResolver: nil, configureBundle: { url in
+        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], externalResolvers: [:], externalSymbolResolver: nil, configureBundle: { url in
             try """
             # ``MyKit``
             
@@ -3080,7 +3080,7 @@ Document
         XCTAssertEqual((moduleRenderNode.references[protocolReference.absoluteString] as? TopicRenderReference)?.title, "My custom symbol name")
         
         let protocolNode = try context.entity(with: protocolReference)
-        XCTAssertEqual(protocolNode.name, .symbol(declaration: .init([.plain("My custom symbol name")])))
+        XCTAssertEqual(protocolNode.name, .symbol(name: "My custom symbol name"))
         let protocolSymbol = try XCTUnwrap(protocolNode.semantic as? Symbol)
         XCTAssertEqual(protocolSymbol.title, "My custom symbol name")
         

--- a/Tests/SwiftDocCTests/Rendering/AvailabilityRenderOrderTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/AvailabilityRenderOrderTests.swift
@@ -17,7 +17,7 @@ class AvailabilityRenderOrderTests: XCTestCase {
         forResource: "Availability.symbols", withExtension: "json", subdirectory: "Test Resources")!
     
     func testSortingAtRenderTime() throws {
-        let (bundleURL, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], codeListings: [:]) { url in
+        let (bundleURL, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: []) { url in
             try? FileManager.default.copyItem(at: self.availabilitySGFURL, to: url.appendingPathComponent("Availability.symbols.json"))
         }
         defer {

--- a/Tests/SwiftDocCTests/Rendering/ConstraintsRenderSectionTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/ConstraintsRenderSectionTests.swift
@@ -19,7 +19,7 @@ fileprivate let jsonEncoder = JSONEncoder()
 class ConstraintsRenderSectionTests: XCTestCase {
     
     func testSingleConstraint() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], codeListings: [:]) { bundleURL in
+        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: []) { bundleURL in
             // Add constraints to `MyClass`
             let graphURL = bundleURL.appendingPathComponent("mykit-iOS.symbols.json")
             var graph = try jsonDecoder.decode(SymbolGraph.self, from: try Data(contentsOf: graphURL))
@@ -49,7 +49,7 @@ class ConstraintsRenderSectionTests: XCTestCase {
     }
 
     func testSingleRedundantConstraint() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], codeListings: [:]) { bundleURL in
+        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: []) { bundleURL in
             // Add constraints to `MyClass`
             let graphURL = bundleURL.appendingPathComponent("mykit-iOS.symbols.json")
             var graph = try jsonDecoder.decode(SymbolGraph.self, from: try Data(contentsOf: graphURL))
@@ -78,7 +78,7 @@ class ConstraintsRenderSectionTests: XCTestCase {
     }
 
     func testSingleRedundantConstraintForLeaves() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], codeListings: [:]) { bundleURL in
+        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: []) { bundleURL in
             // Add constraints to `MyClass`
             let graphURL = bundleURL.appendingPathComponent("mykit-iOS.symbols.json")
             var graph = try jsonDecoder.decode(SymbolGraph.self, from: try Data(contentsOf: graphURL))
@@ -107,7 +107,7 @@ class ConstraintsRenderSectionTests: XCTestCase {
     }
 
     func testPreservesNonRedundantConstraints() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], codeListings: [:]) { bundleURL in
+        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: []) { bundleURL in
             // Add constraints to `MyClass`
             let graphURL = bundleURL.appendingPathComponent("mykit-iOS.symbols.json")
             var graph = try jsonDecoder.decode(SymbolGraph.self, from: try Data(contentsOf: graphURL))
@@ -137,7 +137,7 @@ class ConstraintsRenderSectionTests: XCTestCase {
     }
 
     func testGroups2Constraints() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], codeListings: [:]) { bundleURL in
+        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: []) { bundleURL in
             // Add constraints to `MyClass`
             let graphURL = bundleURL.appendingPathComponent("mykit-iOS.symbols.json")
             var graph = try jsonDecoder.decode(SymbolGraph.self, from: try Data(contentsOf: graphURL))
@@ -167,7 +167,7 @@ class ConstraintsRenderSectionTests: XCTestCase {
     }
 
     func testGroups3Constraints() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], codeListings: [:]) { bundleURL in
+        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: []) { bundleURL in
             // Add constraints to `MyClass`
             let graphURL = bundleURL.appendingPathComponent("mykit-iOS.symbols.json")
             var graph = try jsonDecoder.decode(SymbolGraph.self, from: try Data(contentsOf: graphURL))
@@ -198,7 +198,7 @@ class ConstraintsRenderSectionTests: XCTestCase {
     }
 
     func testRenderReferences() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], codeListings: [:]) { bundleURL in
+        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: []) { bundleURL in
             // Add constraints to `MyClass`
             let graphURL = bundleURL.appendingPathComponent("mykit-iOS.symbols.json")
             var graph = try jsonDecoder.decode(SymbolGraph.self, from: try Data(contentsOf: graphURL))
@@ -236,7 +236,7 @@ class ConstraintsRenderSectionTests: XCTestCase {
     }
 
     func testRenderReferencesWithNestedTypeInSelf() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], codeListings: [:]) { bundleURL in
+        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: []) { bundleURL in
             // Add constraints to `MyClass`
             let graphURL = bundleURL.appendingPathComponent("mykit-iOS.symbols.json")
             var graph = try jsonDecoder.decode(SymbolGraph.self, from: try Data(contentsOf: graphURL))

--- a/Tests/SwiftDocCTests/Rendering/DefaultAvailabilityTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/DefaultAvailabilityTests.swift
@@ -33,7 +33,7 @@ class DefaultAvailabilityTests: XCTestCase {
     // Test whether the default availability is loaded from Info.plist and applied during render time
     func testBundleWithDefaultAvailability() throws {
         // Copy an Info.plist with default availability
-        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], codeListings: [:]) { (url) in
+        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: []) { (url) in
             try? FileManager.default.removeItem(at: url.appendingPathComponent("Info.plist"))
             try? FileManager.default.copyItem(at: self.infoPlistAvailabilityURL, to: url.appendingPathComponent("Info.plist"))
             
@@ -105,7 +105,7 @@ class DefaultAvailabilityTests: XCTestCase {
     // Test whether the default availability is merged with beta status from the command line
     func testBundleWithDefaultAvailabilityInBetaDocs() throws {
         // Copy an Info.plist with default availability
-        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], codeListings: [:]) { (url) in
+        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: []) { (url) in
             try? FileManager.default.removeItem(at: url.appendingPathComponent("Info.plist"))
             try? FileManager.default.copyItem(at: self.infoPlistAvailabilityURL, to: url.appendingPathComponent("Info.plist"))
         }
@@ -148,7 +148,7 @@ class DefaultAvailabilityTests: XCTestCase {
     // Mac Catalyst info.plist availability and not on iOS availability.
     func testBundleWithMissingCatalystAvailability() throws {
         // Copy an Info.plist with default availability
-        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], codeListings: [:]) { (url) in
+        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: []) { (url) in
             do {
                 try FileManager.default.removeItem(at: url.appendingPathComponent("Info.plist"))
                 try String(contentsOf: self.infoPlistAvailabilityURL).write(to: url.appendingPathComponent("Info.plist"), atomically: true, encoding: .utf8)
@@ -192,7 +192,7 @@ class DefaultAvailabilityTests: XCTestCase {
     // Test whether the default availability is not beta when not matching current target platform
     func testBundleWithDefaultAvailabilityNotInBetaDocs() throws {
         // Copy an Info.plist with default availability of macOS 10.15.1
-        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], codeListings: [:]) { (url) in
+        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: []) { (url) in
             try? FileManager.default.removeItem(at: url.appendingPathComponent("Info.plist"))
             try? FileManager.default.copyItem(at: self.infoPlistAvailabilityURL, to: url.appendingPathComponent("Info.plist"))
         }
@@ -217,7 +217,7 @@ class DefaultAvailabilityTests: XCTestCase {
 
     // Test that a symbol is unavailable and default availability does not precede the "unavailable" attribute.
     func testUnavailableAvailability() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], codeListings: [:]) { _ in }
+        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: []) { _ in }
         
         // Set a beta status for the docs (which would normally be set via command line argument)
         context.externalMetadata.currentPlatforms = ["iOS": PlatformVersion(VersionTriplet(14, 0, 0), beta: true)]
@@ -348,7 +348,7 @@ class DefaultAvailabilityTests: XCTestCase {
     // Test that setting default availability doesn't prevent symbols with "universal" deprecation
     // (i.e. a platform of '*' and unconditional deprecation) from showing up as deprecated.
     func testUniversalDeprecationWithDefaultAvailability() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "BundleWithLonelyDeprecationDirective", excludingPaths: [], codeListings: [:]) { (url) in
+        let (_, bundle, context) = try testBundleAndContext(copying: "BundleWithLonelyDeprecationDirective", excludingPaths: []) { (url) in
             try? FileManager.default.removeItem(at: url.appendingPathComponent("Info.plist"))
             try? FileManager.default.copyItem(at: self.infoPlistAvailabilityURL, to: url.appendingPathComponent("Info.plist"))
         }

--- a/Tests/SwiftDocCTests/Rendering/DefaultCodeListingSyntaxTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/DefaultCodeListingSyntaxTests.swift
@@ -49,7 +49,6 @@ class DefaultCodeBlockSyntaxTests: XCTestCase {
                 defaultCodeListingLanguage: nil
             ),
             baseURL: testBundleWithLanguageDefault.baseURL,
-            attributedCodeListings: testBundleWithLanguageDefault.attributedCodeListings,
             symbolGraphURLs: testBundleWithLanguageDefault.symbolGraphURLs,
             markupURLs: testBundleWithLanguageDefault.markupURLs,
             miscResourceURLs: testBundleWithLanguageDefault.miscResourceURLs

--- a/Tests/SwiftDocCTests/Rendering/DeprecationSummaryTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/DeprecationSummaryTests.swift
@@ -48,7 +48,7 @@ class DeprecationSummaryTests: XCTestCase {
 
     /// Test for a warning when symbol is not deprecated
     func testIncorrectlyAuthoredDeprecatedSummary() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], codeListings: [:], configureBundle: { url in
+        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], configureBundle: { url in
             // Add a sidecar file with wrong deprecated summary
             try """
             # ``SideKit/SideClass``

--- a/Tests/SwiftDocCTests/Rendering/DocumentationContentRendererTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/DocumentationContentRendererTests.swift
@@ -169,7 +169,7 @@ private extension DocumentationContentRendererTests {
                 .swift,
                 .init(id: DocumentationDataVariantsTrait.otherLanguage.interfaceLanguage!)
             ],
-            name: DocumentationNode.Name.symbol(declaration: AttributedCodeListing.Line()),
+            name: .symbol(name: ""),
             markup: Document(parsing: ""),
             semantic: nil,
             platformNames: nil

--- a/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorTests.swift
@@ -281,7 +281,7 @@ class RenderNodeTranslatorTests: XCTestCase {
     // Verifies that links to sections include their container's abstract rdar://72110558
     func testSectionAbstracts() throws {
         // Create an article including a link to a tutorial section
-        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], codeListings: [:], configureBundle: { url in
+        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], configureBundle: { url in
             try """
             # Article
             Article abstract
@@ -365,7 +365,7 @@ class RenderNodeTranslatorTests: XCTestCase {
     
     /// Tests the ordering of automatic groups for symbols
     func testAutomaticTaskGroupsOrderingInSymbols() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], codeListings: [:], externalResolvers: [:], externalSymbolResolver: nil, configureBundle: { url in
+        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], externalResolvers: [:], externalSymbolResolver: nil, configureBundle: { url in
             try """
             # ``SideKit/SideClass``
             SideClass abstract
@@ -492,7 +492,7 @@ class RenderNodeTranslatorTests: XCTestCase {
     
     /// Tests the ordering of automatic groups for articles
     func testAutomaticTaskGroupsOrderingInArticles() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], codeListings: [:], externalResolvers: [:], externalSymbolResolver: nil, configureBundle: { url in
+        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], externalResolvers: [:], externalSymbolResolver: nil, configureBundle: { url in
             try """
             # Article
             Article abstract
@@ -599,7 +599,7 @@ class RenderNodeTranslatorTests: XCTestCase {
 
     /// Tests the ordering of automatic groups in defining protocol
     func testOrderingOfAutomaticGroupsInDefiningProtocol() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], codeListings: [:], externalResolvers: [:], externalSymbolResolver: nil, configureBundle: { url in
+        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], externalResolvers: [:], externalSymbolResolver: nil, configureBundle: { url in
             //
         })
         
@@ -649,7 +649,7 @@ class RenderNodeTranslatorTests: XCTestCase {
             forResource: "FancyProtocol.symbols", withExtension: "json", subdirectory: "Test Resources")!
 
         // Create a test bundle copy with the symbol graph from above
-        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], codeListings: [:]) { url in
+        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: []) { url in
             try? FileManager.default.copyItem(at: fancyProtocolSGFURL, to: url.appendingPathComponent("FancyProtocol.symbols.json"))
         }
 
@@ -885,7 +885,7 @@ class RenderNodeTranslatorTests: XCTestCase {
     // Verifies we don't render links to non linkable nodes.
     func testNonLinkableNodes() throws {
         // Create a bundle with variety absolute and relative links and symbol links to a non linkable node.
-        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], codeListings: [:], externalResolvers: [:], externalSymbolResolver: nil, configureBundle: { url in
+        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], externalResolvers: [:], externalSymbolResolver: nil, configureBundle: { url in
             try """
             # ``SideKit/SideClass``
             Abstract.
@@ -940,7 +940,7 @@ class RenderNodeTranslatorTests: XCTestCase {
         
         do {
             // Create a bundle with a link in abstract, then verify the render reference is present in `SideKit` render node references.
-            let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], codeListings: [:], externalResolvers: [:], externalSymbolResolver: nil, configureBundle: { url in
+            let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], externalResolvers: [:], externalSymbolResolver: nil, configureBundle: { url in
                 try """
                 # ``SideKit/SideClass``
                 This is a link to <doc:/documentation/SideKit/SideClass/Element>.

--- a/Tests/SwiftDocCTests/XCTestCase+LoadingTestData.swift
+++ b/Tests/SwiftDocCTests/XCTestCase+LoadingTestData.swift
@@ -18,7 +18,6 @@ extension XCTestCase {
     
     /// Loads a documentation bundle from the given source URL and creates a documentation context.
     func loadBundle(from bundleURL: URL,
-                    codeListings: [String : AttributedCodeListing] = [:],
                     externalResolvers: [String: ExternalDocumentationSource] = [:],
                     externalSymbolResolver: GlobalExternalSymbolResolver? = nil,
                     fallbackResolver: ConvertServiceFallbackResolver? = nil,
@@ -35,8 +34,7 @@ extension XCTestCase {
         // Load the bundle using automatic discovery
         let automaticDataProvider = try LocalFileSystemDataProvider(rootURL: bundleURL)
         // Mutate the bundle to include the code listings, then apply to the workspace using a manual provider.
-        var bundle = try XCTUnwrap(automaticDataProvider.bundles().first)
-        bundle.attributedCodeListings = codeListings
+        let bundle = try XCTUnwrap(automaticDataProvider.bundles().first)
         let dataProvider = PrebuiltLocalFileSystemDataProvider(bundles: [bundle])
         try workspace.registerProvider(dataProvider)
         return (bundleURL, bundle, context)
@@ -68,7 +66,6 @@ extension XCTestCase {
     
     func testBundleAndContext(copying name: String,
                               excludingPaths excludedPaths: [String] = [],
-                              codeListings: [String : AttributedCodeListing] = [:],
                               externalResolvers: [BundleIdentifier : ExternalDocumentationSource] = [:],
                               externalSymbolResolver: GlobalExternalSymbolResolver? = nil,
                               fallbackResolver: ConvertServiceFallbackResolver? = nil,
@@ -95,21 +92,20 @@ extension XCTestCase {
         
         return try loadBundle(
             from: bundleURL,
-            codeListings: codeListings,
             externalResolvers: externalResolvers,
             externalSymbolResolver: externalSymbolResolver,
             fallbackResolver: fallbackResolver
         )
     }
     
-    func testBundleAndContext(named name: String, codeListings: [String : AttributedCodeListing] = [:], externalResolvers: [String: ExternalDocumentationSource] = [:]) throws -> (URL, DocumentationBundle, DocumentationContext) {
+    func testBundleAndContext(named name: String, externalResolvers: [String: ExternalDocumentationSource] = [:]) throws -> (URL, DocumentationBundle, DocumentationContext) {
         let bundleURL = try XCTUnwrap(Bundle.module.url(
             forResource: name, withExtension: "docc", subdirectory: "Test Bundles"))
-        return try loadBundle(from: bundleURL, codeListings: codeListings, externalResolvers: externalResolvers)
+        return try loadBundle(from: bundleURL, externalResolvers: externalResolvers)
     }
     
-    func testBundleAndContext(named name: String, codeListings: [String : AttributedCodeListing] = [:], externalResolvers: [String: ExternalDocumentationSource] = [:]) throws -> (DocumentationBundle, DocumentationContext) {
-        let (_, bundle, context) = try testBundleAndContext(named: name, codeListings: codeListings, externalResolvers: externalResolvers)
+    func testBundleAndContext(named name: String, externalResolvers: [String: ExternalDocumentationSource] = [:]) throws -> (DocumentationBundle, DocumentationContext) {
+        let (_, bundle, context) = try testBundleAndContext(named: name, externalResolvers: externalResolvers)
         return (bundle, context)
     }
     


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

This removes the AttributedCodeListing type that isn't used for anything. There's no way for developers to pass this form of code listings to DocC (unless they use some other tool that imports the SwiftDocC module). `AttributedCodeListing.Line` appears in public API `DocumentationNode.Name.symbol` but DocC only ever creates `symbol` name values with a single plain text token.

Note, AttributedCodeListing is a feature that was superseded by Snippets and has never been available via the `docc` command line tool.

## Dependencies

None.

## Testing

This is a non-functional change. Everything should continue to behave as before. There's nothing in particular to test.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] ~Added~ Updated tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] ~Updated documentation if necessary~ Not applicable
