### PR TITLE
Address warnings about retroactively conforming types from other modules to protocols

### DIFF
--- a/Sources/SwiftDocC/DocumentationService/Convert/Symbol Link Resolution/DocCSymbolRepresentable.swift
+++ b/Sources/SwiftDocC/DocumentationService/Convert/Symbol Link Resolution/DocCSymbolRepresentable.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -163,6 +163,13 @@ public extension Collection where Element: DocCSymbolRepresentable {
         }
     }
 }
+
+// DocCSymbolRepresentable inherits from Equatable. If SymbolKit added Equatable conformance in the future, this could behave differently.
+// It's reasonable to expect that symbols with the same unique ID would be equal but it's possible that SymbolKit's implementation would consider more symbol properties.
+//
+// In the long term we should try to phase out DocCSymbolRepresentable since it doesn't reflect how DocC resolves links or disambiguated symbols in links.
+extension SymbolGraph.Symbol: @retroactive Equatable {}
+extension UnifiedSymbolGraph.Symbol: @retroactive Equatable {}
 
 extension SymbolGraph.Symbol: DocCSymbolRepresentable {
     public var preciseIdentifier: String? {

--- a/Sources/SwiftDocC/Infrastructure/Symbol Graph/AccessControl+Comparable.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Graph/AccessControl+Comparable.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -10,7 +10,9 @@
 
 import SymbolKit
 
-extension SymbolGraph.Symbol.AccessControl: Comparable {
+// SymbolKit doesn't define any access control values ("open", "public", "internal", "filePrivate", and "private", are defined in SwiftDocC).
+// Since AccessControl only has a string raw value, it's unlikely that SymbolKit would add a Comparable default implementation.
+extension SymbolGraph.Symbol.AccessControl: @retroactive Comparable {
     private var level: Int? {
         switch self {
         case .private : return 1

--- a/Sources/SwiftDocC/Utility/SemanticVersion+Comparable.swift
+++ b/Sources/SwiftDocC/Utility/SemanticVersion+Comparable.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -11,7 +11,11 @@
 import Foundation
 import SymbolKit
 
-extension SymbolGraph.SemanticVersion: Comparable {
+// If SymbolKit adds Comparable conformance it's reasonable to expect that its behavior would be compatible.
+//
+// If a future SymbolKit implementation considers the "prerelease" and "buildMetadata" components _after_ the
+// "major", "minor", and "patch" components, that remains compatible with the behavior that SwiftDocC expects.
+extension SymbolGraph.SemanticVersion: @retroactive Comparable {
     /// Compares two semantic versions.
     public static func < (lhs: SymbolGraph.SemanticVersion, rhs: SymbolGraph.SemanticVersion) -> Bool {
         return (lhs.major, lhs.minor, lhs.patch) < (rhs.major, rhs.minor, rhs.patch)

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/Options/DocumentationCoverageOptionsArgument.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/Options/DocumentationCoverageOptionsArgument.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -86,8 +86,8 @@ public struct DocumentationCoverageOptionsArgument: ParsableArguments {
 }
 
 // SwiftDocCUtilities imports SwiftDocC. SwiftDocC does not link against ArgumentParser (because it isn't about CLI). We conform here because this is the first place that we can. We implement in DocC.
-extension DocumentationCoverageLevel: ExpressibleByArgument {}
-extension DocumentationCoverageOptions.KindFilterOptions.BitFlagRepresentation: ExpressibleByArgument {}
+extension DocumentationCoverageLevel: @retroactive ExpressibleByArgument {}
+extension DocumentationCoverageOptions.KindFilterOptions.BitFlagRepresentation: @retroactive ExpressibleByArgument {}
 
 extension DocumentationCoverageOptions {
     public init(from arguments: DocumentationCoverageOptionsArgument) {

--- a/Sources/generate-symbol-graph/main.swift
+++ b/Sources/generate-symbol-graph/main.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -57,7 +57,8 @@ func directiveUSR(_ directiveName: String) -> String {
     "__docc_universal_symbol_reference_$\(directiveName)"
 }
 
-extension SymbolGraph.Symbol.DeclarationFragments.Fragment: ExpressibleByStringInterpolation {
+// This conformance it only relevant to the `generate-symbol-graph` script.
+extension SymbolGraph.Symbol.DeclarationFragments.Fragment: @retroactive ExpressibleByStringInterpolation {
     public init(stringLiteral value: String) {
         self.init(kind: .text, spelling: value, preciseIdentifier: nil)
     }
@@ -71,7 +72,8 @@ extension SymbolGraph.Symbol.DeclarationFragments.Fragment: ExpressibleByStringI
     }
 }
 
-extension SymbolGraph.LineList.Line: ExpressibleByStringInterpolation {
+// This conformance it only relevant to the `generate-symbol-graph` script.
+extension SymbolGraph.LineList.Line: @retroactive ExpressibleByStringInterpolation {
     public init(stringLiteral value: String) {
         self.init(text: value, range: nil)
     }

--- a/Tests/SwiftDocCTests/Model/RenderNodeSerializationTests.swift
+++ b/Tests/SwiftDocCTests/Model/RenderNodeSerializationTests.swift
@@ -225,7 +225,7 @@ class RenderNodeSerializationTests: XCTestCase {
             let kind: RenderNode.Kind
         }
         func decodeKind(jsonString: String) throws -> RenderNode.Kind {
-            return try JSONDecoder().decode(Wrapper.self, from: "{ \"kind\" : \(jsonString) }".data(using: .utf8)!).kind
+            return try JSONDecoder().decode(RenderNode.Kind.self, from: Data(jsonString.utf8))
         }
         
         // Both values can be decoded

--- a/Tests/SwiftDocCTests/Semantics/Reference/RowTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/Reference/RowTests.swift
@@ -283,7 +283,8 @@ class RowTests: XCTestCase {
 
 }
 
-extension RenderBlockContent: ExpressibleByStringLiteral {
+// RenderBlockContent is defined in SwiftDocC. We would know if we added public ExpressibleByStringLiteral conformance (which is unlikely).
+extension RenderBlockContent: @retroactive ExpressibleByStringLiteral {
     public init(stringLiteral value: String) {
         self = RenderBlockContent.paragraph(Paragraph(inlineContent: [.text(value)]))
     }


### PR DESCRIPTION
<!--
If you're opening a PR to cherry-pick a change for a release branch, use this template instead:
https://github.com/apple/swift-docc/blob/main/.github/PULL_REQUEST_TEMPLATE/CHERRY_PICK.md
-->

Bug/issue #, if applicable: 

## Summary

This adds the `@retroactive` attribute with explanatory comments to address warnings about adding protocol conformance to types defined in other modules.

It also fixes a false-positive code warning in a test.

## Dependencies

None.

## Testing

This is a non-functional change. Everything should continue to behave as before. There's nothing in particular to test.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] ~Added tests~ Not applicable
- [x] Ran the `./bin/test` script and it succeeded
- [x] ~Updated documentation if necessary~ Not applicable 
