### PR TITLE
Remove unused code in RenderNodeTranslator

### DIFF
--- a/Sources/SwiftDocC/Converter/DocumentationContextConverter.swift
+++ b/Sources/SwiftDocC/Converter/DocumentationContextConverter.swift
@@ -94,7 +94,6 @@ public class DocumentationContextConverter {
             context: context,
             bundle: bundle,
             identifier: node.reference,
-            source: source,
             renderContext: renderContext,
             emitSymbolSourceFileURIs: shouldEmitSymbolSourceFileURIs,
             emitSymbolAccessLevels: shouldEmitSymbolAccessLevels,

--- a/Sources/SwiftDocC/Converter/DocumentationContextConverter.swift
+++ b/Sources/SwiftDocC/Converter/DocumentationContextConverter.swift
@@ -83,9 +83,8 @@ public class DocumentationContextConverter {
     /// Convert a documentation node into a render node to get a self-contained, persist-able representation of a given topic's data, so you can write it to disk, send it over a network, or otherwise process it.
     /// - Parameters:
     ///   - node: The documentation node to convert.
-    ///   - source: The source file for the documentation node.
     /// - Returns: The render node representation of the documentation node.
-    public func renderNode(for node: DocumentationNode, at source: URL?) throws -> RenderNode? {
+    public func renderNode(for node: DocumentationNode) throws -> RenderNode? {
         guard !node.isVirtual else {
             return nil
         }
@@ -101,5 +100,10 @@ public class DocumentationContextConverter {
             symbolIdentifiersWithExpandedDocumentation: symbolIdentifiersWithExpandedDocumentation
         )
         return translator.visit(node.semantic) as? RenderNode
+    }
+    
+    @available(*, deprecated, renamed: "renderNode(for:)", message: "Use 'renderNode(for:)' instead. This deprecated API will be removed after 6.1 is released")
+    public func renderNode(for node: DocumentationNode, at source: URL?) throws -> RenderNode? {
+        return try self.renderNode(for: node)
     }
 }

--- a/Sources/SwiftDocC/Converter/DocumentationNodeConverter.swift
+++ b/Sources/SwiftDocC/Converter/DocumentationNodeConverter.swift
@@ -35,10 +35,14 @@ public struct DocumentationNodeConverter {
     /// Convert a documentation node into a render node to get a self-contained, persistable representation of a given topic's data, so you can write it to disk, send it over a network, or otherwise process it.
     /// - Parameters:
     ///   - node: The documentation node to convert.
-    ///   - source: The source file for the documentation node.
     /// - Returns: The render node representation of the documentation node.
-    public func convert(_ node: DocumentationNode, at source: URL?) throws -> RenderNode {
+    public func convert(_ node: DocumentationNode) throws -> RenderNode {
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         return translator.visit(node.semantic) as! RenderNode
+    }
+    
+    @available(*, deprecated, renamed: "convert(_:)", message: "Use 'convert(_:)' instead. This deprecated API will be removed after 6.1 is released")
+    public func convert(_ node: DocumentationNode, at source: URL?) throws -> RenderNode {
+        return try convert(node)
     }
 }

--- a/Sources/SwiftDocC/Converter/DocumentationNodeConverter.swift
+++ b/Sources/SwiftDocC/Converter/DocumentationNodeConverter.swift
@@ -38,7 +38,7 @@ public struct DocumentationNodeConverter {
     ///   - source: The source file for the documentation node.
     /// - Returns: The render node representation of the documentation node.
     public func convert(_ node: DocumentationNode, at source: URL?) throws -> RenderNode {
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: source)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         return translator.visit(node.semantic) as! RenderNode
     }
 }

--- a/Sources/SwiftDocC/Infrastructure/DocumentationConverter.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationConverter.swift
@@ -318,8 +318,6 @@ public struct DocumentationConverter: DocumentationConverterProtocol {
         var conversionProblems: [Problem] = references.concurrentPerform { identifier, results in
             // If cancelled skip all concurrent conversion work in this block.
             guard !isConversionCancelled() else { return }
-
-            let source = context.documentURL(for: identifier)
             
             // Wrap JSON encoding in an autorelease pool to avoid retaining the autoreleased ObjC objects returned by `JSONSerialization`
             autoreleasepool {
@@ -330,7 +328,7 @@ public struct DocumentationConverter: DocumentationConverterProtocol {
                         return
                     }
 
-                    guard let renderNode = try converter.renderNode(for: entity, at: source) else {
+                    guard let renderNode = try converter.renderNode(for: entity) else {
                         // No render node was produced for this entity, so just skip it.
                         return
                     }

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -1745,7 +1745,6 @@ public struct RenderNodeTranslator: SemanticVisitor {
     var context: DocumentationContext
     var bundle: DocumentationBundle
     var identifier: ResolvedTopicReference
-    var source: URL?
     var imageReferences: [String: ImageReference] = [:]
     var videoReferences: [String: VideoReference] = [:]
     var fileReferences: [String: FileReference] = [:]
@@ -1952,7 +1951,6 @@ public struct RenderNodeTranslator: SemanticVisitor {
         context: DocumentationContext,
         bundle: DocumentationBundle,
         identifier: ResolvedTopicReference,
-        source: URL?,
         renderContext: RenderContext? = nil,
         emitSymbolSourceFileURIs: Bool = false,
         emitSymbolAccessLevels: Bool = false,
@@ -1962,7 +1960,6 @@ public struct RenderNodeTranslator: SemanticVisitor {
         self.context = context
         self.bundle = bundle
         self.identifier = identifier
-        self.source = source
         self.renderContext = renderContext
         self.contentRenderer = DocumentationContentRenderer(documentationContext: context, bundle: bundle)
         self.shouldEmitSymbolSourceFileURIs = emitSymbolSourceFileURIs

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -353,7 +353,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
 
     /// Returns a description of the total estimated duration to complete the tutorials of the given technology.
     /// - Returns: The estimated duration, or `nil` if there are no tutorials with time estimates.
-    private func totalEstimatedDuration(for technology: Technology) -> String? {
+    private func totalEstimatedDuration() -> String? {
         var totalDurationMinutes: Int? = nil
 
         for node in context.breadthFirstSearch(from: identifier) {
@@ -378,7 +378,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
         node.metadata.title = technology.intro.title
         node.metadata.category = technology.name
         node.metadata.categoryPathComponent = identifier.url.lastPathComponent
-        node.metadata.estimatedTime = totalEstimatedDuration(for: technology)
+        node.metadata.estimatedTime = totalEstimatedDuration()
         node.metadata.role = DocumentationContentRenderer.role(for: .technology).rawValue
         
         let documentationNode = try! context.entity(with: identifier)

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -45,9 +45,6 @@ public struct RenderNodeTranslator: SemanticVisitor {
     /// Whether the documentation converter should include access level information for symbols.
     var shouldEmitSymbolAccessLevels: Bool
     
-    /// Whether tutorials that are not curated in a tutorials overview should be translated.
-    var shouldRenderUncuratedTutorials: Bool = false
-    
     /// The source repository where the documentation's sources are hosted.
     var sourceRepository: SourceRepository?
     
@@ -974,11 +971,6 @@ public struct RenderNodeTranslator: SemanticVisitor {
         return nil
     }
 
-    /// The current module context for symbols.
-    private var currentSymbolModuleName: String? = nil
-    /// The current symbol context.
-    private var currentSymbol: ResolvedTopicReference? = nil
-
     /// Renders automatically generated task groups
     private mutating func renderAutomaticTaskGroupsSection(_ taskGroups: [AutomaticTaskGroupSection], contentCompiler: inout RenderContentCompiler) -> [TaskGroupRenderSection] {
         return taskGroups.map { group in
@@ -1207,8 +1199,6 @@ public struct RenderNodeTranslator: SemanticVisitor {
         
         var node = RenderNode(identifier: identifier, kind: .symbol)
         var contentCompiler = RenderContentCompiler(context: context, bundle: bundle, identifier: identifier)
-
-        currentSymbol = identifier
         
         /*
          FIXME: We shouldn't be doing this kind of crawling here.
@@ -1673,7 +1663,6 @@ public struct RenderNodeTranslator: SemanticVisitor {
         addReferences(contentCompiler.linkReferences, to: &node)
         addReferences(linkReferences, to: &node)
         
-        currentSymbol = nil
         return node
     }
 

--- a/Tests/SwiftDocCTests/Converter/DocumentationContextConverterTests.swift
+++ b/Tests/SwiftDocCTests/Converter/DocumentationContextConverterTests.swift
@@ -27,8 +27,8 @@ class DocumentationContextConverterTests: XCTestCase {
         for identifier in context.knownPages {
             let documentationNode = try XCTUnwrap(try context.entity(with: identifier))
             
-            let renderNode1 = try perNodeConverter.convert(documentationNode, at: nil)
-            let renderNode2 = try bulkNodeConverter.renderNode(for: documentationNode, at: nil)
+            let renderNode1 = try perNodeConverter.convert(documentationNode)
+            let renderNode2 = try bulkNodeConverter.renderNode(for: documentationNode)
             
             // Compare the two nodes are identical
             let data1 = try encoder.encode(renderNode1)
@@ -55,8 +55,7 @@ class DocumentationContextConverterTests: XCTestCase {
                 renderContext: renderContext,
                 emitSymbolSourceFileURIs: true)
             
-            let renderNode = try XCTUnwrap(documentationContextConverter.renderNode(
-                for: fillIntroducedSymbolNode, at: nil))
+            let renderNode = try XCTUnwrap(documentationContextConverter.renderNode(for: fillIntroducedSymbolNode))
             XCTAssertEqual(renderNode.metadata.sourceFileURI, "file:///tmp/FillIntroduced.swift")
         }
         
@@ -66,8 +65,7 @@ class DocumentationContextConverterTests: XCTestCase {
                 context: context,
                 renderContext: renderContext)
             
-            let renderNode = try XCTUnwrap(documentationContextConverter.renderNode(
-                for: fillIntroducedSymbolNode, at: nil))
+            let renderNode = try XCTUnwrap(documentationContextConverter.renderNode(for: fillIntroducedSymbolNode))
             XCTAssertNil(renderNode.metadata.sourceFileURI)
         }
     }
@@ -88,8 +86,7 @@ class DocumentationContextConverterTests: XCTestCase {
                 emitSymbolAccessLevels: true
             )
             
-            let renderNode = try XCTUnwrap(documentationContextConverter.renderNode(
-                for: fillIntroducedSymbolNode, at: nil))
+            let renderNode = try XCTUnwrap(documentationContextConverter.renderNode(for: fillIntroducedSymbolNode))
             XCTAssertEqual(renderNode.metadata.symbolAccessLevel, "public")
         }
         
@@ -99,8 +96,7 @@ class DocumentationContextConverterTests: XCTestCase {
                 context: context,
                 renderContext: renderContext)
             
-            let renderNode = try XCTUnwrap(documentationContextConverter.renderNode(
-                for: fillIntroducedSymbolNode, at: nil))
+            let renderNode = try XCTUnwrap(documentationContextConverter.renderNode(for: fillIntroducedSymbolNode))
             XCTAssertNil(renderNode.metadata.symbolAccessLevel)
         }
     }

--- a/Tests/SwiftDocCTests/Converter/RenderNodeCodableTests.swift
+++ b/Tests/SwiftDocCTests/Converter/RenderNodeCodableTests.swift
@@ -203,12 +203,7 @@ class RenderNodeCodableTests: XCTestCase {
         )
         context.topicGraph.addNode(topicGraphNode)
         
-        var translator = RenderNodeTranslator(
-            context: context,
-            bundle: bundle,
-            identifier: reference,
-            source: nil
-        )
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
         let node = try XCTUnwrap(translator.visitArticle(article) as? RenderNode)
         XCTAssertEqual(node.topicSectionsStyle, .compactGrid)
         

--- a/Tests/SwiftDocCTests/Converter/TopicRenderReferenceEncoderTests.swift
+++ b/Tests/SwiftDocCTests/Converter/TopicRenderReferenceEncoderTests.swift
@@ -170,7 +170,7 @@ class TopicRenderReferenceEncoderTests: XCTestCase {
         // For reach topic encode its render node and verify the references are in alphabetical order.
         for reference in context.knownPages {
             let node = try context.entity(with: reference)
-            let renderNode = try converter.convert(node, at: nil)
+            let renderNode = try converter.convert(node)
             
             // Get the encoded JSON as string
             let encodedData = try renderNode.encodeToJSON(with: encoder, renderReferenceCache: cache)
@@ -228,7 +228,7 @@ class TopicRenderReferenceEncoderTests: XCTestCase {
         // For reach topic encode its render node and verify the references are in alphabetical order.
         for reference in context.knownPages {
             let node = try context.entity(with: reference)
-            let renderNode = try converter.convert(node, at: nil)
+            let renderNode = try converter.convert(node)
             
             // Get the encoded JSON as string
             let encodedData = try renderNode.encodeToJSON(with: encoder)

--- a/Tests/SwiftDocCTests/Indexing/IndexingTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/IndexingTests.swift
@@ -19,7 +19,7 @@ class IndexingTests: XCTestCase {
         let tutorialReference = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/tutorials/Test-Bundle/TestTutorial", sourceLanguage: .swift)
         let node = try context.entity(with: tutorialReference)
         let tutorial = node.semantic as! Tutorial
-        var converter = RenderNodeTranslator(context: context, bundle: bundle, identifier: tutorialReference, source: context.documentURL(for: tutorialReference))
+        var converter = RenderNodeTranslator(context: context, bundle: bundle, identifier: tutorialReference)
         let renderNode = converter.visit(tutorial) as! RenderNode
         let indexingRecords = try renderNode.indexingRecords(onPage: tutorialReference)
         XCTAssertEqual(4, indexingRecords.count)
@@ -93,7 +93,7 @@ class IndexingTests: XCTestCase {
         let articleReference = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/tutorials/Test-Bundle/TestTutorialArticle", sourceLanguage: .swift)
         let node = try context.entity(with: articleReference)
         let article = node.semantic as! TutorialArticle
-        var converter = RenderNodeTranslator(context: context, bundle: bundle, identifier: articleReference, source: context.documentURL(for: articleReference))
+        var converter = RenderNodeTranslator(context: context, bundle: bundle, identifier: articleReference)
         let renderNode = converter.visit(article) as! RenderNode
         let indexingRecords = try renderNode.indexingRecords(onPage: articleReference)
         
@@ -191,7 +191,7 @@ class IndexingTests: XCTestCase {
         let articleReference = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit", sourceLanguage: .swift)
         let node = try context.entity(with: articleReference)
         let article = node.semantic as! Symbol
-        var converter = RenderNodeTranslator(context: context, bundle: bundle, identifier: articleReference, source: context.documentURL(for: articleReference))
+        var converter = RenderNodeTranslator(context: context, bundle: bundle, identifier: articleReference)
         let renderNode = converter.visit(article) as! RenderNode
         let indexingRecords = try renderNode.indexingRecords(onPage: articleReference)
         
@@ -224,7 +224,7 @@ class IndexingTests: XCTestCase {
         let articleReference = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit/MyProtocol", sourceLanguage: .swift)
         let node = try context.entity(with: articleReference)
         let article = node.semantic as! Symbol
-        var converter = RenderNodeTranslator(context: context, bundle: bundle, identifier: articleReference, source: context.documentURL(for: articleReference))
+        var converter = RenderNodeTranslator(context: context, bundle: bundle, identifier: articleReference)
         let renderNode = converter.visit(article) as! RenderNode
         let indexingRecords = try renderNode.indexingRecords(onPage: articleReference)
         

--- a/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
@@ -412,9 +412,8 @@ Root
             builder.setup()
             
             for identifier in context.knownPages {
-                let source = context.documentURL(for: identifier)
                 let entity = try context.entity(with: identifier)
-                let renderNode = try XCTUnwrap(converter.renderNode(for: entity, at: source))
+                let renderNode = try XCTUnwrap(converter.renderNode(for: entity))
                 try builder.index(renderNode: renderNode)
             }
             
@@ -601,9 +600,8 @@ Root
         builder.setup()
         
         for identifier in context.knownPages {
-            let source = context.documentURL(for: identifier)
             let entity = try context.entity(with: identifier)
-            let renderNode = try XCTUnwrap(converter.renderNode(for: entity, at: source))
+            let renderNode = try XCTUnwrap(converter.renderNode(for: entity))
             try builder.index(renderNode: renderNode)
         }
         
@@ -646,10 +644,9 @@ Root
         fromDecodedBuilder.setup()
         
         for identifier in context.knownPages {
-            let source = context.documentURL(for: identifier)
             let entity = try context.entity(with: identifier)
             
-            let renderNode = try XCTUnwrap(converter.renderNode(for: entity, at: source))
+            let renderNode = try XCTUnwrap(converter.renderNode(for: entity))
             XCTAssertNil(renderNode.variantOverrides)
             try fromMemoryBuilder.index(renderNode: renderNode)
             
@@ -878,9 +875,8 @@ Root
             builder.setup()
             
             for identifier in context.knownPages {
-                let source = context.documentURL(for: identifier)
                 let entity = try context.entity(with: identifier)
-                let renderNode = try XCTUnwrap(converter.renderNode(for: entity, at: source))
+                let renderNode = try XCTUnwrap(converter.renderNode(for: entity))
                 try builder.index(renderNode: renderNode)
             }
             
@@ -927,9 +923,8 @@ Root
             builder.setup()
             
             for identifier in context.knownPages {
-                let source = context.documentURL(for: identifier)
                 let entity = try context.entity(with: identifier)
-                let renderNode = try converter.convert(entity, at: source)
+                let renderNode = try converter.convert(entity)
                 try builder.index(renderNode: renderNode)
             }
             
@@ -1006,9 +1001,8 @@ Root
             builder.setup()
             
             for identifier in context.knownPages {
-                let source = context.documentURL(for: identifier)
                 let entity = try context.entity(with: identifier)
-                var renderNode = try XCTUnwrap(converter.renderNode(for: entity, at: source))
+                var renderNode = try XCTUnwrap(converter.renderNode(for: entity))
                 
                 if renderNode.identifier.path == "/documentation/MyKit" {
                     guard let reference = renderNode.topicSections.first?.identifiers.first else {
@@ -1067,9 +1061,8 @@ Root
         builder.setup()
         
         for identifier in context.knownPages {
-            let source = context.documentURL(for: identifier)
             let entity = try context.entity(with: identifier)
-            let renderNode = try XCTUnwrap(converter.renderNode(for: entity, at: source))
+            let renderNode = try XCTUnwrap(converter.renderNode(for: entity))
             try builder.index(renderNode: renderNode)
         }
         
@@ -1172,9 +1165,8 @@ Root
         builder.setup()
         
         for identifier in context.knownPages {
-            let source = context.documentURL(for: identifier)
             let entity = try context.entity(with: identifier)
-            let renderNode = try XCTUnwrap(converter.renderNode(for: entity, at: source))
+            let renderNode = try XCTUnwrap(converter.renderNode(for: entity))
             try builder.index(renderNode: renderNode)
         }
         
@@ -1202,9 +1194,8 @@ Root
         builder.navigatorIndex?.pathHasher = .fnv1
         
         for identifier in context.knownPages {
-            let source = context.documentURL(for: identifier)
             let entity = try context.entity(with: identifier)
-            let renderNode = try XCTUnwrap(converter.renderNode(for: entity, at: source))
+            let renderNode = try XCTUnwrap(converter.renderNode(for: entity))
             try builder.index(renderNode: renderNode)
         }
         
@@ -1648,9 +1639,8 @@ Root
         builder.setup()
         
         for identifier in context.knownPages {
-            let source = context.documentURL(for: identifier)
             let entity = try context.entity(with: identifier)
-            let renderNode = try converter.convert(entity, at: source)
+            let renderNode = try converter.convert(entity)
             try builder.index(renderNode: renderNode)
         }
         
@@ -1965,9 +1955,8 @@ Root
         builder.setup()
 
         for identifier in context.knownPages {
-            let source = context.documentURL(for: identifier)
             let entity = try context.entity(with: identifier)
-            let renderNode = try XCTUnwrap(converter.renderNode(for: entity, at: source))
+            let renderNode = try XCTUnwrap(converter.renderNode(for: entity))
             try builder.index(renderNode: renderNode)
         }
 

--- a/Tests/SwiftDocCTests/Indexing/RenderIndexTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/RenderIndexTests.swift
@@ -746,9 +746,8 @@ final class RenderIndexTests: XCTestCase {
         builder.setup()
         
         for identifier in context.knownPages {
-            let source = context.documentURL(for: identifier)
             let entity = try context.entity(with: identifier)
-            let renderNode = try XCTUnwrap(converter.renderNode(for: entity, at: source))
+            let renderNode = try XCTUnwrap(converter.renderNode(for: entity))
             try builder.index(renderNode: renderNode)
         }
         

--- a/Tests/SwiftDocCTests/Infrastructure/AnchorSectionTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/AnchorSectionTests.swift
@@ -67,7 +67,7 @@ class AnchorSectionTests: XCTestCase {
 
         // Verify collecting section render references
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
-        let renderNode = try converter.convert(entity, at: nil)
+        let renderNode = try converter.convert(entity)
 
         let sectionReference = try XCTUnwrap(renderNode.references["doc://org.swift.docc.example/documentation/TechnologyX/Article#Article-Sub-Section"] as? TopicRenderReference)
         XCTAssertEqual(sectionReference.title, "Article Sub-Section")
@@ -125,7 +125,7 @@ class AnchorSectionTests: XCTestCase {
 
         // Verify collecting section render references
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
-        let renderNode = try converter.convert(entity, at: nil)
+        let renderNode = try converter.convert(entity)
 
         let sectionReference = try XCTUnwrap(renderNode.references["doc://org.swift.docc.example/documentation/CoolFramework/CoolClass#Symbol-Sub-Section"] as? TopicRenderReference)
         XCTAssertEqual(sectionReference.title, "Symbol Sub-Section")
@@ -183,7 +183,7 @@ class AnchorSectionTests: XCTestCase {
 
         // Verify collecting section render references
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
-        let renderNode = try converter.convert(entity, at: nil)
+        let renderNode = try converter.convert(entity)
 
         let sectionReference = try XCTUnwrap(renderNode.references["doc://org.swift.docc.example/documentation/CoolFramework#Module-Sub-Section"] as? TopicRenderReference)
         XCTAssertEqual(sectionReference.title, "Module Sub-Section")

--- a/Tests/SwiftDocCTests/Infrastructure/AutoCapitalizationTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/AutoCapitalizationTests.swift
@@ -102,7 +102,7 @@ class AutoCapitalizationTests: XCTestCase {
         XCTAssertEqual(parameterSections[.swift]?.parameters.map(\.name), ["one", "two", "three", "four", "five"])
         
         let parameterSectionTranslator = ParametersSectionTranslator()
-        var renderNodeTranslator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference, source: url)
+        var renderNodeTranslator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
         var renderNode = renderNodeTranslator.visit(symbol) as! RenderNode
         let translatedParameters = parameterSectionTranslator.translateSection(for: symbol, renderNode: &renderNode, renderNodeTranslator: &renderNodeTranslator)
         let paramsRenderSection = translatedParameters?.defaultValue?.section as! ParametersRenderSection
@@ -149,7 +149,7 @@ class AutoCapitalizationTests: XCTestCase {
         XCTAssertEqual(parameterSections[.swift]?.parameters.map(\.name), ["one", "two", "three", "four", "five"])
         
         let parameterSectionTranslator = ParametersSectionTranslator()
-        var renderNodeTranslator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference, source: url)
+        var renderNodeTranslator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
         var renderNode = renderNodeTranslator.visit(symbol) as! RenderNode
         let translatedParameters = parameterSectionTranslator.translateSection(for: symbol, renderNode: &renderNode, renderNodeTranslator: &renderNodeTranslator)
         let paramsRenderSection = translatedParameters?.defaultValue?.section as! ParametersRenderSection
@@ -190,7 +190,7 @@ class AutoCapitalizationTests: XCTestCase {
         let symbol = try XCTUnwrap(node.semantic as? Symbol)
         
         let returnsSectionTranslator = ReturnsSectionTranslator()
-        var renderNodeTranslator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference, source: url)
+        var renderNodeTranslator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
         var renderNode = renderNodeTranslator.visit(symbol) as! RenderNode
         let translatedReturns = returnsSectionTranslator.translateSection(for: symbol, renderNode: &renderNode, renderNodeTranslator: &renderNodeTranslator)
         let returnsRenderSection = translatedReturns?.defaultValue?.section as! ContentRenderSection

--- a/Tests/SwiftDocCTests/Infrastructure/AutomaticCurationTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/AutomaticCurationTests.swift
@@ -97,7 +97,7 @@ class AutomaticCurationTests: XCTestCase {
         line: UInt = #line
     ) throws {
         let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: path, sourceLanguage: .swift))
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = try XCTUnwrap(translator.visit(node.semantic) as? RenderNode, file: file, line: line)
         
         for section in renderNode.topicSections {
@@ -132,7 +132,7 @@ class AutomaticCurationTests: XCTestCase {
         
         // Compile the render node to flex the automatic curator
         let symbol = node.semantic as! Symbol
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visit(symbol) as! RenderNode
         
         // Verify that uncurated element `SideKit/SideClass/Element` is
@@ -181,7 +181,7 @@ class AutomaticCurationTests: XCTestCase {
             let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/SideKit/SideClass", sourceLanguage: .swift))
             // Compile docs and verify the generated Topics section
             let symbol = node.semantic as! Symbol
-            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
             let renderNode = translator.visit(symbol) as! RenderNode
             
             // Verify that all the symbols are curated, either manually or automatically
@@ -341,7 +341,7 @@ class AutomaticCurationTests: XCTestCase {
         // The first topic section
         do {
             let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/SideKit/SideClass", sourceLanguage: .swift))
-            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
             let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode
             
             // SideKit includes the "Manually curated" task group and additional automatically created groups.
@@ -357,7 +357,7 @@ class AutomaticCurationTests: XCTestCase {
         // The second topic section
         do {
             let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/SideKit/SideClassFour", sourceLanguage: .swift))
-            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
             let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode
             
             // The other symbols in the same topic section appear in this See Also section
@@ -370,7 +370,7 @@ class AutomaticCurationTests: XCTestCase {
         // The second topic section
         do {
             let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/SideKit/SideClassSix", sourceLanguage: .swift))
-            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
             let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode
             
             // The other symbols in the same topic section appear in this See Also section
@@ -382,21 +382,21 @@ class AutomaticCurationTests: XCTestCase {
         // The automatically curated symbols shouldn't have a See Also section
         do {
             let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/SideKit/SideClassEight", sourceLanguage: .swift))
-            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
             let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode
             
             XCTAssertNil(renderNode.seeAlsoSections.first, "This symbol was automatically curated and shouldn't have a See Also section")
         }
         do {
             let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/SideKit/SideClassNine", sourceLanguage: .swift))
-            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
             let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode
             
             XCTAssertNil(renderNode.seeAlsoSections.first, "This symbol was automatically curated and shouldn't have a See Also section")
         }
         do {
             let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/SideKit/SideClassTen", sourceLanguage: .swift))
-            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
             let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode
             
             XCTAssertNil(renderNode.seeAlsoSections.first, "This symbol was automatically curated and shouldn't have a See Also section")
@@ -423,7 +423,7 @@ class AutomaticCurationTests: XCTestCase {
         do {
             // Get the framework render node
             let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/TestBed", sourceLanguage: .swift))
-            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
             let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode
             
             // Verify that `B` isn't automatically curated under the framework node
@@ -436,7 +436,7 @@ class AutomaticCurationTests: XCTestCase {
         do {
             // Get the `A` render node
             let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/TestBed/A", sourceLanguage: .swift))
-            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
             let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode
             
             // Verify that `B` was in fact curated under `A`
@@ -764,11 +764,7 @@ class AutomaticCurationTests: XCTestCase {
 
         // Compile the render node to flex the automatic curator
         let symbol = protocolDocumentationNode.semantic as! Symbol
-        var translator = RenderNodeTranslator(
-            context: context,
-            bundle: bundle,
-            identifier: protocolDocumentationNode.reference,
-            source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: protocolDocumentationNode.reference)
         let renderNode = translator.visit(symbol) as! RenderNode
 
         XCTAssertEqual(renderNode.topicSections.count, 1)
@@ -822,7 +818,7 @@ class AutomaticCurationTests: XCTestCase {
              let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ModuleName/SomeClass", sourceLanguage: .swift))
 
              // Compile docs and verify the generated Topics section
-             var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+             var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
              let renderNode = try XCTUnwrap(translator.visit(node.semantic) as? RenderNode)
 
              // Verify that there are no duplicate sections in `SomeClass`'s "Topics" section

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -1925,7 +1925,7 @@ let expected = """
             )
         }
         
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: moduleReference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: moduleReference)
         let renderNode = translator.visit(moduleSymbol) as! RenderNode
         
         // Verify that the resolved links rendered as links
@@ -2529,7 +2529,7 @@ let expected = """
         
         // Render declaration and compare token kinds with symbol graph
         let symbol = myFunc.semantic as! Symbol
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: myFunc.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: myFunc.reference)
         let renderNode = translator.visitSymbol(symbol) as! RenderNode
         
         let declarationTokens = renderNode.primaryContentSections.mapFirst { section -> [String]? in
@@ -2673,7 +2673,7 @@ let expected = """
         let node = try context.entity(with: reference)
 
         let symbol = node.semantic as! Symbol
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
         let renderNode = translator.visitSymbol(symbol) as! RenderNode
 
         return (node, renderNode)

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -1301,9 +1301,7 @@ class DocumentationContextTests: XCTestCase {
             let node = try context.entity(with: identifier)
             
             let converter = DocumentationContextConverter(bundle: bundle, context: context, renderContext: renderContext)
-            
-            let source = context.documentURL(for: identifier)
-            let renderNode = try XCTUnwrap(converter.renderNode(for: node, at: source))
+            let renderNode = try XCTUnwrap(converter.renderNode(for: node))
             
             XCTAssertEqual(
                 !testData.expectsToResolveArticleReference,
@@ -2465,9 +2463,8 @@ let expected = """
         
         let renderContext = RenderContext(documentationContext: context, bundle: bundle)
         let converter = DocumentationContextConverter(bundle: bundle, context: context, renderContext: renderContext)
-        let source = context.documentURL(for: moduleReference)
         
-        let renderNode = try XCTUnwrap(converter.renderNode(for: moduleNode, at: source))
+        let renderNode = try XCTUnwrap(converter.renderNode(for: moduleNode))
         let curatedTopic = try XCTUnwrap(renderNode.topicSections.first?.identifiers.first)
         
         let topicReference = try XCTUnwrap(renderNode.references[curatedTopic] as? TopicRenderReference)
@@ -3174,20 +3171,20 @@ let expected = """
         // Verify that the links are resolved in the render model.
         let bundle = try XCTUnwrap(context.registeredBundles.first)
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
-        let renderNode = try converter.convert(entity, at: nil)
+        let renderNode = try converter.convert(entity)
         
         XCTAssertEqual(renderNode.topicSections.map(\.anchor), [
             "Another-topic-section"
         ])
         
         let firstReference = try XCTUnwrap(context.knownPages.first(where: { $0.lastPathComponent == "First" }))
-        let firstRenderNode = try converter.convert(context.entity(with: firstReference), at: nil)
+        let firstRenderNode = try converter.convert(context.entity(with: firstReference))
         XCTAssertEqual(firstRenderNode.topicSections.map(\.anchor), [
             "Topics"
         ])
         
         let secondReference = try XCTUnwrap(context.knownPages.first(where: { $0.lastPathComponent == "Second" }))
-        let secondRenderNode = try converter.convert(context.entity(with: secondReference), at: nil)
+        let secondRenderNode = try converter.convert(context.entity(with: secondReference))
         XCTAssertEqual(secondRenderNode.topicSections.map(\.anchor), [
             "Some-topic-section"
         ])

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationCuratorTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationCuratorTests.swift
@@ -445,7 +445,7 @@ class DocumentationCuratorTests: XCTestCase {
         XCTAssertEqual("doc://com.test.TestBed/documentation/TestBed/MyArticle", symbol.topics?.taskGroups.first?.links.first?.destination)
         
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
-        let renderNode = try converter.convert(entity, at: nil)
+        let renderNode = try converter.convert(entity)
         
         // Verify the article identifier is included in the task group for the render node.
         XCTAssertEqual("doc://com.test.TestBed/documentation/TestBed/MyArticle", renderNode.topicSections.first?.identifiers.first)

--- a/Tests/SwiftDocCTests/Infrastructure/ExternalPathHierarchyResolverTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/ExternalPathHierarchyResolverTests.swift
@@ -661,7 +661,7 @@ class ExternalPathHierarchyResolverTests: XCTestCase {
         
         let linkSummaries: [LinkDestinationSummary] = try dependencyContext.knownPages.flatMap { reference in
             let entity = try dependencyContext.entity(with: reference)
-            let renderNode = try XCTUnwrap(dependencyConverter.renderNode(for: entity, at: nil))
+            let renderNode = try XCTUnwrap(dependencyConverter.renderNode(for: entity))
             
             return entity.externallyLinkableElementSummaries(context: dependencyContext, renderNode: renderNode, includeTaskGroups: false)
         }
@@ -749,7 +749,7 @@ class ExternalPathHierarchyResolverTests: XCTestCase {
         do {
             let reference = ResolvedTopicReference(bundleIdentifier: mainBundle.identifier, path: "/documentation/Main/SomeClass", sourceLanguage: .swift)
             let entity = try mainContext.entity(with: reference)
-            let renderNode = try XCTUnwrap(mainConverter.renderNode(for: entity, at: nil))
+            let renderNode = try XCTUnwrap(mainConverter.renderNode(for: entity))
             
             XCTAssertEqual(renderNode.relationshipSections.count, 2)
             let inheritsFromSection = try XCTUnwrap(renderNode.relationshipSections.first)
@@ -773,7 +773,7 @@ class ExternalPathHierarchyResolverTests: XCTestCase {
         do {
             let reference = ResolvedTopicReference(bundleIdentifier: mainBundle.identifier, path: "/documentation/Main/SomeClass/someFunction(parameter:)", sourceLanguage: .swift)
             let entity = try mainContext.entity(with: reference)
-            let renderNode = try XCTUnwrap(mainConverter.renderNode(for: entity, at: nil))
+            let renderNode = try XCTUnwrap(mainConverter.renderNode(for: entity))
             
             XCTAssertEqual(renderNode.primaryContentSections.count, 1)
             let declarationSection = try XCTUnwrap(renderNode.primaryContentSections.first as? DeclarationsRenderSection)
@@ -951,7 +951,7 @@ class ExternalPathHierarchyResolverTests: XCTestCase {
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
         for reference in context.knownPages {
             let node = try context.entity(with: reference)
-            let renderNode = try converter.convert(node, at: nil)
+            let renderNode = try converter.convert(node)
             entitySummaries.append(contentsOf: node.externallyLinkableElementSummaries(context: context, renderNode: renderNode, includeTaskGroups: false))
         }
         

--- a/Tests/SwiftDocCTests/Infrastructure/ExternalReferenceResolverTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/ExternalReferenceResolverTests.swift
@@ -139,8 +139,7 @@ class ExternalReferenceResolverTests: XCTestCase {
             sourceLanguage: .swift
         )
         let node = try context.entity(with: sideClassReference)
-        let fileURL = try XCTUnwrap(context.documentURL(for: node.reference))
-        let renderNode = try converter.convert(node, at: fileURL)
+        let renderNode = try converter.convert(node)
         
         // First assert that the external reference is included in the render node's references
         // and is defined as expected.
@@ -293,7 +292,7 @@ class ExternalReferenceResolverTests: XCTestCase {
                 "The test content should include a link for the external reference resolver to resolve"
             )
             
-            let renderNode = try converter.convert(node, at: fileURL)
+            let renderNode = try converter.convert(node)
             
             guard let symbolRenderReference = renderNode.references[expectedReference] as? TopicRenderReference else {
                 XCTFail("The external reference should be resolved and included among the Tutorial's references.")
@@ -336,12 +335,7 @@ class ExternalReferenceResolverTests: XCTestCase {
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
         let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/SideKit/SideClass", sourceLanguage: .swift))
         
-        guard let fileURL = context.documentURL(for: node.reference) else {
-            XCTFail("Unable to find the file for \(node.reference.path)")
-            return
-        }
-        
-        let renderNode = try converter.convert(node, at: fileURL)
+        let renderNode = try converter.convert(node)
         
         guard let symbolRenderReference = renderNode.references["doc://com.test.external/path/to/external/symbol"] as? TopicRenderReference else {
             XCTFail("The external reference should be resolved and included among the SideClass symbols's references.")
@@ -391,8 +385,7 @@ class ExternalReferenceResolverTests: XCTestCase {
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
         let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/article", sourceLanguage: .swift))
         
-        let fileURL = try XCTUnwrap(context.documentURL(for: node.reference))
-        let renderNode = try converter.convert(node, at: fileURL)
+        let renderNode = try converter.convert(node)
         
         XCTAssertEqual(externalResolver.resolvedExternalPaths, ["/path/to/external/symbol"], "The authored link was resolved")
         
@@ -439,12 +432,7 @@ class ExternalReferenceResolverTests: XCTestCase {
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
         let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/SideKit/SideClass", sourceLanguage: .swift))
         
-        guard let fileURL = context.documentURL(for: node.reference) else {
-            XCTFail("Unable to find the file for \(node.reference.path)")
-            return
-        }
-        
-        let renderNode = try converter.convert(node, at: fileURL)
+        let renderNode = try converter.convert(node)
         
         guard let sampleRenderReference = renderNode.references["doc://com.test.external/path/to/external/sample"] as? TopicRenderReference else {
             XCTFail("The external reference should be resolved and included among the SideClass symbols's references.")
@@ -543,12 +531,7 @@ class ExternalReferenceResolverTests: XCTestCase {
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
         let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/SomeSample", sourceLanguage: .swift))
         
-        guard let fileURL = context.documentURL(for: node.reference) else {
-            XCTFail("Unable to find the file for \(node.reference.path)")
-            return
-        }
-        
-        let renderNode = try converter.convert(node, at: fileURL)
+        let renderNode = try converter.convert(node)
         
         XCTAssertEqual(context.assetManagers.keys.sorted(), ["org.swift.docc.sample"],
                        "The external bundle for the external asset shouldn't have it's own asset manager")
@@ -819,7 +802,7 @@ class ExternalReferenceResolverTests: XCTestCase {
         // Get MyKit symbol
         let entity = try context.entity(with: .init(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit", sourceLanguage: .swift))
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
-        let renderNode = try converter.convert(entity, at: nil)
+        let renderNode = try converter.convert(entity)
         
         let taskGroupLinks = try XCTUnwrap(renderNode.seeAlsoSections.first?.identifiers)
         // Verify the unresolved links are not included in the task group.
@@ -945,8 +928,7 @@ class ExternalReferenceResolverTests: XCTestCase {
             sourceLanguage: .swift
         )
         let node = try context.entity(with: mixedLanguageFrameworkReference)
-        let fileURL = try XCTUnwrap(context.documentURL(for: node.reference))
-        let renderNode = try converter.convert(node, at: fileURL)
+        let renderNode = try converter.convert(node)
         // Topic identifiers in the Swift variant of the `MixedLanguageFramework` symbol
         let swiftTopicIDs = renderNode.topicSections.flatMap(\.identifiers)
         
@@ -1089,7 +1071,7 @@ class ExternalReferenceResolverTests: XCTestCase {
         do {
             let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/unit-test/First", sourceLanguage: .swift)
             let node = try context.entity(with: reference)
-            let rendered = try converter.convert(node, at: nil)
+            let rendered = try converter.convert(node)
             
             XCTAssertEqual(rendered.seeAlsoSections.count, 1, "The page should only have the automatic See Also section created based on the curation on the Root page.")
             let seeAlso = try XCTUnwrap(rendered.seeAlsoSections.first)
@@ -1103,7 +1085,7 @@ class ExternalReferenceResolverTests: XCTestCase {
         do {
             let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/unit-test/Second", sourceLanguage: .swift)
             let node = try context.entity(with: reference)
-            let rendered = try converter.convert(node, at: nil)
+            let rendered = try converter.convert(node)
             
             XCTAssertEqual(rendered.seeAlsoSections.count, 1, "The page should only have the automatic See Also section created based on the curation on the Root page.")
             let seeAlso = try XCTUnwrap(rendered.seeAlsoSections.first)
@@ -1144,7 +1126,7 @@ class ExternalReferenceResolverTests: XCTestCase {
         let reference = try XCTUnwrap(context.soleRootModuleReference)
         let node = try context.entity(with: reference)
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
-        let rendered = try converter.convert(node, at: nil)
+        let rendered = try converter.convert(node)
         
         XCTAssertEqual(rendered.seeAlsoSections.count, 1, "The page should only have the authored See Also section.")
         let seeAlso = try XCTUnwrap(rendered.seeAlsoSections.first)

--- a/Tests/SwiftDocCTests/Infrastructure/NodeTagsTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/NodeTagsTests.swift
@@ -33,7 +33,7 @@ class NodeTagsTests: XCTestCase {
         XCTAssertTrue(symbol.isSPI)
 
         // Verify the render node contains the SPI tag.
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = try XCTUnwrap(translator.visit(symbol) as? RenderNode)
 
         XCTAssertEqual(renderNode.metadata.tags, [.spi])
@@ -44,7 +44,7 @@ class NodeTagsTests: XCTestCase {
         let moduleSymbol = try XCTUnwrap(moduleNode.semantic as? Symbol)
 
         // Verify the render node contains the SPI tag.
-        var moduleTranslator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var moduleTranslator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let moduleRenderNode = try XCTUnwrap(moduleTranslator.visit(moduleSymbol) as? RenderNode)
         let linkReference = try XCTUnwrap(moduleRenderNode.references["doc://com.tests.spi/documentation/Minimal_docs/Test"] as? TopicRenderReference)
         

--- a/Tests/SwiftDocCTests/Infrastructure/ReferenceResolverTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/ReferenceResolverTests.swift
@@ -101,7 +101,7 @@ class ReferenceResolverTests: XCTestCase {
         
         // Get a translated render node
         let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/SideKit", sourceLanguage: .swift))
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode
         
         // Verify resolved links
@@ -127,7 +127,7 @@ class ReferenceResolverTests: XCTestCase {
         
         // Get a translated render node
         let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/SideKit", sourceLanguage: .swift))
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode
         
         // Verify resolved links
@@ -153,7 +153,7 @@ class ReferenceResolverTests: XCTestCase {
         
         // Get a translated render node
         let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/SideKit/SideClass/myFunction()", sourceLanguage: .swift))
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode
         
         // Verify resolved links
@@ -179,7 +179,7 @@ class ReferenceResolverTests: XCTestCase {
         
         // Get a translated render node
         let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/SideKit/SideClass/myFunction()", sourceLanguage: .swift))
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode
         
         // Verify resolved links
@@ -204,7 +204,7 @@ class ReferenceResolverTests: XCTestCase {
         
         // Get a translated render node
         let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/SideKit/SideClass/myFunction()", sourceLanguage: .swift))
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode
         
         // Verify resolved links
@@ -230,7 +230,7 @@ class ReferenceResolverTests: XCTestCase {
         
         // Get a translated render node
         let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/SideKit/SideClass/myFunction()", sourceLanguage: .swift))
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode
         
         // Verify resolved links
@@ -378,7 +378,7 @@ class ReferenceResolverTests: XCTestCase {
         
         // Get a translated render node
         let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/BundleWithRelativePathAmbiguity/Dependency", sourceLanguage: .swift))
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode
         
         let content = try XCTUnwrap(renderNode.primaryContentSections.first as? ContentRenderSection).content
@@ -410,7 +410,7 @@ class ReferenceResolverTests: XCTestCase {
         let (bundle, context) = try testBundleAndContext(named: "ModuleWithSingleExtension")
 
         let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ModuleWithSingleExtension", sourceLanguage: .swift))
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode
 
         // The only children of the root topic should be the `MyNamespace` enum - i.e. the Swift
@@ -454,7 +454,7 @@ class ReferenceResolverTests: XCTestCase {
         // Load the RenderNode for the root article and make sure that the `Swift/Array` symbol link
         // is not rendered as a link
         let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ModuleWithSingleExtension", sourceLanguage: .swift))
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode
 
         XCTAssertEqual(renderNode.abstract, [
@@ -525,7 +525,7 @@ class ReferenceResolverTests: XCTestCase {
         let (bundle, context) = try testBundleAndContext(named: "ModuleWithConformanceAndExtension")
 
         let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ModuleWithConformanceAndExtension/MyProtocol", sourceLanguage: .swift))
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode
 
         let conformanceSection = try XCTUnwrap(renderNode.relationshipSections.first(where: { $0.type == RelationshipsGroup.Kind.conformingTypes.rawValue }))
@@ -541,7 +541,7 @@ class ReferenceResolverTests: XCTestCase {
         let (bundle, context) = try testBundleAndContext(named: "ModuleWithEmptyDeclarationFragments")
 
         let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ModuleWithEmptyDeclarationFragments", sourceLanguage: .swift))
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode
 
         // Despite having an extension to Float, there are no symbols added by that extension, so

--- a/Tests/SwiftDocCTests/LinkTargets/LinkDestinationSummaryTests.swift
+++ b/Tests/SwiftDocCTests/LinkTargets/LinkDestinationSummaryTests.swift
@@ -106,7 +106,7 @@ class ExternalLinkableTests: XCTestCase {
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
         
         let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/tutorials/TestBundle/Tutorial", sourceLanguage: .swift))
-        let renderNode = try converter.convert(node, at: nil)
+        let renderNode = try converter.convert(node)
         
         let summaries = node.externallyLinkableElementSummaries(context: context, renderNode: renderNode)
         let pageSummary = summaries[0]
@@ -163,7 +163,7 @@ class ExternalLinkableTests: XCTestCase {
         do {
             let symbolReference = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit/MyClass", sourceLanguage: .swift)
             let node = try context.entity(with: symbolReference)
-            let renderNode = try converter.convert(node, at: nil)
+            let renderNode = try converter.convert(node)
             let summary = node.externallyLinkableElementSummaries(context: context, renderNode: renderNode)[0]
             
             XCTAssertEqual(summary.title, "MyClass")
@@ -207,7 +207,7 @@ class ExternalLinkableTests: XCTestCase {
         do {
             let symbolReference = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit/MyProtocol", sourceLanguage: .swift)
             let node = try context.entity(with: symbolReference)
-            let renderNode = try converter.convert(node, at: nil)
+            let renderNode = try converter.convert(node)
             let summary = node.externallyLinkableElementSummaries(context: context, renderNode: renderNode)[0]
             
             XCTAssertEqual(summary.title, "MyProtocol")
@@ -248,7 +248,7 @@ class ExternalLinkableTests: XCTestCase {
         do {
             let symbolReference = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit/MyClass/myFunction()", sourceLanguage: .swift)
             let node = try context.entity(with: symbolReference)
-            let renderNode = try converter.convert(node, at: nil)
+            let renderNode = try converter.convert(node)
             let summary = node.externallyLinkableElementSummaries(context: context, renderNode: renderNode)[0]
             
             XCTAssertEqual(summary.title, "myFunction()")
@@ -283,7 +283,7 @@ class ExternalLinkableTests: XCTestCase {
         do {
             let symbolReference = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit/globalFunction(_:considering:)", sourceLanguage: .swift)
             let node = try context.entity(with: symbolReference)
-            let renderNode = try converter.convert(node, at: nil)
+            let renderNode = try converter.convert(node)
             let summary = node.externallyLinkableElementSummaries(context: context, renderNode: renderNode)[0]
             
             XCTAssertEqual(summary.title, "globalFunction(_:considering:)")
@@ -340,7 +340,7 @@ class ExternalLinkableTests: XCTestCase {
         do {
             let symbolReference = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit/MyClass/myFunction()", sourceLanguage: .swift)
             let node = try context.entity(with: symbolReference)
-            let renderNode = try converter.convert(node, at: nil)
+            let renderNode = try converter.convert(node)
             var summary = node.externallyLinkableElementSummaries(context: context, renderNode: renderNode)[0]
             
             XCTAssertEqual(summary.title, "myFunction()")
@@ -445,7 +445,7 @@ class ExternalLinkableTests: XCTestCase {
         do {
             let symbolReference = ResolvedTopicReference(bundleIdentifier: "org.swift.MixedLanguageFramework", path: "/documentation/MixedLanguageFramework/Bar", sourceLanguage: .swift)
             let node = try context.entity(with: symbolReference)
-            let renderNode = try converter.convert(node, at: nil)
+            let renderNode = try converter.convert(node)
             let summary = node.externallyLinkableElementSummaries(context: context, renderNode: renderNode)[0]
             
             XCTAssertEqual(summary.title, "Bar")
@@ -504,7 +504,7 @@ class ExternalLinkableTests: XCTestCase {
         do {
             let symbolReference = ResolvedTopicReference(bundleIdentifier: "org.swift.MixedLanguageFramework", path: "/documentation/MixedLanguageFramework/Bar/myStringFunction(_:)", sourceLanguage: .swift)
             let node = try context.entity(with: symbolReference)
-            let renderNode = try converter.convert(node, at: nil)
+            let renderNode = try converter.convert(node)
             let summary = node.externallyLinkableElementSummaries(context: context, renderNode: renderNode)[0]
             
             XCTAssertEqual(summary.title, "myStringFunction(_:)")
@@ -742,7 +742,7 @@ class ExternalLinkableTests: XCTestCase {
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
 
         let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyModule/MyClass/myFunc()-9sdsh", sourceLanguage: .swift))
-        let renderNode = try converter.convert(node, at: nil)
+        let renderNode = try converter.convert(node)
 
         let summaries = node.externallyLinkableElementSummaries(context: context, renderNode: renderNode)
         let pageSummary = summaries[0]

--- a/Tests/SwiftDocCTests/Model/RenderHierarchyTranslatorTests.swift
+++ b/Tests/SwiftDocCTests/Model/RenderHierarchyTranslatorTests.swift
@@ -102,7 +102,7 @@ class RenderHierarchyTranslatorTests: XCTestCase {
         // Get a translated render node
         let identifier = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/tutorials/Test-Bundle/TestTutorial", sourceLanguage: .swift)
         let node = try context.entity(with: identifier)
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: identifier, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: identifier)
         let renderNode = translator.visit(node.semantic) as! RenderNode
 
         guard let renderHierarchy = renderNode.hierarchy, case RenderHierarchy.tutorials(let hierarchy) = renderHierarchy else {

--- a/Tests/SwiftDocCTests/Model/RenderNodeDiffingBundleTests.swift
+++ b/Tests/SwiftDocCTests/Model/RenderNodeDiffingBundleTests.swift
@@ -289,10 +289,9 @@ class RenderNodeDiffingBundleTests: XCTestCase {
         let converter = DocumentationContextConverter(bundle: bundle, context: context, renderContext: renderContext)
         
         for identifier in context.knownPages {
-            let source = context.documentURL(for: identifier)
             let entity = try context.entity(with: identifier)
-            let renderNodeFirst = try XCTUnwrap(converter.renderNode(for: entity, at: source))
-            let renderNodeSecond = try XCTUnwrap(converter.renderNode(for: entity, at: source))
+            let renderNodeFirst = try XCTUnwrap(converter.renderNode(for: entity))
+            let renderNodeSecond = try XCTUnwrap(converter.renderNode(for: entity))
             
             let differences = renderNodeSecond._difference(from: renderNodeFirst)
             XCTAssertTrue(differences.isEmpty, "Both render nodes should be identical.")
@@ -310,9 +309,8 @@ class RenderNodeDiffingBundleTests: XCTestCase {
                                                                                    sourceLanguage: .swift))
         var renderContext = RenderContext(documentationContext: contextOriginal, bundle: bundleOriginal)
         var converter = DocumentationContextConverter(bundle: bundleOriginal, context: contextOriginal, renderContext: renderContext)
-        var fileURL = try XCTUnwrap(contextOriginal.documentURL(for: nodeOriginal.reference))
         
-        let renderNodeOriginal = try XCTUnwrap(converter.renderNode(for: nodeOriginal, at: fileURL))
+        let renderNodeOriginal = try XCTUnwrap(converter.renderNode(for: nodeOriginal))
         
         // Make copy of the bundle on disk, modify the document, and write it
         let (_, bundleModified, contextModified) = try testBundleAndContext(copying: bundleName) { url in
@@ -323,9 +321,8 @@ class RenderNodeDiffingBundleTests: XCTestCase {
                                                                                    sourceLanguage: .swift))
         renderContext = RenderContext(documentationContext: contextModified, bundle: bundleModified)
         converter = DocumentationContextConverter(bundle: bundleModified, context: contextModified, renderContext: renderContext)
-        fileURL = try XCTUnwrap(contextModified.documentURL(for: nodeModified.reference))
         
-        let renderNodeModified = try XCTUnwrap(converter.renderNode(for: nodeModified, at: fileURL))
+        let renderNodeModified = try XCTUnwrap(converter.renderNode(for: nodeModified))
         
         let differences = renderNodeModified._difference(from: renderNodeOriginal)
         

--- a/Tests/SwiftDocCTests/Model/RenderNodeSerializationTests.swift
+++ b/Tests/SwiftDocCTests/Model/RenderNodeSerializationTests.swift
@@ -108,7 +108,7 @@ class RenderNodeSerializationTests: XCTestCase {
         
         XCTAssertEqual(problems.count, 1, "Found problems \(problems.map { DiagnosticConsoleWriter.formattedDescription(for: $0.diagnostic) }) analyzing tutorial markup")
         
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         
         let renderNode = translator.visit(tutorial) as! RenderNode
         checkRoundTrip(renderNode)
@@ -131,7 +131,7 @@ class RenderNodeSerializationTests: XCTestCase {
         
         XCTAssertEqual(problems.count, 0, "Found problems \(problems.map { DiagnosticConsoleWriter.formattedDescription(for: $0.diagnostic) }) analyzing article markup")
         
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         
         let renderNode = translator.visit(article) as! RenderNode
         checkRoundTrip(renderNode)
@@ -156,7 +156,7 @@ class RenderNodeSerializationTests: XCTestCase {
         
         XCTAssertEqual(problems.count, 1, "Found problems \(problems.map { DiagnosticConsoleWriter.formattedDescription(for: $0.diagnostic) }) analyzing tutorial markup")
         
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         
         let renderNode = translator.visit(tutorial) as! RenderNode
         let data = try encode(renderNode: renderNode)
@@ -206,7 +206,7 @@ class RenderNodeSerializationTests: XCTestCase {
             return
         }
 
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
 
         var renderNode = translator.visit(article) as! RenderNode
 

--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeMultiLanguageTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeMultiLanguageTests.swift
@@ -448,7 +448,7 @@ class SemaToRenderNodeMixedLanguageTests: XCTestCase {
         
         XCTAssert(context.problems.isEmpty, "Encountered unexpected problems: \(context.problems)")
         
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = try XCTUnwrap(translator.visit(symbol) as? RenderNode)
         
         XCTAssert(context.problems.isEmpty, "Encountered unexpected problems: \(context.problems)")

--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
@@ -32,7 +32,7 @@ class SemaToRenderNodeTests: XCTestCase {
         
         XCTAssertEqual(problems.count, 1, "Found problems \(DiagnosticConsoleWriter.formattedDescription(for: problems)) analyzing tutorial markup")
         
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         
         let renderNode = translator.visit(tutorial) as! RenderNode
         
@@ -417,7 +417,7 @@ class SemaToRenderNodeTests: XCTestCase {
                 return
             }
             
-            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
             let renderNode = translator.visit(tutorial) as! RenderNode
             let intro = renderNode.sections.compactMap { $0 as? IntroRenderSection }.first!
             XCTAssertEqual(RenderReferenceIdentifier(backgroundIdentifier), intro.backgroundImage)
@@ -436,7 +436,7 @@ class SemaToRenderNodeTests: XCTestCase {
         
         let article = node.semantic as! TutorialArticle
         
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         
         let renderNode = translator.visit(article) as! RenderNode
         
@@ -586,7 +586,7 @@ class SemaToRenderNodeTests: XCTestCase {
         // Verify we emit a diagnostic for the chapter with no tutorial references.
         XCTAssertEqual(problems.count, expectedProblemsCount, "Found problems \(DiagnosticConsoleWriter.formattedDescription(for: problems)) analyzing tutorial markup")
         
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         
         let renderNode = translator.visit(technology) as! RenderNode
         
@@ -822,7 +822,7 @@ class SemaToRenderNodeTests: XCTestCase {
         
         XCTAssertEqual(problems.count, 0, "Found problems \(DiagnosticConsoleWriter.formattedDescription(for: problems)) analyzing tutorial markup")
         
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         
         let renderNode = translator.visit(technology) as! RenderNode
 
@@ -958,7 +958,7 @@ class SemaToRenderNodeTests: XCTestCase {
         
         let symbol = node.semantic as! Symbol
         
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         
         let renderNode = translator.visit(symbol) as! RenderNode
         guard renderNode.primaryContentSections.count == 4 else {
@@ -1250,7 +1250,7 @@ class SemaToRenderNodeTests: XCTestCase {
         XCTAssertNotNil(context.externalCache["s:10Foundation4DataV"])
         XCTAssertNotNil(context.externalCache["s:5Foundation0A5NSCodableP"])
         
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: myProtocol.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: myProtocol.reference)
 
         let renderNode = translator.visit(myProtocolSymbol) as! RenderNode
         guard renderNode.primaryContentSections.count == 4 else {
@@ -1334,7 +1334,7 @@ class SemaToRenderNodeTests: XCTestCase {
         let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/MyClass/myFunction()", sourceLanguage: .swift))
         
         let symbol = node.semantic as! Symbol
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         
         let renderNode = translator.visit(symbol) as! RenderNode
         guard let conf = renderNode.metadata.conformance else {
@@ -1354,7 +1354,7 @@ class SemaToRenderNodeTests: XCTestCase {
         let parent = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/MyClass", sourceLanguage: .swift))
         
         let parentSymbol = parent.semantic as! Symbol
-        var parentTranslator = RenderNodeTranslator(context: context, bundle: bundle, identifier: parent.reference, source: nil)
+        var parentTranslator = RenderNodeTranslator(context: context, bundle: bundle, identifier: parent.reference)
         
         let parentRenderNode = parentTranslator.visit(parentSymbol) as! RenderNode
         guard let functionReference = parentRenderNode.references["doc://org.swift.docc.example/documentation/MyKit/MyClass/myFunction()"] as? TopicRenderReference else {
@@ -1386,7 +1386,7 @@ class SemaToRenderNodeTests: XCTestCase {
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
         let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/MyProtocol", sourceLanguage: .swift))
         let symbol = node.semantic as! Symbol
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visit(symbol) as! RenderNode
         
         // Test conditional conformance for the conforming type
@@ -1408,7 +1408,7 @@ class SemaToRenderNodeTests: XCTestCase {
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
         let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/MyClass", sourceLanguage: .swift))
         let symbol = node.semantic as! Symbol
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visit(symbol) as! RenderNode
         
         // Test conditional conformance for the conforming type
@@ -1432,7 +1432,7 @@ class SemaToRenderNodeTests: XCTestCase {
         
         // Compile docs and verify contents
         let symbol = node.semantic as! Symbol
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
 
         let renderNode = translator.visit(symbol) as! RenderNode
 
@@ -1497,7 +1497,7 @@ class SemaToRenderNodeTests: XCTestCase {
         
         // Compile docs and verify contents
         let symbol = node.semantic as! Symbol
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         
         let renderNode = translator.visit(symbol) as! RenderNode
         
@@ -1558,7 +1558,7 @@ class SemaToRenderNodeTests: XCTestCase {
             
             // Compile docs and verify contents
             let symbol = node.semantic as! Symbol
-            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
             
             let renderNode = translator.visit(symbol) as! RenderNode
             
@@ -1596,7 +1596,7 @@ class SemaToRenderNodeTests: XCTestCase {
         
         XCTAssertTrue(problems.isEmpty)
         
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         
         let renderNode = translator.visit(tutorial) as! RenderNode
         
@@ -1709,7 +1709,7 @@ Document
         let document = Document(parsing: markupSource, options: [])
         let node = DocumentationNode(reference: ResolvedTopicReference(bundleIdentifier: "org.swift.docc", path: "/blah", sourceLanguage: .swift), kind: .article, sourceLanguage: .swift, name: .conceptual(title: "Title"), markup: document, semantic: Semantic())
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         
         XCTAssertNotNil(translator.visit(MarkupContainer(document.children)))
         }
@@ -1720,7 +1720,7 @@ Document
         
         // Compile docs and verify contents
         let symbol = node.semantic as! Symbol
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         
         let renderNode = translator.visit(symbol) as! RenderNode
         
@@ -1826,7 +1826,7 @@ Document
         let (_, bundle, context) = try loadBundle(from: targetURL)
         let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/Test-Bundle/article2", sourceLanguage: .swift))
         let article = node.semantic as! Article
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         return translator.visit(article) as! RenderNode
     }
     
@@ -1914,7 +1914,7 @@ Document
         
         // Not a beta platform
         do {
-            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference, source: nil)
+            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
             let renderNode = translator.visitSymbol(symbol) as! RenderNode
             
             // Verify platform beta was plumbed all the way to the render JSON
@@ -1927,7 +1927,7 @@ Document
 
         // Different platform is beta
         do {
-            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference, source: nil)
+            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
             let renderNode = translator.visitSymbol(symbol) as! RenderNode
             
             // Verify platform beta was plumbed all the way to the render JSON
@@ -1938,7 +1938,7 @@ Document
         context.externalMetadata.currentPlatforms = ["macOS": PlatformVersion(VersionTriplet(100, 0, 0), beta: true)]
         
         do {
-            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference, source: nil)
+            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
             let renderNode = translator.visitSymbol(symbol) as! RenderNode
             
             // Verify platform beta was plumbed all the way to the render JSON
@@ -1949,7 +1949,7 @@ Document
         context.externalMetadata.currentPlatforms = ["macOS": PlatformVersion(VersionTriplet(10, 15, 0), beta: true)]
         
         do {
-            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference, source: nil)
+            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
             let renderNode = translator.visitSymbol(symbol) as! RenderNode
             
             // Verify platform beta was plumbed all the way to the render JSON
@@ -1968,7 +1968,7 @@ Document
             let node = try context.entity(with: reference)
             let symbol = node.semantic as! Symbol
             
-            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference, source: nil)
+            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
             let renderNode = translator.visitSymbol(symbol) as! RenderNode
             
             // Verify task group link is beta
@@ -1988,7 +1988,7 @@ Document
             let node = try context.entity(with: reference)
             let symbol = node.semantic as! Symbol
             
-            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference, source: nil)
+            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
             let renderNode = translator.visitSymbol(symbol) as! RenderNode
             
             // Verify task group link is beta
@@ -2011,7 +2011,7 @@ Document
             let node = try context.entity(with: reference)
             let symbol = node.semantic as! Symbol
 
-            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference, source: nil)
+            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
             let renderNode = translator.visitSymbol(symbol) as! RenderNode
             
             // Verify task group link is beta
@@ -2032,7 +2032,7 @@ Document
             let node = try context.entity(with: reference)
             let symbol = node.semantic as! Symbol
             
-            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference, source: nil)
+            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
             let renderNode = translator.visitSymbol(symbol) as! RenderNode
             
             // Verify task group link is beta
@@ -2056,7 +2056,7 @@ Document
         let node = try context.entity(with: reference)
         let symbol = node.semantic as! Symbol
         
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
         let renderNode = translator.visitSymbol(symbol) as! RenderNode
         
         // The reference is deprecated on all platforms
@@ -2080,7 +2080,7 @@ Document
         let node = try context.entity(with: reference)
         let symbol = node.semantic as! Symbol
         
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
         let renderNode = translator.visitSymbol(symbol) as! RenderNode
         
         // The reference is not deprecated on all platforms
@@ -2104,7 +2104,7 @@ Document
         let node = try context.entity(with: reference)
         let symbol = node.semantic as! Symbol
         
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
         let renderNode = translator.visitSymbol(symbol) as! RenderNode
         
         // Verify that the reference is deprecated on all platforms
@@ -2118,7 +2118,7 @@ Document
         let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/MyClass", sourceLanguage: .swift))
         
         let symbol = node.semantic as! Symbol
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         
         let renderNode = translator.visit(symbol) as! RenderNode
         guard let fragments = renderNode.metadata.fragments else {
@@ -2138,7 +2138,7 @@ Document
         let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/MyClass/myFunction()", sourceLanguage: .swift))
         
         let symbol = try XCTUnwrap(node.semantic as? Symbol)
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         
         let renderNode = try XCTUnwrap(translator.visit(symbol) as? RenderNode)
         XCTAssertEqual(renderNode.metadata.extendedModule, "MyKit")
@@ -2151,7 +2151,7 @@ Document
         do {
             let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/SideKit/SideProtocol", sourceLanguage: .swift))
             let symbol = node.semantic as! Symbol
-            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
             let renderNode = translator.visit(symbol) as! RenderNode
 
             guard let requiredFuncReference = renderNode.references["doc://org.swift.docc.example/documentation/SideKit/SideProtocol/func()-6ijsi"] else {
@@ -2167,7 +2167,7 @@ Document
         do {
             let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/SideKit/SideProtocol/func()-6ijsi", sourceLanguage: .swift))
             let symbol = node.semantic as! Symbol
-            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
             let renderNode = translator.visit(symbol) as! RenderNode
 
             // Verify that the render reference to a required symbol includes the 'required' key and the number of default implementations provided.
@@ -2187,7 +2187,7 @@ Document
         do {
             let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/SideKit/SideProtocol/func()-6ijsi", sourceLanguage: .swift))
             let symbol = node.semantic as! Symbol
-            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
             let renderNode = translator.visit(symbol) as! RenderNode
 
             // Test that default implementations are listed ONLY under Default Implementations and not Topics
@@ -2203,7 +2203,7 @@ Document
         let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/MyClass", sourceLanguage: .swift))
         
         let symbol = node.semantic as! Symbol
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         
         let renderNode = translator.visit(symbol) as! RenderNode
         let encoded = try JSONEncoder().encode(renderNode)
@@ -2232,7 +2232,7 @@ Document
         let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/MyClass", sourceLanguage: .swift))
         
         let symbol = node.semantic as! Symbol
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         
         let renderNode = translator.visit(symbol) as! RenderNode
         
@@ -2251,7 +2251,7 @@ Document
         let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit", sourceLanguage: .swift))
         
         let symbol = node.semantic as! Symbol
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         
         let renderNode = translator.visit(symbol) as! RenderNode
 
@@ -2271,7 +2271,7 @@ Document
         let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/tutorials/TestOverview", sourceLanguage: .swift))
         
         let symbol = node.semantic as! Technology
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         
         let renderNode = translator.visit(symbol) as! RenderNode
 
@@ -2297,7 +2297,7 @@ Document
         // Navigator title with trailing "\n"
         XCTAssertEqual(symbol.navigator?.count, 11)
 
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visit(symbol) as! RenderNode
 
         // Verify trailing newline removed from subheading
@@ -2313,7 +2313,7 @@ Document
         let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/Test-Bundle/article", sourceLanguage: .swift))
         
         let article = node.semantic as! Article
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         
         let renderNode = translator.visit(article) as! RenderNode
         
@@ -2335,7 +2335,7 @@ Document
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
         let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/MyClass/myFunction()", sourceLanguage: .swift))
         let symbol = node.semantic as! Symbol
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         
         let renderNode = translator.visit(symbol) as! RenderNode
         
@@ -2358,7 +2358,7 @@ Document
         let node = try context.entity(with: myFuncReference)
         let symbol = node.semantic as! Symbol
 
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         translator.collectedTopicReferences.append(myFuncReference)
         let renderNode = translator.visit(symbol) as! RenderNode
 
@@ -2374,7 +2374,7 @@ Document
         let node = try context.entity(with: myFuncReference)
         let symbol = node.semantic as! Symbol
 
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visit(symbol) as! RenderNode
 
         let renderReference = try XCTUnwrap(renderNode.references[myFuncReference.absoluteString] as? TopicRenderReference)
@@ -2442,7 +2442,7 @@ Document
         
         XCTAssert(problems.filter { $0.diagnostic.severity == .error }.isEmpty, "Found errors when analyzing Tutorials overview.")
         
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         
         // Verify we don't crash.
         _ = translator.visit(technology)
@@ -2460,7 +2460,7 @@ Document
                 return
             }
         
-            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
             XCTAssertNil(translator.visit(tutorial), "Render node for uncurated tutorial should not have been produced")
         }
     }
@@ -2534,7 +2534,7 @@ Document
         
         XCTAssert(problems.filter { $0.diagnostic.severity == .error }.isEmpty, "Found errors when analyzing tutorial.")
         
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         
         // Verify we don't crash.
         _ = translator.visit(tutorial)
@@ -2556,7 +2556,7 @@ Document
             let node = try context.entity(with: myFuncReference)
             let symbol = node.semantic as! Symbol
             
-            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
             let renderNode = translator.visit(symbol) as! RenderNode
             let asides = try XCTUnwrap(renderNode.primaryContentSections.first(where: { $0.kind == .content }) as? ContentRenderSection)
             
@@ -2602,7 +2602,7 @@ Document
         
         // Verify that by default we inherit docs.
         do {
-            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
             let renderNode = try XCTUnwrap(translator.visit(symbol) as? RenderNode)
 
             // Verify the expected inherited abstract text.
@@ -2629,7 +2629,7 @@ Document
         
         // Verify that by default we inherit docs.
         do {
-            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
             let renderNode = try XCTUnwrap(translator.visit(symbol) as? RenderNode)
 
             // Verify the expected default abstract text.
@@ -2655,7 +2655,7 @@ Document
         
         // Verify that by default we don't inherit docs and we generate default abstract.
         do {
-            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
             let renderNode = try XCTUnwrap(translator.visit(symbol) as? RenderNode)
 
             // Verify the expected default abstract text.
@@ -2684,7 +2684,7 @@ Document
         
         // Verify the doc extension was matched to the inherited symbol.
         do {
-            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
             let renderNode = try XCTUnwrap(translator.visit(symbol) as? RenderNode)
 
             // Verify the expected default abstract text.
@@ -2829,7 +2829,7 @@ Document
             
             // Verify the doc extension was matched to the inherited symbol.
             do {
-                var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+                var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
                 let renderNode = try XCTUnwrap(translator.visit(symbol) as? RenderNode)
                 
                 // Verify the expected default abstract text.
@@ -2858,7 +2858,7 @@ Document
         
         // Verify that by default we don't inherit docs and we generate default abstract.
         do {
-            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
             let renderNode = try XCTUnwrap(translator.visit(symbol) as? RenderNode)
 
             // Verify the expected default abstract text.
@@ -2891,7 +2891,7 @@ Document
         let node = try context.entity(with: reference)
         let symbol = try XCTUnwrap(node.semantic as? Symbol)
 
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = try XCTUnwrap(translator.visit(symbol) as? RenderNode)
 
         // Verify that an undocumented symbol gets a nil abstract.
@@ -3005,7 +3005,7 @@ Document
         let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit", sourceLanguage: .swift))
         let symbol = try XCTUnwrap(node.semantic as? Symbol)
         
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = try XCTUnwrap(translator.visit(symbol) as? RenderNode)
         
         let reference = try XCTUnwrap(renderNode.references["doc://org.swift.docc.example/documentation/MyKit/MyProtocol"] as? TopicRenderReference)
@@ -3058,7 +3058,7 @@ Document
             XCTAssertEqual(titleVariant.variant, "My custom conceptual name")
         }
         
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: moduleNode.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: moduleNode.reference)
         let moduleRenderNode = try XCTUnwrap(translator.visit(moduleSymbol) as? RenderNode)
         
         XCTAssertEqual(moduleRenderNode.metadata.title, "My custom conceptual name")
@@ -3104,7 +3104,7 @@ Document
         
         let functionNode = try context.entity(with: functionReference)
         let functionSymbol = try XCTUnwrap(functionNode.semantic as? Symbol)
-        translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: functionNode.reference, source: nil)
+        translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: functionNode.reference)
         let functionRenderNode = try XCTUnwrap(translator.visit(functionSymbol) as? RenderNode)
         XCTAssertTrue(functionRenderNode.metadata.modulesVariants.variants.isEmpty)
         // Test that the symbol name `MyKit` is not added as a related module.
@@ -3175,7 +3175,7 @@ Document
             XCTFail("Couldn't create technology from markup: \(problems)")
             return
         }
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = try XCTUnwrap(translator.visit(technology) as? RenderNode)
         XCTAssertEqual(renderNode.references.count, 5)
         XCTAssertNotNil(renderNode.references["doc://org.swift.docc.example/tutorials/Test-Bundle/TestTutorial"] as? TopicRenderReference)
@@ -3217,7 +3217,7 @@ Document
         
         let moduleNode = try context.entity(with: moduleReference)
         
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: moduleNode.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: moduleNode.reference)
         let moduleRenderNode = try XCTUnwrap(translator.visit(moduleNode.semantic) as? RenderNode)
         
         XCTAssertEqual(
@@ -3260,7 +3260,7 @@ Document
         
         let articleNode = try context.entity(with: articleReference)
         
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: articleNode.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: articleNode.reference)
         let articleRenderNode = try XCTUnwrap(translator.visit(articleNode.semantic) as? RenderNode)
         
         XCTAssertEqual(

--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
@@ -3314,7 +3314,7 @@ Document
         XCTAssertEqual(documentationNode.availableVariantTraits.count, 2, "This page has Swift and Objective-C variants")
         
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
-        let renderNode = try converter.convert(documentationNode, at: nil)
+        let renderNode = try converter.convert(documentationNode)
         
         let topicSectionsVariants = renderNode.topicSectionsVariants
         
@@ -3376,7 +3376,7 @@ Document
         XCTAssertEqual(documentationNode.availableVariantTraits.count, 1)
         
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
-        let renderNode = try converter.convert(documentationNode, at: nil)
+        let renderNode = try converter.convert(documentationNode)
         
         let topicSection = renderNode.topicSectionsVariants.defaultValue
         
@@ -3395,7 +3395,7 @@ Document
             let node = try context.entity(with: root)
             
             let converter = DocumentationNodeConverter(bundle: bundle, context: context)
-            let renderNode = try converter.convert(node, at: nil)
+            let renderNode = try converter.convert(node)
             
             let swiftTopicSections = renderNode.topicSectionsVariants.defaultValue
             XCTAssertEqual(swiftTopicSections.flatMap { [$0.title!] + $0.identifiers }, [
@@ -3428,7 +3428,7 @@ Document
             let node = try context.entity(with: reference)
             
             let converter = DocumentationNodeConverter(bundle: bundle, context: context)
-            let renderNode = try converter.convert(node, at: nil)
+            let renderNode = try converter.convert(node)
             
             let swiftTopicSections = renderNode.topicSectionsVariants.defaultValue
             XCTAssertEqual(swiftTopicSections.flatMap { [$0.title!] + $0.identifiers }, [

--- a/Tests/SwiftDocCTests/Rendering/AutomaticSeeAlsoTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/AutomaticSeeAlsoTests.swift
@@ -31,7 +31,7 @@ class AutomaticSeeAlsoTests: XCTestCase {
         
         // Get a translated render node
         let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/SideKit/SideClass", sourceLanguage: .swift))
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode
         
         // Verify there is no See Also
@@ -62,7 +62,7 @@ class AutomaticSeeAlsoTests: XCTestCase {
         
         // Get a translated render node
         let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/SideKit/SideClass", sourceLanguage: .swift))
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode
         
         // Verify there is an authored See Also from markdown
@@ -105,7 +105,7 @@ class AutomaticSeeAlsoTests: XCTestCase {
         
         // Get a translated render node
         let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/SideKit/SideClass", sourceLanguage: .swift))
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode
         
         // Verify there is an authored See Also & automatically created See Also
@@ -122,7 +122,7 @@ class AutomaticSeeAlsoTests: XCTestCase {
         // Verify that articles get same automatic See Also sections as symbols
         do {
             let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/Test-Bundle/sidearticle", sourceLanguage: .swift))
-            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
             let renderNode = translator.visit(node.semantic as! Article) as! RenderNode
             
             // Verify there is an automacially created See Also
@@ -172,7 +172,7 @@ class AutomaticSeeAlsoTests: XCTestCase {
         
         // Get a translated render node
         let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/SideKit/SideClass", sourceLanguage: .swift))
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode
         
         // Verify there is an authored See Also but no automatically created See Also
@@ -185,7 +185,7 @@ class AutomaticSeeAlsoTests: XCTestCase {
         // Verify that article without options directive still gets automatic See Also sections
         do {
             let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/Test-Bundle/sidearticle", sourceLanguage: .swift))
-            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
             let renderNode = translator.visit(node.semantic as! Article) as! RenderNode
             
             // Verify there is an automacially created See Also
@@ -236,7 +236,7 @@ class AutomaticSeeAlsoTests: XCTestCase {
         
         // Get a translated render node
         let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/SideKit/SideClass", sourceLanguage: .swift))
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode
         
         // Verify there is an authored See Also but no automatically created See Also
@@ -249,7 +249,7 @@ class AutomaticSeeAlsoTests: XCTestCase {
         // Verify that article without options directive still gets automatic See Also sections
         do {
             let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/Test-Bundle/sidearticle", sourceLanguage: .swift))
-            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
             let renderNode = translator.visit(node.semantic as! Article) as! RenderNode
             
             // Verify there is an automacially created See Also
@@ -287,7 +287,7 @@ class AutomaticSeeAlsoTests: XCTestCase {
         
         // Get a translated render node
         let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: "MyKit", path: "/documentation/MyKit/MyClass/myFunction()", sourceLanguage: .swift))
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode
         
         // Verify there is a See Also with the resolved tutorial reference

--- a/Tests/SwiftDocCTests/Rendering/AvailabilityRenderOrderTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/AvailabilityRenderOrderTests.swift
@@ -26,7 +26,7 @@ class AvailabilityRenderOrderTests: XCTestCase {
 
         let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/Availability/MyStruct", sourceLanguage: .swift))
         
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode
         
         // Verify that all the symbol's availabilities were sorted into the order

--- a/Tests/SwiftDocCTests/Rendering/ConstraintsRenderSectionTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/ConstraintsRenderSectionTests.swift
@@ -42,7 +42,7 @@ class ConstraintsRenderSectionTests: XCTestCase {
         // Compile docs and verify contents
         let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/MyClass", sourceLanguage: .swift))
         let symbol = node.semantic as! Symbol
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visitSymbol(symbol) as! RenderNode
         
         XCTAssertEqual(renderNode.metadata.conformance?.constraints.map(flattenInlineElements).joined(), "Label is Text.")
@@ -72,7 +72,7 @@ class ConstraintsRenderSectionTests: XCTestCase {
         // Compile docs and verify contents
         let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/MyClass", sourceLanguage: .swift))
         let symbol = node.semantic as! Symbol
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visitSymbol(symbol) as! RenderNode
         XCTAssertNil(renderNode.metadata.conformance)
     }
@@ -101,7 +101,7 @@ class ConstraintsRenderSectionTests: XCTestCase {
         // Compile docs and verify contents
         let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/MyClass/myFunction()", sourceLanguage: .swift))
         let symbol = node.semantic as! Symbol
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visitSymbol(symbol) as! RenderNode
         XCTAssertNil(renderNode.metadata.conformance)
     }
@@ -131,7 +131,7 @@ class ConstraintsRenderSectionTests: XCTestCase {
         // Compile docs and verify contents
         let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/MyClass/myFunction()", sourceLanguage: .swift))
         let symbol = node.semantic as! Symbol
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visitSymbol(symbol) as! RenderNode
         XCTAssertEqual(renderNode.metadata.conformance?.constraints.map(flattenInlineElements).joined(), "Element is MyClass.")
     }
@@ -161,7 +161,7 @@ class ConstraintsRenderSectionTests: XCTestCase {
         // Compile docs and verify contents
         let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/MyClass/myFunction()", sourceLanguage: .swift))
         let symbol = node.semantic as! Symbol
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visitSymbol(symbol) as! RenderNode
         XCTAssertEqual(renderNode.metadata.conformance?.constraints.map(flattenInlineElements).joined(), "Element conforms to MyProtocol and Equatable.")
     }
@@ -192,7 +192,7 @@ class ConstraintsRenderSectionTests: XCTestCase {
         // Compile docs and verify contents
         let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/MyClass/myFunction()", sourceLanguage: .swift))
         let symbol = node.semantic as! Symbol
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visitSymbol(symbol) as! RenderNode
         XCTAssertEqual(renderNode.metadata.conformance?.constraints.map(flattenInlineElements).joined(), "Element conforms to MyProtocol, Equatable, and Hashable.")
     }
@@ -222,7 +222,7 @@ class ConstraintsRenderSectionTests: XCTestCase {
         // Compile docs and verify contents
         let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/MyClass", sourceLanguage: .swift))
         let symbol = node.semantic as! Symbol
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visitSymbol(symbol) as! RenderNode
         
         guard let renderReference = renderNode.references.first(where: { (key, value) -> Bool in
@@ -260,7 +260,7 @@ class ConstraintsRenderSectionTests: XCTestCase {
         // Compile docs and verify contents
         let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/MyClass", sourceLanguage: .swift))
         let symbol = node.semantic as! Symbol
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visitSymbol(symbol) as! RenderNode
         
         guard let renderReference = renderNode.references.first(where: { (key, value) -> Bool in

--- a/Tests/SwiftDocCTests/Rendering/DeclarationsRenderSectionTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/DeclarationsRenderSectionTests.swift
@@ -180,12 +180,7 @@ class DeclarationsRenderSectionTests: XCTestCase {
                 sourceLanguage: .swift
             )
             let symbol = try XCTUnwrap(context.entity(with: reference).semantic as? Symbol)
-            var translator = RenderNodeTranslator(
-                context: context,
-                bundle: bundle,
-                identifier: reference,
-                source: nil
-            )
+            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
             let renderNode = try XCTUnwrap(translator.visitSymbol(symbol) as? RenderNode)
             let declarationsSection = try XCTUnwrap(renderNode.primaryContentSections.compactMap({ $0 as? DeclarationsRenderSection }).first)
             XCTAssertEqual(declarationsSection.declarations.count, 1)
@@ -236,12 +231,7 @@ class DeclarationsRenderSectionTests: XCTestCase {
                 sourceLanguage: .swift
             )
             let symbol = try XCTUnwrap(context.entity(with: reference).semantic as? Symbol)
-            var translator = RenderNodeTranslator(
-                context: context,
-                bundle: bundle,
-                identifier: reference,
-                source: nil
-            )
+            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
             let renderNode = try XCTUnwrap(translator.visitSymbol(symbol) as? RenderNode)
             let declarationsSection = try XCTUnwrap(renderNode.primaryContentSections.compactMap({ $0 as? DeclarationsRenderSection }).first)
             XCTAssertEqual(declarationsSection.declarations.count, 1)
@@ -296,12 +286,7 @@ class DeclarationsRenderSectionTests: XCTestCase {
                 sourceLanguage: .swift
             )
             let symbol = try XCTUnwrap(context.entity(with: reference).semantic as? Symbol)
-            var translator = RenderNodeTranslator(
-                context: context,
-                bundle: bundle,
-                identifier: reference,
-                source: nil
-            )
+            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
             let renderNode = try XCTUnwrap(translator.visitSymbol(symbol) as? RenderNode)
             let declarationsSection = try XCTUnwrap(renderNode.primaryContentSections.compactMap({ $0 as? DeclarationsRenderSection }).first)
             XCTAssertEqual(declarationsSection.declarations.count, 1)
@@ -351,12 +336,7 @@ class DeclarationsRenderSectionTests: XCTestCase {
                 sourceLanguage: .swift
             )
             let symbol = try XCTUnwrap(context.entity(with: reference).semantic as? Symbol)
-            var translator = RenderNodeTranslator(
-                context: context,
-                bundle: bundle,
-                identifier: reference,
-                source: nil
-            )
+            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
             let renderNode = try XCTUnwrap(translator.visitSymbol(symbol) as? RenderNode)
             let declarationsSection = try XCTUnwrap(renderNode.primaryContentSections.compactMap({ $0 as? DeclarationsRenderSection }).first)
             XCTAssertEqual(declarationsSection.declarations.count, 1)

--- a/Tests/SwiftDocCTests/Rendering/DeclarationsRenderSectionTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/DeclarationsRenderSectionTests.swift
@@ -139,12 +139,7 @@ class DeclarationsRenderSectionTests: XCTestCase {
             sourceLanguage: .swift
         )
         let symbol = try XCTUnwrap(context.entity(with: reference).semantic as? Symbol)
-        var translator = RenderNodeTranslator(
-            context: context,
-            bundle: bundle,
-            identifier: reference,
-            source: nil
-        )
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
         let renderNode = try XCTUnwrap(translator.visitSymbol(symbol) as? RenderNode)
         let declarationsSection = try XCTUnwrap(renderNode.primaryContentSections.compactMap({ $0 as? DeclarationsRenderSection }).first)
 

--- a/Tests/SwiftDocCTests/Rendering/DefaultAvailabilityTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/DefaultAvailabilityTests.swift
@@ -71,9 +71,8 @@ class DefaultAvailabilityTests: XCTestCase {
         // Test if the default availability is used for modules
         do {
             let identifier = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit", fragment: nil, sourceLanguage: .swift)
-            let source = context.documentURL(for: identifier)
             let node = try context.entity(with: identifier)
-            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: source)
+            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
             let renderNode = translator.visit(node.semantic) as! RenderNode
             
             XCTAssertEqual(renderNode.metadata.platforms?.map({ "\($0.name ?? "") \($0.introduced ?? "")" }).sorted(), expectedDefaultAvailability)
@@ -82,9 +81,8 @@ class DefaultAvailabilityTests: XCTestCase {
         // Test if the default availability is used for symbols with no explicit availability
         do {
             let identifier = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit/MyClass/init()-3743d", fragment: nil, sourceLanguage: .swift)
-            let source = context.documentURL(for: identifier)
             let node = try context.entity(with: identifier)
-            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: source)
+            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
             let renderNode = translator.visit(node.semantic) as! RenderNode
             
             XCTAssertEqual(renderNode.metadata.platforms?.map({ "\($0.name ?? "") \($0.introduced ?? "")" }).sorted(), [expectedDefaultAvailability.last ?? ""])
@@ -93,9 +91,8 @@ class DefaultAvailabilityTests: XCTestCase {
         // Test if the default availability is NOT used for symbols with explicit availability
         do {
             let identifier = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit/MyClass", fragment: nil, sourceLanguage: .swift)
-            let source = context.documentURL(for: identifier)
             let node = try context.entity(with: identifier)
-            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: source)
+            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
             let renderNode = translator.visit(node.semantic) as! RenderNode
             
             XCTAssertNotEqual(renderNode.metadata.platforms?.map({ "\($0.name ?? "") \($0.introduced ?? "")" }), expectedDefaultAvailability)
@@ -120,9 +117,8 @@ class DefaultAvailabilityTests: XCTestCase {
         // verify that the Mac Catalyst platform's name (including a space) is rendered correctly
         do {
             let identifier = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit", fragment: nil, sourceLanguage: .swift)
-            let source = context.documentURL(for: identifier)
             let node = try context.entity(with: identifier)
-            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: source)
+            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
             let renderNode = translator.visit(node.semantic) as! RenderNode
             
             XCTAssertEqual(renderNode.metadata.platforms?.map({ "\($0.name ?? "") \($0.introduced ?? "")\($0.isBeta == true ? "(beta)" : "")" }).sorted(), [
@@ -136,9 +132,8 @@ class DefaultAvailabilityTests: XCTestCase {
         // Test whether we:
         // 1) Fallback on iOS when Mac Catalyst availability is missing
         // 2) Render [Beta] or not for Mac Catalyst's inherited iOS availability
-        let source = context.documentURL(for: reference)
         let node = try context.entity(with: reference)
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference, source: source)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
         let renderNode = translator.visit(node.semantic) as! RenderNode
         
         XCTAssertEqual(renderNode.metadata.platforms?.map({ "\($0.name ?? "") \($0.introduced ?? "")\($0.isBeta == true ? "(beta)" : "")" }).sorted(), expected, file: (file), line: line)
@@ -203,9 +198,8 @@ class DefaultAvailabilityTests: XCTestCase {
         // Test if the module availability is not "beta" for the "macOS" platform (since 10.15.1 != 10.16)
         do {
             let identifier = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit", fragment: nil, sourceLanguage: .swift)
-            let source = context.documentURL(for: identifier)
             let node = try context.entity(with: identifier)
-            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: source)
+            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
             let renderNode = translator.visit(node.semantic) as! RenderNode
             
             XCTAssertEqual(renderNode.metadata.platforms?.map({ "\($0.name ?? "") \($0.introduced ?? "")\($0.isBeta == true ? "(beta)" : "")" }).sorted(), [
@@ -224,7 +218,6 @@ class DefaultAvailabilityTests: XCTestCase {
         
         do {
             let identifier = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit/MyClass/myFunction()", fragment: nil, sourceLanguage: .swift)
-            let source = context.documentURL(for: identifier)
             let node = try context.entity(with: identifier)
             
             // Add some available and unavailable platforms to the symbol
@@ -237,7 +230,7 @@ class DefaultAvailabilityTests: XCTestCase {
                 SymbolGraph.Symbol.Availability.AvailabilityItem(domain: .init(rawValue: "macOS"), introducedVersion: nil, deprecatedVersion: nil, obsoletedVersion: nil, message: nil, renamed: nil, isUnconditionallyDeprecated: false, isUnconditionallyUnavailable: true, willEventuallyBeDeprecated: false),
             ])
             
-            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: source)
+            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
             let renderNode = translator.visit(node.semantic) as! RenderNode
             
             // Verify that the 'watchOS' & 'tvOS' platforms are filtered out because the symbol is unavailable
@@ -363,12 +356,7 @@ class DefaultAvailabilityTests: XCTestCase {
         
         // Compile docs and verify contents
         let symbol = node.semantic as! Symbol
-        var translator = RenderNodeTranslator(
-            context: context,
-            bundle: bundle,
-            identifier: node.reference,
-            source: nil
-        )
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         
         guard let renderNode = translator.visit(symbol) as? RenderNode else {
             XCTFail("Could not compile the node")

--- a/Tests/SwiftDocCTests/Rendering/DefaultCodeListingSyntaxTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/DefaultCodeListingSyntaxTests.swift
@@ -27,10 +27,8 @@ class DefaultCodeBlockSyntaxTests: XCTestCase {
         func renderSection(for bundle: DocumentationBundle, in context: DocumentationContext) throws -> ContentRenderSection {
             let identifier = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/Test-Bundle/Default-Code-Listing-Syntax", fragment: nil, sourceLanguage: .swift)
 
-            let source = context.documentURL(for: identifier)
-
             let node = try context.entity(with: identifier)
-            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: source)
+            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
             let renderNode = translator.visit(node.semantic) as! RenderNode
 
             return renderNode.primaryContentSections.first! as! ContentRenderSection

--- a/Tests/SwiftDocCTests/Rendering/DeprecationSummaryTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/DeprecationSummaryTests.swift
@@ -36,7 +36,7 @@ class DeprecationSummaryTests: XCTestCase {
         
         // Compile docs and verify contents
         let symbol = node.semantic as! Symbol
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         
         guard let renderNode = translator.visit(symbol) as? RenderNode else {
             XCTFail("Could not compile the node")
@@ -71,7 +71,7 @@ class DeprecationSummaryTests: XCTestCase {
         
         // Compile docs and verify contents
         let symbol = node.semantic as! Symbol
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         
         guard let renderNode = translator.visit(symbol) as? RenderNode else {
             XCTFail("Could not compile the node")
@@ -99,12 +99,7 @@ class DeprecationSummaryTests: XCTestCase {
 
         // Compile docs and verify contents
         let symbol = node.semantic as! Symbol
-        var translator = RenderNodeTranslator(
-            context: context,
-            bundle: bundle,
-            identifier: node.reference,
-            source: nil
-        )
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
 
         guard let renderNode = translator.visit(symbol) as? RenderNode else {
             XCTFail("Could not compile the node")
@@ -138,12 +133,7 @@ class DeprecationSummaryTests: XCTestCase {
         
         // Compile docs and verify contents
         let symbol = node.semantic as! Symbol
-        var translator = RenderNodeTranslator(
-            context: context,
-            bundle: bundle,
-            identifier: node.reference,
-            source: nil
-        )
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         
         guard let renderNode = translator.visit(symbol) as? RenderNode else {
             XCTFail("Could not compile the node")
@@ -170,12 +160,7 @@ class DeprecationSummaryTests: XCTestCase {
       
       // Compile docs and verify contents
       let symbol = node.semantic as! Symbol
-      var translator = RenderNodeTranslator(
-          context: context,
-          bundle: bundle,
-          identifier: node.reference,
-          source: nil
-      )
+      var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
       
       guard let renderNode = translator.visit(symbol) as? RenderNode else {
           XCTFail("Could not compile the node")

--- a/Tests/SwiftDocCTests/Rendering/ExternalLinkTitleTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/ExternalLinkTitleTests.swift
@@ -25,7 +25,7 @@ public class ExternalLinkTitleTests: XCTestCase {
         
         
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let result = translator.visit(MarkupContainer(document.children)) as! [RenderBlockContent]
         
         return (translator, result)

--- a/Tests/SwiftDocCTests/Rendering/HeadingAnchorTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/HeadingAnchorTests.swift
@@ -40,7 +40,7 @@ class HeadingAnchorTests: XCTestCase {
         let node = try context.entity(with: reference)
         let renderContext = RenderContext(documentationContext: context, bundle: bundle)
         let converter = DocumentationContextConverter(bundle: bundle, context: context, renderContext: renderContext)
-        let renderNode = try XCTUnwrap(converter.renderNode(for: node, at: nil))
+        let renderNode = try XCTUnwrap(converter.renderNode(for: node))
 
         // Check heading anchors are encoded
         let contentSection = try XCTUnwrap(renderNode.primaryContentSections.first as? ContentRenderSection)

--- a/Tests/SwiftDocCTests/Rendering/MentionsRenderSectionTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/MentionsRenderSectionTests.swift
@@ -28,9 +28,8 @@ class MentionsRenderSectionTests: XCTestCase {
             path: "/documentation/MentionedIn/ArticleMentioningSymbol",
             sourceLanguage: .swift
         )
-        let source = context.documentURL(for: identifier)
         let node = try context.entity(with: identifier)
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: source)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visit(node.semantic) as! RenderNode
         let mentionsSection = try XCTUnwrap(renderNode.primaryContentSections.mapFirst { $0 as? MentionsRenderSection })
         XCTAssertEqual(1, mentionsSection.mentions.count)
@@ -47,9 +46,8 @@ class MentionsRenderSectionTests: XCTestCase {
             path: "/documentation/MentionedIn/MyClass/myFunction()",
             sourceLanguage: .swift
         )
-        let source = context.documentURL(for: identifier)
         let node = try context.entity(with: identifier)
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: source)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visit(node.semantic) as! RenderNode
         let mentionsSection = renderNode.primaryContentSections.mapFirst { $0 as? MentionsRenderSection }
         XCTAssertNil(mentionsSection)

--- a/Tests/SwiftDocCTests/Rendering/PageKindTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/PageKindTests.swift
@@ -23,12 +23,7 @@ class PageKindTests: XCTestCase {
             sourceLanguage: .swift
         )
         let article = try XCTUnwrap(context.entity(with: reference).semantic as? Article)
-        var translator = RenderNodeTranslator(
-            context: context,
-            bundle: bundle,
-            identifier: reference,
-            source: nil
-        )
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
         return try XCTUnwrap(translator.visitArticle(article) as? RenderNode)
     }
     

--- a/Tests/SwiftDocCTests/Rendering/PlatformAvailabilityTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/PlatformAvailabilityTests.swift
@@ -41,12 +41,7 @@ class PlatformAvailabilityTests: XCTestCase {
             sourceLanguage: .swift
         )
         let article = try XCTUnwrap(context.entity(with: reference).semantic as? Article)
-        var translator = RenderNodeTranslator(
-            context: context,
-            bundle: bundle,
-            identifier: reference,
-            source: nil
-        )
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
         let renderNode = try XCTUnwrap(translator.visitArticle(article) as? RenderNode)
         let availability = try XCTUnwrap(renderNode.metadata.platformsVariants.defaultValue)
         XCTAssertEqual(availability.count, 1)
@@ -64,12 +59,7 @@ class PlatformAvailabilityTests: XCTestCase {
             sourceLanguage: .swift
         )
         let symbol = try XCTUnwrap(context.entity(with: reference).semantic as? Symbol)
-        var translator = RenderNodeTranslator(
-            context: context,
-            bundle: bundle,
-            identifier: reference,
-            source: nil
-        )
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
         let renderNode = try XCTUnwrap(translator.visitSymbol(symbol) as? RenderNode)
         let availability = try XCTUnwrap(renderNode.metadata.platformsVariants.defaultValue)
         XCTAssertEqual(availability.count, 1)
@@ -86,12 +76,7 @@ class PlatformAvailabilityTests: XCTestCase {
             sourceLanguage: .swift
         )
         let article = try XCTUnwrap(context.entity(with: reference).semantic as? Article)
-        var translator = RenderNodeTranslator(
-            context: context,
-            bundle: bundle,
-            identifier: reference,
-            source: nil
-        )
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
         let renderNode = try XCTUnwrap(translator.visitArticle(article) as? RenderNode)
         let availability = try XCTUnwrap(renderNode.metadata.platformsVariants.defaultValue)
         XCTAssertEqual(availability.count, 3)
@@ -115,12 +100,7 @@ class PlatformAvailabilityTests: XCTestCase {
             sourceLanguage: .swift
         )
         let article = try XCTUnwrap(context.entity(with: reference).semantic as? Article)
-        var translator = RenderNodeTranslator(
-            context: context,
-            bundle: bundle,
-            identifier: reference,
-            source: nil
-        )
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
         let renderNode = try XCTUnwrap(translator.visitArticle(article) as? RenderNode)
         let availability = try XCTUnwrap(renderNode.metadata.platformsVariants.defaultValue)
         XCTAssertEqual(availability.count, 2)
@@ -143,12 +123,7 @@ class PlatformAvailabilityTests: XCTestCase {
             sourceLanguage: .swift
         )
         let symbol = try XCTUnwrap(context.entity(with: reference).semantic as? Symbol)
-        var translator = RenderNodeTranslator(
-            context: context,
-            bundle: bundle,
-            identifier: reference,
-            source: nil
-        )
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
         let renderNode = try XCTUnwrap(translator.visitSymbol(symbol) as? RenderNode)
         let availability = try XCTUnwrap(renderNode.metadata.platformsVariants.defaultValue)
         XCTAssertEqual(availability.count, 5)

--- a/Tests/SwiftDocCTests/Rendering/PlatformAvailabilityTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/PlatformAvailabilityTests.swift
@@ -171,12 +171,7 @@ class PlatformAvailabilityTests: XCTestCase {
             sourceLanguage: .swift
         )
         let article = try XCTUnwrap(context.entity(with: reference).semantic as? Article)
-        var translator = RenderNodeTranslator(
-            context: context,
-            bundle: bundle,
-            identifier: reference,
-            source: nil
-        )
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
         let renderNode = try XCTUnwrap(translator.visitArticle(article) as? RenderNode)
         let availability = try XCTUnwrap(renderNode.metadata.platformsVariants.defaultValue)
         XCTAssertEqual(availability.count, 1)
@@ -199,12 +194,7 @@ class PlatformAvailabilityTests: XCTestCase {
             sourceLanguage: .swift
         )
         let article = try XCTUnwrap(context.entity(with: reference).semantic as? Article)
-        var translator = RenderNodeTranslator(
-            context: context,
-            bundle: bundle,
-            identifier: reference,
-            source: nil
-        )
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
         let renderNode = try XCTUnwrap(translator.visitArticle(article) as? RenderNode)
         let availability = try XCTUnwrap(renderNode.metadata.platformsVariants.defaultValue)
         XCTAssertEqual(availability.count, 3)
@@ -236,12 +226,7 @@ class PlatformAvailabilityTests: XCTestCase {
             sourceLanguage: .swift
         )
         let symbol = try XCTUnwrap(context.entity(with: reference).semantic as? Symbol)
-        var translator = RenderNodeTranslator(
-            context: context,
-            bundle: bundle,
-            identifier: reference,
-            source: nil
-        )
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
         let renderNode = try XCTUnwrap(translator.visitSymbol(symbol) as? RenderNode)
         let availability = try XCTUnwrap(renderNode.metadata.platformsVariants.defaultValue)
         XCTAssertEqual(availability.count, 1)

--- a/Tests/SwiftDocCTests/Rendering/RenderMetadataTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/RenderMetadataTests.swift
@@ -152,7 +152,7 @@ class RenderMetadataTests: XCTestCase {
 
         // Get a translated render node
         let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/BundleWithRelativePathAmbiguity/Dependency/AmbiguousType", sourceLanguage: .swift))
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode
         XCTAssertEqual(renderNode.metadata.modules?.first?.name, "BundleWithRelativePathAmbiguity")
         XCTAssertEqual(renderNode.metadata.modules?.first?.relatedModules, ["Dependency"])

--- a/Tests/SwiftDocCTests/Rendering/RenderMetadataTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/RenderMetadataTests.swift
@@ -78,10 +78,8 @@ class RenderMetadataTests: XCTestCase {
             let renderContext = RenderContext(documentationContext: context, bundle: bundle)
             let converter = DocumentationContextConverter(bundle: bundle, context: context, renderContext: renderContext)
             for identifier in context.knownPages {
-                let source = context.documentURL(for: identifier)
-                
                 let entity = try context.entity(with: identifier)
-                let renderNode = try XCTUnwrap(converter.renderNode(for: entity, at: source))
+                let renderNode = try XCTUnwrap(converter.renderNode(for: entity))
                 
                 XCTAssertNotNil(renderNode.metadata.title, "Missing `title` in metadata for \(identifier.absoluteString) of kind \(entity.kind.id) in the \(bundleName) bundle")
                 
@@ -111,7 +109,7 @@ class RenderMetadataTests: XCTestCase {
         
         // Verify the rendered metadata contains the bystanders
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
-        let renderNode = try converter.convert(entity, at: nil)
+        let renderNode = try converter.convert(entity)
         XCTAssertEqual(renderNode.metadata.modules?.first?.name, "MyKit")
         XCTAssertEqual(renderNode.metadata.modules?.first?.relatedModules, ["Foundation"])
     }
@@ -138,7 +136,7 @@ class RenderMetadataTests: XCTestCase {
 
         // Verify the rendered metadata contains the bystanders
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
-        let renderNode = try converter.convert(entity, at: nil)
+        let renderNode = try converter.convert(entity)
         XCTAssertEqual(renderNode.metadata.modules?.first?.name, "OverlayTest")
         XCTAssertEqual(renderNode.metadata.modules?.first?.relatedModules, ["BaseKit"])
     }

--- a/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorSymbolVariantsTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorSymbolVariantsTests.swift
@@ -1168,12 +1168,7 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
         assertAfterApplyingVariant: (RenderNode) throws -> (),
         assertDataAfterApplyingVariant: (Data) throws -> () = { _ in }
     ) throws {
-        var translator = RenderNodeTranslator(
-            context: context,
-            bundle: bundle,
-            identifier: identifier,
-            source: nil
-        )
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: identifier)
         
         configureRenderNodeTranslator(&translator)
         

--- a/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorTests.swift
@@ -21,7 +21,7 @@ class RenderNodeTranslatorTests: XCTestCase {
         
         let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: forSymbolPath, sourceLanguage: .swift))
         
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode
         
         guard let section = renderNode.primaryContentSections.last(where: { section -> Bool in
@@ -294,7 +294,7 @@ class RenderNodeTranslatorTests: XCTestCase {
         let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/Test-Bundle/article", sourceLanguage: .swift)
         let node = try context.entity(with: reference)
         let article = try XCTUnwrap(node.semantic as? Article)
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
         let renderedNode = translator.visit(article) as! RenderNode
 
         // Verify that the render reference to a section includes the container symbol's abstract
@@ -346,7 +346,7 @@ class RenderNodeTranslatorTests: XCTestCase {
         let topicGraphNode = TopicGraph.Node(reference: reference, kind: .article, source: .file(url: URL(fileURLWithPath: "/path/to/article.md")), title: "My Article")
         context.topicGraph.addNode(topicGraphNode)
     
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
         let node = try XCTUnwrap(translator.visitArticle(article) as? RenderNode)
         XCTAssertEqual(node.topicSections.count, 2)
         
@@ -376,7 +376,7 @@ class RenderNodeTranslatorTests: XCTestCase {
         })
         
         let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/SideKit/SideClass", sourceLanguage: .swift)
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
         let node = try XCTUnwrap(try? context.entity(with: reference))
         
         // Test manual task groups and automatic symbol groups ordering
@@ -503,7 +503,7 @@ class RenderNodeTranslatorTests: XCTestCase {
         })
         
         let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/Test-Bundle/article", sourceLanguage: .swift)
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
         let node = try XCTUnwrap(try? context.entity(with: reference))
         
         // Test the manual curation task groups
@@ -606,7 +606,7 @@ class RenderNodeTranslatorTests: XCTestCase {
         // Verify "Default Implementations" group on the implementing type
         do {
             let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/SideKit/SideClass/Element", sourceLanguage: .swift)
-            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference, source: nil)
+            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
             let node = try XCTUnwrap(try? context.entity(with: reference))
             
             let symbol = try XCTUnwrap(node.semantic as? Symbol)
@@ -625,7 +625,7 @@ class RenderNodeTranslatorTests: XCTestCase {
         // Verify automatically generated api collection
         do {
             let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/SideKit/SideClass/Element/Protocol-Implementations", sourceLanguage: .swift)
-            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference, source: nil)
+            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
             let node = try XCTUnwrap(try? context.entity(with: reference))
             
             let article = try XCTUnwrap(node.semantic as? Article)
@@ -654,7 +654,7 @@ class RenderNodeTranslatorTests: XCTestCase {
         }
 
         let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/FancyProtocol/SomeClass", sourceLanguage: .swift)
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
         let node = try context.entity(with: reference)
         let symbol = try XCTUnwrap(node.semantic as? Symbol)
         let renderNode = try XCTUnwrap(translator.visitSymbol(symbol) as? RenderNode)
@@ -857,7 +857,7 @@ class RenderNodeTranslatorTests: XCTestCase {
         let (_, bundle, context) = try loadBundle(from: bundleURL)
 
         let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: path, sourceLanguage: .swift)
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
         let node = try context.entity(with: reference)
         let symbol = try XCTUnwrap(node.semantic as? Symbol)
         return try XCTUnwrap(translator.visitSymbol(symbol) as? RenderNode)
@@ -871,7 +871,7 @@ class RenderNodeTranslatorTests: XCTestCase {
         
         // Verify that the ordering of default implementations is deterministic
         for _ in 0..<100 {
-            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: structReference, source: nil)
+            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: structReference)
             let renderNode = try XCTUnwrap(translator.visitSymbol(symbol) as? RenderNode)
             let section = renderNode.topicSections.first(where: { $0.title == "Default Implementations" })
             XCTAssertEqual(section?.identifiers, [
@@ -900,7 +900,7 @@ class RenderNodeTranslatorTests: XCTestCase {
         })
 
         let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/SideKit/SideClass", sourceLanguage: .swift)
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
         let node = try XCTUnwrap(try? context.entity(with: reference))
         
         let symbol = try XCTUnwrap(node.semantic as? Symbol)
@@ -930,7 +930,7 @@ class RenderNodeTranslatorTests: XCTestCase {
             let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/SideKit", sourceLanguage: .swift)
             let node = try context.entity(with: reference)
             
-            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference, source: nil)
+            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
             let symbol = try XCTUnwrap(node.semantic as? Symbol)
             let renderNode = try XCTUnwrap(translator.visitSymbol(symbol) as? RenderNode)
             
@@ -950,7 +950,7 @@ class RenderNodeTranslatorTests: XCTestCase {
             let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/SideKit", sourceLanguage: .swift)
             let node = try context.entity(with: reference)
             
-            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference, source: nil)
+            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
             let symbol = try XCTUnwrap(node.semantic as? Symbol)
             let renderNode = try XCTUnwrap(translator.visitSymbol(symbol) as? RenderNode)
             
@@ -963,7 +963,7 @@ class RenderNodeTranslatorTests: XCTestCase {
         let (bundle, context) = try testBundleAndContext(named: "Snippets")
         let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/Snippets/Snippets", sourceLanguage: .swift)
         let article = try XCTUnwrap(context.entity(with: reference).semantic as? Article)
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
         let renderNode = try XCTUnwrap(translator.visitArticle(article) as? RenderNode)
         let discussion = try XCTUnwrap(renderNode.primaryContentSections.first(where: { $0.kind == .content }) as? ContentRenderSection)
         
@@ -993,7 +993,7 @@ class RenderNodeTranslatorTests: XCTestCase {
         let (bundle, context) = try testBundleAndContext(named: "Snippets")
         let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/Snippets/Snippets", sourceLanguage: .swift)
         let article = try XCTUnwrap(context.entity(with: reference).semantic as? Article)
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
         let renderNode = try XCTUnwrap(translator.visitArticle(article) as? RenderNode)
         let discussion = try XCTUnwrap(renderNode.primaryContentSections.first(where: { $0.kind == .content }) as? ContentRenderSection)
         
@@ -1017,7 +1017,7 @@ class RenderNodeTranslatorTests: XCTestCase {
         let (bundle, context) = try testBundleAndContext(named: "Snippets")
         let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/Snippets/Snippets", sourceLanguage: .swift)
         let article = try XCTUnwrap(context.entity(with: reference).semantic as? Article)
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
         let renderNode = try XCTUnwrap(translator.visitArticle(article) as? RenderNode)
         let discussion = try XCTUnwrap(renderNode.primaryContentSections.first(where: { $0.kind == .content }) as? ContentRenderSection)
 
@@ -1048,7 +1048,7 @@ class RenderNodeTranslatorTests: XCTestCase {
         let (bundle, context) = try testBundleAndContext(named: "Snippets")
         let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/Snippets/SliceIndentation", sourceLanguage: .swift)
         let article = try XCTUnwrap(context.entity(with: reference).semantic as? Article)
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
         let renderNode = try XCTUnwrap(translator.visitArticle(article) as? RenderNode)
         let discussion = try XCTUnwrap(renderNode.primaryContentSections.first(where: { $0.kind == .content }) as? ContentRenderSection)
         
@@ -1077,12 +1077,7 @@ class RenderNodeTranslatorTests: XCTestCase {
             sourceLanguage: .swift
         )
         let article = try XCTUnwrap(context.entity(with: reference).semantic as? Article)
-        var translator = RenderNodeTranslator(
-            context: context,
-            bundle: bundle,
-            identifier: reference,
-            source: nil
-        )
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
         let renderNode = try XCTUnwrap(translator.visitArticle(article) as? RenderNode)
         
         let discussion = try XCTUnwrap(
@@ -1111,12 +1106,7 @@ class RenderNodeTranslatorTests: XCTestCase {
             sourceLanguage: .swift
         )
         let article = try XCTUnwrap(context.entity(with: reference).semantic as? Article)
-        var translator = RenderNodeTranslator(
-            context: context,
-            bundle: bundle,
-            identifier: reference,
-            source: nil
-        )
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
         let renderNode = try XCTUnwrap(translator.visitArticle(article) as? RenderNode)
         
         let discussion = try XCTUnwrap(
@@ -1144,12 +1134,7 @@ class RenderNodeTranslatorTests: XCTestCase {
             sourceLanguage: .swift
         )
         let article = try XCTUnwrap(context.entity(with: reference).semantic as? Article)
-        var translator = RenderNodeTranslator(
-            context: context,
-            bundle: bundle,
-            identifier: reference,
-            source: nil
-        )
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
         let renderNode = try XCTUnwrap(translator.visitArticle(article) as? RenderNode)
         
         let discussion = try XCTUnwrap(
@@ -1186,12 +1171,7 @@ class RenderNodeTranslatorTests: XCTestCase {
              sourceLanguage: .swift
          )
          let article = try XCTUnwrap(context.entity(with: reference).semantic as? Article)
-         var translator = RenderNodeTranslator(
-             context: context,
-             bundle: bundle,
-             identifier: reference,
-             source: nil
-         )
+         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
          let renderNode = try XCTUnwrap(translator.visitArticle(article) as? RenderNode)
     
          let encodedArticle = try JSONEncoder().encode(renderNode)
@@ -1267,12 +1247,7 @@ class RenderNodeTranslatorTests: XCTestCase {
             sourceLanguage: .swift
         )
         let symbol = try XCTUnwrap(context.entity(with: reference).semantic as? Symbol)
-        var translator = RenderNodeTranslator(
-            context: context,
-            bundle: bundle,
-            identifier: reference,
-            source: nil
-        )
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
         let renderNode = try XCTUnwrap(translator.visitSymbol(symbol) as? RenderNode)
    
         let encodedSymbol = try JSONEncoder().encode(renderNode)
@@ -1288,12 +1263,7 @@ class RenderNodeTranslatorTests: XCTestCase {
             sourceLanguage: .swift
         )
         let symbol = try XCTUnwrap(context.entity(with: reference).semantic as? Symbol)
-        var translator = RenderNodeTranslator(
-            context: context,
-            bundle: bundle,
-            identifier: reference,
-            source: nil
-        )
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
         let renderNode = try XCTUnwrap(translator.visitSymbol(symbol) as? RenderNode)
    
         let encodedSymbol = try JSONEncoder().encode(renderNode)
@@ -1372,7 +1342,7 @@ class RenderNodeTranslatorTests: XCTestCase {
         ) throws -> RenderNode {
             let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: referencePath, sourceLanguage: .swift)
             let symbol = try XCTUnwrap(context.entity(with: reference).semantic as? Article)
-            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference, source: nil)
+            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
             return try XCTUnwrap(translator.visitArticle(symbol) as? RenderNode)
         }
         
@@ -1409,7 +1379,7 @@ class RenderNodeTranslatorTests: XCTestCase {
         for (index, reference) in overloadReferences.indexed() {
             let documentationNode = try context.entity(with: reference)
             
-            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference, source: nil)
+            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
             let symbol = try XCTUnwrap(documentationNode.semantic as? Symbol)
             let renderNode = try XCTUnwrap(translator.visitSymbol(symbol) as? RenderNode)
             

--- a/Tests/SwiftDocCTests/Rendering/RoleTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/RoleTests.swift
@@ -30,10 +30,9 @@ class RoleTests: XCTestCase {
         // Compile docs and verify contents
         for (path, expectedRole) in expectedRoles {
             let identifier = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: path, fragment: nil, sourceLanguage: .swift)
-            let source = context.documentURL(for: identifier)
             do {
                 let node = try context.entity(with: identifier)
-                var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: source)
+                var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
                 let renderNode = translator.visit(node.semantic) as! RenderNode
                 XCTAssertEqual(expectedRole, renderNode.metadata.role, "Unexpected role \(renderNode.metadata.role!.singleQuoted) for identifier \(identifier.path)")
             } catch {
@@ -47,9 +46,8 @@ class RoleTests: XCTestCase {
         let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle")
 
         let identifier = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit", fragment: nil, sourceLanguage: .swift)
-        let source = context.documentURL(for: identifier)
         let node = try context.entity(with: identifier)
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: source)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visit(node.semantic) as! RenderNode
 
         XCTAssertEqual((renderNode.references["doc://org.swift.docc.example/documentation/MyKit"] as? TopicRenderReference)?.role, "collection")
@@ -61,9 +59,8 @@ class RoleTests: XCTestCase {
         let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle")
 
         let identifier = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/tutorials/Test-Bundle/TestTutorial", fragment: nil, sourceLanguage: .swift)
-        let source = context.documentURL(for: identifier)
         let node = try context.entity(with: identifier)
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: source)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visit(node.semantic) as! RenderNode
 
         XCTAssertEqual((renderNode.references["doc://org.swift.docc.example/tutorials/TestOverview"] as? TopicRenderReference)?.role, "overview")

--- a/Tests/SwiftDocCTests/Rendering/SampleDownloadTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/SampleDownloadTests.swift
@@ -133,12 +133,7 @@ class SampleDownloadTests: XCTestCase {
             sourceLanguage: .swift
         )
         let article = try XCTUnwrap(context.entity(with: reference).semantic as? Article)
-        var translator = RenderNodeTranslator(
-            context: context,
-            bundle: bundle,
-            identifier: reference,
-            source: nil
-        )
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
         return try XCTUnwrap(translator.visitArticle(article) as? RenderNode)
     }
 

--- a/Tests/SwiftDocCTests/Rendering/TermListTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/TermListTests.swift
@@ -91,7 +91,7 @@ class TermListTests: XCTestCase {
         let entity = try context.entity(with: reference)
         
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
-        let renderNode = try converter.convert(entity, at: nil)
+        let renderNode = try converter.convert(entity)
         
         let overviewSection = try XCTUnwrap(renderNode.primaryContentSections.first as? ContentRenderSection)
         

--- a/Tests/SwiftDocCTests/Semantics/DoxygenTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/DoxygenTests.swift
@@ -102,7 +102,7 @@ class DoxygenTests: XCTestCase {
         ])
 
         // Verify the expected content in the render model
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = try XCTUnwrap(translator.visit(node.semantic) as? RenderNode)
 
         XCTAssertEqual(renderNode.abstract, [.text("This is an abstract.")])

--- a/Tests/SwiftDocCTests/Semantics/VideoMediaTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/VideoMediaTests.swift
@@ -326,12 +326,7 @@ class VideoMediaTests: XCTestCase {
             path: "",
             sourceLanguage: .swift
         )
-        var translator = RenderNodeTranslator(
-            context: context,
-            bundle: bundle,
-            identifier: reference,
-            source: nil
-        )
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
         let videoMediaReference = translator.visitVideoMedia(video!) as! RenderReferenceIdentifier
         let videoMedia = translator.videoReferences[videoMediaReference.identifier]
         // Check that the video references in the node translator contains the alt text.

--- a/Tests/SwiftDocCTests/XCTestCase+LoadingTestData.swift
+++ b/Tests/SwiftDocCTests/XCTestCase+LoadingTestData.swift
@@ -112,7 +112,7 @@ extension XCTestCase {
     func renderNode(atPath path: String, fromTestBundleNamed testBundleName: String) throws -> RenderNode {
         let (bundle, context) = try testBundleAndContext(named: testBundleName)
         let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: path, sourceLanguage: .swift))
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference, source: nil)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         return try XCTUnwrap(translator.visit(node.semantic) as? RenderNode)
     }
     

--- a/Tests/SwiftDocCUtilitiesTests/ConvertActionIndexerTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ConvertActionIndexerTests.swift
@@ -43,7 +43,7 @@ class ConvertActionIndexerTests: XCTestCase {
         // Add /documentation/MyKit to the index, verify the tree dump
         do {
             let reference = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit", sourceLanguage: .swift)
-            let renderNode = try converter.convert(context.entity(with: reference), at: nil)
+            let renderNode = try converter.convert(context.entity(with: reference))
 
             try FileManager.default.createDirectory(at: testBundleURL.appendingPathComponent("index1"), withIntermediateDirectories: false, attributes: nil)
             let indexer = try ConvertAction.Indexer(outputURL: testBundleURL.appendingPathComponent("index1"), bundleIdentifier: context.registeredBundles.first!.identifier)
@@ -65,10 +65,10 @@ class ConvertActionIndexerTests: XCTestCase {
         // and verify the tree.
         do {
             let reference1 = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit", sourceLanguage: .swift)
-            let renderNode1 = try converter.convert(context.entity(with: reference1), at: nil)
+            let renderNode1 = try converter.convert(context.entity(with: reference1))
 
             let reference2 = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/Test-Bundle/Default-Code-Listing-Syntax", sourceLanguage: .swift)
-            let renderNode2 = try converter.convert(context.entity(with: reference2), at: nil)
+            let renderNode2 = try converter.convert(context.entity(with: reference2))
 
             try FileManager.default.createDirectory(at: testBundleURL.appendingPathComponent("index2"), withIntermediateDirectories: false, attributes: nil)
             let indexer = try ConvertAction.Indexer(outputURL: testBundleURL.appendingPathComponent("index2"), bundleIdentifier: context.registeredBundles.first!.identifier)


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

This removes some unused code in `RenderNodeTranslator` that I stumbled upon while working on something else.

## Dependencies

None

## Testing

This is a non-functional change. Everything should continue to behave as before. There's nothing in particular to test.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] ~Added~ Updated tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] ~Updated documentation if necessary~ Not applicable
