### PR TITLE
Lower severity of source-symbol-not-found diagnostic

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphRelationshipsBuilder.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphRelationshipsBuilder.swift
@@ -18,7 +18,7 @@ struct SymbolGraphRelationshipsBuilder {
         static func sourceNotFound(_ relationship: SymbolGraph.Relationship) -> Problem {
             return Problem(
                 diagnostic: Diagnostic(
-                    source: nil, severity: .error, range: nil,identifier: "org.swift.docc.SymbolNodeNotFound",
+                    source: nil, severity: .warning, range: nil,identifier: "org.swift.docc.SymbolNodeNotFound",
                     summary: "Source symbol \(relationship.source.singleQuoted) not found locally, from \(relationship.kind.rawValue.singleQuoted) relationship to \(relationship.target.singleQuoted)",
                     explanation: """
                     The "source" of a symbol graph relationship should always refer to a symbol in the same symbol graph file.

--- a/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
@@ -946,8 +946,18 @@ class ConvertActionTests: XCTestCase {
                     start: nil,
                     source: nil,
                     severity: .error,
-                    summary: "Symbol with identifier 's:5MyKit0A5ProtocolP' couldn't be found",
-                    explanation: nil,
+                    summary: "Source symbol 's:5MyKit0A5ProtocolP' not found locally, from 'conformsTo' relationship to 's:5Foundation0A5EarhartP'",
+                    explanation: """
+                    The "source" of a symbol graph relationship should always refer to a symbol in the same symbol graph file.
+                    If it doesn't, then the tool that created the symbol graph file should move the relationship to the symbol graph file that defines the "source" symbol \
+                    or remove the relationship if none of the created symbol graph file defines the "source" symbol.
+                    
+                    The "target" may refer to a symbol in another module.
+                    For example, if local symbol conforms to a protocol from another module, \
+                    there will be a "{ source: local-symbol-ID, kind: conformsTo, target: protocol-in-other-module-ID }" relationship.
+                    
+                    A symbol graph relationship with a non-local "source" symbol is a bug in the tool that created the symbol graph file.
+                    """,
                     notes: []
                 ),
             ]),


### PR DESCRIPTION
<!--
If you're opening a PR to cherry-pick a change for a release branch, use this template instead:
https://github.com/apple/swift-docc/blob/main/.github/PULL_REQUEST_TEMPLATE/CHERRY_PICK.md
-->

Bug/issue #, if applicable: 

## Summary

This PR makes two changes to the diagnostic when the source symbol of a symbol graph relationship can't be found: 
- Elaborate in the summary and explanation to clarify that this is an issue with the tool that created the symbol graph and not something that the developer can resolve themselves.
- Lower the severity of this diagnostic so that this issue doesn't fail the build. 

Since the solution to this issue is for the tool that created the symbol graph file to not include this relationship (or move it to a different file), it's safe for DocC to proceed without processing this symbol graph relationship. 

## Dependencies

None.

## Testing

- Manually edit a symbol graph file to add a relationship where the "source" isn't a symbol ID for a symbol defined in that symbol graph file.
- Build documentation for that symbol graph file.
- There should be a warning, not an error, about the incorrect symbol graph relationship.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] ~Added~ Updated tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] ~Updated documentation if necessary~ Not applicable
