### PR TITLE
Remove `nil` default values from primary content section.

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/Variants/VariantCollection+Coding.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Variants/VariantCollection+Coding.swift
@@ -108,6 +108,10 @@ extension KeyedEncodingContainer {
         try encodeIfNotEmpty(variantCollectionValues.compactMap(\.defaultValue), forKey: key)
         
         for (index, variantCollection) in variantCollectionValues.enumerated() {
+            // Filter `nil` default values.
+            guard variantCollection.defaultValue != nil else {
+                continue
+            }
             variantCollection.addVariantsToEncoder(
                 encoder,
                 


### PR DESCRIPTION

<!--
If you're opening a PR to cherry-pick a change for a release branch, use this template instead:
https://github.com/apple/swift-docc/blob/main/.github/PULL_REQUEST_TEMPLATE/CHERRY_PICK.md
-->

Bug/issue #, if applicable:  139195428

## Summary 

The encoder for the primary content section now checks for nil values within the collection, instead of just checking for empty arrays. Previously, this led to issues when calculating the index for the replace patcher.

## Dependencies

_Describe any dependencies this PR might have, such as an associated branch in another repository._

## Testing

_Describe how a reviewer can test the functionality of your PR. Provide test content to test with if
applicable._

Steps:
1. _Provide setup instructions._
2. _Explain in detail how the functionality can be tested._

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [ ] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary
