### PR TITLE
Add a utility to update the years in license comments of modified files

### DIFF
--- a/bin/update-license-comments/Package.swift
+++ b/bin/update-license-comments/Package.swift
@@ -13,6 +13,9 @@ import PackageDescription
 
 let package = Package(
     name: "update-license-for-modified-files",
+    platforms: [
+        .macOS(.v13)
+    ],
     targets: [
         .executableTarget(
             name: "update-license-for-modified-files"


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

This adds a small utility to make it easier to update the year information in the license comments of modified files.

I recently did some semi-automated changes where I modified a large number of test files. To help myself accurately update the license comments for all those modified files, I wrote this tiny utility for myself. However, I'm opening this PR since that same utility could be useful for others who are contributing to DocC.

You can either use it:
 - before committing your staged changes, using `swift run update-license-for-modified-files --staged`
 - after you've made a number of commits, using `swift run update-license-for-modified-files`.
 
Since we squash commits when merging PRs it doesn't really matter which option you use.
 
See the `swift run update-license-for-modified-files --help` text for more information.

## Dependencies

_Describe any dependencies this PR might have, such as an associated branch in another repository._

## Testing

1. Modify and stage some files where the year in the license comment isn't 2025
2. Run `swift run update-license-for-modified-files --staged`
  - The year in the license comment of those staged files should be updated to extend to 2025
  - Any modified but unstated files shouldn't be modified.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- ~[ ] Added tests~ n/a
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
