### PR TITLE
Add warnings for multiple root pages

### DIFF
--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContext+RootPageTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContext+RootPageTests.swift
@@ -257,6 +257,12 @@ class DocumentationContext_RootPageTests: XCTestCase {
             let solution = try XCTUnwrap(problem.possibleSolutions.first)
             XCTAssertEqual(solution.summary, "Remove the 'TechnologyRoot' directive")
             XCTAssertEqual(solution.replacements.count, 1)
+            
+            // Verify that diagnostic notes point to the symbol graph file
+            XCTAssertEqual(problem.diagnostic.notes.count, 1, "Should have a note pointing to the symbol graph file")
+            let note = try XCTUnwrap(problem.diagnostic.notes.first)
+            XCTAssertTrue(note.source.lastPathComponent.hasSuffix(".symbols.json"), "Note should point to a symbol graph file")
+            XCTAssertTrue(note.message.contains("Symbol graph file"), "Note should mention symbol graph file")
         }
     }
     


### PR DESCRIPTION
**Fixes:** #1170

## Summary

This PR implements warnings when DocC documentation contains more than one root page, addressing unexpected input configurations that may lead to unexpected behaviors.

**Expected User Experience:**
When developers call `docc convert` directly with custom inputs that contain multiple root pages (either multiple main modules from symbol graphs or multiple `@TechnologyRoot` directives), DocC will now emit helpful warnings to alert them about the unexpected configuration.

**Implementation Overview:**
- Added warning logic in `DocumentationContext.swift` to detect multiple main modules during symbol graph processing
- Added warning logic to detect multiple `@TechnologyRoot` directives after article processing
- Implemented proper diagnostic messages with source location association for TechnologyRoot warnings
- Added automatic fix suggestions for TechnologyRoot warnings
- Created comprehensive test coverage for both warning scenarios

## Dependencies

No external dependencies. This is a self-contained enhancement to the existing DocC codebase.

## Testing

### Steps:

1. **Setup Instructions:**
   - Check out the `feature/multiple-root-page-warnings` branch
   - Run `swift test --filter DocumentationContext_RootPageTests` to verify the new tests pass

2. **Testing Multiple TechnologyRoot Directives:**
   - Create a `.docc` catalog with multiple articles containing `@TechnologyRoot` directives
   - Run `docc convert` on the catalog
   - Verify warnings are emitted for each extra `@TechnologyRoot` directive with source location and fix suggestions

3. **Testing Multiple Main Modules:**
   - Create a `.docc` catalog with multiple symbol graph files for different modules
   - Run `docc convert` on the catalog
   - Verify a warning is emitted about multiple main modules

**Test Content:**
The test files in `Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContext+RootPageTests.swift` provide examples of both scenarios:
- `testWarnsAboutMultipleTechnologyRootDirectives()` - Tests multiple `@TechnologyRoot` directives
- `testWarnsAboutMultipleMainModules()` - Tests multiple main modules from symbol graphs

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary

---