### PR TITLE
Replace duplicate logic with equivalent SymbolKit API

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
@@ -96,8 +96,8 @@ struct PathHierarchy {
             let moduleNode: Node
             
             if !loader.hasPrimaryURL(moduleName: moduleName) {
-                guard let moduleName = SymbolGraphLoader.moduleNameFor(url),
-                      let existingModuleNode = roots[moduleName]
+                let (moduleName, _) = GraphCollector.moduleNameFor(graph, at: url)
+                guard let existingModuleNode = roots[moduleName]
                 else { continue }
                 moduleNode = existingModuleNode
             } else if let existingModuleNode = roots[moduleName] {

--- a/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphLoader.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphLoader.swift
@@ -90,7 +90,7 @@ struct SymbolGraphLoader {
 
                 symbolGraphTransformer?(&symbolGraph)
 
-                let (moduleName, isMainSymbolGraph) = Self.moduleNameFor(symbolGraph, at: symbolGraphURL)
+                let (moduleName, isMainSymbolGraph) = GraphCollector.moduleNameFor(symbolGraph, at: symbolGraphURL)
                 // If the bundle provides availability defaults add symbol availability data.
                 self.addDefaultAvailability(to: &symbolGraph, moduleName: moduleName)
 
@@ -320,30 +320,6 @@ struct SymbolGraphLoader {
         }
         
         return fileName.split(separator: "@", maxSplits: 1).last.map({ String($0) })
-    }
-    
-    /// Returns the module name of a symbol graph based on the JSON data and file name.
-    ///
-    /// Useful during decoding the symbol graphs to implement the correct name logic starting with the module name in the JSON.
-    private static func moduleNameFor(_ symbolGraph: SymbolGraph, at url: URL) -> (String, Bool) {
-        let isMainSymbolGraph = !url.lastPathComponent.contains("@")
-        
-        let moduleName: String
-        if isMainSymbolGraph || symbolGraph.module.bystanders != nil {
-            // For main symbol graphs, get the module name from the symbol graph's data
-
-            // When bystander modules are present, the symbol graph is a cross-import overlay, and
-            // we need to preserve the original module name to properly render it. It is still
-            // kept with the extension symbols, due to the merging behavior of UnifiedSymbolGraph.
-            moduleName = symbolGraph.module.name
-        } else {
-            // For extension symbol graphs, derive the extended module's name from the file name.
-            //
-            // The per-symbol `extendedModule` value is the same as the main module for most symbols, so it's not a good way to find the name
-            // of the module that was extended (rdar://63200368).
-            moduleName = SymbolGraphLoader.moduleNameFor(url)!
-        }
-        return (moduleName, isMainSymbolGraph)
     }
 }
 

--- a/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphLoader.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphLoader.swift
@@ -302,25 +302,6 @@ struct SymbolGraphLoader {
             symbolGraph.symbols = symbolsWithFilledIntroducedVersions
         }
     }
-    
-    /// Returns the module name, if any, in the file name of a given symbol-graph URL.
-    ///
-    /// Returns "Combine", if it's a main symbol-graph file, such as "Combine.symbols.json".
-    /// Returns "Swift", if it's an extension file such as, "Combine@Swift.symbols.json".
-    /// - parameter url: A URL to a symbol graph file.
-    /// - returns: A module name, or `nil` if the file name cannot be parsed.
-    static func moduleNameFor(_ url: URL) -> String? {
-        let fileName = url.lastPathComponent.components(separatedBy: ".symbols.json")[0]
-
-        let fileNameComponents = fileName.components(separatedBy: "@")
-        if fileNameComponents.count > 2 {
-            // Two "@"s found in the name - it's a cross import symbol graph:
-            // "Framework1@Framework2@_Framework1_Framework2.symbols.json"
-            return fileNameComponents[0]
-        }
-        
-        return fileName.split(separator: "@", maxSplits: 1).last.map({ String($0) })
-    }
 }
 
 extension SymbolGraph.SemanticVersion {


### PR DESCRIPTION
Originally found while debugging #1084, and recently updated the logic in https://github.com/swiftlang/swift-docc-symbolkit/pull/101 to match this version, which was used in preference of the SymbolKit version.

## Summary

This removes the logic from DocC, favoring the loading in SymbolKit, and consolidating the logic into a single place. This was originally opened at #1091, but the code had changed significantly since that update, so it was easier to create a new PR with the change after applying feedback from the earlier PR.

The equivalent logic that I'm consolidating towards is https://github.com/swiftlang/swift-docc-symbolkit/blob/main/Sources/SymbolKit/UnifiedSymbolGraph/GraphCollector.swift#L121-L178

## Testing

The existing tests within DocC work this logic extensively.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests - _no additional tests needed_
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary - _no documentation changes are relevant, internal implementation details only_
