### PR TITLE
Fix `@SupportedLanguage` directive for articles

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -630,7 +630,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
         node.hierarchyVariants = hierarchyVariants
         
         // Emit variants only if we're not compiling an article-only catalog to prevent renderers from
-        // advertising the page as "Swift", which is the language DocC assigns to pages in article only pages.
+        // advertising the page as "Swift", which is the language DocC assigns to pages in article only catalogs.
         // (github.com/swiftlang/swift-docc/issues/240).
         if let topLevelModule = context.soleRootModuleReference,
            try! context.entity(with: topLevelModule).kind.isSymbol

--- a/Sources/SwiftDocC/Semantics/Article/Article.swift
+++ b/Sources/SwiftDocC/Semantics/Article/Article.swift
@@ -66,6 +66,18 @@ public final class Article: Semantic, MarkupConvertible, Abstracted, Redirected,
         return abstractSection?.paragraph
     }
 
+    /// The list of supported languages for the article, if present.
+    ///
+    /// This information is available via `@SupportedLanguage` in the `@Metadata` directive.
+    public var supportedLanguages: Set<SourceLanguage>? {
+        guard let metadata = self.metadata else {
+            return nil
+        }
+
+        let langs = metadata.supportedLanguages.map(\.language)
+        return langs.isEmpty ? nil : Set(langs)
+    }
+
     /// An optional custom deprecation summary for a deprecated symbol.
     private(set) public var deprecationSummary: MarkupContainer?
     

--- a/Sources/SwiftDocC/Semantics/Metadata/Metadata.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/Metadata.swift
@@ -105,7 +105,7 @@ public final class Metadata: Semantic, AutomaticDirectiveConvertible {
     
     func validate(source: URL?, problems: inout [Problem]) -> Bool {
         // Check that something is configured in the metadata block
-        if documentationOptions == nil && technologyRoot == nil && displayName == nil && pageImages.isEmpty && customMetadata.isEmpty && callToAction == nil && availability.isEmpty && pageKind == nil && pageColor == nil && titleHeading == nil && redirects == nil && alternateRepresentations.isEmpty {
+        if documentationOptions == nil && technologyRoot == nil && displayName == nil && pageImages.isEmpty && customMetadata.isEmpty && callToAction == nil && availability.isEmpty && pageKind == nil && pageColor == nil && supportedLanguages.isEmpty && titleHeading == nil && redirects == nil && alternateRepresentations.isEmpty {
             let diagnostic = Diagnostic(
                 source: source,
                 severity: .information,

--- a/Tests/SwiftDocCTests/Semantics/ArticleTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/ArticleTests.swift
@@ -249,4 +249,26 @@ class ArticleTests: XCTestCase {
         XCTAssertNil(semantic.metadata?.pageKind)
         XCTAssertNil(semantic.metadata?.titleHeading)
     }
+
+    func testSupportedLanguageDirective() async throws {
+        let source = """
+        # Root
+
+        @Metadata {
+          @SupportedLanguage(swift)
+          @SupportedLanguage(objc)
+          @SupportedLanguage(data)
+        }
+        """
+        let document = Document(parsing: source, options: [.parseBlockDirectives])
+        let (bundle, _) = try await testBundleAndContext()
+        var problems = [Problem]()
+        let article = Article(from: document, source: nil, for: bundle, problems: &problems)
+
+        XCTAssert(problems.isEmpty, "Unexpectedly found problems: \(DiagnosticConsoleWriter.formattedDescription(for: problems))")
+
+        XCTAssertNotNil(article)
+        XCTAssertNotNil(article?.metadata, "Article should have a metadata container since the markup has a @Metadata directive")
+        XCTAssertEqual(article?.metadata?.supportedLanguages.map(\.language), [.swift, .objectiveC, .data])
+    }
 }


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://160284853

## Summary

The `@SupportedLanguage` directive allows specifying a language that an
article is available in. It can be used within the `@Metadata` directive
like in the below example, where the article is made available in both
Swift and Objective-C:

```

@metadata {
  @SupportedLanguage(swift)
  @SupportedLanguage(objc)
}
```

This directive is processed when creating the topic graph node for the
article. The supported languages of an article need to be stored in the
resolved topic reference that eventually gets serialised into the render
node, which the navigator uses. When a catalog contains more than one
module, any articles present are not registered in the documentation
cache, since it is not possible to determine what module it is belongs
to. In such cases, to correctly include the set of supported languages,
they must be added to the reference in the topic graph node during
creation, rather than creating the reference and later updating this
information during registration. This patch adds the logic to store the
set of supported languages during topic node creation for all articles,
indepedent of the cache registration.

## Dependencies

N/A

## Testing

Unit tests have been added to test this functionality when creating the documentation node and reference for articles containing the directive.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
