### PR TITLE
Avoid full URL parsing to trim a known prefix from a reference string

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/External Data/OutOfProcessReferenceResolver.swift
+++ b/Sources/SwiftDocC/Infrastructure/External Data/OutOfProcessReferenceResolver.swift
@@ -411,7 +411,10 @@ extension OutOfProcessReferenceResolver {
                 return .success( makeReference(for: cachedSummary) )
             }
             
-            let linkString = unresolvedReference.topicURL.url.withoutHostAndPortAndScheme().standardized.absoluteString
+            let linkString = String(
+                unresolvedReferenceString.dropFirst(6) // "doc://"
+                    .drop(while: { $0 != "/" })        // the known identifier (host component)
+            )
             let response: ResponseV2 = try longRunningProcess.sendAndWait(request: RequestV2.link(linkString))
             
             switch response {

--- a/Tests/SwiftDocCTests/OutOfProcessReferenceResolverV2Tests.swift
+++ b/Tests/SwiftDocCTests/OutOfProcessReferenceResolverV2Tests.swift
@@ -531,6 +531,9 @@ class OutOfProcessReferenceResolverV2Tests: XCTestCase {
             read                                                           # Wait for 3rd request
             echo $REPLY >> \(savedRequestsFile.path)                       # Save the raw request
             echo '{"failure":"ignored error message"}'                     # Respond
+            read                                                           # Wait for 4th request
+            echo $REPLY >> \(savedRequestsFile.path)                       # Save the raw request
+            echo '{"failure":"ignored error message"}'                     # Respond
             """.write(to: executableLocation, atomically: true, encoding: .utf8)
             
             // `0o0700` is `-rwx------` (read, write, & execute only for owner)
@@ -544,10 +547,11 @@ class OutOfProcessReferenceResolverV2Tests: XCTestCase {
             TextFile(name: "Something.md", utf8Content: """
             # My root page
             
-            This page contains an 3 external links hat will fail to resolve: 
+            This page contains an 4 external links that will fail to resolve: 
             - <doc://\(externalBundleID.rawValue)/some-link>
             - <doc://\(externalBundleID.rawValue)/path/to/some-link>
             - <doc://\(externalBundleID.rawValue)/path/to/some-link#some-fragment>
+            - <doc://\(externalBundleID.rawValue)//not-parsable-as-url>
             """)
         ])
         let inputDirectory = Folder(name: "path", content: [Folder(name: "to", content: [catalog])])
@@ -568,6 +572,7 @@ class OutOfProcessReferenceResolverV2Tests: XCTestCase {
         XCTAssertEqual(readRequests, """
         {"link":"/some-link"}
         {"link":"/path/to/some-link"}
+        {"link":"//not-parsable-as-url"}
         {"link":"/path/to/some-link#some-fragment"}
         """)
     }


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://162860967

## Summary

This uses simpler string trimming instead of full URL parsing to trim a known prefix from a reference string. 

Doing so avoids a crash when the written link has two or more slashes after the identifier (corresponding to a host component in a URL.

## Dependencies

None.

## Testing

See https://github.com/swiftlang/swift-docc/pull/1320 but include `<doc://com.test.bundle//path/to/something>` (with two slashes after the identifier).

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
