### PR TITLE
Store all source languages in documentation node

### DIFF
--- a/Sources/SwiftDocC/Model/DocumentationNode.swift
+++ b/Sources/SwiftDocC/Model/DocumentationNode.swift
@@ -238,7 +238,7 @@ public struct DocumentationNode {
                 Symbol.Overloads(references: [], displayIndex: overloadData.overloadGroupIndex)
             })
 
-        var languages = Set([reference.sourceLanguage])
+        var languages = reference.sourceLanguages
         var operatingSystemName = platformName.map({ Set([$0]) }) ?? []
         
         for (_, symbolAvailability) in symbolAvailabilityVariants.allValues {
@@ -776,7 +776,7 @@ public struct DocumentationNode {
         
         let symbolAvailability = symbol.mixins[SymbolGraph.Symbol.Availability.mixinKey] as? SymbolGraph.Symbol.Availability
         
-        var languages = Set([reference.sourceLanguage])
+        var languages = reference.sourceLanguages
         var operatingSystemName = platformName.map({ Set([$0]) }) ?? []
         
         let availabilityDomains = symbolAvailability?.availability.compactMap({ $0.domain?.rawValue })
@@ -859,7 +859,7 @@ public struct DocumentationNode {
         self.semantic = article
         self.sourceLanguage = reference.sourceLanguage
         self.name = .conceptual(title: article.title?.title ?? "")
-        self.availableSourceLanguages = [reference.sourceLanguage]
+        self.availableSourceLanguages = reference.sourceLanguages
         self.docChunks = [DocumentationChunk(source: .documentationExtension, markup: articleMarkup)]
         self.markup = articleMarkup
         self.isVirtual = false

--- a/Tests/SwiftDocCTests/Model/DocumentationNodeTests.swift
+++ b/Tests/SwiftDocCTests/Model/DocumentationNodeTests.swift
@@ -76,4 +76,27 @@ class DocumentationNodeTests: XCTestCase {
         XCTAssertEqual(DocumentationNode.symbolKind(for: .typeConstant), .typeProperty)
         XCTAssertEqual(DocumentationNode.symbolKind(for: .object), .dictionary)
     }
+
+    func testWithMultipleSourceLanguages() throws {
+        let sourceLanguages: Set<SourceLanguage> = [.swift, .objectiveC]
+        // Test if articles contain all available source languages
+        let article = Article(markup: Document(parsing: "# Title", options: []), metadata: nil, redirects: nil, options: [:])
+        let articleNode = try DocumentationNode(
+            reference: ResolvedTopicReference(bundleID: "org.swift.docc", path: "/blah", sourceLanguages: sourceLanguages),
+            article: article
+        )
+        XCTAssertEqual(articleNode.availableSourceLanguages, sourceLanguages)
+
+        // Test if symbols contain all available source languages
+        let symbol = makeSymbol(id: "blah", kind: .class, pathComponents: ["blah"])
+        let symbolNode = DocumentationNode(
+            reference: ResolvedTopicReference(bundleID: "org.swift.docc", path: "/blah", sourceLanguages: sourceLanguages),
+            symbol: symbol,
+            platformName: nil,
+            moduleReference: ResolvedTopicReference(bundleID: "org.swift.docc", path: "/blah", sourceLanguages: sourceLanguages),
+            article: nil,
+            engine: DiagnosticEngine()
+        )
+        XCTAssertEqual(symbolNode.availableSourceLanguages, sourceLanguages)
+    }
 }


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://163034867

## Summary

The documentation node stores the list of source languages that the node is available in. Previously, this information was being stored in the render node as a set containing the singular source language of the node. This worked in the past when Swift was the only relevant language, but `sourceLanguage` is now relegated to a backwards-compatible property that queries `sourceLanguages` for the value it returns. This patch updates the documentation node constructors to correctly store the set of source languages in the node.

## Dependencies

N/A

## Testing

Unit tests have been added to verify that this information is now stored correctly. They fail when the changes are reverted.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
