### PR TITLE
Index external entities after local entities

### DIFF
--- a/Tests/SwiftDocCTests/Indexing/ExternalRenderNodeTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/ExternalRenderNodeTests.swift
@@ -507,4 +507,150 @@ class ExternalRenderNodeTests: XCTestCase {
         XCTAssertEqual(objcNavigatorExternalRenderNode.metadata.title, objcTitle)
         XCTAssertTrue(objcNavigatorExternalRenderNode.metadata.isBeta)
     }
+
+    func testExternalLinksInContentDontAffectNavigatorIndex() async throws {
+        let externalResolver = ExternalReferenceResolverTests.TestExternalReferenceResolver()
+        externalResolver.expectedReferencePath = "/documentation/testbundle/sampleclass"
+
+        let catalog = Folder(name: "unit-test.docc", content: [
+            TextFile(name: "Article.md", utf8Content: """
+            # Article
+            
+            This is an internal article with an external link <doc://\(externalResolver.bundleID)/documentation/TestBundle/SampleClass> which clashes with the curated local link.
+            
+            External links in content should not affect the navigator.
+                        
+            ## Topics
+            
+            - ``SampleClass``
+            """),
+            TextFile(name: "SampleClass.md", utf8Content: """
+            # ``SampleClass``
+            
+            This extends the documentation for this symbol.
+                        
+            ## Topics
+            
+            - <doc:ChildArticleA>
+            - <doc:ChildArticleB>
+            """),
+            TextFile(name: "ChildArticleA.md", utf8Content: """
+            # ChildArticleA
+            
+            A child article.
+            """),
+            TextFile(name: "ChildArticleB.md", utf8Content: """
+            # ChildArticleB
+            
+            A child article.
+            """),
+            // Symbol graph with a class that matches an external link path
+            JSONFile(name: "TestBundle.symbols.json", content: makeSymbolGraph(moduleName: "TestBundle", symbols: [
+                makeSymbol(id: "some-symbol-id", language: .swift, kind: .class, pathComponents: ["SampleClass"])
+            ])),
+        ])
+
+        var configuration = DocumentationContext.Configuration()
+        configuration.externalDocumentationConfiguration.sources[externalResolver.bundleID] = externalResolver
+        let (bundle, context) = try await loadBundle(catalog: catalog, configuration: configuration)
+        XCTAssert(context.problems.isEmpty, "Unexpectedly found problems: \(context.problems.map(\.diagnostic.summary))")
+
+        let renderIndexFolder = try createTemporaryDirectory()
+        let indexBuilder = NavigatorIndex.Builder(outputURL: renderIndexFolder, bundleIdentifier: bundle.id.rawValue, sortRootChildrenByName: true, groupByLanguage: true)
+        indexBuilder.setup()
+        let outputConsumer = TestExternalRenderNodeOutputConsumer(indexBuilder: indexBuilder)
+
+        let problems = try ConvertActionConverter.convert(
+            context: context,
+            outputConsumer: outputConsumer,
+            sourceRepository: nil,
+            emitDigest: false,
+            documentationCoverageOptions: .noCoverage
+        )
+        XCTAssert(problems.isEmpty, "Unexpectedly found problems: \(DiagnosticConsoleWriter.formattedDescription(for: problems))")
+        indexBuilder.finalize(emitJSONRepresentation: true, emitLMDBRepresentation: false)
+
+        XCTAssertEqual(
+            try RenderIndex.fromURL(renderIndexFolder.appendingPathComponent("index.json", isDirectory: false)),
+            try RenderIndex.fromString(
+                """
+                {
+                  "includedArchiveIdentifiers": [
+                    "unit-test"
+                  ],
+                  "interfaceLanguages": {
+                    "swift": [
+                      {
+                        "children": [
+                          {
+                            "title": "Articles",
+                            "type": "groupMarker"
+                          },
+                          {
+                            "children": [
+                              {
+                                "children": [
+                                  {
+                                    "path": "/documentation/unit-test/childarticlea",
+                                    "title": "ChildArticleA",
+                                    "type": "article"
+                                  },
+                                  {
+                                    "path": "/documentation/unit-test/childarticleb",
+                                    "title": "ChildArticleB",
+                                    "type": "article"
+                                  }
+                                ],
+                                "path": "/documentation/testbundle/sampleclass",
+                                "title": "SampleClass",
+                                "type": "class"
+                              }
+                            ],
+                            "path": "/documentation/unit-test/article",
+                            "title": "Article",
+                            "type": "symbol"
+                          }
+                        ],
+                        "path": "/documentation/testbundle",
+                        "title": "TestBundle",
+                        "type": "module"
+                      }
+                    ]
+                  },
+                  "schemaVersion": {
+                    "major": 0,
+                    "minor": 1,
+                    "patch": 2
+                  }
+                }
+                """
+            )
+        )
+    }
+}
+
+private class TestExternalRenderNodeOutputConsumer: ConvertOutputConsumer, ExternalNodeConsumer {
+    let indexBuilder: Synchronized<NavigatorIndex.Builder>!
+
+    init(indexBuilder: NavigatorIndex.Builder) {
+        self.indexBuilder = Synchronized<NavigatorIndex.Builder>(indexBuilder)
+    }
+
+    func consume(externalRenderNode: ExternalRenderNode) throws {
+        try self.indexBuilder.sync { try $0.index(renderNode: externalRenderNode) }
+    }
+
+    func consume(renderNode: RenderNode) throws {
+        try self.indexBuilder.sync { try $0.index(renderNode: renderNode) }
+    }
+
+    func consume(assetsInBundle bundle: DocumentationBundle) throws { }
+    func consume(linkableElementSummaries: [LinkDestinationSummary]) throws { }
+    func consume(indexingRecords: [IndexingRecord]) throws { }
+    func consume(assets: [RenderReferenceType: [any RenderReference]]) throws { }
+    func consume(benchmarks: Benchmark) throws { }
+    func consume(documentationCoverageInfo: [CoverageDataEntry]) throws { }
+    func consume(renderReferenceStore: RenderReferenceStore) throws { }
+    func consume(buildMetadata: BuildMetadata) throws { }
+    func consume(linkResolutionInformation: SerializableLinkResolutionInformation) throws { }
 }


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://163018922

## Summary

The navigation indexing code skips all further nodes after it has already indexed a node with a given identifier [1].

This can result in an odd interaction when there is an external link which is resolved to a path that the bundle serves itself (or more colloquially, a catalog has an external link to itself).

Since external entities are indexed before local entities, they were always be preferred over local entities, resulting in local entities mistakenly being dropped from the navigator altogether. The resulting navigator is incorrect and missing nodes, due to external entities not having hierarchy information. This issue was introduced when support for external links in the navigator was introduced.

This PR updates `ConvertActionConverter` to always index local entities first. If any external entities clash with local entities, they will be resolved as the local entity (including its hierarchy) in the navigator.

[1]: https://github.com/swiftlang/swift-docc/blob/b27288dd99b0e2715ed1a2d5720cd0f23118c030/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift#L711-L713
[2]: https://github.com/swiftlang/swift-docc/commit/65aaf926ec079ddbd40f29540d4180a70af99e5e

## Dependencies

N/A

## Testing

Use the test bundle from [Example.zip](https://github.com/user-attachments/files/23456620/Example.zip).

Steps:
1. Run `DOCC_LINK_RESOLVER_EXECUTABLE=Example/test-data-external-resolver swift run docc preview Example/Example.docc`
2. Verify that http://localhost:8080/documentation/example-bundle/articlea has two links in the Topics section, and that the first one resolves to a local entity, not the external entity.
3. Verify the navigation hierarchy contains `ArticleC`, curated in local node `ArticleB`.
<img width="443" height="127" alt="Screenshot 2025-11-10 at 14 57 52" src="https://github.com/user-attachments/assets/53fd8039-a8ef-4ce7-bdce-807145091a6b" />

This can in general be verified by adding an external link to a page's content, which links to an entity that resolves to the same relative presentation URL of a local entity. If the resulting navigator is unchanged when adding this external links vs removing it, then the code is working as expected. 

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- ~~[ ] Updated documentation if necessary~~ N/A
