### PR TITLE
trim whitespace in the DoxygenTests when calling the MarkupFormatter

### DIFF
--- a/Tests/SwiftDocCTests/Semantics/DoxygenTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/DoxygenTests.swift
@@ -96,7 +96,7 @@ class DoxygenTests: XCTestCase {
         let symbol = try XCTUnwrap(node.semantic as? Symbol)
 
         XCTAssertEqual(symbol.abstract?.format(), "This is an abstract.")
-        XCTAssertEqual(symbol.discussion?.content.map { $0.format() }, [
+        XCTAssertEqual(symbol.discussion?.content.map { $0.format().trimmingCharacters(in: .whitespacesAndNewlines) }, [
             #"\abstract This is description with abstract."#,
             #"\discussion This is a discussion linking to ``doc://unit-test/documentation/ModuleName/AnotherClass`` and ``doc://unit-test/documentation/ModuleName/AnotherClass/prop``."#,
             #"\note This is a note linking to ``doc://unit-test/documentation/ModuleName/Class3`` and ``Class3/prop2``."#


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://163704908

## Summary

When https://github.com/swiftlang/swift-markdown/pull/237 was merged, a test in Swift-DocC started failing due to changes in the Swift-Markdown formatter. This PR updates the test assertion to trim whitespace and newlines, since the failure we saw was that an extra newline character was being inserted at the beginnings of lines.

## Dependencies

None (The PR in Swift-Markdown was reverted, but the change here passes before and after the change is present.)

## Testing

This is a test-only change. Ensure that all tests continue to pass, even after running `swift package update swift-markdown`.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ n/a ] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ n/a ] Updated documentation if necessary
