### PR TITLE
Exclude CMakeLists.txt files from SwiftPM targets

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -48,6 +48,7 @@ let package = Package(
                 .product(name: "CLMDB", package: "swift-lmdb"),
                 .product(name: "Crypto", package: "swift-crypto"),
             ],
+            exclude: ["CMakeLists.txt"],
             swiftSettings: swiftSettings
         ),
         .testTarget(
@@ -72,6 +73,7 @@ let package = Package(
                 .product(name: "NIOHTTP1", package: "swift-nio", condition: .when(platforms: [.macOS, .iOS, .linux, .android])),
                 .product(name: "ArgumentParser", package: "swift-argument-parser")
             ],
+            exclude: ["CMakeLists.txt"],
             swiftSettings: swiftSettings
         ),
         .testTarget(
@@ -104,6 +106,7 @@ let package = Package(
             dependencies: [
                 .target(name: "SwiftDocCUtilities"),
             ],
+            exclude: ["CMakeLists.txt"],
             swiftSettings: swiftSettings
         ),
 
@@ -125,7 +128,6 @@ let package = Package(
             ],
             swiftSettings: swiftSettings
         ),
-        
     ]
 )
 


### PR DESCRIPTION
## Summary

SwiftPM requires that all files within a target are accounted for as part of the build. If there are extraneous files that do not form a part of the target, the package manager emits a warning about unhandled files. This patch updates Package.swift to exclude all CMakeLists.txt files from their relevant SwiftPM targets to remove this warning.

## Dependencies

N/A

## Testing

N/A

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- ~[ ] Added tests~
- ~[ ] Ran the `./bin/test` script and it succeeded~
- ~[ ] Updated documentation if necessary~
