### PR TITLE
Fix typo in doc comment for NavigatorItem.init?(rawValue:)

### DIFF
--- a/Sources/SwiftDocC/Indexing/Navigator/NavigatorItem.swift
+++ b/Sources/SwiftDocC/Indexing/Navigator/NavigatorItem.swift
@@ -112,7 +112,7 @@ public final class NavigatorItem: Serializable, Codable, Equatable, CustomString
     /**
      Initialize a `NavigatorItem` using raw data.
      
-     - Parameters rawValue: The `Data` from which the instance should be deserialized from.
+     - Parameter rawValue: The `Data` from which the instance should be deserialized from.
      */
     required public init?(rawValue: Data) {
         let data = rawValue


### PR DESCRIPTION
## Summary

Fixes a typo in the doc comment that prevented the documentation from rendering correctly in Xcode. I assume this also affects other editors and DocC's rendering, but I haven't tested it in other contexts.

## Dependencies

(none)

## Testing

I performed no testing other than checking the rendered result in Xcode in the Opt+Click popover.

Thorough testing would involve inspecting the before/after rendering result in DocC itself.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [ ] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary

I didn't perform any of these steps as this is a simple one-character change in a doc comment. No changes to the code itself.