### PR TITLE
Encode absolute presentation URL if present

### DIFF
--- a/Sources/SwiftDocC/LinkTargets/LinkDestinationSummary.swift
+++ b/Sources/SwiftDocC/LinkTargets/LinkDestinationSummary.swift
@@ -726,7 +726,7 @@ extension LinkDestinationSummary {
         } else {
             try container.encode(kind, forKey: .kind)
         }
-        try container.encode(relativePresentationURL, forKey: .relativePresentationURL)
+        try container.encode(absolutePresentationURL ?? relativePresentationURL, forKey: .relativePresentationURL)
         try container.encode(referenceURL, forKey: .referenceURL)
         try container.encode(title, forKey: .title)
         try container.encodeIfPresent(abstract, forKey: .abstract)

--- a/Tests/SwiftDocCTests/Infrastructure/ExternalReferenceResolverTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/ExternalReferenceResolverTests.swift
@@ -1420,7 +1420,10 @@ class ExternalReferenceResolverTests: XCTestCase {
             """.utf8))
         XCTAssertEqual(externalEntity.relativePresentationURL.absoluteString, "/path/to/something")
         XCTAssertEqual(externalEntity.absolutePresentationURL?.absoluteString, "https://com.example/path/to/something")
-        
+
+        // Test that encoding the link summary preserves the absolute URL
+        try assertRoundTripCoding(externalEntity)
+
         let resolver = Resolver(entityToReturn: externalEntity)
         
         var configuration = DocumentationContext.Configuration()


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://164628218

## Summary

Support for absolute URLs in link summaries was added in 7db36ad21303f2b85c094b7add3023b4c9e1111e.

It added support for absolute URLs when decoding a link summary, but not when encoding it: https://github.com/swiftlang/swift-docc/blob/cfcd96f0e992af2287661f6a26e8398096f6bc1e/Sources/SwiftDocC/LinkTargets/LinkDestinationSummary.swift#L772-L773 https://github.com/swiftlang/swift-docc/blob/cfcd96f0e992af2287661f6a26e8398096f6bc1e/Sources/SwiftDocC/LinkTargets/LinkDestinationSummary.swift#L728

Both are needed when using an external link resolver, as the external link resolver needs to encode the entity to send it to DocC.

## Dependencies

N/A

## Testing

Unit tested.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- ~~[ ] Updated documentation if necessary~~ N/A
