### PR TITLE
Comment out directory missing CMakeLists.txt

### DIFF
--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -7,4 +7,3 @@ Licensed under Apache License v2.0 with Runtime Library Exception
 See https://swift.org/LICENSE.txt for license information
 #]]
 
-add_subdirectory(docc)


### PR DESCRIPTION
Windows PR testing for the Swift repository is broken. Try this to unbreak them.