### PR TITLE
added cmakelist file to SwiftDocCUtilities

### DIFF
--- a/Sources/SwiftDocCUtilities/CMakeLists.txt
+++ b/Sources/SwiftDocCUtilities/CMakeLists.txt
@@ -1,0 +1,81 @@
+#[[
+This source file is part of the Swift open source project
+
+Copyright © 2014 - 2025 Apple Inc. and the Swift project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+#]]
+
+add_library(SwiftDocCUtilities
+  Action/Action.swift
+  Action/ActionResult.swift
+  Action/Actions/Action+MoveOutput.swift
+  Action/Actions/Convert/ConvertAction.swift
+  Action/Actions/Convert/ConvertFileWritingConsumer.swift
+  Action/Actions/Convert/CoverageDataEntry+generateSummary.swift
+  Action/Actions/Convert/Indexer.swift
+  Action/Actions/Convert/JSONEncodingRenderNodeWriter.swift
+  Action/Actions/CoverageAction.swift
+  Action/Actions/EmitGeneratedCurationAction.swift
+  Action/Actions/IndexAction.swift
+  Action/Actions/Init/CatalogTemplate.swift
+  Action/Actions/Init/CatalogTemplateKind.swift
+  Action/Actions/Init/InitAction.swift
+  Action/Actions/Merge/MergeAction.swift
+  Action/Actions/Merge/MergeAction+SynthesizedLandingPage.swift
+  Action/Actions/PreviewAction.swift
+  Action/Actions/TransformForStaticHostingAction.swift
+  ArgumentParsing/ActionExtensions/Action+performAndHandleResult.swift
+  ArgumentParsing/ActionExtensions/ConvertAction+CommandInitialization.swift
+  ArgumentParsing/ActionExtensions/EmitGeneratedCurationAction+CommandInitialization.swift
+  ArgumentParsing/ActionExtensions/IndexAction+CommandInitialization.swift
+  ArgumentParsing/ActionExtensions/InitAction+CommandInitialization.swift
+  ArgumentParsing/ActionExtensions/PreviewAction+CommandInitialization.swift
+  ArgumentParsing/ActionExtensions/TransformForStaticHostingAction+CommandInitialization.swift
+  ArgumentParsing/ArgumentValidation/URLArgumentValidator.swift
+  ArgumentParsing/Options/DirectoryPathOption.swift
+  ArgumentParsing/Options/DocumentationArchiveOption.swift
+  ArgumentParsing/Options/DocumentationBundleOption.swift
+  ArgumentParsing/Options/DocumentationCoverageOptionsArgument.swift
+  ArgumentParsing/Options/InitOptions.swift
+  ArgumentParsing/Options/OutOfProcessLinkResolverOption.swift
+  ArgumentParsing/Options/PreviewOptions.swift
+  "ArgumentParsing/Options/Source Repository/SourceRepositoryArguments.swift"
+  ArgumentParsing/Options/TemplateOption.swift
+  ArgumentParsing/Subcommands/Convert.swift
+  ArgumentParsing/Subcommands/EmitGeneratedCuration.swift
+  ArgumentParsing/Subcommands/Index.swift
+  ArgumentParsing/Subcommands/Init.swift
+  ArgumentParsing/Subcommands/Merge.swift
+  ArgumentParsing/Subcommands/Preview.swift
+  ArgumentParsing/Subcommands/ProcessArchive.swift
+  ArgumentParsing/Subcommands/ProcessCatalog.swift
+  ArgumentParsing/Subcommands/TransformForStaticHosting.swift
+  Docc.swift
+  PreviewServer/PreviewHTTPHandler.swift
+  PreviewServer/PreviewServer.swift
+  PreviewServer/RequestHandler/DefaultRequestHandler.swift
+  PreviewServer/RequestHandler/ErrorRequestHandler.swift
+  PreviewServer/RequestHandler/FileRequestHandler.swift
+  PreviewServer/RequestHandler/HTTPResponseHead+FromRequest.swift
+  PreviewServer/RequestHandler/RequestHandlerFactory.swift
+  Transformers/StaticHostableTransformer.swift
+  Utility/DirectoryMonitor.swift
+  Utility/FoundationExtensions/Sequence+Unique.swift
+  Utility/FoundationExtensions/String+Path.swift
+  Utility/FoundationExtensions/URL+IsAbsoluteWebURL.swift
+  Utility/FoundationExtensions/URL+Relative.swift
+  Utility/PlatformArgumentParser.swift
+  Utility/Signal.swift
+  Utility/Throttle.swift)
+target_link_libraries(SwiftDocCUtilities PUBLIC
+  SwiftDocC
+  ArgumentParser::ArgumentParser)
+
+if(BUILD_SHARED_LIBS)
+  install(TARGETS SwiftDocCUtilities
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+endif()


### PR DESCRIPTION
## Summary
swiftlang/swift builds are failing when building docs in windows due to SwiftDocCUtilities not having a `CMakeLists.txt` file.

`[2025-11-17 01:28:56] Building 'C:\Users\swift-ci\jenkins\workspace\swift-PR-windows\swift-docc' to 'T:\x86_64-unknown-windows-msvc\DocC' ...
C:\Program Files\CMake\bin\cmake.exe -B T:\x86_64-unknown-windows-msvc\DocC -S C:\Users\swift-ci\jenkins\workspace\swift-PR-windows\swift-docc -G Ninja -D ArgumentParser_DIR=T:/x86_64-unknown-windows-msvc/ArgumentParser/cmake/modules -D BUILD_SHARED_LIBS=YES -D CMAKE_BUILD_TYPE=Release -D CMAKE_C_COMPILER=T:/5/bin/clang-cl.exe -D CMAKE_C_COMPILER_TARGET=x86_64-unknown-windows-msvc -D CMAKE_C_FLAGS=/GS- /Gw /Gy /Oy /Oi /Zc:inline -D CMAKE_EXE_LINKER_FLAGS=/INCREMENTAL:NO /OPT:REF /OPT:ICF -D CMAKE_FIND_PACKAGE_PREFER_CONFIG=YES -D CMAKE_INSTALL_PREFIX=T:/Program Files/Swift/Toolchains/0.0.0+Asserts/usr -D CMAKE_MAKE_PROGRAM=C:/Program Files/Microsoft Visual Studio/2022/Community/Common7/IDE/CommonExtensions/Microsoft/CMake/Ninja/ninja.exe -D CMAKE_SHARED_LINKER_FLAGS=/INCREMENTAL:NO /OPT:REF /OPT:ICF -D CMAKE_STATIC_LIBRARY_PREFIX_Swift=lib -D CMAKE_Swift_COMPILER=T:/5/bin/swiftc.exe -D CMAKE_Swift_COMPILER_TARGET=x86_64-unknown-windows-msvc -D CMAKE_Swift_COMPILER_WORKS=YES -D CMAKE_Swift_FLAGS=-sdk \"T:/Program Files/Swift/Platforms/Windows.platform/Developer/SDKs/Windows.sdk\" -gnone -Xlinker /INCREMENTAL:NO -Xlinker /OPT:REF -Xlinker /OPT:ICF -D CMAKE_Swift_FLAGS_RELEASE=-O -D CMAKE_Swift_FLAGS_RELWITHDEBINFO=-O -D cmark-gfm_DIR=T:/Program Files/Swift/Toolchains/0.0.0+Asserts/usr/lib/cmake -D LMDB_DIR=T:/x86_64-unknown-windows-msvc/LMDB/cmake/modules -D SwiftASN1_DIR=T:/x86_64-unknown-windows-msvc/ASN1/cmake/modules -D SwiftCrypto_DIR=T:/x86_64-unknown-windows-msvc/Crypto/cmake/modules -D SwiftMarkdown_DIR=T:/x86_64-unknown-windows-msvc/Markdown/cmake/modules -D SymbolKit_DIR=T:/x86_64-unknown-windows-msvc/SymbolKit/cmake/modules
-- The C compiler identification is Clang 21.1.6 with MSVC-like command-line
-- The Swift compiler identification is Apple 6.3
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: T:/5/bin/clang-cl.exe - skipped
-- Detecting C compile features
-- Detecting C compile features - done
CMake Error at Sources/CMakeLists.txt:11 (add_subdirectory):
  The source directory

    C:/Users/swift-ci/jenkins/workspace/swift-PR-windows/swift-docc/Sources/SwiftDocCUtilities

  does not contain a CMakeLists.txt file.
`