### PR TITLE
fix: fixed MultipleChoice symbol in Assessments docs

### DIFF
--- a/Sources/docc/DocCDocumentation.docc/Reference Syntax/Tutorials Syntax/Top-Level Directives/Tutorial/Assessments/Assessments.md
+++ b/Sources/docc/DocCDocumentation.docc/Reference Syntax/Tutorials Syntax/Top-Level Directives/Tutorial/Assessments/Assessments.md
@@ -8,7 +8,7 @@ Tests the reader's knowledge at the end of a tutorial page.
 
 ## Overview
 
-Use the `Assessment` directive to display an assessments section that helps the reader check their knowledge of your Swift framework or package APIs at the end of a tutorial page. An assessment includes a set of multiple-choice questions that you create using the`MultipleChoice`` directive. If the reader gets a question wrong, you can provide a hint that points them toward the correct answer so they can try again.
+Use the `Assessment` directive to display an assessments section that helps the reader check their knowledge of your Swift framework or package APIs at the end of a tutorial page. An assessment includes a set of multiple-choice questions that you create using the ``MultipleChoice`` directive. If the reader gets a question wrong, you can provide a hint that points them toward the correct answer so they can try again.
 
 ```
 @Tutorial(time: 30) {


### PR DESCRIPTION
## Summary

Fixed MultipleChoice symbol in Assessments docs. Documentation change only.

## Dependencies

N/A

## Testing

N/A

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [ ] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
