### PR TITLE
[6.3] Encode absolute presentation URL if present (#1346)

### DIFF
--- a/Sources/SwiftDocC/LinkTargets/LinkDestinationSummary.swift
+++ b/Sources/SwiftDocC/LinkTargets/LinkDestinationSummary.swift
@@ -112,7 +112,8 @@ public struct LinkDestinationSummary: Codable, Equatable {
     //  so that external documentation sources don't need to provide that data.
     //  Adding new required properties is considered breaking change since existing external documentation sources
     //  wouldn't necessarily meet these new requirements.
-    
+    //  Make sure to update the encoding, decoding and Equatable implementations when adding new properties.
+
     /// A collection of identifiers that all relate to some common task, as described by the title.
     public struct TaskGroup: Codable, Equatable {
         /// The title of this task group
@@ -725,7 +726,7 @@ extension LinkDestinationSummary {
         } else {
             try container.encode(kind, forKey: .kind)
         }
-        try container.encode(relativePresentationURL, forKey: .relativePresentationURL)
+        try container.encode(absolutePresentationURL ?? relativePresentationURL, forKey: .relativePresentationURL)
         try container.encode(referenceURL, forKey: .referenceURL)
         try container.encode(title, forKey: .title)
         try container.encodeIfPresent(abstract, forKey: .abstract)
@@ -935,12 +936,15 @@ extension LinkDestinationSummary {
         guard lhs.kind == rhs.kind else { return false }
         guard lhs.language == rhs.language else { return false }
         guard lhs.relativePresentationURL == rhs.relativePresentationURL else { return false }
+        guard lhs.absolutePresentationURL == rhs.absolutePresentationURL else { return false }
         guard lhs.title == rhs.title else { return false }
         guard lhs.abstract == rhs.abstract else { return false }
         guard lhs.availableLanguages == rhs.availableLanguages else { return false }
         guard lhs.platforms == rhs.platforms else { return false }
         guard lhs.taskGroups == rhs.taskGroups else { return false }
+        guard lhs.plainTextDeclaration == rhs.plainTextDeclaration else { return false }
         guard lhs.subheadingDeclarationFragments == rhs.subheadingDeclarationFragments else { return false }
+        guard lhs.navigatorDeclarationFragments == rhs.navigatorDeclarationFragments else { return false }
         guard lhs.redirects == rhs.redirects else { return false }
         guard lhs.topicImages == rhs.topicImages else { return false }
         guard lhs.variants == rhs.variants else { return false }

--- a/Tests/SwiftDocCTests/Infrastructure/ExternalReferenceResolverTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/ExternalReferenceResolverTests.swift
@@ -1420,7 +1420,10 @@ class ExternalReferenceResolverTests: XCTestCase {
             """.utf8))
         XCTAssertEqual(externalEntity.relativePresentationURL.absoluteString, "/path/to/something")
         XCTAssertEqual(externalEntity.absolutePresentationURL?.absoluteString, "https://com.example/path/to/something")
-        
+
+        // Test that encoding the link summary preserves the absolute URL
+        try assertRoundTripCoding(externalEntity)
+
         let resolver = Resolver(entityToReturn: externalEntity)
         
         var configuration = DocumentationContext.Configuration()


### PR DESCRIPTION
**Explanation**: A small bug fix which makes sure all new fields in `LinkDestinationSummary` are encoded, decoded and part of its equality comparison.
**Scope**: Limited to additions to the `Encodable`, `Decodable` and `Equatable` implementations of `LinkDestinationSummary`.
**Issue**: rdar://164628218.
**Risk:** Low. Affects only how we encode/decode optional `LinkDestinationSummary` properties.
**Testing**: Added new tests which verify that roundtrip encoding works as expected for `LinkDestinationSummary`. All existing unit tests pass.
**Reviewer:** @d-ronnqvist 
**Original PR**: https://github.com/swiftlang/swift-docc/pull/1346