### PR TITLE
[6.3] Reset unsupported metadata configuration like the doc comment says

### DIFF
--- a/Tests/SwiftDocCTests/Semantics/SymbolTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/SymbolTests.swift
@@ -1315,8 +1315,6 @@ class SymbolTests: XCTestCase {
                 "org.swift.docc.Metadata.InvalidPageColorInDocumentationComment",
                 "org.swift.docc.Metadata.InvalidTitleHeadingInDocumentationComment",
                 "org.swift.docc.Metadata.InvalidRedirectedInDocumentationComment",
-                
-                "org.swift.docc.unresolvedResource", // For the "test" asset that doesn't exist.
             ]
         )
         


### PR DESCRIPTION
**Explanation**: Updates the `@Metadata` validation for in-source documentation comments to match the behavior that's both documented and described in the user-facing diagnostic.
**Scope**: Validation of `@Metadata` directives. 
**Issue**: rdar://161219604.
**Risk:** Low. Only affects validation of `@Metadata` directives that are not supported in-source.
**Testing**: Updated test to verify that unsupported directives are not processed further after that diagnostic is raised. All existing unit tests pass.
**Reviewer:** @snprajwal 
**Original PR**: https://github.com/swiftlang/swift-docc/pull/1312