### PR TITLE
[6.3][cherrypick] OpenBSD support. (#1348)

### DIFF
--- a/Sources/SwiftDocC/Benchmark/Benchmark.swift
+++ b/Sources/SwiftDocC/Benchmark/Benchmark.swift
@@ -48,6 +48,8 @@ public class Benchmark: Encodable {
     public let platform = "Android"
     #elseif os(FreeBSD)
     public let platform = "FreeBSD"
+    #elseif os(OpenBSD)
+    public let platform = "OpenBSD"
     #else
     public let platform = "unsupported"
     #endif

--- a/Sources/SwiftDocC/Benchmark/Metrics/PeakMemory.swift
+++ b/Sources/SwiftDocC/Benchmark/Metrics/PeakMemory.swift
@@ -67,7 +67,7 @@ extension Benchmark {
             ) else { return nil }
             return Int64(pmcStats.PeakWorkingSetSize)
         }
-        #elseif os(FreeBSD)
+        #elseif os(FreeBSD) || os(OpenBSD)
         private static func peakMemory() -> Int64? {
             var usage = rusage()
             if (getrusage(RUSAGE_SELF, &usage) == -1) {

--- a/Sources/SwiftDocC/Infrastructure/External Data/OutOfProcessReferenceResolver.swift
+++ b/Sources/SwiftDocC/Infrastructure/External Data/OutOfProcessReferenceResolver.swift
@@ -517,7 +517,7 @@ private class LongRunningService: ExternalLinkResolving {
 /// This private class is only used by the ``OutOfProcessReferenceResolver`` and shouldn't be used for general communication with other processes.
 private class LongRunningProcess: ExternalLinkResolving {
     
-    #if os(macOS) || os(Linux) || os(Android) || os(FreeBSD)
+    #if os(macOS) || os(Linux) || os(Android) || os(FreeBSD) || os(OpenBSD)
     private let process: Process
     
     init(location: URL, errorOutputHandler: @escaping (String) -> Void) throws {

--- a/Sources/SwiftDocC/Model/Rendering/RenderContext.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderContext.swift
@@ -61,7 +61,7 @@ public struct RenderContext {
             )
         }
         
-        #if os(macOS) || os(iOS) || os(Android) || os(Windows) || os(FreeBSD)
+        #if os(macOS) || os(iOS) || os(Android) || os(Windows) || os(FreeBSD) || os(OpenBSD)
         // Concurrently render content on macOS/iOS, Windows & Android
         let results: [(reference: ResolvedTopicReference, content: RenderReferenceStore.TopicContent)] = references.concurrentPerform { reference, results in
             results.append((reference, renderContentFor(reference)))

--- a/Sources/SwiftDocC/Utility/FoundationExtensions/AutoreleasepoolShim.swift
+++ b/Sources/SwiftDocC/Utility/FoundationExtensions/AutoreleasepoolShim.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-#if os(Linux) || os(Android) || os(Windows) || os(FreeBSD)
+#if os(Linux) || os(Android) || os(Windows) || os(FreeBSD) || os(OpenBSD)
 /// A shim for non-ObjC targets that runs the given block of code.
 ///
 /// The existence of this shim allows you the use of auto-release pools to optimize memory footprint on Darwin platforms while maintaining

--- a/Sources/SwiftDocC/Utility/Synchronization.swift
+++ b/Sources/SwiftDocC/Utility/Synchronization.swift
@@ -35,7 +35,7 @@ public class Synchronized<Value> {
     #elseif os(Linux) || os(Android)
     /// A lock type appropriate for the current platform.
     var lock: UnsafeMutablePointer<pthread_mutex_t>
-    #elseif os(FreeBSD)
+    #elseif os(FreeBSD) || os(OpenBSD)
     /// A lock type appropriate for the current platform.
     var lock: UnsafeMutablePointer<pthread_mutex_t?>
     #elseif os(Windows)
@@ -56,7 +56,7 @@ public class Synchronized<Value> {
         lock = UnsafeMutablePointer<pthread_mutex_t>.allocate(capacity: 1)
         lock.initialize(to: pthread_mutex_t())
         pthread_mutex_init(lock, nil)
-        #elseif os(FreeBSD)
+        #elseif os(FreeBSD) || os(OpenBSD)
         lock = UnsafeMutablePointer<pthread_mutex_t?>.allocate(capacity: 1)
         lock.initialize(to: nil)
         pthread_mutex_init(lock, nil)
@@ -84,7 +84,7 @@ public class Synchronized<Value> {
         #elseif os(Linux) || os(Android)
         pthread_mutex_lock(lock)
         defer { pthread_mutex_unlock(lock) }
-        #elseif os(FreeBSD)
+        #elseif os(FreeBSD) || os(OpenBSD)
         pthread_mutex_lock(lock)
         defer { pthread_mutex_unlock(lock) }
         #elseif os(Windows)
@@ -123,7 +123,7 @@ extension Lock {
         #elseif os(Linux) || os(Android)
         pthread_mutex_lock(lock)
         defer { pthread_mutex_unlock(lock) }
-        #elseif os(FreeBSD)
+        #elseif os(FreeBSD) || os(OpenBSD)
         pthread_mutex_lock(lock)
         defer { pthread_mutex_unlock(lock) }
         #elseif os(Windows)

--- a/Sources/SwiftDocCUtilities/Utility/DirectoryMonitor.swift
+++ b/Sources/SwiftDocCUtilities/Utility/DirectoryMonitor.swift
@@ -11,7 +11,7 @@
 import Foundation
 import SwiftDocC
 
-#if !os(Linux) && !os(Android) && !os(Windows) && !os(FreeBSD)
+#if !os(Linux) && !os(Android) && !os(Windows) && !os(FreeBSD) && !os(OpenBSD)
 import Darwin
 
 /// A throttle object to filter events that come too fast.

--- a/Sources/SwiftDocCUtilities/Utility/Signal.swift
+++ b/Sources/SwiftDocCUtilities/Utility/Signal.swift
@@ -27,7 +27,7 @@ public struct Signal {
         signalAction.__sigaction_handler = unsafeBitCast(callback, to: sigaction.__Unnamed_union___sigaction_handler.self)
         #elseif os(Android)
         signalAction.sa_handler = callback
-        #elseif os(FreeBSD)
+        #elseif os(FreeBSD) || os(OpenBSD)
         signalAction.__sigaction_u.__sa_handler = callback
         #else
         signalAction.__sigaction_u = unsafeBitCast(callback, to: __sigaction_u.self)

--- a/Sources/docc/main.swift
+++ b/Sources/docc/main.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-#if os(macOS) || os(Linux) || os(Android) || os(Windows) || os(FreeBSD)
+#if os(macOS) || os(Linux) || os(Android) || os(Windows) || os(FreeBSD) || os(OpenBSD)
 import SwiftDocCUtilities
 
 await Task {

--- a/Tests/SwiftDocCTests/Servers/DocumentationSchemeHandlerTests.swift
+++ b/Tests/SwiftDocCTests/Servers/DocumentationSchemeHandlerTests.swift
@@ -24,7 +24,7 @@ class DocumentationSchemeHandlerTests: XCTestCase {
         forResource: "LegacyBundle_DoNotUseInNewTests", withExtension: "docc", subdirectory: "Test Bundles")!
     
     func testDocumentationSchemeHandler() {
-        #if !os(Linux) && !os(Android) && !os(Windows) && !os(FreeBSD)
+        #if !os(Linux) && !os(Android) && !os(Windows) && !os(FreeBSD) && !os(OpenBSD)
         let topicSchemeHandler = DocumentationSchemeHandler(withTemplateURL: templateURL)
         
         let request = URLRequest(url:  baseURL.appendingPathComponent("/images/figure1.jpg"))
@@ -50,7 +50,7 @@ class DocumentationSchemeHandlerTests: XCTestCase {
     }
     
     func testSetData() {
-        #if !os(Linux) && !os(Android) && !os(Windows) && !os(FreeBSD)
+        #if !os(Linux) && !os(Android) && !os(Windows) && !os(FreeBSD) && !os(OpenBSD)
         let topicSchemeHandler = DocumentationSchemeHandler(withTemplateURL: templateURL)
         
         let data = "hello!".data(using: .utf8)!

--- a/Tests/SwiftDocCTests/Servers/FileServerTests.swift
+++ b/Tests/SwiftDocCTests/Servers/FileServerTests.swift
@@ -164,7 +164,7 @@ class FileServerTests: XCTestCase {
         (response, data) = fileServer.response(to: failingRequest)
         XCTAssertNil(data)
         // Initializing a URLResponse with `nil` as MIME type in Linux returns nil
-        #if os(Linux) || os(Android) || os(Windows) || os(FreeBSD)
+        #if os(Linux) || os(Android) || os(Windows) || os(FreeBSD) || os(OpenBSD)
         XCTAssertNil(response.mimeType)
         #else
         // Doing the same in macOS or iOS returns the default MIME type

--- a/Tests/SwiftDocCTests/Utility/LMDBTests.swift
+++ b/Tests/SwiftDocCTests/Utility/LMDBTests.swift
@@ -237,7 +237,7 @@ final class SwiftLMDBTests: XCTestCase {
     }
     
     func testArrayOfInt() throws {
-#if !os(Linux) && !os(Android) && !os(Windows) && !os(FreeBSD)
+#if !os(Linux) && !os(Android) && !os(Windows) && !os(FreeBSD) && !os(OpenBSD)
         let database = try environment.openDatabase()
         
         var array: [UInt32] = []

--- a/Tests/SwiftDocCUtilitiesTests/C+Extensions.swift
+++ b/Tests/SwiftDocCUtilitiesTests/C+Extensions.swift
@@ -11,7 +11,7 @@
 import Foundation
 #if os(Windows)
 import ucrt
-#elseif os(Linux) || os(Android) || os(FreeBSD)
+#elseif os(Linux) || os(Android) || os(FreeBSD) || os(OpenBSD)
 import Glibc
 #else
 import Darwin

--- a/Tests/SwiftDocCUtilitiesTests/DirectoryMonitorTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/DirectoryMonitorTests.swift
@@ -11,7 +11,7 @@
 import XCTest
 @testable import SwiftDocCUtilities
 
-#if !os(Linux) && !os(Android) && !os(Windows) && !os(FreeBSD)
+#if !os(Linux) && !os(Android) && !os(Windows) && !os(FreeBSD) && !os(OpenBSD)
 fileprivate extension NSNotification.Name {
     static let testNodeUpdated = NSNotification.Name(rawValue: "testNodeUpdated")
     static let testDirectoryReloaded = NSNotification.Name(rawValue: "testDirectoryReloaded")
@@ -24,7 +24,7 @@ func fileURLsAreEqual(_ url1: URL, _ url2: URL) -> Bool {
 #endif
 
 class DirectoryMonitorTests: XCTestCase {
-    #if !os(Linux) && !os(Android) && !os(Windows) && !os(FreeBSD)
+    #if !os(Linux) && !os(Android) && !os(Windows) && !os(FreeBSD) && !os(OpenBSD)
     // - MARK: Directory watching test infra
     
     /// Method that automates setting up a directory monitor, setting up the relevant expectations for a test,
@@ -115,7 +115,7 @@ class DirectoryMonitorTests: XCTestCase {
     /// Tests a succession of file system changes and verifies that they produce
     /// the expected monitor events.
     func testMonitorUpdates() throws {
-        #if !os(Linux) && !os(Android) && !os(Windows) && !os(FreeBSD)
+        #if !os(Linux) && !os(Android) && !os(Windows) && !os(FreeBSD) && !os(OpenBSD)
 
         // Create temp folder & sub-folder.
         let tempSubfolderURL = try createTemporaryDirectory(named: "subfolder")
@@ -164,7 +164,7 @@ class DirectoryMonitorTests: XCTestCase {
     }
     
     func testMonitorDoesNotTriggerUpdates() throws {
-        #if !os(Linux) && !os(Android) && !os(Windows) && !os(FreeBSD)
+        #if !os(Linux) && !os(Android) && !os(Windows) && !os(FreeBSD) && !os(OpenBSD)
         
         // Create temp folder & sub-folder.
         let tempSubfolderURL = try createTemporaryDirectory(named: "subfolder")
@@ -197,7 +197,7 @@ class DirectoryMonitorTests: XCTestCase {
     
     /// Tests a zero sum change aggregation triggers an event.
     func testMonitorZeroSumSizeChangesUpdates() throws {
-        #if !os(Linux) && !os(Android) && !os(Windows) && !os(FreeBSD)
+        #if !os(Linux) && !os(Android) && !os(Windows) && !os(FreeBSD) && !os(OpenBSD)
 
         // Create temp folder & sub-folder.
         let tempSubfolderURL = try createTemporaryDirectory(named: "subfolder")

--- a/build-script-helper.py
+++ b/build-script-helper.py
@@ -176,6 +176,11 @@ def get_swiftpm_options(action, args):
     ]
     if action == 'install':
       swiftpm_args += ['--disable-local-rpath']
+  elif build_os.startswith('openbsd'):
+    swiftpm_args += [
+      '-Xlinker', '-rpath', '-Xlinker', '$ORIGIN/../lib/swift/openbsd',
+      '-Xlinker', '-z', '-Xlinker', 'origin',
+    ]
   else:
     swiftpm_args += [
       # Library rpath for swift, dispatch, Foundation, etc. when installing


### PR DESCRIPTION
- **Explanation**: ensure docc builds and runs on OpenBSD. Accepting this on the release branch will assist building and eventually packaging docc with the 6.3 release on this platform.

- **Scope**: Changes are only applicable to OpenBSD.

- **GitHub Issue**: Of relevance to the OpenBSD port issue in swiftlang/swift#78437

- **Risk**: Minimal risk, since there should be no change for other platforms.

- **Testing**: Passes CI, tested locally.

- **Reviewer**: @d-ronnqvist 