### PR TITLE
Revert "Revert "Minimally integrate per-page HTML content into each "index.html" file""

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -44,6 +44,7 @@ let package = Package(
             name: "SwiftDocC",
             dependencies: [
                 .target(name: "DocCCommon"),
+                .target(name: "DocCHTML"),
                 .product(name: "Markdown", package: "swift-markdown"),
                 .product(name: "SymbolKit", package: "swift-docc-symbolkit"),
                 .product(name: "CLMDB", package: "swift-lmdb"),

--- a/Sources/SwiftDocC/CMakeLists.txt
+++ b/Sources/SwiftDocC/CMakeLists.txt
@@ -175,6 +175,8 @@ add_library(SwiftDocC
   Model/Rendering/Diffing/Differences.swift
   Model/Rendering/Diffing/RenderNode+Diffable.swift
   Model/Rendering/DocumentationContentRenderer.swift
+  Model/Rendering/HTML/HTMLContentConsumer.swift
+  Model/Rendering/HTML/HTMLRenderer.swift
   Model/Rendering/LinkTitleResolver.swift
   "Model/Rendering/Navigation Tree/RenderHierarchy.swift"
   "Model/Rendering/Navigation Tree/RenderHierarchyChapter.swift"
@@ -465,6 +467,8 @@ add_library(SwiftDocC
   Utility/Version.swift)
 target_link_libraries(SwiftDocC PRIVATE
   DocCCommon)
+target_link_libraries(SwiftDocC PRIVATE
+  DocCHTML)
 target_link_libraries(SwiftDocC PUBLIC
   SwiftMarkdown::Markdown
   DocC::SymbolKit

--- a/Sources/SwiftDocC/Infrastructure/ConvertActionConverter.swift
+++ b/Sources/SwiftDocC/Infrastructure/ConvertActionConverter.swift
@@ -26,6 +26,7 @@ package enum ConvertActionConverter {
     /// - Parameters:
     ///   - context: The context that the bundle is a part of.
     ///   - outputConsumer: The consumer that the conversion passes outputs of the conversion to.
+    ///   - htmlContentConsumer: The consumer for HTML content that the conversion produces, or `nil` if the conversion shouldn't produce any HTML content.
     ///   - sourceRepository: The source repository where the documentation's sources are hosted.
     ///   - emitDigest: Whether the conversion should pass additional metadata output––such as linkable entities information, indexing information, or asset references by asset type––to the consumer.
     ///   - documentationCoverageOptions: The level of experimental documentation coverage information that the conversion should pass to the consumer.
@@ -33,6 +34,7 @@ package enum ConvertActionConverter {
     package static func convert(
         context: DocumentationContext,
         outputConsumer: some ConvertOutputConsumer & ExternalNodeConsumer,
+        htmlContentConsumer: (any HTMLContentConsumer)?,
         sourceRepository: SourceRepository?,
         emitDigest: Bool,
         documentationCoverageOptions: DocumentationCoverageOptions
@@ -103,7 +105,7 @@ package enum ConvertActionConverter {
 
         let renderSignpostHandle = signposter.beginInterval("Render", id: signposter.makeSignpostID(), "Render \(context.knownPages.count) pages")
         
-        var conversionProblems: [Problem] = context.knownPages.concurrentPerform { identifier, results in
+        var conversionProblems: [Problem] = context.knownPages.concurrentPerform { [htmlContentConsumer] identifier, results in
             // If cancelled skip all concurrent conversion work in this block.
             guard !Task.isCancelled else { return }
             
@@ -111,7 +113,19 @@ package enum ConvertActionConverter {
             autoreleasepool {
                 do {
                     let entity = try context.entity(with: identifier)
-
+                    
+                    if let htmlContentConsumer {
+                        var renderer = HTMLRenderer(reference: identifier, context: context, goal: .conciseness)
+                        
+                        if let symbol = entity.semantic as? Symbol {
+                            let renderedPageInfo = renderer.renderSymbol(symbol)
+                            try htmlContentConsumer.consume(pageInfo: renderedPageInfo, forPage: identifier)
+                        } else if let article = entity.semantic as? Article {
+                            let renderedPageInfo = renderer.renderArticle(article)
+                            try htmlContentConsumer.consume(pageInfo: renderedPageInfo, forPage: identifier)
+                        }
+                    }
+                    
                     guard let renderNode = converter.renderNode(for: entity) else {
                         // No render node was produced for this entity, so just skip it.
                         return
@@ -245,5 +259,18 @@ package enum ConvertActionConverter {
         benchmark(add: Benchmark.PeakMemory())
         
         return conversionProblems
+    }
+}
+
+private extension HTMLContentConsumer {
+    func consume(pageInfo: HTMLRenderer.RenderedPageInfo, forPage reference: ResolvedTopicReference) throws {
+        try consume(
+            mainContent: pageInfo.content,
+            metadata: (
+                title: pageInfo.metadata.title,
+                description: pageInfo.metadata.plainDescription
+            ),
+            forPage: reference
+        )
     }
 }

--- a/Sources/SwiftDocC/Infrastructure/ConvertOutputConsumer.swift
+++ b/Sources/SwiftDocC/Infrastructure/ConvertOutputConsumer.swift
@@ -8,8 +8,6 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
-
 /// A consumer for output produced by a documentation conversion.
 ///
 /// Types that conform to this protocol manage what to do with documentation conversion products, for example persist them to disk

--- a/Sources/SwiftDocC/Model/Rendering/HTML/HTMLContentConsumer.swift
+++ b/Sources/SwiftDocC/Model/Rendering/HTML/HTMLContentConsumer.swift
@@ -1,0 +1,40 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2025 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+#if canImport(FoundationXML)
+// TODO: Consider other HTML rendering options as a future improvement (rdar://165755530)
+package import FoundationXML
+#else
+package import Foundation
+#endif
+
+/// A consumer for HTML content produced during documentation conversion.
+package protocol HTMLContentConsumer {
+    // One reason that this is its own protocol, rather than an extension of ConvertOutputConsumer, is so that we can avoid exposing `XMLNode` in any public API.
+    // That way, we are completely free to replace the entire internal HTML rendering implementation with something else in the future, without breaking API.
+    
+    /// Consumes the HTML content and metadata for a given page.
+    ///
+    /// The content and metadata doesn't make up a full valid HTML page.
+    /// It's the consumers responsibility to insert the information into a template or skeletal structure to produce a valid HTML file for each page.
+    ///
+    /// - Parameters:
+    ///   - mainContent: The contents for this page as an XHTML node.
+    ///   - metadata: Metadata information (title and description) about this page.
+    ///   - reference: The resolved topic reference that identifies this page.
+    func consume(
+        mainContent: XMLNode,
+        metadata: (
+            title: String,
+            description: String?
+        ),
+        forPage reference: ResolvedTopicReference
+    ) throws
+}

--- a/Sources/SwiftDocC/Model/Rendering/HTML/HTMLRenderer.swift
+++ b/Sources/SwiftDocC/Model/Rendering/HTML/HTMLRenderer.swift
@@ -1,0 +1,336 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2025 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+#if canImport(FoundationXML)
+// TODO: Consider other HTML rendering options as a future improvement (rdar://165755530)
+import FoundationXML
+import FoundationEssentials
+#else
+import Foundation
+#endif
+import DocCHTML
+import Markdown
+import SymbolKit
+
+/// A link provider that provider structured information about resolved links and assets to the underlying HTML renderer.
+private struct ContextLinkProvider: LinkProvider {
+    let reference: ResolvedTopicReference
+    let context: DocumentationContext
+    let goal: RenderGoal
+    
+    func element(for url: URL) -> LinkedElement? {
+        guard url.scheme == "doc",
+              let rawBundleID = url.host,
+              // TODO: Support returning information about external pages (rdar://165912415)
+              let node = context.documentationCache[ResolvedTopicReference(bundleID: .init(rawValue: rawBundleID), path: url.path, fragment: url.fragment, sourceLanguage: .swift /* The reference's language doesn't matter */)]
+        else {
+            return nil
+        }
+        
+        // A helper function that transforms SymbolKit fragments into renderable identifier/decorator fragments
+        func convert(_ fragments: [SymbolGraph.Symbol.DeclarationFragments.Fragment]) -> [LinkedElement.SymbolNameFragment] {
+            func convert(kind: SymbolGraph.Symbol.DeclarationFragments.Fragment.Kind) -> LinkedElement.SymbolNameFragment.Kind {
+                switch kind {
+                    case .identifier, .externalParameter: .identifier
+                    default:                              .decorator
+                }
+            }
+            guard var current = fragments.first.map({ LinkedElement.SymbolNameFragment(text: $0.spelling, kind: convert(kind: $0.kind)) }) else {
+                return []
+            }
+            
+            // Join together multiple fragments of the same identifier/decorator kind to produce a smaller output.
+            var result: [LinkedElement.SymbolNameFragment] = []
+            for fragment in fragments.dropFirst() {
+                let kind = convert(kind: fragment.kind)
+                if kind == current.kind  {
+                    current.text += fragment.spelling
+                } else {
+                    result.append(current)
+                    current = .init(text: fragment.spelling, kind: kind)
+                }
+            }
+            result.append(current)
+            return result
+        }
+        
+        let subheadings: LinkedElement.Subheadings = if let symbol = node.semantic as? Symbol {
+            switch symbol.subHeadingVariants.values(goal: goal) {
+                case .single(let subHeading):
+                    .single(.symbol(convert(subHeading)))
+                case .languageSpecific(let subHeadings):
+                    .languageSpecificSymbol(subHeadings.mapValues(convert))
+                case .empty:
+                    // This shouldn't happen but because of a shortcoming in the API design of `DocumentationDataVariants`, it can't be guaranteed.
+                    .single(.symbol([]))
+            }
+        } else {
+            .single(.conceptual(node.name.plainText))
+        }
+        
+        return .init(
+            path: Self.filePath(for: node.reference),
+            names: node.makeNames(goal: goal),
+            subheadings: subheadings,
+            abstract: (node.semantic as? (any Abstracted))?.abstract
+        )
+    }
+    
+    func pathForSymbolID(_ usr: String) -> URL? {
+        context.localOrExternalReference(symbolID: usr).map {
+            Self.filePath(for: $0)
+        }
+    }
+    
+    func assetNamed(_ assetName: String) -> LinkedAsset? {
+        guard let asset = context.resolveAsset(named: assetName, in: reference) else {
+            // The context
+            return nil
+        }
+        
+        var files = [LinkedAsset.ColorStyle: [Int: URL]]()
+        for (traits, url) in asset.variants {
+            let scale = (traits.displayScale ?? .standard).scaleFactor
+            
+            files[traits.userInterfaceStyle == .dark ? .dark : .light, default: [:]][scale] = url
+        }
+        
+        return .init(files: files)
+    }
+    
+    func fallbackLinkText(linkString: String) -> String {
+        // For unresolved links, especially to symbols, prefer to display only the the last link component without its disambiguation
+        PathHierarchy.PathParser.parse(path: linkString).components.last.map { String($0.name) } ?? linkString
+    }
+    
+    static func filePath(for reference: ResolvedTopicReference) -> URL {
+        reference.url.withoutHostAndPortAndScheme().appendingPathComponent("index.html")
+    }
+}
+
+// MARK: HTML Renderer
+
+/// A type that renders documentation pages into semantic HTML elements.
+struct HTMLRenderer {
+    let reference: ResolvedTopicReference
+    let context: DocumentationContext
+    let goal: RenderGoal
+    
+    private let renderer: MarkdownRenderer<ContextLinkProvider>
+    
+    init(reference: ResolvedTopicReference, context: DocumentationContext, goal: RenderGoal) {
+        self.reference = reference
+        self.context = context
+        self.goal = goal
+        self.renderer = MarkdownRenderer(
+            path: ContextLinkProvider.filePath(for: reference),
+            goal: goal,
+            linkProvider: ContextLinkProvider(reference: reference, context: context, goal: goal)
+        )
+    }
+    
+    /// Information about a rendered page
+    struct RenderedPageInfo {
+        /// The HTML content of the page as an XMLNode hierarchy.
+        ///
+        /// The string representation of this node hierarchy is intended to be inserted _somewhere_ inside the `<body>` HTML element.
+        /// It _doesn't_ include a page header, footer, navigator, etc. and may be an insufficient representation of the "entire" page
+        var content: XMLNode
+        /// The title and description/abstract of the page.
+        var metadata: Metadata
+        /// Meta information about the page that belongs in the HTML `<head>` element.
+        struct Metadata {
+            /// The plain text title of this page, suitable as content for the HTML `<title>` element.
+            var title: String
+            /// The plain text description/abstract of this page, suitable a data for a `<meta>` element for sharing purposes.
+            var plainDescription: String?
+        }
+    }
+    
+    mutating func renderArticle(_ article: Article) -> RenderedPageInfo {
+        let node = context.documentationCache[reference]!
+        
+        let main = XMLElement(name: "main")
+        let articleElement = XMLElement(name: "article")
+        main.addChild(articleElement)
+        
+        let hero = XMLElement(name: "section")
+        articleElement.addChild(hero)
+        
+        // Title
+        hero.addChild(
+            .element(named: "h1", children: [.text(node.name.plainText)])
+        )
+        
+        // Abstract
+        if let abstract = article.abstract {
+            let paragraph = renderer.visit(abstract) as! XMLElement
+            if goal == .richness {
+                paragraph.addAttribute(XMLNode.attribute(withName: "id", stringValue: "abstract") as! XMLNode)
+            }
+            hero.addChild(paragraph)
+        }
+        
+        return RenderedPageInfo(
+            content: goal == .richness ? main : articleElement,
+            metadata: .init(
+                title: article.title?.plainText ?? node.name.plainText,
+                plainDescription: article.abstract?.plainText
+            )
+        )
+    }
+    
+    mutating func renderSymbol(_ symbol: Symbol) -> RenderedPageInfo {
+        let main = XMLElement(name: "main")
+        let articleElement = XMLElement(name: "article")
+        main.addChild(articleElement)
+        
+        let hero = XMLElement(name: "section")
+        articleElement.addChild(hero)
+        
+        // Title
+        switch symbol.titleVariants.values(goal: goal) {
+            case .single(let title):
+                hero.addChild(
+                    .element(named: "h1", children: renderer.wordBreak(symbolName: title))
+                )
+            case .languageSpecific(let languageSpecificTitles):
+                for (language, languageSpecificTitle) in languageSpecificTitles.sorted(by: { $0.key < $1.key }) {
+                    hero.addChild(
+                        .element(named: "h1", children: renderer.wordBreak(symbolName: languageSpecificTitle), attributes: ["class": "\(language.id)-only"])
+                    )
+                }
+            case .empty:
+                // This shouldn't happen but because of a shortcoming in the API design of `DocumentationDataVariants`, it can't be guaranteed.
+                hero.addChild(
+                    .element(named: "h1", children: renderer.wordBreak(symbolName: symbol.title /* This is internally force unwrapped */))
+                )
+        }
+        
+        // Abstract
+        if let abstract = symbol.abstract {
+            let paragraph = renderer.visit(abstract) as! XMLElement
+            if goal == .richness {
+                paragraph.addAttribute(XMLNode.attribute(withName: "id", stringValue: "abstract") as! XMLNode)
+            }
+            hero.addChild(paragraph)
+        }
+        
+        return RenderedPageInfo(
+            content: goal == .richness ? main : articleElement,
+            metadata: .init(
+                title: symbol.title,
+                plainDescription: symbol.abstract?.plainText
+            )
+        )
+    }
+    
+    // TODO: As a future enhancement, add another layer on top of this that creates complete HTML pages (both `<head>` and `<body>`) (rdar://165912669)
+}
+
+// MARK: Helpers
+
+// Note; this isn't a Comparable conformance so that it can remain private to this file.
+private extension DocumentationDataVariantsTrait {
+    static func < (lhs: DocumentationDataVariantsTrait, rhs: DocumentationDataVariantsTrait) -> Bool {
+        if let lhs = lhs.sourceLanguage {
+            if let rhs = rhs.sourceLanguage {
+                return lhs < rhs
+            }
+            return true // nil is after anything
+        }
+        return false // nil is after anything
+    }
+}
+
+private extension XMLElement {
+    func addChildren(_ nodes: [XMLNode]) {
+        for node in nodes {
+            addChild(node)
+        }
+    }
+}
+
+private extension DocumentationNode {
+    func makeNames(goal: RenderGoal) -> LinkedElement.Names {
+        switch name {
+        case .conceptual(let title):
+            // This node has a single "conceptual" name.
+            // It could either be an article or a symbol with an authored `@DisplayName`.
+            .single(.conceptual(title))
+        case .symbol(let nodeTitle):
+            if let symbol = semantic as? Symbol {
+                symbol.makeNames(goal: goal, fallbackTitle: nodeTitle)
+            } else {
+                // This node has a symbol name, but for some reason doesn't have a symbol semantic.
+                // That's a bit strange and unexpected, but we can still make a single name for it.
+                .single(.symbol(nodeTitle))
+            }
+        }
+    }
+}
+
+private extension Symbol {
+    func makeNames(goal: RenderGoal, fallbackTitle: String) -> LinkedElement.Names {
+        switch titleVariants.values(goal: goal) {
+            case .single(let title):
+                .single(.symbol(title))
+            case .languageSpecific(let titles):
+                .languageSpecificSymbol(titles)
+            case .empty:
+                // This shouldn't happen but because of a shortcoming in the API design of `DocumentationDataVariants`, it can't be guaranteed.
+                .single(.symbol(fallbackTitle))
+        }
+    }
+}
+
+private enum VariantValues<Value> {
+    case single(Value)
+    case languageSpecific([SourceLanguage: Value])
+    // This is necessary because of a shortcoming in the API design of `DocumentationDataVariants`.
+    case empty
+}
+
+// Both `DocumentationDataVariants` and `VariantCollection` are really hard to work with correctly and neither offer a good API that both:
+// - Makes a clear distinction between when a value will always exist and when the "values" can be empty.
+// - Allows the caller to iterate over all the values.
+// TODO: Design and implement a better solution for representing language specific variations of a value (rdar://166211961)
+private extension DocumentationDataVariants where Variant: Equatable {
+    func values(goal: RenderGoal) -> VariantValues<Variant> {
+        guard let primaryValue = firstValue else {
+            return .empty
+        }
+               
+        guard goal == .richness else {
+            // On the rendered page, language specific symbol information _could_ be hidden through CSS but that wouldn't help the tool that reads the raw HTML.
+            // So that tools don't need to filter out language specific information themselves, include only the primary language's value.
+            return .single(primaryValue)
+        }
+        
+        let values = allValues
+        guard allValues.count > 1 else {
+            // Return a single value to simplify the caller's code
+            return .single(primaryValue)
+        }
+        
+        // Check if the variants has any language-specific values (that are _actually_ different from the primary value)
+        if values.contains(where: { _, value in value != primaryValue }) {
+            // There are multiple distinct values
+            return .languageSpecific([SourceLanguage: Variant](
+                values.map { trait, value in
+                    (trait.sourceLanguage ?? .swift, value)
+                }, uniquingKeysWith: { _, new in new }
+            ))
+        } else {
+            // There are multiple values, but the're all the same
+            return .single(primaryValue)
+        }
+    }
+}

--- a/Sources/SwiftDocCTestUtilities/SymbolGraphCreation.swift
+++ b/Sources/SwiftDocCTestUtilities/SymbolGraphCreation.swift
@@ -90,6 +90,7 @@ extension XCTestCase {
         location: (position: SymbolGraph.LineList.SourceRange.Position, url: URL)? = (defaultSymbolPosition, defaultSymbolURL),
         signature: SymbolGraph.Symbol.FunctionSignature? = nil,
         availability: [SymbolGraph.Symbol.Availability.AvailabilityItem]? = nil,
+        declaration: [SymbolGraph.Symbol.DeclarationFragments.Fragment]? = nil,
         otherMixins: [any Mixin] = []
     ) -> SymbolGraph.Symbol {
         precondition(!pathComponents.isEmpty, "Need at least one path component to name the symbol")
@@ -104,10 +105,24 @@ extension XCTestCase {
         if let availability {
             mixins.append(SymbolGraph.Symbol.Availability(availability: availability))
         }
+        if let declaration {
+            mixins.append(SymbolGraph.Symbol.DeclarationFragments(declarationFragments: declaration))
+        }
+        
+        let names = if let declaration {
+            SymbolGraph.Symbol.Names(
+                title: pathComponents.last!, // Verified above to exist
+                navigator: declaration,
+                subHeading: declaration,
+                prose: nil
+            )
+        } else {
+            makeSymbolNames(name: pathComponents.last!) // Verified above to exist
+        }
         
         return SymbolGraph.Symbol(
             identifier: SymbolGraph.Symbol.Identifier(precise: id, interfaceLanguage: language.id),
-            names: makeSymbolNames(name: pathComponents.last!),
+            names: names,
             pathComponents: pathComponents,
             docComment: docComment.map {
                 makeLineList(

--- a/Sources/SwiftDocCUtilities/Action/Actions/Convert/ConvertAction.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Convert/ConvertAction.swift
@@ -320,6 +320,7 @@ public struct ConvertAction: AsyncAction {
                 try ConvertActionConverter.convert(
                     context: context,
                     outputConsumer: outputConsumer,
+                    htmlContentConsumer: nil,
                     sourceRepository: sourceRepository,
                     emitDigest: emitDigest,
                     documentationCoverageOptions: documentationCoverageOptions

--- a/Sources/SwiftDocCUtilities/Action/Actions/Convert/FileWritingHTMLContentConsumer.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Convert/FileWritingHTMLContentConsumer.swift
@@ -1,0 +1,119 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2025 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+#if canImport(FoundationXML)
+// TODO: Consider other HTML rendering options as a future improvement (rdar://165755530)
+import FoundationXML
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+import SwiftDocC
+import DocCHTML
+
+struct FileWritingHTMLContentConsumer: HTMLContentConsumer {
+    var targetFolder: URL
+    var fileManager: any FileManagerProtocol
+    var prettyPrintOutput: Bool
+    
+    private struct HTMLTemplate {
+        var original: String
+        var contentReplacementRange:     Range<String.Index>
+        var titleReplacementRange:       Range<String.Index>
+        var descriptionReplacementRange: Range<String.Index>
+        
+        init(data: Data) throws {
+            let content = String(decoding: data, as: UTF8.self)
+            
+            // ???: Should we parse the content with XMLParser instead? If so, what do we do if it's not valid XHTML?
+            let noScriptStart = content.utf8.firstRange(of:  "<noscript>".utf8)!.upperBound
+            let noScriptEnd   = content.utf8.firstRange(of: "</noscript>".utf8)!.lowerBound
+            
+            let titleStart = content.utf8.firstRange(of:  "<title>".utf8)!.upperBound
+            let titleEnd   = content.utf8.firstRange(of: "</title>".utf8)!.lowerBound
+            
+            let beforeHeadEnd = content.utf8.firstRange(of: "</head>".utf8)!.lowerBound
+            
+            original = content
+            // TODO: If the template doesn't already contain a <noscript> element, add one to the start of the <body> element
+            // TODO: If the template doesn't already contain a <title> element, add one to the end of the <head> element
+            contentReplacementRange     = noScriptStart ..< noScriptEnd
+            titleReplacementRange       = titleStart    ..< titleEnd
+            descriptionReplacementRange = beforeHeadEnd ..< beforeHeadEnd
+            
+            assert(titleReplacementRange.upperBound       < descriptionReplacementRange.lowerBound, "The title replacement range should be before the description replacement range")
+            assert(descriptionReplacementRange.upperBound < contentReplacementRange.lowerBound,     "The description replacement range should be before the content replacement range")
+        }
+        
+        func makeContent(
+            content: XMLNode,
+            title: String,
+            plainDescription: String?,
+            prettyPrint: Bool
+        ) -> String {
+            var copy = original
+            // Replace the content in reverse order so that the earlier ranges remain valid.
+            copy.replaceSubrange(contentReplacementRange, with: content.rendered(prettyPrinted: prettyPrint))
+            if let plainDescription {
+                let metaDescription = XMLNode.element(named: "meta", attributes: ["name": "description", "content": plainDescription])
+                copy.replaceSubrange(descriptionReplacementRange, with: metaDescription.rendered(prettyPrinted: prettyPrint))
+            }
+            copy.replaceSubrange(titleReplacementRange,   with: title)
+            
+            return copy
+        }
+    }
+    private var htmlTemplate: HTMLTemplate
+    private let fileWriter: JSONEncodingRenderNodeWriter
+    
+    init(
+        targetFolder: URL,
+        fileManager: some FileManagerProtocol,
+        htmlTemplate: URL,
+        prettyPrintOutput: Bool = shouldPrettyPrintOutputJSON
+    ) throws {
+        self.targetFolder = targetFolder
+        self.fileManager = fileManager
+        self.htmlTemplate = try HTMLTemplate(data: fileManager.contents(of: htmlTemplate))
+        self.prettyPrintOutput = prettyPrintOutput
+        self.fileWriter = JSONEncodingRenderNodeWriter(
+            targetFolder: targetFolder,
+            fileManager: fileManager,
+            transformForStaticHostingIndexHTML: nil
+        )
+    }
+    
+    func consume(
+        mainContent: XMLNode,
+        metadata: (title: String, description: String?),
+        forPage reference: ResolvedTopicReference
+    ) throws {
+        let htmlString = htmlTemplate.makeContent(
+            content: mainContent,
+            title: metadata.title,
+            plainDescription: metadata.description,
+            prettyPrint: prettyPrintOutput
+        )
+        
+        let relativeFilePath = NodeURLGenerator.fileSafeReferencePath(reference, lowercased: true) + "/index.html"
+        try fileWriter.write(Data(htmlString.utf8), toFileSafePath: relativeFilePath)
+    }
+}
+
+private extension XMLNode {
+    func rendered(prettyPrinted: Bool) -> String {
+        if prettyPrinted {
+            xmlString(options: [.nodePrettyPrint, .nodeCompactEmptyElement])
+        } else {
+            xmlString(options: .nodeCompactEmptyElement)
+        }
+    }
+}

--- a/Sources/SwiftDocCUtilities/CMakeLists.txt
+++ b/Sources/SwiftDocCUtilities/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library(SwiftDocCUtilities STATIC
   Action/Actions/Convert/ConvertAction.swift
   Action/Actions/Convert/ConvertFileWritingConsumer.swift
   Action/Actions/Convert/CoverageDataEntry+generateSummary.swift
+  Action/Actions/Convert/FileWritingHTMLContentConsumer.swift
   Action/Actions/Convert/Indexer.swift
   Action/Actions/Convert/JSONEncodingRenderNodeWriter.swift
   Action/Actions/CoverageAction.swift

--- a/Tests/SwiftDocCTests/DeprecatedDiagnosticsDigestWarningTests.swift
+++ b/Tests/SwiftDocCTests/DeprecatedDiagnosticsDigestWarningTests.swift
@@ -29,6 +29,7 @@ class DeprecatedDiagnosticsDigestWarningTests: XCTestCase {
         _ = try ConvertActionConverter.convert(
             context: context,
             outputConsumer: outputConsumer,
+            htmlContentConsumer: nil,
             sourceRepository: nil,
             emitDigest: true,
             documentationCoverageOptions: .noCoverage
@@ -53,6 +54,7 @@ class DeprecatedDiagnosticsDigestWarningTests: XCTestCase {
         _ = try ConvertActionConverter.convert(
             context: context,
             outputConsumer: outputConsumer,
+            htmlContentConsumer: nil,
             sourceRepository: nil,
             emitDigest: true,
             documentationCoverageOptions: .noCoverage

--- a/Tests/SwiftDocCTests/Indexing/ExternalRenderNodeTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/ExternalRenderNodeTests.swift
@@ -563,6 +563,7 @@ class ExternalRenderNodeTests: XCTestCase {
         let problems = try ConvertActionConverter.convert(
             context: context,
             outputConsumer: outputConsumer,
+            htmlContentConsumer: nil,
             sourceRepository: nil,
             emitDigest: false,
             documentationCoverageOptions: .noCoverage

--- a/Tests/SwiftDocCTests/TestRenderNodeOutputConsumer.swift
+++ b/Tests/SwiftDocCTests/TestRenderNodeOutputConsumer.swift
@@ -98,6 +98,7 @@ extension XCTestCase {
         _ = try ConvertActionConverter.convert(
             context: context,
             outputConsumer: outputConsumer,
+            htmlContentConsumer: nil,
             sourceRepository: sourceRepository,
             emitDigest: false,
             documentationCoverageOptions: .noCoverage

--- a/Tests/SwiftDocCUtilitiesTests/FileWritingHTMLContentConsumerTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/FileWritingHTMLContentConsumerTests.swift
@@ -1,0 +1,318 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2025 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+
+import Foundation
+@testable import SwiftDocCUtilities
+import SwiftDocC
+import SymbolKit
+import XCTest
+import SwiftDocCTestUtilities
+
+final class FileWritingHTMLContentConsumerTests: XCTestCase {
+    
+    func testWritesContentInsideHTMLTemplate() async throws {
+        let catalog = Folder(name: "ModuleName.docc", content: [
+            TextFile(name: "SomeArticle.md", utf8Content: """
+            # Some article
+            
+            This is an _formatted_ article.
+            
+            ## Custom discussion
+            
+            It explains how a developer can perform some task using ``SomeClass`` in this module.
+            
+            ### Details
+            
+            This subsection describes something more detailed.
+            
+            ## See Also
+            
+            - ``SomeClass``
+            """),
+            
+            JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(moduleName: "ModuleName", symbols: [
+                makeSymbol(id: "some-class-id", kind: .class, pathComponents: ["SomeClass"], docComment: """
+                Some in-source description of this class.
+                """, declaration: [
+                    .init(kind: .keyword,    spelling: "class",     preciseIdentifier: nil),
+                    .init(kind: .text,       spelling: " ",         preciseIdentifier: nil),
+                    .init(kind: .identifier, spelling: "SomeClass", preciseIdentifier: nil),
+                ]),
+                makeSymbol(
+                    id: "some-method-id", kind: .method, pathComponents: ["SomeClass", "someMethod(with:and:)"],
+                    docComment: """
+                    Some in-source description of this method.
+                    
+                    Further description of this method and how to use it.
+                    
+                    - Parameters: 
+                      - first:  Description of the `first` parameter.
+                      - second: Description of the `second` parameter.
+                    - Returns:  Description of the return value.
+                    
+                    ## See Also
+                    
+                    - <doc:SomeArticle>
+                    """,
+                    signature: .init(
+                        parameters: [
+                            .init(name: "first", externalName: "with", declarationFragments: [
+                                .init(kind: .identifier,     spelling: "first",  preciseIdentifier: nil),
+                                .init(kind: .text,           spelling: ": ",     preciseIdentifier: nil),
+                                .init(kind: .typeIdentifier, spelling: "Int",    preciseIdentifier: "s:Si"),
+                            ], children: []),
+                            .init(name: "second", externalName: "and", declarationFragments: [
+                                .init(kind: .identifier,     spelling: "first",  preciseIdentifier: nil),
+                                .init(kind: .text,           spelling: ": ",     preciseIdentifier: nil),
+                                .init(kind: .typeIdentifier, spelling: "String", preciseIdentifier: "s:Ss"),
+                            ], children: [])
+                        ],
+                        returns: [
+                            .init(kind: .typeIdentifier,     spelling: "Bool",    preciseIdentifier: "s:Sb"),
+                        ]
+                    ),
+                    declaration: [
+                        .init(kind: .keyword,           spelling: "func",       preciseIdentifier: nil),
+                        .init(kind: .text,              spelling: " ",          preciseIdentifier: nil),
+                        .init(kind: .identifier,        spelling: "someMethod", preciseIdentifier: nil),
+                        .init(kind: .text,              spelling: "(",          preciseIdentifier: nil),
+                        .init(kind: .externalParameter, spelling: "with",       preciseIdentifier: nil),
+                        .init(kind: .text,              spelling: " ",          preciseIdentifier: nil),
+                        .init(kind: .internalParameter, spelling: "first",      preciseIdentifier: nil),
+                        .init(kind: .text,              spelling: ": ",         preciseIdentifier: nil),
+                        .init(kind: .typeIdentifier,    spelling: "Int",        preciseIdentifier: "s:Si"),
+                        .init(kind: .text,              spelling: ", ",         preciseIdentifier: nil),
+                        .init(kind: .externalParameter, spelling: "and",        preciseIdentifier: nil),
+                        .init(kind: .text,              spelling: " ",          preciseIdentifier: nil),
+                        .init(kind: .internalParameter, spelling: "second",     preciseIdentifier: nil),
+                        .init(kind: .text,              spelling: ": ",         preciseIdentifier: nil),
+                        .init(kind: .typeIdentifier,    spelling: "String",     preciseIdentifier: "s:SS"),
+                        .init(kind: .text,              spelling: ") -> ",      preciseIdentifier: nil),
+                        .init(kind: .typeIdentifier,    spelling: "Bool",       preciseIdentifier: "s:Sb"),
+                    ]
+                )
+            ], relationships: [
+                .init(source: "some-method-id", target: "some-class-id", kind: .memberOf, targetFallback: nil)
+            ])),
+            
+            TextFile(name: "ModuleName.md", utf8Content: """
+            # ``ModuleName``
+            
+            Some **formatted** description of this module
+            
+            ## Topics
+            
+            ### Something custom
+            
+            A custom _formatted_ description of this topic section
+            
+            - <doc:SomeArticle>
+            - ``SomeClass``
+            """)
+        ])
+        
+        let htmlTemplate = TextFile(name: "index.html", utf8Content: """
+        <html>
+          <head>
+            <meta charset="utf-8" />
+            <link rel="icon" href="/favicon.ico" />
+            <title>Documentation</title>
+            <script>var baseUrl = "/"</script>
+          </head>
+          <body>
+            <noscript>
+              <p>Some existing information inside the no script tag</p>
+            </noscript>
+            <div id="app"></div>
+          </body>
+        </html>
+        """)
+        
+        let fileSystem = try TestFileSystem(folders: [
+            Folder(name: "path", content: [
+                Folder(name: "to", content: [
+                    catalog
+                ])
+            ]),
+            Folder(name: "template", content: [
+                htmlTemplate
+            ]),
+            Folder(name: "output-dir", content: [])
+        ])
+        
+        let (inputs, dataProvider) = try DocumentationContext.InputsProvider(fileManager: fileSystem)
+            .inputsAndDataProvider(startingPoint: URL(fileURLWithPath: "/path/to/\(catalog.name)"), options: .init())
+        
+        let context = try await DocumentationContext(bundle: inputs, dataProvider: dataProvider, configuration: .init())
+        
+        let htmlConsumer = try FileWritingHTMLContentConsumer(
+            targetFolder: URL(fileURLWithPath: "/output-dir"),
+            fileManager: fileSystem,
+            htmlTemplate: URL(fileURLWithPath: "/template/index.html"),
+            prettyPrintOutput: true
+        )
+        
+        _ = try ConvertActionConverter.convert(
+            context: context,
+            outputConsumer: TestOutputConsumer(),
+            htmlContentConsumer: htmlConsumer,
+            sourceRepository: nil,
+            emitDigest: false,
+            documentationCoverageOptions: .noCoverage
+        )
+        
+        // Because the TestOutputConsumer below, doesn't create any files, we only expect the HTML files in the output directory
+        XCTAssertEqual(fileSystem.dump(subHierarchyFrom: "/output-dir"), """
+        output-dir/
+        ╰─ documentation/
+           ╰─ modulename/
+              ├─ index.html
+              ├─ somearticle/
+              │  ╰─ index.html
+              ╰─ someclass/
+                 ├─ index.html
+                 ╰─ somemethod(with:and:)/
+                    ╰─ index.html
+        """)
+        
+        try assert(readHTML: fileSystem.contents(of: URL(fileURLWithPath: "/output-dir/documentation/modulename/index.html")), matches: """
+        <html>
+          <head>
+            <meta charset="utf-8" />
+            <link rel="icon" href="/favicon.ico" />
+            <title>ModuleName</title>
+            <script>var baseUrl = "/"</script>
+          <meta content="Some formatted description of this module" name="description"/></head>
+          <body>
+            <noscript>
+              <article>
+                <section>
+                  <h1>ModuleName</h1>
+                  <p>Some <b>formatted</b> description of this module</p>
+                </section>
+              </article>
+            </noscript>
+            <div id="app"></div>
+          </body>
+        </html>
+        """)
+        
+        try assert(readHTML: fileSystem.contents(of: URL(fileURLWithPath: "/output-dir/documentation/modulename/someclass/index.html")), matches: """
+        <html>
+          <head>
+            <meta charset="utf-8" />
+            <link rel="icon" href="/favicon.ico" />
+            <title>SomeClass</title>
+            <script>var baseUrl = "/"</script>
+          <meta content="Some in-source description of this class." name="description"/></head>
+          <body>
+            <noscript>
+              <article>
+                <section>
+                  <h1>SomeClass</h1>
+                  <p>Some in-source description of this class.</p>
+                </section>
+              </article>
+            </noscript>
+            <div id="app"></div>
+          </body>
+        </html>
+        """)
+        
+        try assert(readHTML: fileSystem.contents(of: URL(fileURLWithPath: "/output-dir/documentation/modulename/someclass/somemethod(with:and:)/index.html")), matches: """
+        <html>
+          <head>
+            <meta charset="utf-8" />
+            <link rel="icon" href="/favicon.ico" />
+            <title>someMethod(with:and:)</title>
+            <script>var baseUrl = "/"</script>
+          <meta content="Some in-source description of this method." name="description"/></head>
+          <body>
+            <noscript>
+              <article>
+                <section>
+                  <h1>someMethod(with:and:)</h1>
+                  <p>Some in-source description of this method.</p>
+                </section>
+              </article>
+            </noscript>
+            <div id="app"></div>
+          </body>
+        </html>
+        """)
+        
+        try assert(readHTML: fileSystem.contents(of: URL(fileURLWithPath: "/output-dir/documentation/modulename/somearticle/index.html")), matches: """
+        <html>
+          <head>
+            <meta charset="utf-8" />
+            <link rel="icon" href="/favicon.ico" />
+            <title>Some article</title>
+            <script>var baseUrl = "/"</script>
+          <meta content="This is an formatted article." name="description"/></head>
+          <body>
+            <noscript>
+              <article>
+                <section>
+                  <h1>Some article</h1>
+                  <p>This is an <i>formatted</i> article.</p>
+                </section>
+              </article>
+            </noscript>
+            <div id="app"></div>
+          </body>
+        </html>
+        """)
+    }
+
+}
+
+// MARK: Helpers
+
+private class TestOutputConsumer: ConvertOutputConsumer, ExternalNodeConsumer {
+    func consume(renderNode: RenderNode) throws { }
+    func consume(assetsInBundle bundle: DocumentationBundle) throws { }
+    func consume(linkableElementSummaries: [LinkDestinationSummary]) throws { }
+    func consume(indexingRecords: [IndexingRecord]) throws { }
+    func consume(assets: [RenderReferenceType: [any RenderReference]]) throws { }
+    func consume(benchmarks: Benchmark) throws { }
+    func consume(documentationCoverageInfo: [CoverageDataEntry]) throws { }
+    func consume(renderReferenceStore: RenderReferenceStore) throws { }
+    func consume(buildMetadata: BuildMetadata) throws { }
+    func consume(linkResolutionInformation: SerializableLinkResolutionInformation) throws { }
+    func consume(externalRenderNode: ExternalRenderNode) throws { }
+}
+
+private func assert(readHTML: Data, matches expectedHTML: String, file: StaticString = #filePath, line: UInt = #line) {
+    // XMLNode on macOS and Linux pretty print with different indentation.
+    // To compare the XML structure without getting false positive failures because of indentation and other formatting differences,
+    // we explicitly process each string into an easy-to-compare format.
+    func formatForTestComparison(_ xmlString: String) -> String {
+        // This is overly simplified and won't result in "pretty" XML for general use but sufficient for test content comparisons
+        xmlString
+            // Put each tag on its own line
+            .replacingOccurrences(of: ">", with: ">\n")
+            // Remove leading indentation
+            .components(separatedBy: .newlines)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: "\n")
+            // Explicitly escape a few HTML characters that appear in the test content
+            .replacingOccurrences(of: "–", with: "&#x2013;") // en-dash
+            .replacingOccurrences(of: "—", with: "&#x2014;") // em-dash
+    }
+    
+    XCTAssertEqual(
+        formatForTestComparison(String(decoding: readHTML, as: UTF8.self)),
+        formatForTestComparison(expectedHTML),
+        file: file,
+        line: line
+    )
+}

--- a/Tests/SwiftDocCUtilitiesTests/MergeActionTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/MergeActionTests.swift
@@ -940,7 +940,7 @@ class MergeActionTests: XCTestCase {
             
             let outputConsumer = ConvertFileWritingConsumer(targetFolder: outputPath, bundleRootFolder: catalogDir, fileManager: fileSystem, context: context, indexer: indexer, transformForStaticHostingIndexHTML: nil, bundleID: inputs.id)
             
-            let convertProblems = try ConvertActionConverter.convert(context: context, outputConsumer: outputConsumer, sourceRepository: nil, emitDigest: false, documentationCoverageOptions: .noCoverage)
+            let convertProblems = try ConvertActionConverter.convert(context: context, outputConsumer: outputConsumer, htmlContentConsumer: nil, sourceRepository: nil, emitDigest: false, documentationCoverageOptions: .noCoverage)
             XCTAssert(convertProblems.isEmpty, "Unexpected problems: \(context.problems.map(\.diagnostic.summary).joined(separator: "\n"))", file: file, line: line)
             
             let navigatorProblems = indexer.finalize(emitJSON: true, emitLMDB: false)


### PR DESCRIPTION
Reverts swiftlang/swift-docc#1392

----

Now that https://github.com/swiftlang/swift/pull/85995 is merged, and DocC once again included in the Windows build, the changes in #1383 shouldn't have any impact on the Windows tests anymore. I'm verifying that with a cross-repo test (in https://github.com/swiftlang/swift/pull/84510#issuecomment-3645418566) but it takes few hours to run.

----

Like I said in my original review of https://github.com/swiftlang/swift-docc/pull/818 and [my later PR to revert it](https://github.com/swiftlang/swift-docc/pull/1353#issuecomment-3543001029):

I really don't think that any integration that can cause blocking CI failures for the toolchain should be merged again until after DocC has a Windows CI. I feel that the only correct order to do add DocC to the Windows build is:
1. Add the CMake files to the DocC repo
2. Set up a Windows CI for DocC
3. Integrate DocC into the Windows build

If we keep trying to skip step 2 I think it's better to undo step 1 by merging https://github.com/swiftlang/swift-docc/pull/1353 so that step 1 and 2 can be added back _together_ before step 3. 