### PR TITLE
Read extended module from SymbolGraph.

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
@@ -85,8 +85,8 @@ struct PathHierarchy {
             let moduleNode: Node
             
             if !loader.hasPrimaryURL(moduleName: moduleName) {
-                guard let moduleName = SymbolGraphLoader.moduleNameFor(url),
-                      let existingModuleNode = roots[moduleName]
+                let (moduleName, _) = GraphCollector.moduleNameFor(graph, at: url)
+                guard let existingModuleNode = roots[moduleName]
                 else { continue }
                 moduleNode = existingModuleNode
             } else if let existingModuleNode = roots[moduleName] {

--- a/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphLoader.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphLoader.swift
@@ -314,48 +314,12 @@ struct SymbolGraphLoader {
             symbolGraph.symbols = symbolsWithFilledIntroducedVersions
         }
     }
-    
-    /// Returns the module name, if any, in the file name of a given symbol-graph URL.
-    ///
-    /// Returns "Combine", if it's a main symbol-graph file, such as "Combine.symbols.json".
-    /// Returns "Swift", if it's an extension file such as, "Combine@Swift.symbols.json".
-    /// - parameter url: A URL to a symbol graph file.
-    /// - returns: A module name, or `nil` if the file name cannot be parsed.
-    static func moduleNameFor(_ url: URL) -> String? {
-        let fileName = url.lastPathComponent.components(separatedBy: ".symbols.json")[0]
 
-        let fileNameComponents = fileName.components(separatedBy: "@")
-        if fileNameComponents.count > 2 {
-            // Two "@"s found in the name - it's a cross import symbol graph:
-            // "Framework1@Framework2@_Framework1_Framework2.symbols.json"
-            return fileNameComponents[0]
-        }
-        
-        return fileName.split(separator: "@", maxSplits: 1).last.map({ String($0) })
-    }
-    
     /// Returns the module name of a symbol graph based on the JSON data and file name.
     ///
     /// Useful during decoding the symbol graphs to implement the correct name logic starting with the module name in the JSON.
     private static func moduleNameFor(_ symbolGraph: SymbolGraph, at url: URL) -> (String, Bool) {
-        let isMainSymbolGraph = !url.lastPathComponent.contains("@")
-        
-        let moduleName: String
-        if isMainSymbolGraph || symbolGraph.module.bystanders != nil {
-            // For main symbol graphs, get the module name from the symbol graph's data
-
-            // When bystander modules are present, the symbol graph is a cross-import overlay, and
-            // we need to preserve the original module name to properly render it. It is still
-            // kept with the extension symbols, due to the merging behavior of UnifiedSymbolGraph.
-            moduleName = symbolGraph.module.name
-        } else {
-            // For extension symbol graphs, derive the extended module's name from the file name.
-            //
-            // The per-symbol `extendedModule` value is the same as the main module for most symbols, so it's not a good way to find the name
-            // of the module that was extended (rdar://63200368).
-            moduleName = SymbolGraphLoader.moduleNameFor(url)!
-        }
-        return (moduleName, isMainSymbolGraph)
+        return GraphCollector.moduleNameFor(symbolGraph, at: url)
     }
     
     private static func applyWorkaroundFor139305015(to symbolGraph: inout SymbolGraph) {


### PR DESCRIPTION
## Summary

This is a companion change to the change in the Swift compiler to [emit the "extended" module](https://github.com/swiftlang/swift/pull/86057) as an additional field in the symbol graph. Reading the base and extended modules from the file name is not feasible for module's with long names. A new compiler option was added in [Swift #83782](https://github.com/swiftlang/swift/pull/83782) to allow emitting symbol graph file's without both module names in the file name. The shortened format isn't yet supported by swift-docc though.

This also relies on a corresponding change [to swift-docc-symbolkit](https://github.com/swiftlang/swift-docc-symbolkit/pull/107) where `GraphCollector.moduleNameFor` is updated.

The change here consolidates some `moduleNameFor` functionality where swift-docc was implementing similar behavior as exists in swift-docc-symbolkit, while already depending on symbolkit so it seems prudent to just share the implementation of `moduleNameFor`.

https://github.com/swiftlang/swift-docc/issues/1399

### Backwards Compatibility

swift-docc must continue to function with symbolgraph data generated by previous versions of the swift toolchain (before https://github.com/swiftlang/swift/pull/86057). This change to swift-docc delegates computing the module name for grouping symbols from swift-docc to existing functionality inside swift-docc-symbolkit, which is already a dependency of the former. The `moduleNameFor` [implementation in swift-docc-symbolkit today](https://github.com/swiftlang/swift-docc-symbolkit/blob/6c96b743cb993ad9af4d2cd1d95165fd28475bed/Sources/SymbolKit/UnifiedSymbolGraph/GraphCollector.swift#L121-L180) detects the extended module name by extracting it from a `ModuleNameA@ModuleNameB` style file name.

In the related change, to [swift-docc-symbolkit](https://github.com/swiftlang/swift-docc-symbolkit/pull/107), the functionality that is being used from swift-docc-symbolkit is also updated in a backwards compatible way. `GraphCollector.moduleNameFor` continues to use the existing implementation if the newly added `extended` field is not present in the symbolgraph.

## Dependencies

- https://github.com/swiftlang/swift/pull/86057
- https://github.com/swiftlang/swift-docc-symbolkit/pull/107

## Testing

_Describe how a reviewer can test the functionality of your PR. Provide test content to test with if
applicable._

Steps:
1. _Provide setup instructions._
2. _Explain in detail how the functionality can be tested._

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary

No new tests added because all behavior is expected to be identical and existing tests are passing.