### PR TITLE
[6.3] Fix CMake build

### DIFF
--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -8,6 +8,7 @@ See https://swift.org/LICENSE.txt for license information
 #]]
 
 add_subdirectory(DocCCommon)
+add_subdirectory(DocCHTML)
 add_subdirectory(SwiftDocC)
 add_subdirectory(SwiftDocCUtilities)
 add_subdirectory(docc)


### PR DESCRIPTION
- **Explanation**: This fixes the Windows CMake file lists.
- **Scope**: Windows CMake build
- **Issue**: 
- **Risk**: Low.
- **Testing**: None.
- **Reviewer**: @compnerd 
- **Original PR**: https://github.com/swiftlang/swift-docc/pull/1404

