### PR TITLE
[6.3] Include availability for fallback platforms in articles

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphLoader.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphLoader.swift
@@ -224,35 +224,37 @@ struct SymbolGraphLoader {
             for (selector, _) in symbol.mixins {
                 if var symbolAvailability = (symbol.mixins[selector]?["availability"] as? SymbolGraph.Symbol.Availability) {
                     guard !symbolAvailability.availability.isEmpty else { continue }
-                    // For platforms with a fallback option (e.g., Catalyst and iOS), apply the explicit availability annotation of the fallback platform when it is not explicitly available on the primary platform.
-                    DefaultAvailability.fallbackPlatforms.forEach { (fallbackPlatform, inheritedPlatform) in
+                    // For platforms with a fallback option (e.g. Catalyst and iPadOS),
+                    // if the availability is not explicitly available for the platform,
+                    // apply the explicit availability annotation of the fallback platform.
+                    DefaultAvailability.fallbackPlatforms.forEach { (platform, fallback) in
                         guard
-                            var inheritedAvailability = symbolAvailability.availability.first(where: {
-                                $0.matches(inheritedPlatform)
+                            var fallbackAvailability = symbolAvailability.availability.first(where: {
+                                $0.matches(fallback)
                             }),
-                            let fallbackAvailabilityIntroducedVersion = symbolAvailability.availability.first(where: {
-                                $0.matches(fallbackPlatform)
+                            let platformAvailabilityIntroducedVersion = symbolAvailability.availability.first(where: {
+                                $0.matches(platform)
                             })?.introducedVersion,
-                            let defaultAvailabilityIntroducedVersion = defaultAvailabilities.first(where: { $0.platformName ==  fallbackPlatform })?.introducedVersion
+                            let defaultAvailabilityIntroducedVersion = defaultAvailabilities.first(where: { $0.platformName ==  platform })?.introducedVersion
                         else { return }
                         // Ensure that the availability version is not overwritten if the symbol has an explicit availability annotation for that platform.
-                        if SymbolGraph.SemanticVersion(string: defaultAvailabilityIntroducedVersion) == fallbackAvailabilityIntroducedVersion {
-                            inheritedAvailability.domain = SymbolGraph.Symbol.Availability.Domain(rawValue: fallbackPlatform.rawValue)
+                        if SymbolGraph.SemanticVersion(string: defaultAvailabilityIntroducedVersion) == platformAvailabilityIntroducedVersion {
+                            fallbackAvailability.domain = SymbolGraph.Symbol.Availability.Domain(rawValue: platform.rawValue)
                             symbolAvailability.availability.removeAll(where: {
-                                $0.matches(fallbackPlatform)
+                                $0.matches(platform)
                             })
-                            symbolAvailability.availability.append(inheritedAvailability)
+                            symbolAvailability.availability.append(fallbackAvailability)
                         }
                     }
                     // Add fallback availability.
-                    for (fallbackPlatform, inheritedPlatform) in missingFallbackPlatforms {
-                        if !symbolAvailability.contains(fallbackPlatform) {
+                    for (platform, fallback) in missingFallbackPlatforms {
+                        if !symbolAvailability.contains(platform) {
                             for var fallbackAvailability in symbolAvailability.availability {
                                 // Add the platform fallback to the availability mixin the platform is inheriting from.
                                 // The added availability copies the entire availability information,
                                 // including deprecated and obsolete versions.
-                                if fallbackAvailability.matches(inheritedPlatform) {
-                                    fallbackAvailability.domain = SymbolGraph.Symbol.Availability.Domain(rawValue: fallbackPlatform.rawValue)
+                                if fallbackAvailability.matches(fallback) {
+                                    fallbackAvailability.domain = SymbolGraph.Symbol.Availability.Domain(rawValue: platform.rawValue)
                                     symbolAvailability.availability.append(fallbackAvailability)
                                 }
                             }

--- a/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/DeclarationsSectionTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/DeclarationsSectionTranslator.swift
@@ -200,9 +200,9 @@ struct DeclarationsSectionTranslator: RenderSectionTranslator {
             func expandPlatformsWithFallbacks(_ platforms: [PlatformName?]) -> [PlatformName?] {
                 guard !platforms.isEmpty else { return platforms }
 
-                // Add fallback platforms if their primary platform is present but the fallback is missing
-                let fallbacks = DefaultAvailability.fallbackPlatforms.compactMap { fallback, primary in
-                    platforms.contains(primary) && !platforms.contains(fallback) ? fallback : nil
+                // Add fallback platforms if the platform is missing but the fallback is present
+                let fallbacks = DefaultAvailability.fallbackPlatforms.compactMap { platform, fallback in
+                    platforms.contains(fallback) && !platforms.contains(platform) ? platform : nil
                 }
                 return platforms + fallbacks
             }


### PR DESCRIPTION
- **Explanation**: When DocC processes the availability information for symbol graphs, it identifies if fallback platforms are available, and if so, injects platforms that inherit their availability from the fallback platforms. E.g. the iPadOS and Mac Catalyst platforms inherit their availability from iOS. In the case of articles, the platform availability information is not used in rendering the page. However, sample code pages are processed as articles with a different page kind, and these pages do render the platform availability information. Hence, it is necessary to also process the fallback platforms when setting the availability for an article's render node in order to correctly display the list of supported platforms for sample code pages. This patch updates the logic in the render node translator to process the availability information for articles correctly and include fallback platforms.
- **Scope**: Render JSON update, UI update
- **Issue**: rdar://158230351
- **Risk**: Low.
- **Testing**: The unit tests for availability information have been updated to verify that fallback platforms are included, and that their beta status is correctly inherited.
- **Reviewer**: @d-ronnqvist
- **Original PR**: #1408