### PR TITLE
Flatten group marker node children in navigator

### DIFF
--- a/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
+++ b/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
@@ -797,8 +797,6 @@ extension NavigatorIndex {
             // Process the children
             var children = [Identifier]()
             for (index, child) in renderNode.navigatorChildren(for: traits).enumerated() {
-                let groupIdentifier: Identifier?
-                
                 if let title = child.name {
                     let fragment = "\(title)#\(index)".addingPercentEncoding(withAllowedCharacters: .urlPathAllowed)!
                     
@@ -824,10 +822,6 @@ extension NavigatorIndex {
                     
                     identifierToNode[identifier] = navigatorGroup
                     children.append(identifier)
-                    
-                    groupIdentifier = identifier
-                } else {
-                    groupIdentifier = nil
                 }
                 
                 let identifiers = child.references.map { reference in
@@ -838,14 +832,8 @@ extension NavigatorIndex {
                     )
                 }
                 
-                var nestedChildren = [Identifier]()
                 for identifier in identifiers {
-                    if child.referencesAreNested {
-                        nestedChildren.append(identifier)
-                    } else {
-                        children.append(identifier)
-                    }
-                    
+                    children.append(identifier)
                     // If a topic has been already curated and has a valid node processed, flag it as multi-curated.
                     if curatedIdentifiers.contains(identifier) && pendingUncuratedReferences.contains(identifier) {
                         multiCurated[identifier] = identifierToNode[identifier]
@@ -854,10 +842,6 @@ extension NavigatorIndex {
                     } else { // Otherwise keep track for later.
                         curatedIdentifiers.insert(identifier)
                     }
-                }
-                
-                if let groupIdentifier, !nestedChildren.isEmpty {
-                    identifierToChildren[groupIdentifier] = nestedChildren
                 }
             }
             

--- a/Tests/SwiftDocCTests/Test Resources/TestBundle-RenderIndex.json
+++ b/Tests/SwiftDocCTests/Test Resources/TestBundle-RenderIndex.json
@@ -723,15 +723,13 @@
           {
             "children" : [
               {
-                "children" : [
-                  {
-                    "path" : "\/documentation\/sidekit\/sideprotocol\/func()-2dxqn",
-                    "title" : "func1()",
-                    "type" : "method"
-                  }
-                ],
                 "title" : "SideProtocol Implementations",
                 "type" : "groupMarker"
+              },
+              {
+                "path" : "\/documentation\/sidekit\/sideprotocol\/func()-2dxqn",
+                "title" : "func1()",
+                "type" : "method"
               }
             ],
             "path" : "\/documentation\/sidekit\/sideprotocol\/func()",

--- a/Tests/SwiftDocCTests/Test Resources/testNavigatorIndexGeneration.txt
+++ b/Tests/SwiftDocCTests/Test Resources/testNavigatorIndexGeneration.txt
@@ -151,8 +151,8 @@
 ┃ ┣╸SideProtocol
 ┃ ┃ ┣╸Instance Methods
 ┃ ┃ ┗╸func1()
-┃ ┃   ┗╸SideProtocol Implementations
-┃ ┃     ┗╸func1()
+┃ ┃   ┣╸SideProtocol Implementations
+┃ ┃   ┗╸func1()
 ┃ ┣╸Classes
 ┃ ┗╸UncuratedClass
 ┃   ┣╸Variables

--- a/Tests/SwiftDocCTests/Test Resources/testNavigatorIndexGenerationWithLanguageGrouping.txt
+++ b/Tests/SwiftDocCTests/Test Resources/testNavigatorIndexGenerationWithLanguageGrouping.txt
@@ -152,8 +152,8 @@
   ┃ ┣╸SideProtocol
   ┃ ┃ ┣╸Instance Methods
   ┃ ┃ ┗╸func1()
-  ┃ ┃   ┗╸SideProtocol Implementations
-  ┃ ┃     ┗╸func1()
+  ┃ ┃   ┣╸SideProtocol Implementations
+  ┃ ┃   ┗╸func1()
   ┃ ┣╸Classes
   ┃ ┗╸UncuratedClass
   ┃   ┣╸Variables

--- a/Tests/SwiftDocCTests/Test Resources/testNavigatorIndexPageTitleGeneration.txt
+++ b/Tests/SwiftDocCTests/Test Resources/testNavigatorIndexPageTitleGeneration.txt
@@ -151,8 +151,8 @@
 ┃ ┣╸SideProtocol
 ┃ ┃ ┣╸Instance Methods
 ┃ ┃ ┗╸func1()
-┃ ┃   ┗╸SideProtocol Implementations
-┃ ┃     ┗╸func1()
+┃ ┃   ┣╸SideProtocol Implementations
+┃ ┃   ┗╸func1()
 ┃ ┣╸Classes
 ┃ ┗╸UncuratedClass
 ┃   ┣╸Variables


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://165630645

## Summary

The navigator index constructs group marker nodes and nests references as child nodes under the group if the render relationship specifies that references are nested. While this information is relevant to the render JSON itself, the rendering spec for the navigator expects that group marker nodes do not contain any child nodes [1]. This means that with the current navigator index, the child nodes of a group marker nodes are elided when rendering. In practice, this situation is encountered only with non-generated default implementation groups, where the render JSON includes the references as children of the group. This patch updates the navigator index to insert references at the same level as the group marker, allowing the frontend to render these nodes correctly.

[1]: https://github.com/swiftlang/swift-docc-render/blob/0d779421a47163e0c891fd20212e51670f07a003/src/components/Navigator/NavigatorCardItem.vue#L196

## Dependencies

N/A

## Testing

The existing tests have been updated to validate this behaviour correctly. It can also be visually verified:

- Run `docc preview` with the `LegacyBundle_DoNotUseInNewTests.docc` test bundle
- Visit http://localhost:8080/documentation/sidekit/sideprotocol/func()

| `main` | Patched |
|--------|---------|
|<img width="957" height="639" alt="Screenshot 2026-01-27 at 12 12 16" src="https://github.com/user-attachments/assets/4cd9012e-1e84-4361-b0b2-741b21a038fc" />|<img width="944" height="648" alt="Screenshot 2026-01-27 at 12 13 05" src="https://github.com/user-attachments/assets/f73df736-672d-422d-9baf-a68e611c022f" />|

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
