### PR TITLE
Skip failing testSymbolLinksInDeclarationsAndRelationships test

### DIFF
--- a/Tests/SwiftDocCTests/Infrastructure/ExternalPathHierarchyResolverTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/ExternalPathHierarchyResolverTests.swift
@@ -686,6 +686,7 @@ class ExternalPathHierarchyResolverTests: XCTestCase {
     }
     
     func testSymbolLinksInDeclarationsAndRelationships() async throws {
+        throw XCTSkip("Skipping due to CI failures - rdar://169083752")
         // Build documentation for the dependency first
         let symbols = [("First", .class), ("Second", .protocol), ("Third", .struct), ("Fourth", .enum)].map { (name: String, kind: SymbolGraph.Symbol.KindIdentifier) in
             return SymbolGraph.Symbol(


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://169083752

## Summary

Skip testSymbolLinksInDeclarationsAndRelationships test that is causing CI failures. https://ci.swift.org/view/Apple%20Silicon%20(main)/job/oss-swift-pr-test-macos-arm64/1561/console

## Dependencies

N/A

## Testing

Existing tests should pass.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- ~[ ] Added tests~ N/A
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
