### PR TITLE
Add CLI flag to provide custom host for previews

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -390,8 +390,11 @@ Starting Local Preview Server
 Monitoring ~/Developer/swift-docc/Sources/SwiftDocC/SwiftDocC.docc for changes...
 ```
 
-And if you navigate to <http://localhost:8080/documentation/swiftdocc> you'll see
-the rendered documentation for `SwiftDocC`.
+And if you navigate to <http://localhost:8080/documentation/swiftdocc> you'll
+see the rendered documentation for `SwiftDocC`. If your browser isn't running
+on the same computer as Swift-DocC, you may need to provide the server's public
+host name or IP address (or just `0.0.0.0`) with the `--host` option to allow
+the browser to connect.
 
 ### Using Docker to Test Swift-DocC for Linux
 
@@ -628,4 +631,4 @@ project's technical documentation:
   with support for building and viewing documentation for your framework and
   its dependencies.
 
-<!-- Copyright (c) 2021-2025 Apple Inc and the Swift Project authors. All Rights Reserved. -->
+<!-- Copyright (c) 2021-2026 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Sources/DocCCommandLine/ArgumentParsing/ActionExtensions/PreviewAction+CommandInitialization.swift
+++ b/Sources/DocCCommandLine/ArgumentParsing/ActionExtensions/PreviewAction+CommandInitialization.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -24,6 +24,7 @@ extension PreviewAction {
     {
         // Initialize the `PreviewAction` from the options provided by the `Preview` command
         try self.init(
+            host: previewOptions.host,
             port: previewOptions.port,
             createConvertAction: {
                 try ConvertAction(

--- a/Sources/DocCCommandLine/ArgumentParsing/Options/PreviewOptions.swift
+++ b/Sources/DocCCommandLine/ArgumentParsing/Options/PreviewOptions.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -17,6 +17,15 @@ import Foundation
 public struct PreviewOptions: ParsableArguments {
     public init() { }
 
+    /// The host name to use for the preview web server.
+    ///
+    /// Defaults to `localhost`.
+    @Option(
+        name: .long,
+        help: ArgumentHelp(
+            "Host name to use for the preview web server.",
+            valueName: "host-name"))
+    public var host: String = "localhost"
     /// The port number to use for the preview web server.
     ///
     /// Defaults to `8080`.

--- a/Sources/DocCCommandLine/ArgumentParsing/Subcommands/Preview.swift
+++ b/Sources/DocCCommandLine/ArgumentParsing/Subcommands/Preview.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -20,9 +20,9 @@ extension Docc {
         public static var configuration = CommandConfiguration(
             abstract: "Convert documentation inputs and preview the documentation output.",
             usage: """
-            docc preview [<catalog-path>] [--port <port-number>] [--additional-symbol-graph-dir <symbol-graph-dir>]
-            docc preview [<catalog-path>] [--port <port-number>] [--additional-symbol-graph-dir <symbol-graph-dir>] [--output-dir <output-dir>]
-            docc preview [<catalog-path>] [--port <port-number>] [--additional-symbol-graph-dir <symbol-graph-dir>] [--output-dir <output-dir>] [<availability-options>] [<diagnostic-options>] [<source-repository-options>] [<hosting-options>] [<info-plist-fallbacks>] [<feature-flags>] [<other-options>]
+            docc preview [<catalog-path>] [--host <host-name>] [--port <port-number>] [--additional-symbol-graph-dir <symbol-graph-dir>]
+            docc preview [<catalog-path>] [--host <host-name>] [--port <port-number>] [--additional-symbol-graph-dir <symbol-graph-dir>] [--output-dir <output-dir>]
+            docc preview [<catalog-path>] [--host <host-name>] [--port <port-number>] [--additional-symbol-graph-dir <symbol-graph-dir>] [--output-dir <output-dir>] [<availability-options>] [<diagnostic-options>] [<source-repository-options>] [<hosting-options>] [<info-plist-fallbacks>] [<feature-flags>] [<other-options>]
             """,
             discussion: """
             The 'preview' command extends the 'convert' command by running a preview server and monitoring the documentation input for modifications to rebuild the documentation.

--- a/Tests/DocCCommandLineTests/ArgumentParsing/PreviewSubcommandTests.swift
+++ b/Tests/DocCCommandLineTests/ArgumentParsing/PreviewSubcommandTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -96,6 +96,25 @@ class PreviewSubcommandTests: XCTestCase {
                 "--port", "42",
                 testBundleURL.path,
             ]))
+        }
+
+        // Test default host is localhost
+        do {
+            setenv(TemplateOption.environmentVariableKey, templateDir.path, 1)
+            let preview = try Docc.Preview.parse([
+                testBundleURL.path,
+            ])
+            XCTAssertEqual(preview.previewOptions.host, "localhost", "Default host should be localhost")
+        }
+
+        // Test custom host
+        do {
+            setenv(TemplateOption.environmentVariableKey, templateDir.path, 1)
+            let preview = try Docc.Preview.parse([
+                "--host", "0.0.0.0",
+                testBundleURL.path,
+            ])
+            XCTAssertEqual(preview.previewOptions.host, "0.0.0.0", "Custom host should be set correctly")
         }
     }
 }


### PR DESCRIPTION
## Summary

`docc preview` allows providing a custom port via the `--port` flag. The default host used is `localhost`. However, it is also desirable to allow using a custom host in order to serve the preview outside the local machine, e.g. by binding to `0.0.0.0` instead. This patch adds a `--host` flag that accepts a string parameter which is used as the host on the local machine for the HTTP server.

Supersedes #713 with changes to prevent breaking the public API.

## Dependencies

N/A

## Testing

Unit tests and integration tests have been added in to verify this functionality.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
