### PR TITLE
Include availability for fallback platforms when using @Available in symbols

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -1309,15 +1309,13 @@ public struct RenderNodeTranslator: SemanticVisitor {
         } ?? .init(defaultValue: defaultAvailability)
 
         if let availability = documentationNode.metadata?.availability, !availability.isEmpty {
-            let renderAvailability = availability.compactMap({
-                let currentPlatform = PlatformName(metadataPlatform: $0.platform).flatMap { name in
-                    context.configuration.externalMetadata.currentPlatforms?[name.displayName]
-                }
-                return .init($0, current: currentPlatform)
-            }).sorted(by: AvailabilityRenderOrder.compare)
+            let allRenderAvailabilities = renderAvailabilities(
+                from: availability,
+                currentPlatforms: context.configuration.externalMetadata.currentPlatforms
+            )
 
-            if !renderAvailability.isEmpty {
-                node.metadata.platformsVariants.defaultValue = renderAvailability
+            if !allRenderAvailabilities.isEmpty {
+                node.metadata.platformsVariants.defaultValue = allRenderAvailabilities
             }
         }
         

--- a/Tests/SwiftDocCTests/Rendering/PlatformAvailabilityTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/PlatformAvailabilityTests.swift
@@ -69,12 +69,18 @@ class PlatformAvailabilityTests: XCTestCase {
         let symbol = try XCTUnwrap(context.entity(with: reference).semantic as? Symbol)
         var translator = RenderNodeTranslator(context: context, identifier: reference)
         let renderNode = try XCTUnwrap(translator.visitSymbol(symbol) as? RenderNode)
-        let availability = try XCTUnwrap(renderNode.metadata.platformsVariants.defaultValue)
-        XCTAssertEqual(availability.count, 1)
-        let iosAvailability = try XCTUnwrap(availability.first)
-        XCTAssertEqual(iosAvailability.name, "iOS")
+        let availabilities = try XCTUnwrap(renderNode.metadata.platformsVariants.defaultValue)
+        // iOS introduces iPadOS and Mac Catalyst as fallback platforms
+        XCTAssertEqual(availabilities.count, 3)
+        XCTAssertEqual(availabilities.compactMap(\.name), ["iOS", "iPadOS", "Mac Catalyst"])
+        let iosAvailability = try XCTUnwrap(availabilities.first)
         XCTAssertEqual(iosAvailability.introduced, "16.0")
         XCTAssert(iosAvailability.isBeta != true)
+        // Ensure that the fallback platforms have the same version and beta status as iOS
+        for availability in availabilities.dropFirst() {
+            XCTAssertEqual(availability.introduced, iosAvailability.introduced)
+            XCTAssertEqual(availability.isBeta, iosAvailability.isBeta)
+        }
     }
 
     func testMultiplePlatformAvailabilityFromArticle() async throws {
@@ -242,12 +248,17 @@ class PlatformAvailabilityTests: XCTestCase {
         let symbol = try XCTUnwrap(context.entity(with: reference).semantic as? Symbol)
         var translator = RenderNodeTranslator(context: context, identifier: reference)
         let renderNode = try XCTUnwrap(translator.visitSymbol(symbol) as? RenderNode)
-        let availability = try XCTUnwrap(renderNode.metadata.platformsVariants.defaultValue)
-        XCTAssertEqual(availability.count, 1)
-        let iosAvailability = try XCTUnwrap(availability.first)
-        XCTAssertEqual(iosAvailability.name, "iOS")
+        let availabilities = try XCTUnwrap(renderNode.metadata.platformsVariants.defaultValue)
+        // iOS introduces iPadOS and Mac Catalyst as fallback platforms
+        XCTAssertEqual(availabilities.count, 3)
+        XCTAssertEqual(availabilities.compactMap(\.name), ["iOS", "iPadOS", "Mac Catalyst"])
+        let iosAvailability = try XCTUnwrap(availabilities.first)
         XCTAssertEqual(iosAvailability.introduced, "16.0")
         XCTAssert(iosAvailability.isBeta == true)
+        // Ensure that fallback platforms are also marked as beta
+        for availability in availabilities.dropFirst() {
+            XCTAssert(availability.isBeta == true)
+        }
     }
 
     


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://169441896

## Summary

As a follow up to https://github.com/swiftlang/swift-docc/pull/1408, include availability for fallback platforms for symbols that use the `@Available` directive to override or complement the availability provided by the symbol graph.

The first commit extracts the logic we implemented for articles into a helper function, and the second commit uses it for symbols as well.

## Dependencies

None.

## Testing

Steps:

1. Build documentation for a symbol that defines iOS availability using `@Available`
2. Verify that the rendered documentation shows availability for iOS, iPadOS, and Mac Catalyst, as these should be inferred.

Alternatively, use the `AvailabilityBundle.docc` catalog to test.

## Checklist

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
