### PR TITLE
Added inline code theme variables

### DIFF
--- a/Sources/SwiftDocC/SwiftDocC.docc/Resources/ThemeSettings.spec.json
+++ b/Sources/SwiftDocC/SwiftDocC.docc/Resources/ThemeSettings.spec.json
@@ -350,6 +350,9 @@
                                     "hero-eyebrow": {
                                         "$ref": "#/components/schemas/Color"
                                     },
+                                    "inline-code-background": {
+                                        "$ref": "#/components/schemas/Color"
+                                    },
                                     "link": {
                                         "$ref": "#/components/schemas/Color"
                                     },
@@ -805,6 +808,20 @@
                                     },
                                     "xcode": {
                                         "$ref": "#/components/schemas/URL"
+                                    }
+                                }
+                            },
+                            "inline-code": {
+                                "type": "object",
+                                "description": "Settings related to \"inline code\" elements.",
+                                "properties": {
+                                    "border-radius": {
+                                        "type": "string",
+                                        "description": "A CSS value for `border-radius`."
+                                    },
+                                    "padding": {
+                                        "type": "string",
+                                        "description": "A CSS value for `padding`."
                                     }
                                 }
                             },


### PR DESCRIPTION
Bug/issue: https://github.com/swiftlang/swift-docc-render/issues/892

## Summary

Added "inline-code" theme variables to ThemeSettings spec, as added in https://github.com/swiftlang/swift-docc-render/pull/992

## Dependencies

https://github.com/swiftlang/swift-docc-render/pull/992 (already merged) 

## Testing

Not applicable

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary
