### PR TITLE
Remove colliding articles from uncurated articles

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -1766,7 +1766,13 @@ public class DocumentationContext {
                         ]
                     )
                 )
-                return nil // Don't continue processing this article
+                // In the case of a collision, we drop the article in favour of the symbol.
+                // It also needs to be removed from the list of uncurated articles, so that
+                // it doesn't get pulled in for rendering during link resolution in case
+                // it is referenced by any other page.
+                uncuratedArticles.removeValue(forKey: reference)
+                // Skip processing this article
+                return nil
             } else {
                 documentationCache[reference] = documentation
             }

--- a/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
@@ -1243,6 +1243,8 @@ class PathHierarchyTests: XCTestCase {
         
         let articleNode = try tree.findNode(path: "/MixedLanguageFramework/Bar", onlyFindSymbols: false)
         XCTAssertNotNil(articleNode.symbol, "This should be an article but can't be because of rdar://79745455")
+        // Ensure that the article is dropped from the list of uncurated articles
+        XCTAssertTrue(context.uncuratedArticles.isEmpty)
         // FIXME: Verify that article matches are preferred for general (non-symbol) links once  https://github.com/swiftlang/swift-docc/issues/593 is fixed
 //        XCTAssertNil(articleNode.symbol, "General documentation link find the article")
     }


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://170471665

## Summary

PR #1430 introduced better collision detection for symbols and articles with the same name. However, after reporting the collision and returning nil, the article was still retained in the list of uncurated articles. This led to two issues:

- If the article is not curated anywhere else in the bundle, then a second warning is produced stating that the article is not curated anywhere, despite it being dropped in favour of the symbol.
- If curated elsewhere, then the article is removed from the list of uncurated articles during link resolution, and is included for rendering. A race condition occurs between the colliding symbol and article when emitting the render JSON, leading to indeterministic output for that page across builds. As the navigator consumes the render JSON in-memory, this also means that in some cases, the render JSON contains the symbol while the navigator contains nodes for the article, and vice versa in other cases.

This patch removes the colliding article from the list of uncurated articles if a collision is detected, ensuring it doesn't get included for rendering even if curated.

## Dependencies

N/A

## Testing

The collision detection unit test has been updated to verify this behaviour. It can also be tested with the same instructions as #1430, and by building documentation multiple times to verify that the same output is produced each time.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
