### PR TITLE
Treat API collections as articles in navigator

### DIFF
--- a/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
+++ b/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
@@ -297,9 +297,8 @@ public class NavigatorIndex {
         case container = 254
         case groupMarker = 255 // UInt8.max
                 
-        /// Initialize a page type from a `role` and a `symbolKind` returning the Symbol type.
+        /// Initialize a page type from a `symbolKind` returning the symbol type.
         init(symbolKind: String) {
-            // Prioritize the SymbolKind first
             switch symbolKind.lowercased() {
             case "module": self = .framework
             case "cl", "class": self = .class
@@ -327,7 +326,7 @@ public class NavigatorIndex {
             default: self = .symbol
             }
         }
-        
+        /// Initialize a page type from a `role` returning the document type.
         init(role: String) {
             switch role.lowercased() {
             case "symbol", "containersymbol": self = .symbol
@@ -336,7 +335,7 @@ public class NavigatorIndex {
             case "pseudosymbol": self = .symbol
             case "pseudocollection": self = .framework
             case "collection": self = .framework
-            case "collectiongroup": self = .symbol
+            case "collectiongroup": self = .article
             case "article": self = .article
             case "samplecode": self = .sampleCode
             default: self = .article

--- a/Tests/SwiftDocCTests/Indexing/ExternalRenderNodeTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/ExternalRenderNodeTests.swift
@@ -610,7 +610,7 @@ class ExternalRenderNodeTests: XCTestCase {
                             ],
                             "path": "/documentation/unit-test/article",
                             "title": "Article",
-                            "type": "symbol"
+                            "type": "article"
                           }
                         ],
                         "path": "/documentation/testbundle",

--- a/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
@@ -503,11 +503,6 @@ Root
                 return node.bundleIdentifier == testBundleIdentifier
             }))
             
-            let allNodes = navigatorIndex.navigatorTree.numericIdentifierToNode.values
-            let symbolPages = allNodes.filter { NavigatorIndex.PageType(rawValue: $0.item.pageType)! == .symbol }
-            // Pages with type `symbol` should be 6 (collectionGroup type of pages) as all the others should have a proper type.
-            XCTAssertEqual(symbolPages.count, 6)
-            
             assertUniqueIDs(node: navigatorIndex.navigatorTree.root)
             results.insert(navigatorIndex.navigatorTree.root.dumpTree())
             try FileManager.default.removeItem(at: targetURL)
@@ -1062,11 +1057,6 @@ Root
                 return node.bundleIdentifier == testBundleIdentifier
             }))
             
-            let allNodes = navigatorIndex.navigatorTree.numericIdentifierToNode.values
-            let symbolPages = allNodes.filter { NavigatorIndex.PageType(rawValue: $0.item.pageType)! == .symbol }
-            // Pages with type `symbol` should be 6 (collectionGroup type of pages) as all the others should have a proper type.
-            XCTAssertEqual(symbolPages.count, 6)
-            
             assertUniqueIDs(node: navigatorIndex.navigatorTree.root)
             results.insert(navigatorIndex.navigatorTree.root.dumpTree())
             try FileManager.default.removeItem(at: targetURL)
@@ -1110,11 +1100,6 @@ Root
             XCTAssertTrue(validateTree(node: navigatorIndex.navigatorTree.root, validator: { (node) -> Bool in
                 return node.bundleIdentifier == testBundleIdentifier
             }))
-            
-            let allNodes = navigatorIndex.navigatorTree.numericIdentifierToNode.values
-            let symbolPages = allNodes.filter { NavigatorIndex.PageType(rawValue: $0.item.pageType)! == .symbol }
-            // Pages with type `symbol` should be 6 (collectionGroup type of pages) as all the others should have a proper type.
-            XCTAssertEqual(symbolPages.count, 6)
             
             // Test path persistence
             XCTAssertNil(navigatorIndex.path(for: 0)) // Root should have not path persisted.
@@ -1674,7 +1659,7 @@ Root
         XCTAssertEqual(PageType(role: "pseudosymbol"), .symbol)
         XCTAssertEqual(PageType(role: "pseudocollection"), .framework)
         XCTAssertEqual(PageType(role: "collection"), .framework)
-        XCTAssertEqual(PageType(role: "collectiongroup"), .symbol)
+        XCTAssertEqual(PageType(role: "collectiongroup"), .article)
         XCTAssertEqual(PageType(role: "article"), .article)
         XCTAssertEqual(PageType(role: "samplecode"), .sampleCode)
         

--- a/Tests/SwiftDocCTests/Indexing/RenderIndexTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/RenderIndexTests.swift
@@ -166,7 +166,7 @@ final class RenderIndexTests: XCTestCase {
                       {
                         "title": "APICollection",
                         "path": "/documentation/mixedlanguageframework/apicollection",
-                        "type": "symbol",
+                        "type": "article",
                         "children": [
                             {
                               "title": "Objective-C–only APIs",
@@ -204,7 +204,7 @@ final class RenderIndexTests: XCTestCase {
                           {
                             "path": "/documentation/mixedlanguageframework/mixedlanguageclassconformingtoprotocol/mixedlanguageprotocol-implementations",
                             "title": "MixedLanguageProtocol Implementations",
-                            "type": "symbol",
+                            "type": "article",
                             "children": [
                               {
                                 "title": "Instance Methods",
@@ -391,7 +391,7 @@ final class RenderIndexTests: XCTestCase {
                       {
                         "path": "/documentation/mixedlanguageframework/apicollection",
                         "title": "APICollection",
-                        "type": "symbol",
+                        "type": "article",
                         "children": [
                           {
                             "title": "Swift-only APIs",
@@ -449,7 +449,7 @@ final class RenderIndexTests: XCTestCase {
                           {
                             "path": "/documentation/mixedlanguageframework/mixedlanguageclassconformingtoprotocol/mixedlanguageprotocol-implementations",
                             "title": "MixedLanguageProtocol Implementations",
-                            "type": "symbol",
+                            "type": "article",
                             "children": [
                               {
                                 "title": "Instance Methods",

--- a/Tests/SwiftDocCTests/Test Resources/TestBundle-RenderIndex.json
+++ b/Tests/SwiftDocCTests/Test Resources/TestBundle-RenderIndex.json
@@ -559,7 +559,7 @@
           {
             "path" : "\/documentation\/test-bundle\/article2",
             "title" : "Article 2",
-            "type" : "symbol"
+            "type" : "article"
           },
           {
             "path" : "\/documentation\/test-bundle\/article3",
@@ -587,7 +587,7 @@
           {
             "path" : "\/documentation\/test-bundle\/article2",
             "title" : "Article 2",
-            "type" : "symbol"
+            "type" : "article"
           },
           {
             "title" : "Duplicated",
@@ -596,17 +596,17 @@
           {
             "path" : "\/documentation\/test-bundle\/article2",
             "title" : "Article 2",
-            "type" : "symbol"
+            "type" : "article"
           }
         ],
         "path" : "\/documentation\/test-bundle\/article",
         "title" : "My Cool Article",
-        "type" : "symbol"
+        "type" : "article"
       },
       {
         "path" : "\/documentation\/test-bundle\/article2",
         "title" : "Article 2",
-        "type" : "symbol"
+        "type" : "article"
       },
       {
         "path" : "\/documentation\/test-bundle\/default-code-listing-syntax",
@@ -702,7 +702,7 @@
                 ],
                 "path" : "\/documentation\/sidekit\/sideclass\/element\/protocol-implementations",
                 "title" : "Protocol Implementations",
-                "type" : "symbol"
+                "type" : "article"
               }
             ],
             "path" : "\/documentation\/sidekit\/sideclass\/element",


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://170471605

## Summary

The navigator uses a local enum for page types which is independent of the page types stored in the render JSON, and performs a mapping between the two when indexing a node for the navigator. The curation for the navigator restricts how nodes can be curated across languages:

- Symbols cannot be curated in languages that they are not available in, e.g. Swift symbols cannot be curated in an Objective-C-only page.
- Internal non-symbol pages can be curated across languages by making them available in the target language via the `@SupportedLanguage` directive.
- External non-symbol pages can be indiscriminately curated in a page of any language since a non-symbol page is not semantically attached to a specific language unless explicitly specified via the `@SupportedLanguage` directive.

According to these rules, API collections (which are just articles) can be curated in a page that is of a different language. However, while this works correctly in the topics section, the navigator does not do this due to API collections being treated as a symbol. This patch remaps the API collection to be treated as an article.

## Dependencies

N/A

## Testing

The existing tests have been updated to verify this behaviour. I also ran a documentation build with a test archive 100 times and verified that the output was consistent each time.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
