### PR TITLE
Refine warning about additional first-level headings

### DIFF
--- a/Sources/SwiftDocC/CMakeLists.txt
+++ b/Sources/SwiftDocC/CMakeLists.txt
@@ -457,7 +457,7 @@ add_library(SwiftDocC
   Utility/MarkupExtensions/AnyLink.swift
   Utility/MarkupExtensions/BlockDirectiveExtensions.swift
   Utility/MarkupExtensions/DocumentExtensions.swift
-  Utility/MarkupExtensions/Heading+ContainsAnyLink.swift
+  Utility/MarkupExtensions/Heading+StartsWithAnyLink.swift
   Utility/MarkupExtensions/ImageExtensions.swift
   Utility/MarkupExtensions/ListItemExtractor.swift
   Utility/MarkupExtensions/MarkupChildrenExtensions.swift

--- a/Sources/SwiftDocC/Checker/Checkers/InvalidAdditionalTitle.swift
+++ b/Sources/SwiftDocC/Checker/Checkers/InvalidAdditionalTitle.swift
@@ -37,7 +37,7 @@ public struct InvalidAdditionalTitle: Checker {
         }
         
         // We've found a level-one heading which isn't the title of the document.
-        let isExtensionFile = documentTitle.containsAnyLink
+        let isExtensionFile = documentTitle.startsWithAnyLink
         
         func makeNote(message: @autoclosure () -> String) -> [DiagnosticNote] {
             guard let range = documentTitle.range, let source = sourceFile ?? range.source else {

--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -766,7 +766,7 @@ public class DocumentationContext {
             
             // Since documentation extensions' filenames have no impact on the URL of pages, there is no need to enforce unique filenames for them.
             // At this point we consider all articles with an H1 containing link a "documentation extension."
-            let isDocumentationExtension = (analyzed as? Article)?.title?.containsAnyLink == true
+            let isDocumentationExtension = (analyzed as? Article)?.title?.startsWithAnyLink == true
             
             if let firstFoundAtURL = references[reference], !isDocumentationExtension {
                 let problem = Problem(

--- a/Sources/SwiftDocC/Semantics/Article/Article.swift
+++ b/Sources/SwiftDocC/Semantics/Article/Article.swift
@@ -209,7 +209,7 @@ public final class Article: Semantic, MarkupConvertible, Abstracted, Redirected,
         
         let relevantCategorizedOptions = allCategorizedOptions.compactMapValues(\.first)
         
-        let isDocumentationExtension = title.containsAnyLink
+        let isDocumentationExtension = title.startsWithAnyLink
         if !isDocumentationExtension, let metadata = optionalMetadata, let displayName = metadata.displayName {
             let diagnosticSummary = """
             A \(DisplayName.directiveName.singleQuoted) directive is only supported in documentation extension files. To customize the display name of an article, change the content of the level-1 heading.

--- a/Sources/SwiftDocC/Utility/MarkupExtensions/Heading+StartsWithAnyLink.swift
+++ b/Sources/SwiftDocC/Utility/MarkupExtensions/Heading+StartsWithAnyLink.swift
@@ -14,7 +14,7 @@ extension Heading {
     /// A Boolean value that indicates if this heading contains any link as its first element.
     ///
     /// A first level heading with a link is used to associate a documentation extension file with a symbol.
-    var containsAnyLink: Bool {
+    var startsWithAnyLink: Bool {
         child(at: 0) is (any AnyLink)
     }
 }

--- a/Tests/SwiftDocCTests/Checker/Checkers/InvalidAdditionalTitleTests.swift
+++ b/Tests/SwiftDocCTests/Checker/Checkers/InvalidAdditionalTitleTests.swift
@@ -48,7 +48,7 @@ struct InvalidAdditionalTitleTests {
         let firstHeading  = try #require(document.child(at: 0) as? Heading)
         let secondHeading = try #require(document.child(at: 2) as? Heading)
         
-        let isDocumentationExtensionFile = firstHeading.containsAnyLink
+        let isDocumentationExtensionFile = firstHeading.startsWithAnyLink
         let problem = try #require(problems.first)
         let diagnostic = problem.diagnostic
         


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

This refines the diagnostic about multiple first-level headings in a page based on the guidelines in https://github.com/swiftlang/swift-docc/pull/1442.

It also customizes the warnings depending on if the markdown file is an article or a documentation extension. 

## Dependencies

None.

## Testing

- Build documentation where an article has more than one first-level headings. Note the warning.
- Build documentation where a documentation extension file has more than one first-level headings. Note the different warning.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] ~Added~ Updated tests
- [ ] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary
