### PR TITLE
Avoid "code will never be executed" warning for disabled test

### DIFF
--- a/Tests/SwiftDocCTests/Infrastructure/ExternalPathHierarchyResolverTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/ExternalPathHierarchyResolverTests.swift
@@ -687,7 +687,7 @@ class ExternalPathHierarchyResolverTests: XCTestCase {
     }
     
     func testSymbolLinksInDeclarationsAndRelationships() async throws {
-        throw XCTSkip("Skipping due to CI failures - rdar://169083752")
+        try XCTSkipIf(true, "Skipping due to CI failures - rdar://169083752")
         // Build documentation for the dependency first
         let symbols = [("First", .class), ("Second", .protocol), ("Third", .struct), ("Fourth", .enum)].map { (name: String, kind: SymbolGraph.Symbol.KindIdentifier) in
             return SymbolGraph.Symbol(


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

This uses `try XCTSkipIf(true, "...")` instead of a direct `throw XCTSkip("...")` to avoid the "code will never be executed" warning for a disabled test.

## Dependencies

None.

## Testing

Run the tests. There shouldn't be a "code will never be executed" warning.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [ ] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary
