### PR TITLE
Finish loading external resolvers before registering local symbols

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -2123,6 +2123,9 @@ public class DocumentationContext {
         
         registerRootPages(from: rootPageArticles)
         
+        // `registerSymbols(...)`, just below, calls `resolveExternalSymbols()` internally so we need to have finished loading the external symbol data before calling it.
+        _ = try await loadExternalResolvers
+        
         try registerSymbols(symbolGraphLoader: symbolGraphLoader, documentationExtensions: documentationExtensions)
         // We don't need to keep the loader in memory after we've registered all symbols.
         _ = consume symbolGraphLoader
@@ -2153,8 +2156,6 @@ public class DocumentationContext {
             otherArticles = registerArticles(otherArticles)
             try shouldContinueRegistration()
         }
-        
-        _ = try await loadExternalResolvers
         
         // Third, any processing that relies on resolving other content is done, mainly resolving links.
         preResolveExternalLinks(semanticObjects:


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

This moves the `await` call for the external resolvers before the `registerSymbols(...)`call inside the context's private `register()` implementation because `registerSymbols(...)` internally calls `resolveExternalSymbols(...)` in its implementation.

Without these changes there is a risk that the external resolvers either:
- hadn't finished loading the external resolvers, which would result in links to external symbols not resolving. I think this was the cause of https://github.com/swiftlang/swift-docc/pull/1424
- was in the middle of assigning a value to `LinkResolver.externalResolvers` at the same time as `resolveExternalSymbols(...)` was accessing it, which would _likely_ result in a crash. The command with `--sanitize=thread` below find this case somewhat frequently (roughly 1 in 2 or 1 in 3 times).

## Dependencies

None

## Testing

- Run `for i in {1..10000}; do echo "\n$i"; swift test --sanitize=thread --parallel --filter SwiftDocCTests.DocumentationContextTests/testResolveExternalLinkFromTechnologyRoot; done`
- It shouldn't report any data races 

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary
