### PR TITLE
Make DisplayName directives override both the page title and the navigator title

### DIFF
--- a/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
+++ b/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
@@ -321,7 +321,7 @@ public class NavigatorIndex {
             case "enumsub", "structsub", "instsub", "intfsub", "subscript": self = .subscript
             case "enumcm", "structcm", "clm", "intfcm", "type.method": self = .typeMethod
             case "httpget", "httpput", "httppost", "httppatch", "httpdelete": self = .httpRequest
-            case "dict": self = .dictionarySymbol
+            case "dict", "dictionary": self = .dictionarySymbol
             case "namespace": self = .namespace
             default: self = .symbol
             }

--- a/Sources/SwiftDocC/Model/Rendering/DocumentationContentRenderer.swift
+++ b/Sources/SwiftDocC/Model/Rendering/DocumentationContentRenderer.swift
@@ -91,6 +91,11 @@ public class DocumentationContentRenderer {
             return .init(defaultValue: nil)
         }
         
+        if let customDisplayName = node.metadata?.displayName?.name {
+            // Prefer the custom display name if there is one for this symbol.
+            return .init(defaultValue: [.init(text: customDisplayName, kind: .text)])
+        }
+        
         return VariantCollection<[DeclarationRenderSection.Token]?>(
             from: symbol.navigatorVariants,
             symbol.titleVariants

--- a/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
@@ -2134,6 +2134,57 @@ Root
         XCTAssert(nonBetaNodes.allSatisfy { $0.isBeta == false }) // Sanity check
     }
     
+    func testNavigatorUsesCustomDisplayName() async throws {
+        let catalog = Folder(name: "Something.docc", content: [
+            JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(moduleName: "ModuleName", symbols: [
+                // There's special logic for common Swift symbols, so use another kind of symbol here.
+                makeSymbol(id: "some-symbol-id", language: .data, kind: .dictionary, pathComponents: ["SomeDictionary"])
+            ])),
+            TextFile(name: "SomeDictionary.md", utf8Content: """
+            # ``SomeDictionary``    
+            
+            Customize the display name of this dictionary (for some reason)
+            
+            @Metadata {
+              @DisplayName("Some custom name")
+            }
+            """)
+        ])
+        let (_, context) = try await loadBundle(catalog: catalog)
+        
+        // Navigator Index / Builder can only use real file systems
+        let targetURL = try createTemporaryDirectory()
+        
+        let renderContext = RenderContext(documentationContext: context)
+        let converter = DocumentationContextConverter(context: context, renderContext: renderContext)
+        let builder = NavigatorIndex.Builder(outputURL: targetURL, bundleIdentifier: context.inputs.id.rawValue, sortRootChildrenByName: true)
+        builder.setup()
+        for identifier in context.knownPages {
+            let entity = try context.entity(with: identifier)
+            let renderNode = try XCTUnwrap(converter.renderNode(for: entity))
+            try builder.index(renderNode: renderNode)
+            
+            if identifier.lastPathComponent == "SomeDictionary" {
+                XCTAssertEqual(renderNode.metadata.title, "Some custom name")
+                XCTAssertEqual(renderNode.metadata.navigatorTitle?.map(\.text).joined(), "Some custom name")
+            }
+        }
+        builder.finalize()
+        
+        XCTAssertEqual(builder.navigatorIndex?.navigatorTree.root.dumpTree(), """
+        [Root]
+        ┗╸ModuleName
+          ┣╸Dictionaries
+          ┗╸Some custom name
+        """)
+        
+        let renderIndex = try RenderIndex.fromURL(targetURL.appendingPathComponent("index.json"))
+        XCTAssertEqual(renderIndex.interfaceLanguages["data"]?.map(\.title), [
+            "Dictionaries",
+            "Some custom name",
+        ])
+    }
+    
     private func findNodesWithBetaStatus(in nodes: [RenderIndex.Node], isBeta: Bool) -> [RenderIndex.Node] {
         var betaNodes: [RenderIndex.Node] = []
         


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://170218493

## Summary

This updates the `RenderMetadata` transformation to also use custom `DisplayName` values for the `navigatorTitle`. This behavior matches what's already described in the [DisplayName directive documentation](https://www.swift.org/documentation/docc/displayname#Overview) (my added emphasis):

> **A custom display name appears** in place of the symbol’s name **in the following locations**:
> - The main header on the symbol page
> - **The navigator hierarchy**
> - Breadcrumbs for the symbol page and its child symbol pages
> - Link text anywhere that includes a link to the symbol page

## Dependencies

None.

## Testing

> [!NOTE]
>  because of https://github.com/swiftlang/swift-docc/issues/176 you might get false positives (it working as described without these changes) if you try to verify this behavior with a Swift symbol.

- In some non-Swift project, specify a custom display name using the `DisplayName` directive for one of the symbols and build documentation.
  - On that page, the symbol should display the custom display name instead of its symbol name (this worked before)
  - In the navigator hierarchy, the symbol should _also_ display the custom display name instead of its symbol name (this is new)


## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [ ] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~ The [relevant documentation](https://www.swift.org/documentation/docc/displayname#Overview) already describes this behavior.
