### PR TITLE
Consider unconditionally unavailable platforms in `@Available` render logic

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -78,9 +78,11 @@ public struct RenderNodeTranslator: SemanticVisitor {
     ///
     /// For example, when iOS availability is specified, this also generates iPadOS and Mac Catalyst
     /// availability items using the same version information.
+    /// Any fallback platforms marked as unconditionally unavailable will not be included.
     private func renderAvailabilities(
         from availabilities: [Metadata.Availability],
-        currentPlatforms: [String: PlatformVersion]?
+        currentPlatforms: [String: PlatformVersion]?,
+        unconditionallyUnavailablePlatforms: [PlatformName]
     ) -> [AvailabilityRenderItem] {
         let platforms = availabilities.map { PlatformName(metadataPlatform: $0.platform) }
 
@@ -93,8 +95,10 @@ public struct RenderNodeTranslator: SemanticVisitor {
         // Render availabilities for fallback platforms (e.g., iPadOS and Mac Catalyst from iOS)
         let fallbackAvailabilities = DefaultAvailability.fallbackPlatforms.compactMap { platform, fallback -> AvailabilityRenderItem? in
             // Skip if the platform already has explicit availability,
+            // the platform is explicitly marked unavailable in the module's default availability,
             // or if the fallback platform is not available.
             guard !platforms.contains(platform),
+                  !unconditionallyUnavailablePlatforms.contains(platform),
                   let fallbackIndex = platforms.firstIndex(of: fallback) else {
                 return nil
             }
@@ -878,9 +882,16 @@ public struct RenderNodeTranslator: SemanticVisitor {
         }
 
         if let availabilities = article.metadata?.availability, !availabilities.isEmpty {
+            let unconditionallyUnavailablePlatforms = moduleNames.flatMap { name in
+                context.inputs.info.defaultAvailability?.modules[name]?
+                    .filter { $0.versionInformation == .unavailable }
+                    .map { $0.platformName }
+                ?? []
+            }
             let allRenderAvailabilities = renderAvailabilities(
                 from: availabilities,
-                currentPlatforms: context.configuration.externalMetadata.currentPlatforms
+                currentPlatforms: context.configuration.externalMetadata.currentPlatforms,
+                unconditionallyUnavailablePlatforms: unconditionallyUnavailablePlatforms
             )
 
             if !allRenderAvailabilities.isEmpty {
@@ -1309,9 +1320,14 @@ public struct RenderNodeTranslator: SemanticVisitor {
         } ?? .init(defaultValue: defaultAvailability)
 
         if let availability = documentationNode.metadata?.availability, !availability.isEmpty {
+            let unconditionallyUnavailablePlatforms = context.inputs.info.defaultAvailability?.modules[moduleName.symbolName]?
+                .filter { $0.versionInformation == .unavailable }
+                .map { $0.platformName }
+            ?? []
             let allRenderAvailabilities = renderAvailabilities(
                 from: availability,
-                currentPlatforms: context.configuration.externalMetadata.currentPlatforms
+                currentPlatforms: context.configuration.externalMetadata.currentPlatforms,
+                unconditionallyUnavailablePlatforms: unconditionallyUnavailablePlatforms
             )
 
             if !allRenderAvailabilities.isEmpty {

--- a/Tests/SwiftDocCTests/Rendering/PlatformAvailabilityTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/PlatformAvailabilityTests.swift
@@ -277,8 +277,7 @@ class PlatformAvailabilityTests: XCTestCase {
 struct PlatformAvailabilityTestSuite {
     /// Ensure that adding `@Available` directives in an article causes the final RenderNode to contain the appropriate availability data.
     /// Unavailability information should be taken into account when deriving whether fallback platform availability should be added.
-    @Test(.disabled("This test is currently failing and will be re-enabled in a subsequent commit."))
-    func testPlatformAvailabilityFromArticleRespectsDefaultAvailability() async throws {
+    @Test func testPlatformAvailabilityFromArticleRespectsDefaultAvailability() async throws {
         let catalog = Folder(name: "unit-test.docc", content: [
             JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(moduleName: "ModuleName", symbols: [])),
             TextFile(name: "ModuleName.md", utf8Content: """
@@ -336,8 +335,7 @@ struct PlatformAvailabilityTestSuite {
 
     /// Ensure that adding `@Available` directives in an extension file overrides the symbol's availability.
     /// This should add any missing fallback platforms while respecting the module's default unconditional unavailability.
-    @Test(.disabled("This test is currently failing and will be re-enabled in a subsequent commit."))
-    func testPlatformAvailabilityFromExtensionRespectsDefaultAvailability() async throws {
+    @Test func testPlatformAvailabilityFromExtensionRespectsDefaultAvailability() async throws {
         let catalog = Folder(name: "unit-test.docc", content: [
             JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(moduleName: "ModuleName", symbols: [
                 makeSymbol(id: "some-symbol-id", kind: .class, pathComponents: ["SomeClass"], docComment: """


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://171710882

## Summary

The fallback platform logic introduced in https://github.com/swiftlang/swift-docc/commit/d9f05c3f34dd2f988803d21dad87ea27198f9036 ensured that fallback platforms are correctly added when using the `@Available` directive. For example, if `@Available(iOS, introduced: 16.0)` is specified, fallback platforms iPadOS and Mac Catalyst will also be added as available platforms.

Unfortunately the new logic currently does not take into account that some of these fallback platforms may have been marked as unconditionally unavailable in the `Info.plist`.

This PR updates the availability render logic for both articles and symbols, such that if any applicable unconditional availabilities are known, those fallback platforms are not added as available platforms. This PR only changes the availability behaviour when using the `@Available` directive to override availability for a symbol or article.

In practice what this means is that, if a symbol's availability is overridden in an extension file with the following availability:
```
@Metadata {
    @Available(iOS, introduced: 16.0)
}
```

iPadOS and Mac Catalyst, which are the fallback platforms for iOS, will only be added to the list of availabilities if they haven't been marked as unconditionally unavailable in the `Info.plist`:
```
         <key>CDAppleDefaultAvailability</key>
        <dict>
                <key>MyKit</key>
                <array>
                        <dict>
                                <key>name</key>
                                <string>iPadOS</string>
                                <key>unavailable</key>
                                <true/>
                        </dict>
                        <dict>
                                <key>name</key>
                                <string>Mac Catalyst</string>
                                <key>unavailable</key>
                                <true/>
                        </dict>
                </array>
        </dict>
```

If the fallback platforms have not been marked as unconditionally unavailable, they will still appear as available platforms as expected.

## Dependencies

N/A

## Testing

You can use this unit test bundle `AvailabilityBundleWithUnconditionallyUnavailablePlatforms.docc` to verify this behaviour:
[AvailabilityBundleWithUnconditionallyUnavailablePlatforms.docc.zip](https://github.com/user-attachments/files/25771373/AvailabilityBundleWithUnconditionallyUnavailablePlatforms.docc.zip)

Steps:
1. `swift run docc preview AvailabilityBundleWithUnconditionallyUnavailablePlatforms.docc`
2. All pages in the bundle should show iOS availability only, as iPadOS and Mac Catalyst are configured as unconditionally unavailable.
     - Verify that module page http://localhost:8080/documentation/mykit shows only iOS availability
     -  Verify that article page http://localhost:8080/documentation/availability/availablearticle shows only iOS availability
     - Verify that child symbol page http://localhost:8080/documentation/mykit/myclass shows only iOS availability

Before this change, all three of the above pages with `@Available` directives would show all 3 platforms, iOS, iPadOS and Mac Catalyst.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- ~~[ ] Updated documentation if necessary~~ N/A
