### PR TITLE
Synchronize PreviewServer state to fix `start` and `stop` race condition

### DIFF
--- a/Sources/DocCCommandLine/PreviewServer/PreviewServer.swift
+++ b/Sources/DocCCommandLine/PreviewServer/PreviewServer.swift
@@ -61,11 +61,22 @@ final class PreviewServer {
         }
     }
     
-    private let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
-    private let threadPool = NIOThreadPool(numberOfThreads: System.coreCount)
-
-    private var bootstrap: ServerBootstrap!
-    internal var channel: (any Channel)!
+    private struct State {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+        let threadPool = NIOThreadPool(numberOfThreads: System.coreCount)
+        
+        var bootstrap: ServerBootstrap!
+        var channel: (any Channel)!
+    }
+    
+    private var state = Synchronized(State())
+    
+    @_spi(Testing)
+    public var _boundPort: Int? {
+        state.sync {
+            $0.channel.localAddress?.port
+        }
+    }
     
     private let contentURL: URL
     private let fileManager: any FileManagerProtocol
@@ -120,76 +131,76 @@ final class PreviewServer {
     /// - Parameter onReady: A closure that's executed after the server is bound successfully
     ///   to its destination but before it has started serving content.
     func start(onReady: (() -> Void)? = nil) throws {
-        // Create a server bootstrap
-        bootstrap = ServerBootstrap(group: group)
-            // Learn more about the `listen` command pending clients backlog from its reference;
-            // do that by typing `man 2 listen` on your command line.
-            .serverChannelOption(ChannelOptions.backlog, value: 256)
-            // Enable SO_REUSEADDR for the server itself
-            .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
-
-            // Configure the channel handler - it handles plain HTTP requests
-            .childChannelInitializer { [contentURL, fileManager] channel in
-                // HTTP pipeline
-                return channel.pipeline.configureHTTPServerPipeline(withErrorHandling: true).flatMap {
-                    channel.pipeline.addHandler(PreviewHTTPHandler(rootURL: contentURL, fileManager: fileManager))
+        let closeFuture = try state.sync {
+            // Create a server bootstrap
+            $0.bootstrap = ServerBootstrap(group: $0.group)
+                // Learn more about the `listen` command pending clients backlog from its reference;
+                // do that by typing `man 2 listen` on your command line.
+                .serverChannelOption(ChannelOptions.backlog, value: 256)
+                // Enable SO_REUSEADDR for the server itself
+                .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
+                // Configure the channel handler - it handles plain HTTP requests
+                .childChannelInitializer { [contentURL, fileManager] channel in
+                    // HTTP pipeline
+                    return channel.pipeline.configureHTTPServerPipeline(withErrorHandling: true).flatMap {
+                        channel.pipeline.addHandler(PreviewHTTPHandler(rootURL: contentURL, fileManager: fileManager))
+                    }
                 }
-            }
+                // Enable TCP_NODELAY for the accepted Channels
+                .childChannelOption(ChannelOptions.socket(IPPROTO_TCP, TCP_NODELAY), value: 1)
+                .childChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
+                .childChannelOption(ChannelOptions.maxMessagesPerRead, value: 16)
+                .childChannelOption(ChannelOptions.allowRemoteHalfClosure, value: true)
             
-            // Enable TCP_NODELAY for the accepted Channels
-            .childChannelOption(ChannelOptions.socket(IPPROTO_TCP, TCP_NODELAY), value: 1)
-            .childChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
-            .childChannelOption(ChannelOptions.maxMessagesPerRead, value: 16)
-            .childChannelOption(ChannelOptions.allowRemoteHalfClosure, value: true)
-        
-        // Start the server
-        threadPool.start()
-        
-        do {
-            // Bind to the given destination
+            // Start the server
+            $0.threadPool.start()
+            
             switch bindTo {
             case .localhost(let port):
-                channel = try bootstrap.bind(host: "localhost", port: port).wait()
+                // Customize the errors when binding to a localhost port
+                do {
+                    $0.channel = try $0.bootstrap.bind(host: "localhost", port: port).wait()
+                } catch let error as NIO.IOError where error.errnoCode == EADDRINUSE {
+                    throw Error.portNotAvailable(port: port)
+                } catch {
+                    throw Error.cannotStartServer(port: port)
+                }
+                
             case .socket(let path):
-                channel = try bootstrap.bind(unixDomainSocketPath: path).wait()
+                $0.channel = try $0.bootstrap.bind(unixDomainSocketPath: path).wait()
             }
-        } catch let error as NIO.IOError where error.errnoCode == EADDRINUSE {
-            // The given port is not available.
-            switch bindTo {
-                case .localhost(let port): throw Error.portNotAvailable(port: port)
-                default: throw error
+            
+            guard let _ = $0.channel.localAddress else {
+                throw Error.failedToStart
             }
-        } catch {
-            // Cannot bind the given address/port.
-            switch bindTo {
-                case .localhost(let port): throw Error.cannotStartServer(port: port)
-                default: throw error
-            }
-        }
-        
-        guard let _ = channel.localAddress else {
-            throw Error.failedToStart
+            
+            // Return the closeFuture so that we can `wait()` it outside the synchronization scope.
+            return $0.channel.closeFuture
         }
         
         onReady?()
         
         // This will block until the server is stopped
-        try channel.closeFuture.wait()
+        try closeFuture.wait()
     }
     
     /// Stops the current preview server.
     /// - throws: If the server fails to close the communication channel or the async infrastructure.
     func stop() throws {
-        if let feature = channel?.close(mode: .all) {
-            try feature.wait()
+        try state.sync {
+            if let feature = $0.channel?.close(mode: .all) {
+                try feature.wait()
+            }
+            try $0.group.syncShutdownGracefully()
+            try $0.threadPool.syncShutdownGracefully()
         }
-        try group.syncShutdownGracefully()
-        try threadPool.syncShutdownGracefully()
         print("Stopped preview server at \(bindTo)", to: &logHandle)
     }
     
     deinit {
-        if channel?.isWritable == true {
+        // Only synchronize around the `isWritable` check (as opposed to the full deinitialization scope).
+        // The synchronization lock isn't reentrant and `stop()` also acquires the lock to close and shut down.
+        if state.sync({ $0.channel?.isWritable }) == true {
             try? stop()
         }
     }

--- a/Tests/DocCCommandLineTests/PreviewActionIntegrationTests.swift
+++ b/Tests/DocCCommandLineTests/PreviewActionIntegrationTests.swift
@@ -11,7 +11,7 @@
 #if canImport(NIOHTTP1)
 import XCTest
 @testable import SwiftDocC
-@testable import DocCCommandLine
+@_spi(Testing) @testable import DocCCommandLine
 import DocCTestUtilities
 import NIOCore
 
@@ -305,7 +305,7 @@ class PreviewActionIntegrationTests: XCTestCase {
         XCTAssertNotNil(servers[preview.serverIdentifier])
         
         // We have one preview running on the given port
-        let boundPort = try XCTUnwrap(servers[preview.serverIdentifier]?.channel.localAddress?.port)
+        let boundPort = try XCTUnwrap(servers[preview.serverIdentifier]?._boundPort)
 
         // Try to start another preview on the same port
         try await assert(bindPort: boundPort, expectedErrorMessage: "Port \(boundPort) is not available at the moment, try a different port number")


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://173135444

## Summary

This fixes a few data races in the PreviewServer reported by the ThreadSanitizer.

## Dependencies

None.

## Testing

Run `swift test --sanitize=thread --quiet --parallel --filter DocCCommandLineTests`. 
It shouldn't report any data races.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- ~[ ] Added tests~
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
