### PR TITLE
Add missing symbol kind `httpRequest` to navigator index

### DIFF
--- a/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
+++ b/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -320,7 +320,7 @@ public class NavigatorIndex {
             case "enumdata", "structdata", "cldata", "clconst", "intfdata", "type.property", "typeConstant": self = .instanceVariable
             case "enumsub", "structsub", "instsub", "intfsub", "subscript": self = .subscript
             case "enumcm", "structcm", "clm", "intfcm", "type.method": self = .typeMethod
-            case "httpget", "httpput", "httppost", "httppatch", "httpdelete": self = .httpRequest
+            case "httpget", "httpput", "httppost", "httppatch", "httpdelete", "httprequest": self = .httpRequest
             case "dict", "dictionary": self = .dictionarySymbol
             case "namespace": self = .namespace
             default: self = .symbol

--- a/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -1700,7 +1700,7 @@ Root
         verifySymbolKind(["enumdata", "structdata", "cldata", "clconst", "intfdata"], .instanceVariable)
         verifySymbolKind(["enumsub", "structsub", "instsub", "intfsub"], .subscript)
         verifySymbolKind(["enumcm", "structcm", "clm", "intfcm"], .typeMethod)
-        verifySymbolKind(["httpget", "httpput", "httppost", "httppatch", "httpdelete"], .httpRequest)
+        verifySymbolKind(["httpget", "httpput", "httppost", "httppatch", "httpdelete", "httprequest"], .httpRequest)
         
         // Verify mappings provided from Delphi to SymbolKit
         


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://172829050

## Summary

Fixes an issue where HTTP request symbols had the incorrect page type in the navigator index.  Symbol kind `httpRequest` [1] was missing from the navigator page type initialisation logic, causing all symbols with that kind to be shown as `symbol` in the navigator rather than the more specific `httpRequest` type.

This PR adds the missing symbol kind, which is used when deriving the navigator page type [2].

[1]: https://github.com/swiftlang/swift-docc-symbolkit/blob/4c4ff018e5842d128fceb4f917a94ba2c58c6dd9/Sources/SymbolKit/SymbolGraph/Symbol/KindIdentifier.swift#L84
[2]: https://github.com/swiftlang/swift-docc/blob/3760b4f0bb4d6f5e5548e7d2f78caac92b8f9a3e/Sources/SwiftDocC/Indexing/Navigator/RenderNode%2BNavigatorIndex.swift#L174

## Dependencies

N/A

## Testing

Use catalog [HTTPRequests.docc.zip](https://github.com/user-attachments/files/26187615/HTTPRequests.docc.zip) for an example catalog with HTTP request symbols. A specific navigator icon for HTTP endpoints is expected. In the index JSON, this looks like:
```
          {
            "path": "\/documentation\/httprequests\/get_artist",
            "title": "Get Artist",
            "type": "httpRequest"
          },
``` 

Steps:
1. `swift run docc preview HTTPRequests.docc`
2. Verify that the rendered navigator shows the correct icon for HTTP endpoints (see below).

Before | After
------ | ------
<img width="488" height="276" alt="Screenshot 2026-03-23 at 16 02 31" src="https://github.com/user-attachments/assets/69c508ac-785c-4e48-b248-609f4f999bbe" /> | <img width="487" height="267" alt="Screenshot 2026-03-23 at 16 02 58" src="https://github.com/user-attachments/assets/04bc0ba9-8e43-49f3-acb7-7c2d2205e9e0" />

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- ~~[ ] Updated documentation if necessary~~
