### PR TITLE
Add option to install without building.

### DIFF
--- a/build-script-helper.py
+++ b/build-script-helper.py
@@ -45,6 +45,7 @@ def parse_args(args):
   parser.add_argument('--copy-doccrender-from', default=None, help='The location to copy an existing Swift-DocC-Render template from.')
   parser.add_argument('--copy-doccrender-to', default=None, help='The location to install an existing Swift-DocC-Render template to.')
   parser.add_argument("--cross-compile-hosts", dest="cross_compile_hosts", help="List of cross compile hosts targets.", default=[])
+  parser.add_argument('--install-only', action='store_true', default=False)
   
   parsed = parser.parse_args(args)
 
@@ -124,11 +125,12 @@ def run(args):
     print("** Installing %s **" % package_name)
     
     try:
-      invoke_swift(action='build',
-        products=['docc'],
-        env=env,
-        args=args,
-        swiftpm_args=get_swiftpm_options('install', args))
+      if not args.install_only:
+        invoke_swift(action='build',
+          products=['docc'],
+          env=env,
+          args=args,
+          swiftpm_args=get_swiftpm_options('install', args))
       install(args, env)
     except subprocess.CalledProcessError as e:
       printerr('FAIL: Installing %s failed' % package_name)


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

This allows the build action to be decoupled from the install action, so packaging systems that expect to be able to do discrete installation steps post-build can do so cheaply, without having to effectively start the build over from scratch.

To match existing behavior, this defaults to being disabled. This was introduced previously in swiftlang/swift-package-manager#9050, and the flag has the same name used there.

## Dependencies

No hard dependencies. Changes are being upstreamed to introduce this behavior on some other projects (as mentioned the first change was swiftlang/swift-package-manager#9050, see also e.g., swiftlang/swift-format#1171, swiftlang/sourcekit-lsp#2579).

## Testing

Run build-script-helper's install action without the flag, i.e., use build-script normally. The script's behavior will be unchanged because the flag is disabled by default.

Run build-script-helper's install action with the flag, pointing at the built build artifacts.
The installation will just perform the installation steps without rebuilding, i.e., copy the binaries.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [n/a] Added tests
- [n/a] Ran the `./bin/test` script and it succeeded
- [n/a] Updated documentation if necessary
