### PR TITLE
[6.3][cherrypick] Add option to install without building.

### DIFF
--- a/build-script-helper.py
+++ b/build-script-helper.py
@@ -45,6 +45,7 @@ def parse_args(args):
   parser.add_argument('--copy-doccrender-from', default=None, help='The location to copy an existing Swift-DocC-Render template from.')
   parser.add_argument('--copy-doccrender-to', default=None, help='The location to install an existing Swift-DocC-Render template to.')
   parser.add_argument("--cross-compile-hosts", dest="cross_compile_hosts", help="List of cross compile hosts targets.", default=[])
+  parser.add_argument('--install-only', action='store_true', default=False)
   
   parsed = parser.parse_args(args)
 
@@ -124,11 +125,12 @@ def run(args):
     print("** Installing %s **" % package_name)
     
     try:
-      invoke_swift(action='build',
-        products=['docc'],
-        env=env,
-        args=args,
-        swiftpm_args=get_swiftpm_options('install', args))
+      if not args.install_only:
+        invoke_swift(action='build',
+          products=['docc'],
+          env=env,
+          args=args,
+          swiftpm_args=get_swiftpm_options('install', args))
       install(args, env)
     except subprocess.CalledProcessError as e:
       printerr('FAIL: Installing %s failed' % package_name)


### PR DESCRIPTION

- **Explanation**:

Allows the install action to be run without rebuilding.

- **Scope**:

Minor. Option is not wired up to anything.

- **Issues**:

Of relevance to the OpenBSD port at swiftlang/swift#78437

- **Original PRs**:

#1486

- **Risk**:

Minor. Option is off by default.

- **Testing**:

Passed CI, local testing.

- **Reviewers**:

@heckj 
@d-ronnqvist 