### PR TITLE
Ignore nodes with empty titles in indexing records

### DIFF
--- a/Sources/SwiftDocC/Indexing/IndexingError.swift
+++ b/Sources/SwiftDocC/Indexing/IndexingError.swift
@@ -10,6 +10,7 @@
 
 import Foundation
 
+@available(*, deprecated, message: "This error type is no longer used. This deprecated API will be removed after 6.5 is released.")
 public enum IndexingError: DescribedError {
     /**
      A page or other piece of documentation doesn't have a title, so it can't

--- a/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
+++ b/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
@@ -55,6 +55,7 @@ public class NavigatorIndex {
         case missingBundleIdentifier
         
         /// A RenderNode has no title and won't be indexed.
+        @available(*, deprecated, message: "This error type is no longer used. This deprecated API will be removed after 6.5 is released.")
         case missingTitle(description: String)
         
         /// The navigator index has not been initialized.
@@ -712,8 +713,11 @@ extension NavigatorIndex {
                 return nil // skip as item exists already.
             }
             
-            guard let title = usePageTitle ? renderNode.metadata.title : renderNode.navigatorTitle() else {
-                throw Error.missingTitle(description: "\(renderNode.identifier.absoluteString.singleQuoted) has an empty title and so can't have a usable entry in the index.")
+            guard let title = usePageTitle ? renderNode.metadata.title : renderNode.navigatorTitle(), !title.isEmpty else {
+                // Nodes without a title are erroneous entries in the symbol graph.
+                // An index entry cannot be constructed without a title, so the node is skipped.
+                assertionFailure("\(renderNode.identifier.absoluteString.singleQuoted) has an empty title, and cannot have a usable index entry")
+                return nil
             }
             
             // Get the identifier path

--- a/Sources/SwiftDocC/Indexing/RenderNode+Indexable.swift
+++ b/Sources/SwiftDocC/Indexing/RenderNode+Indexable.swift
@@ -34,7 +34,7 @@ extension RenderNode {
 }
 
 extension RenderNode: Indexable {
-    func topLevelIndexingRecord() throws -> IndexingRecord {
+    func topLevelIndexingRecord() -> IndexingRecord? {
         let kind: IndexingRecord.Kind
         switch self.kind {
         case .tutorial:
@@ -50,8 +50,11 @@ extension RenderNode: Indexable {
         }
         
         guard let title = metadata.title, !title.isEmpty else {
-            // We at least need a title for a search result.
-            throw IndexingError.missingTitle(identifier)
+            // Nodes without a title are erroneous entries in the symbol graph.
+            // A search result cannot be constructed without a title, meaning that
+            // an indexing record for this node is useless. The node is skipped.
+            assertionFailure("\(identifier.absoluteString.singleQuoted) has an empty title, and cannot have a usable search result")
+            return nil
         }
         
         let summaryParagraph: RenderBlockContent?
@@ -79,9 +82,9 @@ extension RenderNode: Indexable {
                     return try sectionsSection.indexingRecords(onPage: page, references: references)
             }
             
-            return [try topLevelIndexingRecord()] + sectionRecords
+            return [topLevelIndexingRecord()].compactMap({ $0 }) + sectionRecords
         default:
-            return [try topLevelIndexingRecord()]
+            return [topLevelIndexingRecord()].compactMap({ $0 })
         }
     }
 }


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://171823225

## Summary

Sometimes, anonymous C symbols can be incorrectly included in the symbol graph file with an empty title and path components. When these symbols are registered in DocC, their render nodes are created successfully, but the lack of a title means that they cannot be reasonably represented in either the navigator or the indexing records. These issues currently cause DocC to emit an irrecoverable error and have the build fail. However, they do not affect DocC's ability to build documentation correctly, and hence do not warrant the severity that they are currently emitted at. This patch updates both the navigator index and indexing record methods to include a debug assertion failure, and return nil when running in release mode to prevent terminating the build.

## Dependencies

N/A

## Testing

N/A. Debug assertions are relevant only when developing.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
