### PR TITLE
Add support for module-name selectors (::) in documentation links

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+PathComponent.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+PathComponent.swift
@@ -164,7 +164,7 @@ extension PathHierarchy.PathParser {
         // the path parser can identify that "ModuleName" (without the leading slash) is a valid module name, but "=(_:_:)" (without the leading slash) isn't.
         // This tells the parser to remove the leading slash from "/ModuleName" and return that this link string represented an absolute link, whereas it leaves
         // "/=(_:_:)" as-is and returns that that link string represented a relative link.
-        let isAbsolute: Bool
+        var isAbsolute: Bool
         if path.first == PathComponentScanner.separator {
             guard let maybeModuleName = components.first?.dropFirst(), !maybeModuleName.isEmpty else {
                 return ([], true, nil)
@@ -179,6 +179,11 @@ extension PathHierarchy.PathParser {
             let name = components.first.map(String.init)
             isAbsolute = name == NodeURLGenerator.Path.documentationFolderName
                       || name == NodeURLGenerator.Path.tutorialsFolderName
+            
+            // A relative link like "ModuleName::SymbolName" is also absolute because it specifies the module to start the search from.
+            if !isAbsolute, let first = components.first, path.hasPrefix(first + PathComponentScanner.moduleSeparator) {
+                isAbsolute = first.isValidModuleName()
+            }
         }
         
         return (components, isAbsolute, anchor)
@@ -210,6 +215,7 @@ private struct PathComponentScanner: ~Copyable {
     private var remaining: Substring
     
     static let separator: Character = "/"
+    static let moduleSeparator: String = "::"
     private static let anchorSeparator: Character = "#"
     
     static let swiftOperatorEnd: Character = ")"
@@ -238,7 +244,7 @@ private struct PathComponentScanner: ~Copyable {
                  + scanPathComponent()
         }
         
-        // If the string doesn't contain a slash then the rest of the string is the component
+        // If the string contains a slash or a module separator then the next component ends there.
         return scanUntilSeparatorAndThenSkipIt()
     }
     
@@ -328,13 +334,34 @@ private struct PathComponentScanner: ~Copyable {
     }
     
     private mutating func scanUntilSeparatorAndThenSkipIt() -> Substring {
-        guard let index = remaining.firstIndex(of: Self.separator) else {
+        let separatorIndex = remaining.firstIndex(of: Self.separator)
+        let moduleSeparatorIndex = remaining.range(of: Self.moduleSeparator)?.lowerBound
+        
+        let index: Substring.Index
+        let separatorLength: Int
+        
+        switch (separatorIndex, moduleSeparatorIndex) {
+        case (let s?, let m?):
+            if s < m {
+                index = s
+                separatorLength = 1
+            } else {
+                index = m
+                separatorLength = Self.moduleSeparator.count
+            }
+        case (let s?, nil):
+            index = s
+            separatorLength = 1
+        case (nil, let m?):
+            index = m
+            separatorLength = Self.moduleSeparator.count
+        case (nil, nil):
             defer { remaining.removeAll() }
             return remaining
         }
         
         defer {
-            remaining = remaining[index...].dropFirst() // drop the slash
+            remaining = remaining[index...].dropFirst(separatorLength)
         }
         return remaining[..<index]
     }

--- a/Tests/SwiftDocCTests/Infrastructure/ModuleSelectorTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/ModuleSelectorTests.swift
@@ -1,0 +1,73 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2024 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+import Testing
+import SymbolKit
+@testable import SwiftDocC
+import DocCTestUtilities
+import DocCCommon
+
+struct ModuleSelectorTests {
+    @Test
+    func resolvesModuleSelectorLinks() async throws {
+        let catalog = Folder(name: "Something.docc") {
+            JSONFile(symbolGraph: makeSymbolGraph(moduleName: "Delta", symbols: [
+                makeSymbol(id: "s:Delta5DeltaV", kind: .struct, pathComponents: ["DeltaStruct"]), // A struct named DeltaStruct
+            ]))
+        }
+        let context = try await load(catalog: catalog)
+        #expect(context.problems.isEmpty, "Unexpected problems: \(context.problems.map(\.diagnostic.summary))")
+
+        let tree = context.linkResolver.localResolver.pathHierarchy
+        
+        let deltaStruct = try tree.find(path: "Delta::DeltaStruct", onlyFindSymbols: true)
+        
+        let expectedStruct = try tree.find(path: "/Delta/DeltaStruct", onlyFindSymbols: true)
+        #expect(deltaStruct == expectedStruct)
+    }
+
+    @Test
+    func resolvesModuleSelectorLinksWithSameNameAsModule() async throws {
+        let catalog = Folder(name: "Something.docc") {
+            JSONFile(symbolGraph: makeSymbolGraph(moduleName: "Delta", symbols: [
+                makeSymbol(id: "s:Delta5DeltaV", kind: .struct, pathComponents: ["Delta"]), // A struct named Delta
+            ]))
+        }
+        let context = try await load(catalog: catalog)
+        #expect(context.problems.isEmpty, "Unexpected problems: \(context.problems.map(\.diagnostic.summary))")
+
+        let tree = context.linkResolver.localResolver.pathHierarchy
+        
+        let deltaStruct = try tree.find(path: "Delta::Delta", onlyFindSymbols: true)
+        
+        let expectedStruct = try tree.find(path: "/Delta/Delta", onlyFindSymbols: true)
+        #expect(deltaStruct == expectedStruct)
+    }
+
+    @Test
+    func resolvesNestedModuleSelectorLinks() async throws {
+        let catalog = Folder(name: "Something.docc") {
+            JSONFile(symbolGraph: makeSymbolGraph(moduleName: "Delta", symbols: [
+                makeSymbol(id: "s:Delta5DeltaV", kind: .struct, pathComponents: ["Delta"]),
+                makeSymbol(id: "s:Delta5DeltaV6NestedV", kind: .struct, pathComponents: ["Delta", "Nested"]),
+            ]))
+        }
+        let context = try await load(catalog: catalog)
+        #expect(context.problems.isEmpty, "Unexpected problems: \(context.problems.map(\.diagnostic.summary))")
+
+        let tree = context.linkResolver.localResolver.pathHierarchy
+        
+        let nestedStruct = try tree.find(path: "Delta::Delta/Nested", onlyFindSymbols: true)
+        
+        let expectedNested = try tree.find(path: "/Delta/Delta/Nested", onlyFindSymbols: true)
+        #expect(nestedStruct == expectedNested)
+    }
+}


### PR DESCRIPTION
This PR adds support for the :: separator in documentation links, consistent with the Swift 6.4 module selector syntax.

- Updated PathComponentScanner to recognize :: as a separator.
- Updated PathParser to treat links starting with ModuleName:: as absolute links.
- Added unit tests to ModuleSelectorTests.swift.