### PR TITLE
Use `collection` navigator type for API collection

### DIFF
--- a/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
+++ b/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
@@ -251,6 +251,7 @@ public class NavigatorIndex {
         case overview = 5
         case resources = 6
         case symbol = 7 // This indicates a generic symbol
+        case collection = 8
         
         // Symbol specialization
         case framework = 10
@@ -335,8 +336,10 @@ public class NavigatorIndex {
             case "dictionarysymbol": self = .dictionarySymbol
             case "pseudosymbol": self = .symbol
             case "pseudocollection": self = .framework
+            // This maps to the "module" render type
             case "collection": self = .framework
-            case "collectiongroup": self = .article
+            // This maps to the "collection" render type which represents API collections
+            case "collectiongroup": self = .collection
             case "article": self = .article
             case "samplecode": self = .sampleCode
             default: self = .article
@@ -346,8 +349,8 @@ public class NavigatorIndex {
         /// Whether this page kind references a symbol.
         var isSymbolKind: Bool {
             switch self {
-            case .root, .article, .tutorial, .section, .learn, .overview, .resources, .framework,
-                    .buildSetting, .sampleCode, .languageGroup, .container, .groupMarker:
+            case .root, .article, .tutorial, .section, .learn, .overview, .resources, .collection,
+                    .framework, .buildSetting, .sampleCode, .languageGroup, .container, .groupMarker:
                 return false
             case .symbol, .class, .structure, .protocol, .enumeration, .function, .extension,
                     .localVariable, .globalVariable, .typeAlias, .associatedType, .operator, .macro,

--- a/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
+++ b/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
@@ -298,6 +298,12 @@ public class NavigatorIndex {
         case languageGroup = 127
         case container = 254
         case groupMarker = 255 // UInt8.max
+
+        // This empty-marker case is here because non-frozen enums are only available when Library Evolution is enabled,
+        // which is not available to Swift Packages without unsafe flags (rdar://78773361).
+        // This can be removed once that is available and applied to Swift-DocC (rdar://89033233).
+        @available(*, deprecated, message: "this enum is non-frozen and may be expanded in the future; add a `default` case instead of matching this one")
+        case _nonFrozenEnum_useDefaultCase = 128
                 
         /// Initialize a page type from a `symbolKind` returning the symbol type.
         init(symbolKind: String) {
@@ -358,6 +364,8 @@ public class NavigatorIndex {
                     .instanceVariable, .subscript, .typeMethod, .typeProperty, .propertyListKey,
                     .httpRequest, .dictionarySymbol, .propertyListKeyReference, .namespace:
                 return true
+            case ._nonFrozenEnum_useDefaultCase:
+                fatalError("Never use '_nonFrozenEnum_useDefaultCase' as a real case.")
             }
         }
     }

--- a/Sources/SwiftDocC/Indexing/RenderIndexJSON/RenderIndex.swift
+++ b/Sources/SwiftDocC/Indexing/RenderIndexJSON/RenderIndex.swift
@@ -363,6 +363,8 @@ extension NavigatorIndex.PageType {
             return RenderNode.Kind.overview.rawValue
         case .resources:
             return "resources"
+        case .collection:
+            return "collection"
         case .symbol:
             return  RenderNode.Kind.symbol.rawValue
         case .framework:

--- a/Sources/SwiftDocC/Indexing/RenderIndexJSON/RenderIndex.swift
+++ b/Sources/SwiftDocC/Indexing/RenderIndexJSON/RenderIndex.swift
@@ -351,6 +351,8 @@ extension NavigatorIndex.PageType {
             return RenderNode.Kind.overview.rawValue
         case .resources:
             return "resources"
+        case .collection:
+            return "collection"
         case .symbol:
             return  RenderNode.Kind.symbol.rawValue
         case .framework:

--- a/Sources/SwiftDocC/Indexing/RenderIndexJSON/RenderIndex.swift
+++ b/Sources/SwiftDocC/Indexing/RenderIndexJSON/RenderIndex.swift
@@ -415,6 +415,8 @@ extension NavigatorIndex.PageType {
             return "container"
         case .groupMarker:
             return "groupMarker"
+        case ._nonFrozenEnum_useDefaultCase:
+            fatalError("Never use '_nonFrozenEnum_useDefaultCase' as a real case.")
         }
     }
 }

--- a/Tests/SwiftDocCTests/Indexing/ExternalRenderNodeTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/ExternalRenderNodeTests.swift
@@ -610,7 +610,7 @@ class ExternalRenderNodeTests: XCTestCase {
                             ],
                             "path": "/documentation/unit-test/article",
                             "title": "Article",
-                            "type": "article"
+                            "type": "collection"
                           }
                         ],
                         "path": "/documentation/testbundle",

--- a/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
@@ -1659,7 +1659,7 @@ Root
         XCTAssertEqual(PageType(role: "pseudosymbol"), .symbol)
         XCTAssertEqual(PageType(role: "pseudocollection"), .framework)
         XCTAssertEqual(PageType(role: "collection"), .framework)
-        XCTAssertEqual(PageType(role: "collectiongroup"), .article)
+        XCTAssertEqual(PageType(role: "collectiongroup"), .collection)
         XCTAssertEqual(PageType(role: "article"), .article)
         XCTAssertEqual(PageType(role: "samplecode"), .sampleCode)
         

--- a/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
@@ -1706,7 +1706,7 @@ Root
         XCTAssertEqual(PageType(role: "pseudosymbol"), .symbol)
         XCTAssertEqual(PageType(role: "pseudocollection"), .framework)
         XCTAssertEqual(PageType(role: "collection"), .framework)
-        XCTAssertEqual(PageType(role: "collectiongroup"), .article)
+        XCTAssertEqual(PageType(role: "collectiongroup"), .collection)
         XCTAssertEqual(PageType(role: "article"), .article)
         XCTAssertEqual(PageType(role: "samplecode"), .sampleCode)
         

--- a/Tests/SwiftDocCTests/Indexing/RenderIndexTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/RenderIndexTests.swift
@@ -166,7 +166,7 @@ final class RenderIndexTests: XCTestCase {
                       {
                         "title": "APICollection",
                         "path": "/documentation/mixedlanguageframework/apicollection",
-                        "type": "article",
+                        "type": "collection",
                         "children": [
                             {
                               "title": "Objective-C–only APIs",
@@ -204,7 +204,7 @@ final class RenderIndexTests: XCTestCase {
                           {
                             "path": "/documentation/mixedlanguageframework/mixedlanguageclassconformingtoprotocol/mixedlanguageprotocol-implementations",
                             "title": "MixedLanguageProtocol Implementations",
-                            "type": "article",
+                            "type": "collection",
                             "children": [
                               {
                                 "title": "Instance Methods",
@@ -391,7 +391,7 @@ final class RenderIndexTests: XCTestCase {
                       {
                         "path": "/documentation/mixedlanguageframework/apicollection",
                         "title": "APICollection",
-                        "type": "article",
+                        "type": "collection",
                         "children": [
                           {
                             "title": "Swift-only APIs",
@@ -449,7 +449,7 @@ final class RenderIndexTests: XCTestCase {
                           {
                             "path": "/documentation/mixedlanguageframework/mixedlanguageclassconformingtoprotocol/mixedlanguageprotocol-implementations",
                             "title": "MixedLanguageProtocol Implementations",
-                            "type": "article",
+                            "type": "collection",
                             "children": [
                               {
                                 "title": "Instance Methods",

--- a/Tests/SwiftDocCTests/Test Resources/TestBundle-RenderIndex.json
+++ b/Tests/SwiftDocCTests/Test Resources/TestBundle-RenderIndex.json
@@ -559,7 +559,7 @@
           {
             "path" : "\/documentation\/test-bundle\/article2",
             "title" : "Article 2",
-            "type" : "article"
+            "type" : "collection"
           },
           {
             "path" : "\/documentation\/test-bundle\/article3",
@@ -587,7 +587,7 @@
           {
             "path" : "\/documentation\/test-bundle\/article2",
             "title" : "Article 2",
-            "type" : "article"
+            "type" : "collection"
           },
           {
             "title" : "Duplicated",
@@ -596,17 +596,17 @@
           {
             "path" : "\/documentation\/test-bundle\/article2",
             "title" : "Article 2",
-            "type" : "article"
+            "type" : "collection"
           }
         ],
         "path" : "\/documentation\/test-bundle\/article",
         "title" : "My Cool Article",
-        "type" : "article"
+        "type" : "collection"
       },
       {
         "path" : "\/documentation\/test-bundle\/article2",
         "title" : "Article 2",
-        "type" : "article"
+        "type" : "collection"
       },
       {
         "path" : "\/documentation\/test-bundle\/default-code-listing-syntax",
@@ -703,7 +703,7 @@
                 ],
                 "path" : "\/documentation\/sidekit\/sideclass\/element\/protocol-implementations",
                 "title" : "Protocol Implementations",
-                "type" : "article"
+                "type" : "collection"
               }
             ],
             "path" : "\/documentation\/sidekit\/sideclass\/element",

--- a/Tests/SwiftDocCTests/Test Resources/TestBundle-RenderIndex.json
+++ b/Tests/SwiftDocCTests/Test Resources/TestBundle-RenderIndex.json
@@ -559,7 +559,7 @@
           {
             "path" : "\/documentation\/test-bundle\/article2",
             "title" : "Article 2",
-            "type" : "article"
+            "type" : "collection"
           },
           {
             "path" : "\/documentation\/test-bundle\/article3",
@@ -587,7 +587,7 @@
           {
             "path" : "\/documentation\/test-bundle\/article2",
             "title" : "Article 2",
-            "type" : "article"
+            "type" : "collection"
           },
           {
             "title" : "Duplicated",
@@ -596,17 +596,17 @@
           {
             "path" : "\/documentation\/test-bundle\/article2",
             "title" : "Article 2",
-            "type" : "article"
+            "type" : "collection"
           }
         ],
         "path" : "\/documentation\/test-bundle\/article",
         "title" : "My Cool Article",
-        "type" : "article"
+        "type" : "collection"
       },
       {
         "path" : "\/documentation\/test-bundle\/article2",
         "title" : "Article 2",
-        "type" : "article"
+        "type" : "collection"
       },
       {
         "path" : "\/documentation\/test-bundle\/default-code-listing-syntax",
@@ -702,7 +702,7 @@
                 ],
                 "path" : "\/documentation\/sidekit\/sideclass\/element\/protocol-implementations",
                 "title" : "Protocol Implementations",
-                "type" : "article"
+                "type" : "collection"
               }
             ],
             "path" : "\/documentation\/sidekit\/sideclass\/element",


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://174485280

## Summary

41331819c fixed an issue in the navigator where API collections were being treated as symbols. It was remapped to the existing `article` render type. However, this diverges from the mapping used by swift-docc-render [1], where API collections are expected to use the `collection` render type in order to have the correct icon in the navigator. The render JSON uses this type, meaning that the icon is correctly present in the topics section, but the navigator now renders the article icon for API collections. This patch introduces the `collection` render type in the navigator.

[1]: https://github.com/swiftlang/swift-docc-render/blob/dc47cbc06e4e574ab9c75e0585fb708c9172051d/src/components/TopicTypeIcon.vue#L53

## Dependencies

N/A

## Testing

Preview a catalog containing an API collection, and view the navigator. Previously, the article icon would be rendered. With this patch, the API collection icon is rendered.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
