### PR TITLE
Avoid creating a cyclic topic graph when symbols are unexpectedly members of themselves

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Symbol Graph/GeneratedDocumentationTopics.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Graph/GeneratedDocumentationTopics.swift
@@ -145,6 +145,7 @@ enum GeneratedDocumentationTopics {
         // Curate all inherited symbols under the collection node
         for childReference in identifiers {
             if let childTopicGraphNode = context.topicGraph.nodeWithReference(childReference) {
+                assert(childReference != parent, "Parent type '\(parent.path)' is unexpectedly included among its members: [\(identifiers.map(\.path).sorted().joined(separator: ", "))]")
                 context.topicGraph.addEdge(from: collectionTopicGraphNode, to: childTopicGraphNode)
             }
         }
@@ -242,7 +243,9 @@ enum GeneratedDocumentationTopics {
                // Get the child symbol
                let childSymbol = child.symbol,
                // Check that there is Swift extension information
-               childSymbol[mixin: SymbolGraph.Symbol.Swift.Extension.self] != nil
+               childSymbol[mixin: SymbolGraph.Symbol.Swift.Extension.self] != nil,
+               // Ignore any faulty relationships
+               relationship.source != relationship.target
             {
                 let originSymbol = context.documentationCache[origin.identifier]?.symbol
                 
@@ -255,6 +258,8 @@ enum GeneratedDocumentationTopics {
         for (typeReference, collections) in inheritanceIndex.implementingTypes where !collections.inheritedFromTypeName.isEmpty {
             for (_, collection) in collections.inheritedFromTypeName where !collection.identifiers.isEmpty {
                 // Create a collection for the given provider type's inherited symbols
+                assert(!collection.identifiers.contains(typeReference), "Parent type '\(typeReference.path)' is unexpectedly included among its members: [\(collection.identifiers.map(\.path).sorted().joined(separator: ", "))]")
+                
                 try createCollectionNode(parent: typeReference, title: collection.title, identifiers: collection.identifiers, context: context)
             }
         }

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -1248,17 +1248,6 @@ public struct RenderNodeTranslator: SemanticVisitor {
         var node = RenderNode(identifier: identifier, kind: .symbol)
         var contentCompiler = RenderContentCompiler(context: context, identifier: identifier)
         
-        /*
-         FIXME: We shouldn't be doing this kind of crawling here.
-         
-         We should be doing a graph search to build up a breadcrumb and pass that to the translator, giving
-         a definitive hierarchy before we even begin to build a RenderNode.
-         */
-        var ref = documentationNode.reference
-        while let grandparent = context.parents(of: ref).first {
-            ref = grandparent
-        }
-        
         let moduleName = context.moduleName(forModuleReference: symbol.moduleReference)
 
         if let crossImportOverlayModule = symbol.crossImportOverlayModule {

--- a/Tests/SwiftDocCTests/Semantics/SymbolTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/SymbolTests.swift
@@ -137,6 +137,30 @@ class SymbolTests: XCTestCase {
         }
     }
     
+    func testRelationshipToSelfDoesNotCauseCyclicTopicGraph() async throws {
+        let symbolID = "some-symbol-id"
+        let catalog = Folder(name: "unit-test.docc") {
+            JSONFile(symbolGraph: makeSymbolGraph(moduleName: "ModuleName", symbols: [
+                makeSymbol(id: symbolID, kind: .struct, pathComponents: ["Something"], otherMixins: [
+                    SymbolGraph.Symbol.Swift.Extension(extendedModule: "ExtendedModuleName", constraints: [])
+                ])
+            ], relationships: [
+                // Symbols shouldn't have memberOf relationships to themselves (rdar://174848289), but we ensure that DocC gracefully handles it when they do.
+                .init(source: symbolID, target: symbolID, kind: .memberOf, targetFallback: nil, mixins: [
+                    SymbolGraph.Relationship.SourceOrigin(identifier: "origin-symbol-id", displayName: "OriginSymbolName")
+                ])
+            ]))
+        }
+        
+        let (_, context) = try await loadBundle(catalog: catalog)
+        XCTAssert(context.problems.isEmpty, "Unexpected problems: \(context.problems.map(\.diagnostic.summary))")
+        
+        for reference in context.knownPages {
+            let cycles = context.topicGraph.reverseEdgesGraph.cycles(from: reference)
+            XCTAssert(cycles.isEmpty, "Unexpectedly found cycles in the topic graph:\n  \(cycles.map { $0.map(\.path).joined(separator: " -> ") }.joined(separator: "\n  "))")
+        }
+    }
+    
     func testAppendingInSourceDocumentationWithArticle() async throws {
         // The article heading—which should always be the symbol link header—is not considered part of the article's content
         let (withEmptyArticleOverride, problems) = try await makeDocumentationNodeSymbol(
@@ -1573,5 +1597,12 @@ extension SourceLocation {
         }
         
         return string.endIndex
+    }
+}
+
+private extension SymbolGraph.Relationship {
+    init(source: String, target: String, kind: Kind, targetFallback: String?, mixins: [any Mixin] = []) {
+        self.init(source: source, target: target, kind: kind, targetFallback: targetFallback)
+        self.mixins = makeMixins(mixins)
     }
 }


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://174319706

## Summary

This updates the logic for synthesized protocol implementation pages to avoid creating a cyclic topic graph when the symbol graph contains unexpected relationships that define a symbol a the member of itself.

## Dependencies

None.

## Testing

I don't know what makes the Swift symbol graph extractor create such unexpected relationships, so in order to test this you would need to manually modify a symbol graph file to include a `SymbolGraph.Symbol.Swift.Extension` trait for a symbol and a `memberOf` relationship to itself for that symbol that also include a `SymbolGraph.Relationship.SourceOrigin` trait—like the setup in `testRelationshipToSelfDoesNotCauseCyclicTopicGraph()`

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
