### PR TITLE
Do not inherit default availability if it is present in-source

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -1295,10 +1295,11 @@ public struct RenderNodeTranslator: SemanticVisitor {
         
         node.metadata.platformsVariants = VariantCollection<[AvailabilityRenderItem]?>(from: symbol.availabilityVariants) { _, inSourceAvailability in
             // Different sources of availability information are added in-order to compute the complete availability information.
+
+            // The default availability is merged with the in-source availability when loading a symbol graph (see ``SymbolGraphLoader.addDefaultAvailability(to:moduleName:)``).
+            // If no in-source availability is present, we fall back to the default availability for the module (in Info.plist).
             // FIXME: Move this logic out of the rendering code (rdar://172280267)
-            
-            // The "default" information provided by the Info.plist is the base information because it applies to every thing in the module.
-            var information = baseAvailabilityByPlatform
+            var information = inSourceAvailability.availability.isEmpty ? baseAvailabilityByPlatform : [String: AvailabilityRenderItem]()
             
             var unavailablePlatformNamesToRemove = [String]()
             

--- a/Tests/SwiftDocCTests/Model/AvailabilityTests.swift
+++ b/Tests/SwiftDocCTests/Model/AvailabilityTests.swift
@@ -170,6 +170,48 @@ struct AvailabilityTests {
         #expect(availability.first(where: { $0.domain?.rawValue == "iPadOS"      })?.introducedVersion?.description ==  "6.0.0")
         #expect(availability.first(where: { $0.domain?.rawValue == "tvOS"        })?.introducedVersion?.description == "10.0.0")
     }
+
+    // Regression test for rdar://174841126
+    // Symbols should not use the module-level default availability (in Info.plist) if in-source availability is present.
+    @Test
+    func symbolWithInSourceAvailabilityDoesNotUseModuleDefaultAvailability() async throws {
+        let macOSOnlySymbol = makeSymbol(
+            id: "macos-only-symbol",
+            kind: .class,
+            pathComponents: ["MacOSOnlyClass"],
+            availability: [makeAvailabilityItem(domainName: "macOS", introduced: SymbolGraph.SemanticVersion(string: "14.0"))]
+        )
+
+        let catalog = Folder(name: "unit-test.docc") {
+            for (platformName, symbols) in [
+            ("macos",   [macOSOnlySymbol]),
+            ("ios",     []),
+            ("watchos", [])
+            ] {
+                JSONFile(name: "ModuleName-\(platformName).symbols.json", content: makeSymbolGraph(
+                    moduleName: "ModuleName",
+                    platform: .init(operatingSystem: .init(name: platformName)),
+                    symbols: symbols
+                    ))
+            }
+
+            InfoPlist(defaultAvailability: [
+                "ModuleName": [
+                    .init(platformName: .macOS,   platformVersion: "10.0"),
+                    .init(platformName: .iOS,     platformVersion: "10.0"),
+                    .init(platformName: .watchOS, platformVersion: "10.0"),
+                ]
+            ])
+        }
+
+        let context = try await load(catalog: catalog)
+
+        let node = try #require(context.documentationCache["macos-only-symbol"])
+        var translator = RenderNodeTranslator(context: context, identifier: node.reference)
+        let availability = try #require((translator.visit(node.semantic as! Symbol) as! RenderNode).metadata.platformsVariants.defaultValue)
+        #expect(availability.map(\.name) == ["macOS"])
+        #expect(availability.map(\.introduced) == ["14.0"])
+    }
     
     @Test
     func unavailableDefaultPlatformsDoNotRemovePlatformsWithSourceAvailability() async throws {


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://174841126

## Summary

With the availability refactor in #1470, we now always use the default availability, and override it with the in-source availability if present for a platform. However, this requires a symbol to be explicitly marked unavailable for that platform. If a symbol graph is present for a platform and does not contain a symbol, we still show the symbol as being available on that platform if it is present in the default availability list. This patch modifies the logic to only include the default availability if there is no in-source availability information at all, and to otherwise start with an empty list and populate the in-source availability

## Dependencies

N/A

## Testing

1. Create a catalog with symbol graphs for more than one platform.
2. Include default availability for all the platforms in `Info.plist`.
3. Include a platform-specific symbol in only one symbol graph.
4. Without this patch, the symbol is shown to be available on all platforms present in the default availability.
5. With this patch, the symbol is shown to only be available on the one platform it is available on.

## Checklist

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
