### PR TITLE
Show Deprecated label in navigator for items that use @DeprecationSummary

### DIFF
--- a/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
+++ b/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
@@ -788,7 +788,8 @@ extension NavigatorIndex {
                 availabilityID: UInt64(availabilityID),
                 icon: renderNode.icon,
                 isExternal: external,
-                isBeta: renderNode.metadata.isBeta
+                isBeta: renderNode.metadata.isBeta,
+                isDeprecated: renderNode.isDeprecated
             )
             navigationItem.path = identifierPath
             

--- a/Sources/SwiftDocC/Indexing/Navigator/NavigatorItem.swift
+++ b/Sources/SwiftDocC/Indexing/Navigator/NavigatorItem.swift
@@ -76,6 +76,9 @@ public final class NavigatorItem: Serializable, Codable, Equatable, CustomString
         - availabilityID:  The identifier of the availability information of the page.
         - path: The path to load the content.
         - icon: A reference to a custom image for this navigator item.
+        - isExternal: A flag indicating whether the navigator item belongs to an external documentation archive.
+        - isBeta: A flag indicating whether the navigator item is in beta.
+        - isDeprecated: A flag indicating whether the navigator item is deprecated.
      */
     init(
         pageType: UInt8,
@@ -113,6 +116,7 @@ public final class NavigatorItem: Serializable, Codable, Equatable, CustomString
         - icon: A reference to a custom image for this navigator item.
         - isExternal: A flag indicating whether the navigator item belongs to an external documentation archive.
         - isBeta: A flag indicating whether the navigator item is in beta.
+        - isDeprecated: A flag indicating whether the navigator item is deprecated.
      */
     public init(
         pageType: UInt8,

--- a/Sources/SwiftDocC/Indexing/Navigator/NavigatorItem.swift
+++ b/Sources/SwiftDocC/Indexing/Navigator/NavigatorItem.swift
@@ -59,6 +59,12 @@ public final class NavigatorItem: Serializable, Codable, Equatable, CustomString
     /// Used for determining whether stray navigation items should remain part of the final navigator.
     var isExternal: Bool = false
     
+    /// A value that indicates whether this item has been deprecated.
+    ///
+    /// This value is `true` if the referenced item is deprecated on any platform
+    /// or has a `@DeprecationSummary` directive.
+    var isDeprecated: Bool = false
+    
     /**
      Initialize a `NavigatorItem` with the given data.
      
@@ -71,7 +77,18 @@ public final class NavigatorItem: Serializable, Codable, Equatable, CustomString
         - path: The path to load the content.
         - icon: A reference to a custom image for this navigator item.
      */
-    init(pageType: UInt8, languageID: UInt8, title: String, platformMask: UInt64, availabilityID: UInt64, path: String, icon: RenderReferenceIdentifier? = nil, isExternal: Bool = false, isBeta: Bool = false) {
+    init(
+        pageType: UInt8,
+        languageID: UInt8,
+        title: String,
+        platformMask: UInt64,
+        availabilityID: UInt64,
+        path: String,
+        icon: RenderReferenceIdentifier? = nil,
+        isExternal: Bool = false,
+        isBeta: Bool = false,
+        isDeprecated: Bool = false
+    ) {
         self.pageType = pageType
         self.languageID = languageID
         self.title = title
@@ -81,6 +98,7 @@ public final class NavigatorItem: Serializable, Codable, Equatable, CustomString
         self.icon = icon
         self.isExternal = isExternal
         self.isBeta = isBeta
+        self.isDeprecated = isDeprecated
     }
     
     /**
@@ -96,7 +114,17 @@ public final class NavigatorItem: Serializable, Codable, Equatable, CustomString
         - isExternal: A flag indicating whether the navigator item belongs to an external documentation archive.
         - isBeta: A flag indicating whether the navigator item is in beta.
      */
-    public init(pageType: UInt8, languageID: UInt8, title: String, platformMask: UInt64, availabilityID: UInt64, icon: RenderReferenceIdentifier? = nil, isExternal: Bool = false, isBeta: Bool = false) {
+    public init(
+        pageType: UInt8,
+        languageID: UInt8,
+        title: String,
+        platformMask: UInt64,
+        availabilityID: UInt64,
+        icon: RenderReferenceIdentifier? = nil,
+        isExternal: Bool = false,
+        isBeta: Bool = false,
+        isDeprecated: Bool = false
+    ) {
         self.pageType = pageType
         self.languageID = languageID
         self.title = title
@@ -105,6 +133,7 @@ public final class NavigatorItem: Serializable, Codable, Equatable, CustomString
         self.icon = icon
         self.isExternal = isExternal
         self.isBeta = isBeta
+        self.isDeprecated = isDeprecated
     }
     
     // MARK: - Serialization and Deserialization
@@ -164,6 +193,16 @@ public final class NavigatorItem: Serializable, Codable, Equatable, CustomString
             let externalValue: UInt8 = unpackedValueFromData(data[cursor..<cursor + length])
             cursor += length
             self.isExternal = externalValue != 0
+            // Encoded `isDeprecated`
+            if cursor < data.count {
+                assert(
+                    cursor + length <= data.count,
+                    "The serialized data is malformed: `isDeprecated` value should not extend past the end of the data"
+                )
+                let deprecatedValue: UInt8 = unpackedValueFromData(data[cursor..<cursor + length])
+                cursor += length
+                self.isDeprecated = deprecatedValue != 0
+            }
         }
 
         assert(cursor == data.count)
@@ -185,6 +224,7 @@ public final class NavigatorItem: Serializable, Codable, Equatable, CustomString
         
         data.append(packedDataFromValue(isBeta ? UInt8(1) : UInt8(0)))
         data.append(packedDataFromValue(isExternal ? UInt8(1) : UInt8(0)))
+        data.append(packedDataFromValue(isDeprecated ? UInt8(1) : UInt8(0)))
         
         return data
     }
@@ -200,7 +240,8 @@ public final class NavigatorItem: Serializable, Codable, Equatable, CustomString
             platformMask: \(platformMask),
             availabilityID: \(availabilityID),
             isBeta: \(isBeta),
-            isExternal: \(isExternal)
+            isExternal: \(isExternal),
+            isDeprecated: \(isDeprecated)
         }
         """
     }

--- a/Sources/SwiftDocC/Indexing/Navigator/RenderNode+NavigatorIndex.swift
+++ b/Sources/SwiftDocC/Indexing/Navigator/RenderNode+NavigatorIndex.swift
@@ -24,6 +24,7 @@ protocol NavigatorIndexableRenderNodeRepresentation<Metadata> {
     var metadata: Metadata { get }
     var topicSections: [TaskGroupRenderSection] { get }
     var defaultImplementationsSections: [TaskGroupRenderSection] { get }
+    var isDeprecated: Bool { get }
 }
 
 /// A language specific representation of a render metadata value for building a navigator index.
@@ -51,6 +52,12 @@ extension NavigatorIndexableRenderNodeRepresentation {
 
 extension RenderNode: NavigatorIndexableRenderNodeRepresentation {}
 extension RenderMetadata: NavigatorIndexableRenderMetadataRepresentation {}
+
+extension RenderNode {
+    var isDeprecated: Bool {
+        deprecationSummary != nil || isPlatformDeprecated
+    }
+}
 
 struct RenderMetadataVariantView: NavigatorIndexableRenderMetadataRepresentation {
     var wrapped: RenderMetadata
@@ -121,6 +128,10 @@ struct RenderNodeVariantView: NavigatorIndexableRenderNodeRepresentation {
     var defaultImplementationsSections: [TaskGroupRenderSection] {
         wrapped.defaultImplementationsSectionsVariants.value(for: traits)
     }
+    var isDeprecated: Bool {
+        wrapped.deprecationSummaryVariants.value(for: traits) != nil
+            || isPlatformDeprecated
+    }
 }
 
 extension NavigatorIndexableRenderMetadataRepresentation {
@@ -130,6 +141,15 @@ extension NavigatorIndexableRenderMetadataRepresentation {
         }
         
         return platforms.allSatisfy { $0.isBeta == true }
+    }
+}
+
+extension NavigatorIndexableRenderNodeRepresentation {
+    var isPlatformDeprecated: Bool {
+        metadata.platforms?.contains { $0.deprecated != nil } == true
+    }
+    var isDeprecated: Bool {
+        isPlatformDeprecated
     }
 }
 

--- a/Sources/SwiftDocC/Indexing/RenderIndexJSON/RenderIndex.swift
+++ b/Sources/SwiftDocC/Indexing/RenderIndexJSON/RenderIndex.swift
@@ -310,23 +310,11 @@ extension RenderIndex {
 
 extension RenderIndex.Node {
     static func fromNavigatorTreeNode(_ node: NavigatorTree.Node, in navigatorIndex: NavigatorIndex, with builder: NavigatorIndex.Builder) -> RenderIndex.Node {
-        // If this node was deprecated on any platform version mark it as deprecated.
-        let isDeprecated: Bool
-        
-        let availabilityIndexEntryIDsForNode = builder.availabilityEntryIDs(for: node.item.availabilityID)
-        if let entryIDs = availabilityIndexEntryIDsForNode {
-            let availabilityInfosForNode = entryIDs.map { ID in navigatorIndex.availabilityIndex.info(for: ID) }
-            // Mark node as deprecated if we have an explicit deprecation version
-            isDeprecated = availabilityInfosForNode.contains { $0?.deprecated != nil }
-        } else {
-            isDeprecated = false
-        }
-        
         return RenderIndex.Node(
             title: node.item.title,
             path: node.item.path,
             pageType: NavigatorIndex.PageType(rawValue: node.item.pageType),
-            isDeprecated: isDeprecated,
+            isDeprecated: node.item.isDeprecated,
             isExternal: node.item.isExternal,
             isBeta: node.item.isBeta,
             children: node.children.map {

--- a/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
@@ -174,6 +174,16 @@ Root
         item1 = NavigatorItem(pageType: 1, languageID: 4, title: "My Title", platformMask: 256, availabilityID: 1024)
         item2 = NavigatorItem(pageType: 1, languageID: 4, title: "My Title", platformMask: 256, availabilityID: 1025)
         XCTAssertNotEqual(item1, item2)
+
+        item1 = NavigatorItem(
+            pageType: 1, languageID: 4, title: "My Title",
+            platformMask: 256, availabilityID: 1024, isDeprecated: true
+        )
+        item2 = NavigatorItem(
+            pageType: 1, languageID: 4, title: "My Title",
+            platformMask: 256, availabilityID: 1024, isDeprecated: false
+        )
+        XCTAssertNotEqual(item1, item2)
     }
     
     func testNavigatorItemRawDumpWithExtraProperties() {
@@ -198,6 +208,43 @@ Root
 
         let fromData = NavigatorItem(rawValue: data)
         XCTAssertEqual(item, fromData)
+    }
+    
+    func testNavigatorItemRawDumpWithIsDeprecated() {
+        let item = NavigatorItem(
+            pageType: 1, languageID: 4, title: "My Title",
+            platformMask: 256, availabilityID: 1024,
+            isExternal: true, isBeta: true, isDeprecated: true
+        )
+        let data = item.rawValue
+        let fromData = NavigatorItem(rawValue: data)
+        XCTAssertEqual(item, fromData)
+        XCTAssertEqual(fromData?.isDeprecated, true)
+    }
+    
+    func testNavigatorItemRawDumpBackwardCompatibilityWithoutIsDeprecated() {
+        // Simulate data serialized before isDeprecated was added.
+        // This data has isBeta and isExternal but NOT isDeprecated.
+        var data = Data()
+        data.append(packedDataFromValue(UInt8(1)))   // pageType
+        data.append(packedDataFromValue(UInt8(4)))   // languageID
+        data.append(packedDataFromValue(UInt64(256))) // platformMask
+        data.append(packedDataFromValue(UInt64(1024)))// availabilityID
+        let title = "My Title"
+        let path = ""
+        data.append(packedDataFromValue(UInt64(title.utf8.count))) // titleLength
+        data.append(packedDataFromValue(UInt64(path.utf8.count)))  // pathLength
+        data.append(Data(title.utf8))
+        data.append(Data(path.utf8))
+        data.append(packedDataFromValue(UInt8(1))) // isBeta = true
+        data.append(packedDataFromValue(UInt8(0))) // isExternal = false
+        // Note: NOT adding isDeprecated byte
+
+        let fromData = NavigatorItem(rawValue: data)
+        XCTAssertNotNil(fromData)
+        XCTAssertEqual(fromData?.isBeta, true)
+        XCTAssertEqual(fromData?.isExternal, false)
+        XCTAssertEqual(fromData?.isDeprecated, false)
     }
     
     func testObjCLanguage() {

--- a/Tests/SwiftDocCTests/Indexing/RenderIndexTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/RenderIndexTests.swift
@@ -680,6 +680,56 @@ final class RenderIndexTests: XCTestCase {
             """#))
     }
     
+    func testRenderIndexGenerationWithDeprecationSummaryOnly() async throws {
+        let catalog = Folder(name: "unit-test.docc", content: [
+            InfoPlist(displayName: "TestBundle", identifier: "com.test.example"),
+            JSONFile(name: "SomeModule.symbols.json", content: makeSymbolGraph(
+                moduleName: "SomeModule",
+                symbols: [
+                    makeSymbol(
+                        id: "some-symbol-id",
+                        kind: .typealias,
+                        pathComponents: ["SomeTypeAlias"]
+                    )
+                ]
+            )),
+            TextFile(name: "SomeTypeAlias.md", utf8Content: """
+            # ``SomeTypeAlias``
+            
+            @DeprecationSummary {
+              Use SomeOtherTypeAlias instead.
+            }
+            """),
+        ])
+
+        let (_, context) = try await loadBundle(catalog: catalog)
+        let renderIndex = try generatedRenderIndex(
+            forIdentifier: "com.test.example",
+            inContext: context
+        )
+
+        let swiftNodes = try XCTUnwrap(renderIndex.interfaceLanguages["swift"])
+        let symbolNode = try XCTUnwrap(
+            findNode(titled: "SomeTypeAlias", in: swiftNodes)
+        )
+        XCTAssertTrue(
+            symbolNode.isDeprecated,
+            "A symbol with @DeprecationSummary but no platform deprecation should appear deprecated in the navigator index."
+        )
+    }
+
+    private func findNode(titled title: String, in nodes: [RenderIndex.Node]) -> RenderIndex.Node? {
+        for node in nodes {
+            if node.title == title {
+                return node
+            }
+            if let children = node.children, let found = findNode(titled: title, in: children) {
+                return found
+            }
+        }
+        return nil
+    }
+
     func testRenderIndexGenerationWithCustomIcon() async throws {
         let renderIndex = try await generatedRenderIndex(for: "BookLikeContent", with: "org.swift.docc.Book")
         try XCTAssertEqual(

--- a/Tests/SwiftDocCTests/Test Resources/TestBundle-RenderIndex.json
+++ b/Tests/SwiftDocCTests/Test Resources/TestBundle-RenderIndex.json
@@ -651,6 +651,7 @@
             "type" : "groupMarker"
           },
           {
+            "deprecated" : true,
             "path" : "\/documentation\/sidekit\/sideclass\/init()",
             "title" : "init()",
             "type" : "init"


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://170218646

## Summary

The navigator sidebar currently doesn't show the "Deprecated" label for symbols or articles that have `@DeprecationSummary` directive but are not deprecated on any platform via availability annotations. This is because the navigator index derived deprecation solely from per-platform availability data in the availability index, ignoring the render node's deprecation summary.

## Dependencies

N/A

## Testing

Run DocC on a symbol that doesn't specify deprecation annotations in code, but uses `@DeprecationSummary` in a documentation extension file. The navigator item for that symbol should show the deprecated label.

## Checklist

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
