### PR TITLE
Remove unused topic graph analysis configuration

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Context/DocumentationContext+Configuration.swift
+++ b/Sources/SwiftDocC/Infrastructure/Context/DocumentationContext+Configuration.swift
@@ -95,16 +95,6 @@ extension DocumentationContext {
             package var shouldStoreManuallyCuratedReferences: Bool = false
         }
         
-        // MARK: Topic analysis
-        
-        /// Configuration related to topic analysis.
-        var topicAnalysisConfiguration = TopicAnalysisConfiguration()
-        
-        /// A collection of configuration related to topic analysis.
-        struct TopicAnalysisConfiguration {
-            var additionalChecks: [DocumentationContext.ReferenceCheck] = []
-        }
-        
         // MARK: Feature flags
         
         /// A collection of feature flags.

--- a/Sources/SwiftDocC/Infrastructure/Context/DocumentationContext+Configuration.swift
+++ b/Sources/SwiftDocC/Infrastructure/Context/DocumentationContext+Configuration.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2024-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information

--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -2792,7 +2792,7 @@ public class DocumentationContext {
      qualified path, instead of a file name, the context will fail to find that resource.
 
      - Returns: A `Foundation.Data` object with the data for the given ``ResourceReference``.
-     - Throws: ``ContextError/notFound(_:)` if a resource with the given was not found.
+     - Throws: ``ContextError/notFound(_:)`` if a resource with the given was not found.
      */
     public func resource(with identifier: ResourceReference, trait: DataTraitCollection = .init()) throws -> Data {
         guard let asset = assetManagers[identifier.bundleID]?.allData(named: identifier.path) else {

--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -2764,7 +2764,7 @@ public class DocumentationContext {
      Analysis that runs after all nodes are successfully registered in the context.
      Useful for checks that need the complete node graph.
      */
-    func topicGraphGlobalAnalysis() {
+    private func topicGraphGlobalAnalysis() {
         // Run pre-defined global analysis.
         for node in topicGraph.nodes.values {
             switch node.kind {
@@ -3099,7 +3099,7 @@ extension DocumentationContext {
     /// The nodes that are allowed to be roots in the topic graph.
     static var allowedRootNodeKinds: [DocumentationNode.Kind] = [.tutorialTableOfContents, .module]
 
-    func analyzeTopicGraph() {
+    private func analyzeTopicGraph() {
         // Find all nodes that are loose in the graph and have no parent but aren't supposed to
         let unexpectedRoots = topicGraph.nodes.values.filter { node in
             return !DocumentationContext.allowedRootNodeKinds.contains(node.kind)
@@ -3117,7 +3117,7 @@ extension DocumentationContext {
         diagnosticEngine.emit(problems)
     }
         
-    func analyzeAlternateRepresentations() {
+    private func analyzeAlternateRepresentations() {
         var problems = [Problem]()
 
         func listSourceLanguages(_ sourceLanguages: Set<SourceLanguage>) -> String {

--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -2433,6 +2433,7 @@ public class DocumentationContext {
         }
     }
     /// A closure type getting the information about a reference in a context and returns any possible problems with it.
+    @available(*, deprecated, message: "This alias is unused. This deprecated API will be removed after 6.4 is released.")
     public typealias ReferenceCheck = (DocumentationContext, ResolvedTopicReference) -> [Problem]
     
     /// Crawls the hierarchy of the given list of nodes, adding relationships in the topic graph for all resolvable task group references.
@@ -2764,14 +2765,6 @@ public class DocumentationContext {
      Useful for checks that need the complete node graph.
      */
     func topicGraphGlobalAnalysis() {
-        // Run any checks added to the context.
-        let problems = knownIdentifiers.flatMap { reference in
-            return configuration.topicAnalysisConfiguration.additionalChecks.flatMap { check in
-                return check(self, reference)
-            }
-        }
-        diagnosticEngine.emit(problems)
-        
         // Run pre-defined global analysis.
         for node in topicGraph.nodes.values {
             switch node.kind {

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -804,28 +804,6 @@ class DocumentationContextTests: XCTestCase {
         let anotherEnumSymbol = try XCTUnwrap(anotherEnumNode.semantic as? Symbol)
         XCTAssertEqual(anotherEnumSymbol.abstract?.plainText, "A documentation extension for an unrelated enum.", "The abstract should be from the symbol's documentation extension.")
     }
-
-    func testGraphChecks() async throws {
-        var configuration = DocumentationContext.Configuration()
-        configuration.topicAnalysisConfiguration.additionalChecks.append(
-            { (context, reference) -> [Problem] in
-                [Problem(diagnostic: Diagnostic(source: reference.url, severity: DiagnosticSeverity.error, range: nil, identifier: "com.tests.testGraphChecks", summary: "test error"), possibleSolutions: [])]
-            }
-        )
-        
-        let catalog = Folder(name: "unit-test.docc", content: [
-            TextFile(name: "Root.md", utf8Content: """
-            # Some root page
-            """)
-        ])
-        let (_, context) = try await loadBundle(catalog: catalog, configuration: configuration)
-        
-        /// Checks if the custom check added problems to the context.
-        let testProblems = context.problems.filter({ (problem) -> Bool in
-            return problem.diagnostic.identifier == "com.tests.testGraphChecks"
-        })
-        XCTAssertTrue(!testProblems.isEmpty)
-    }
     
     func testSupportedAssetTypes() throws {
         for ext in ["jpg", "jpeg", "png", "JPG", "PNG", "PnG", "jPg", "svg", "gif"] {


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

This removes an internal configuration that's never used (only in a test of that configuration's functionality)

## Dependencies

None.

## Testing

Nothing in particular. This isn't a user-facing change.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] ~Added~ Updated tests
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
