### PR TITLE
[6.4] Use `collection` navigator type for API collection (#1505)

### DIFF
--- a/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
+++ b/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
@@ -251,6 +251,7 @@ public class NavigatorIndex {
         case overview = 5
         case resources = 6
         case symbol = 7 // This indicates a generic symbol
+        case collection = 8
         
         // Symbol specialization
         case framework = 10
@@ -297,6 +298,12 @@ public class NavigatorIndex {
         case languageGroup = 127
         case container = 254
         case groupMarker = 255 // UInt8.max
+
+        // This empty-marker case is here because non-frozen enums are only available when Library Evolution is enabled,
+        // which is not available to Swift Packages without unsafe flags (rdar://78773361).
+        // This can be removed once that is available and applied to Swift-DocC (rdar://89033233).
+        @available(*, deprecated, message: "this enum is non-frozen and may be expanded in the future; add a `default` case instead of matching this one")
+        case _nonFrozenEnum_useDefaultCase = 128
                 
         /// Initialize a page type from a `symbolKind` returning the symbol type.
         init(symbolKind: String) {
@@ -335,8 +342,10 @@ public class NavigatorIndex {
             case "dictionarysymbol": self = .dictionarySymbol
             case "pseudosymbol": self = .symbol
             case "pseudocollection": self = .framework
+            // This maps to the "module" render type
             case "collection": self = .framework
-            case "collectiongroup": self = .article
+            // This maps to the "collection" render type which represents API collections
+            case "collectiongroup": self = .collection
             case "article": self = .article
             case "samplecode": self = .sampleCode
             default: self = .article
@@ -346,8 +355,8 @@ public class NavigatorIndex {
         /// Whether this page kind references a symbol.
         var isSymbolKind: Bool {
             switch self {
-            case .root, .article, .tutorial, .section, .learn, .overview, .resources, .framework,
-                    .buildSetting, .sampleCode, .languageGroup, .container, .groupMarker:
+            case .root, .article, .tutorial, .section, .learn, .overview, .resources, .collection,
+                    .framework, .buildSetting, .sampleCode, .languageGroup, .container, .groupMarker:
                 return false
             case .symbol, .class, .structure, .protocol, .enumeration, .function, .extension,
                     .localVariable, .globalVariable, .typeAlias, .associatedType, .operator, .macro,
@@ -355,6 +364,8 @@ public class NavigatorIndex {
                     .instanceVariable, .subscript, .typeMethod, .typeProperty, .propertyListKey,
                     .httpRequest, .dictionarySymbol, .propertyListKeyReference, .namespace:
                 return true
+            case ._nonFrozenEnum_useDefaultCase:
+                fatalError("Never use '_nonFrozenEnum_useDefaultCase' as a real case.")
             }
         }
     }

--- a/Sources/SwiftDocC/Indexing/RenderIndexJSON/RenderIndex.swift
+++ b/Sources/SwiftDocC/Indexing/RenderIndexJSON/RenderIndex.swift
@@ -351,6 +351,8 @@ extension NavigatorIndex.PageType {
             return RenderNode.Kind.overview.rawValue
         case .resources:
             return "resources"
+        case .collection:
+            return "collection"
         case .symbol:
             return  RenderNode.Kind.symbol.rawValue
         case .framework:
@@ -413,6 +415,8 @@ extension NavigatorIndex.PageType {
             return "container"
         case .groupMarker:
             return "groupMarker"
+        case ._nonFrozenEnum_useDefaultCase:
+            fatalError("Never use '_nonFrozenEnum_useDefaultCase' as a real case.")
         }
     }
 }

--- a/Tests/SwiftDocCTests/Indexing/ExternalRenderNodeTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/ExternalRenderNodeTests.swift
@@ -610,7 +610,7 @@ class ExternalRenderNodeTests: XCTestCase {
                             ],
                             "path": "/documentation/unit-test/article",
                             "title": "Article",
-                            "type": "article"
+                            "type": "collection"
                           }
                         ],
                         "path": "/documentation/testbundle",

--- a/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
@@ -1706,7 +1706,7 @@ Root
         XCTAssertEqual(PageType(role: "pseudosymbol"), .symbol)
         XCTAssertEqual(PageType(role: "pseudocollection"), .framework)
         XCTAssertEqual(PageType(role: "collection"), .framework)
-        XCTAssertEqual(PageType(role: "collectiongroup"), .article)
+        XCTAssertEqual(PageType(role: "collectiongroup"), .collection)
         XCTAssertEqual(PageType(role: "article"), .article)
         XCTAssertEqual(PageType(role: "samplecode"), .sampleCode)
         

--- a/Tests/SwiftDocCTests/Indexing/RenderIndexTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/RenderIndexTests.swift
@@ -166,7 +166,7 @@ final class RenderIndexTests: XCTestCase {
                       {
                         "title": "APICollection",
                         "path": "/documentation/mixedlanguageframework/apicollection",
-                        "type": "article",
+                        "type": "collection",
                         "children": [
                             {
                               "title": "Objective-C–only APIs",
@@ -204,7 +204,7 @@ final class RenderIndexTests: XCTestCase {
                           {
                             "path": "/documentation/mixedlanguageframework/mixedlanguageclassconformingtoprotocol/mixedlanguageprotocol-implementations",
                             "title": "MixedLanguageProtocol Implementations",
-                            "type": "article",
+                            "type": "collection",
                             "children": [
                               {
                                 "title": "Instance Methods",
@@ -391,7 +391,7 @@ final class RenderIndexTests: XCTestCase {
                       {
                         "path": "/documentation/mixedlanguageframework/apicollection",
                         "title": "APICollection",
-                        "type": "article",
+                        "type": "collection",
                         "children": [
                           {
                             "title": "Swift-only APIs",
@@ -449,7 +449,7 @@ final class RenderIndexTests: XCTestCase {
                           {
                             "path": "/documentation/mixedlanguageframework/mixedlanguageclassconformingtoprotocol/mixedlanguageprotocol-implementations",
                             "title": "MixedLanguageProtocol Implementations",
-                            "type": "article",
+                            "type": "collection",
                             "children": [
                               {
                                 "title": "Instance Methods",

--- a/Tests/SwiftDocCTests/Test Resources/TestBundle-RenderIndex.json
+++ b/Tests/SwiftDocCTests/Test Resources/TestBundle-RenderIndex.json
@@ -559,7 +559,7 @@
           {
             "path" : "\/documentation\/test-bundle\/article2",
             "title" : "Article 2",
-            "type" : "article"
+            "type" : "collection"
           },
           {
             "path" : "\/documentation\/test-bundle\/article3",
@@ -587,7 +587,7 @@
           {
             "path" : "\/documentation\/test-bundle\/article2",
             "title" : "Article 2",
-            "type" : "article"
+            "type" : "collection"
           },
           {
             "title" : "Duplicated",
@@ -596,17 +596,17 @@
           {
             "path" : "\/documentation\/test-bundle\/article2",
             "title" : "Article 2",
-            "type" : "article"
+            "type" : "collection"
           }
         ],
         "path" : "\/documentation\/test-bundle\/article",
         "title" : "My Cool Article",
-        "type" : "article"
+        "type" : "collection"
       },
       {
         "path" : "\/documentation\/test-bundle\/article2",
         "title" : "Article 2",
-        "type" : "article"
+        "type" : "collection"
       },
       {
         "path" : "\/documentation\/test-bundle\/default-code-listing-syntax",
@@ -703,7 +703,7 @@
                 ],
                 "path" : "\/documentation\/sidekit\/sideclass\/element\/protocol-implementations",
                 "title" : "Protocol Implementations",
-                "type" : "article"
+                "type" : "collection"
               }
             ],
             "path" : "\/documentation\/sidekit\/sideclass\/element",


### PR DESCRIPTION
- **Explanation**: This fixes an issue in the navigator where API collections were using the article icon. This was due to API collections previously being treated as articles as per the fix in 19c593357cc59762f7d1c2a52e1250d19e.
- **Scope**: This change does not modify existing public API, but does introduce a new variant in a public enum. This could lead to breakage if library consumers use the enum in an exhaustive switch without a default case. As the enum is not frozen, the library authors are allowed to introduce new fields. To make this more obvious to consumers, a non-frozen enum variant has been added to ensure a default case is always present.
- **GitHub Issue**: N/A
- **Risk**: N/A
- **Testing**: Unit tests have been added, and the test bundle in the repository has also been used to verify correct behaviour.
- **Reviewer**: @d-ronnqvist @sofiaromorales