### PR TITLE
Allow building from CMake without the toolchain's module config files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,23 +21,99 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 set(CMAKE_Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift)
 set(CMAKE_Swift_COMPILE_OPTIONS_MSVC_RUNTIME_LIBRARY MultiThreadedDLL)
-# Overridden per-target.
-set(CMAKE_Swift_LANGUAGE_VERSION invalid)
 
 include(GNUInstallDirs)
 
+# The full toolchain build has find_package config files for all our
+# dependencies, but at-desk we don't have that luxury. Set this option to use
+# SwiftPM's checkouts instead.
+option(SWIFTDOCC_VENDOR_DEPENDENCIES
+  "Build dependencies from .build/checkouts instead of using find_package"
+  NO)
+set(SWIFTDOCC_DEPS_CHECKOUTS "${CMAKE_CURRENT_SOURCE_DIR}/.build/checkouts"
+  CACHE PATH "Location of SwiftPM-fetched dependency sources")
+
+if(SWIFTDOCC_VENDOR_DEPENDENCIES)
+  include(FetchContent)
+
+  macro(_docc_declare_vendored pkg subdir)
+    if(NOT EXISTS "${SWIFTDOCC_DEPS_CHECKOUTS}/${subdir}")
+      message(FATAL_ERROR
+        "SWIFTDOCC_VENDOR_DEPENDENCIES is ON but ${subdir} was not found at "
+        "${SWIFTDOCC_DEPS_CHECKOUTS}. Run `swift package resolve` first.")
+    endif()
+    # OVERRIDE_FIND_PACKAGE routes both this CMakeLists' `find_package` calls
+    # *and* nested calls inside the vendored dependencies (e.g. swift-crypto
+    # looking up SwiftASN1) through our local checkouts instead of the network.
+    FetchContent_Declare(${pkg}
+      SOURCE_DIR "${SWIFTDOCC_DEPS_CHECKOUTS}/${subdir}"
+      OVERRIDE_FIND_PACKAGE)
+  endmacro()
+
+  # swift-cmark needs to disable testing to build via CMake
+  set(BUILD_TESTING NO)
+
+  _docc_declare_vendored(CLMDB          swift-lmdb)
+  _docc_declare_vendored(ArgumentParser swift-argument-parser)
+  _docc_declare_vendored(SwiftASN1      swift-asn1)
+  _docc_declare_vendored(SwiftCrypto    swift-crypto)
+  _docc_declare_vendored(cmark-gfm      swift-cmark)
+  _docc_declare_vendored(SwiftMarkdown  swift-markdown)
+  _docc_declare_vendored(SymbolKit      swift-docc-symbolkit)
+
+  find_package(CLMDB          REQUIRED)
+  find_package(ArgumentParser REQUIRED)
+  find_package(SwiftASN1      REQUIRED)
+  find_package(SwiftCrypto    REQUIRED)
+  find_package(cmark-gfm      REQUIRED)
+
+  # swift-markdown's `cmake/modules/CMakeLists.txt` calls `export(TARGETS ...
+  # EXPORT_LINK_INTERFACE_LIBRARIES)` on its `Markdown` target, which pulls the
+  # private `libcmark-gfm-extensions` link dep into the exported interface and
+  # fails unless that dep belongs to a build-tree export. swift-cmark itself
+  # already exports `libcmark-gfm` (in `cmarkTargets.cmake`) but not the
+  # extensions target, so place it in a throwaway build-tree export to satisfy
+  # the check; the generated stub file is never consumed.
+  export(TARGETS libcmark-gfm-extensions
+    NAMESPACE _docc_vendor_stub::
+    FILE "${CMAKE_BINARY_DIR}/_docc_vendor_cmark_extensions_stub.cmake")
+
+  find_package(SwiftMarkdown  REQUIRED)
+  find_package(SymbolKit      REQUIRED)
+
+  # LMDB, SymbolKit, and Swift-Markdown are exported into namespaces in the
+  # toolchain build, but not when included directly like this. Re-export them
+  # into the namespaces that the DocC modules expect.
+  if(TARGET CLMDB AND NOT TARGET LMDB::CLMDB)
+    add_library(LMDB::CLMDB ALIAS CLMDB)
+  endif()
+  if(TARGET SymbolKit AND NOT TARGET DocC::SymbolKit)
+    add_library(DocC::SymbolKit ALIAS SymbolKit)
+  endif()
+  if(TARGET Markdown AND NOT TARGET SwiftMarkdown::Markdown)
+    add_library(SwiftMarkdown::Markdown ALIAS Markdown)
+  endif()
+else()
+  find_package(ArgumentParser)
+  find_package(SwiftASN1)
+  find_package(SwiftCrypto)
+  find_package(SwiftMarkdown)
+  find_package(LMDB)
+  find_package(SymbolKit)
+  find_package(cmark-gfm)
+endif()
+
+# Overridden per-target.
+set(CMAKE_Swift_LANGUAGE_VERSION invalid)
+
+# These compile options must apply only to swift-docc's own targets, so they
+# are emitted *after* any vendored dependencies have been added. Vendored deps
+# do not set `Swift_LANGUAGE_VERSION` and would otherwise fail the `EQUAL`
+# generator-expression check on the `ConciseMagicFile` option below.
 add_compile_options("$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-upcoming-feature ExistentialAny>")
 add_compile_options("$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-upcoming-feature InternalImportsByDefault>")
 # Only enable the `ConciseMagicFile` upcoming feature for Swift 5.
 add_compile_options("$<$<AND:$<COMPILE_LANGUAGE:Swift>,$<EQUAL:$<TARGET_PROPERTY:Swift_LANGUAGE_VERSION>,5>>:SHELL:-enable-upcoming-feature ConciseMagicFile>")
-
-find_package(ArgumentParser)
-find_package(SwiftASN1)
-find_package(SwiftCrypto)
-find_package(SwiftMarkdown)
-find_package(LMDB)
-find_package(SymbolKit)
-find_package(cmark-gfm)
 
 add_compile_options("$<$<COMPILE_LANGUAGE:Swift>:-package-name;SwiftDocC>")
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,10 +1,10 @@
 {
-  "originHash" : "eeed44b5b6e983a51b5d5a022a8c2b97a40041bb6c47f5b37c72fe7a3c051a91",
+  "originHash" : "2fff306cb5f2eafe5611ebea6e6ad4ae8fc7053e599ab8d227d0a103774977dd",
   "pins" : [
     {
       "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "location" : "https://github.com/apple/swift-argument-parser",
       "state" : {
         "revision" : "0fbc8848e389af3bb55c182bc19ca9d5dc2f255b",
         "version" : "1.4.0"
@@ -79,7 +79,7 @@
       "location" : "https://github.com/swiftlang/swift-lmdb.git",
       "state" : {
         "branch" : "main",
-        "revision" : "c42582487fe84f72a4d417dd2d8493757bd4d072"
+        "revision" : "a4bc87807721c1fd114bf35464457e2db0d0e6c0"
       }
     },
     {


### PR DESCRIPTION
Bug/issue #, if applicable: None

## Summary

This adds a couple new CMake variables to control how dependencies are loaded:

- `SWIFTDOCC_DEPS_CHECKOUTS` points to a directory where the dependency repositories are checked out. Defaults to `.build/checkouts` (which is populated by `swift package resolve` and other SwiftPM commands that build the project)
- `SWIFTDOCC_VENDOR_DEPENDENCIES`, if set to `YES`, will load dependencies from pre-existing clones in the above directory instead of falling back to the standard `find_package` behavior.

The latter option adds an alternate dependency-loading path which allows for local testing of the CMake configuration as follows:

```sh
swift package resolve
rm -rf .build/cmake
cmake -B .build/cmake -G Ninja -S . -DSWIFTDOCC_VENDOR_DEPENDENCIES=YES
(cd .build/cmake && ninja docc)
```

The goal of making these changes is to allow for testing project changes without needing to wait for a complete toolchain build. I stopped short of adding this to `bin/test`, but it could be added either there or in a CI configuration if we want to test this regularly.

Note that i had to update the pinned version of swift-lmdb because the commit in our Package.resolved file is from before the CMake configuration was added.

## Dependencies

None

## Testing

See the commands above to test the new path. Toolchain builds should still work as before; i will open a test PR on swiftlang/swift to verify.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ n/a ] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ ? ] Updated documentation if necessary (While writing this i realized that this could be added to the CONTRIBUTING.md file if desired. Not sure if we want that, though.)