### PR TITLE
Allow `@PageImage` in `///` documentation comments

### DIFF
--- a/Sources/SwiftDocC/Semantics/Metadata/Metadata.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/Metadata.swift
@@ -231,7 +231,6 @@ public final class Metadata: Semantic, AutomaticDirectiveConvertible {
         validateUnsupportedMetadataDirective(for: titleHeading)
         validateUnsupportedMetadataDirective(for: redirects)
         validateUnsupportedMetadataDirective(for: supportedLanguages)
-        validateUnsupportedMetadataDirective(for: pageImages)
         
         documentationOptions = nil
         technologyRoot       = nil
@@ -242,6 +241,5 @@ public final class Metadata: Semantic, AutomaticDirectiveConvertible {
         titleHeading         = nil
         redirects            = nil
         supportedLanguages   = []
-        pageImages           = []
     }
 }

--- a/Tests/SwiftDocCTests/Semantics/PageImageInDocCommentTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/PageImageInDocCommentTests.swift
@@ -17,41 +17,6 @@ import DocCTestUtilities
 struct PageImageInDocCommentTests {
     
     @Test
-    func parsesPageImageDirectiveFromDocComment() async throws {
-        let catalog = Folder (name : "unit-test.docc", content : [
-            JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(
-                moduleName: "ModuleName",
-                     symbols: [
-                        makeSymbol(
-                            id: "some-symbol-id",
-                            kind: .class,
-                            pathComponents: ["SomeClass"],
-                            docComment: """
-                            The symbol's abstract.
-                                
-                            @Metadata {
-                                @PageImage(source: "my-image", purpose: icon)
-                            }
-                            """
-                        )
-                     ]
-            )),
-            DataFile(name: "my-image.png", data: Data()),
-        ])
-        let context = try await load(catalog: catalog)
-        
-        #expect(context.diagnostics.isEmpty, "Unexpected diagnostics: \(context.diagnostics.map(\.summary))")
-        
-        let node = try #require(context.documentationCache["some-symbol-id"])
-        let pageImages = try #require(node.metadata?.pageImages)
-        #expect(pageImages.count == 1)
-        
-        let pageImage = try #require(pageImages.first)
-        #expect(pageImage.purpose == .icon)
-        #expect(pageImage.source.path == "my-image")
-    }
-    
-    @Test
     func parsesMultiplePageImageDirectivesFromDocComment() async throws {
         let catalog = Folder(name: "unit-test.docc", content: [
             JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(
@@ -87,5 +52,38 @@ struct PageImageInDocCommentTests {
         let cardImage = pageImages.first { $0.purpose == .card }
         #expect(iconImage?.source.path == "icon-image")
         #expect(cardImage?.source.path == "card-image")
+    }
+    
+    @Test
+    func emitsWarningForUnresolvedPageImageInDocComment() async throws {
+        let catalog = Folder(name: "unit-test.docc", content: [
+            JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(
+                moduleName: "ModuleName",
+                symbols: [
+                    makeSymbol(
+                        id: "some-symbol-id",
+                        kind: .class,
+                        pathComponents: ["SomeClass"],
+                        docComment: """
+                            The symbol's abstract.
+                            
+                            @Metadata {
+                                @PageImage(source: "card-image", purpose: card)
+                                @PageImage(source: "missing-image", purpose: icon)
+                            }
+                            """
+                    )
+                ]
+            )),
+            DataFile(name: "card-image.png", data: Data()),
+            // Intentionally no DataFile for "missing-image" the source can't be resolved.
+        ])
+        let context = try await load(catalog: catalog)
+        
+        #expect(context.diagnostics.count == 1)
+        let diagnostic = try #require(context.diagnostics.first)
+        #expect(diagnostic.identifier == "org.swift.docc.unresolvedResource")
+        #expect(diagnostic.severity == .warning)
+        #expect(diagnostic.summary == "Resource 'missing-image' couldn't be found")
     }
 }

--- a/Tests/SwiftDocCTests/Semantics/PageImageInDocCommentTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/PageImageInDocCommentTests.swift
@@ -1,9 +1,12 @@
-//
-//  PageImageInDocCommentTests.swift
-//  SwiftDocC
-//
-//  Created by Demian Yoo on 5/20/26.
-//
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2026 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
 
 import Foundation
 import Testing

--- a/Tests/SwiftDocCTests/Semantics/PageImageInDocCommentTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/PageImageInDocCommentTests.swift
@@ -1,0 +1,88 @@
+//
+//  PageImageInDocCommentTests.swift
+//  SwiftDocC
+//
+//  Created by Demian Yoo on 5/20/26.
+//
+
+import Foundation
+import Testing
+import SymbolKit
+@testable import SwiftDocC
+import DocCTestUtilities
+
+struct PageImageInDocCommentTests {
+    
+    @Test
+    func parsesPageImageDirectiveFromDocComment() async throws {
+        let catalog = Folder (name : "unit-test.docc", content : [
+            JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(
+                moduleName: "ModuleName",
+                     symbols: [
+                        makeSymbol(
+                            id: "some-symbol-id",
+                            kind: .class,
+                            pathComponents: ["SomeClass"],
+                            docComment: """
+                            The symbol's abstract.
+                                
+                            @Metadata {
+                                @PageImage(source: "my-image", purpose: icon)
+                            }
+                            """
+                        )
+                     ]
+            )),
+            DataFile(name: "my-image.png", data: Data()),
+        ])
+        let context = try await load(catalog: catalog)
+        
+        #expect(context.diagnostics.isEmpty, "Unexpected diagnostics: \(context.diagnostics.map(\.summary))")
+        
+        let node = try #require(context.documentationCache["some-symbol-id"])
+        let pageImages = try #require(node.metadata?.pageImages)
+        #expect(pageImages.count == 1)
+        
+        let pageImage = try #require(pageImages.first)
+        #expect(pageImage.purpose == .icon)
+        #expect(pageImage.source.path == "my-image")
+    }
+    
+    @Test
+    func parsesMultiplePageImageDirectivesFromDocComment() async throws {
+        let catalog = Folder(name: "unit-test.docc", content: [
+            JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(
+                moduleName: "ModuleName",
+                symbols: [
+                    makeSymbol(
+                        id: "some-symbol-id",
+                        kind: .class,
+                        pathComponents: ["SomeClass"],
+                        docComment: """
+                        The symbol's abstract.
+                            
+                        @Metadata {
+                            @PageImage(source: "icon-image", purpose: icon)
+                            @PageImage(source: "card-image", purpose: card)
+                        }
+                        """
+                    )
+                ]
+                )),
+            DataFile(name: "icon-image.png", data: Data()),
+            DataFile(name: "card-image.png", data: Data()),
+        ])
+        
+        let context = try await load(catalog: catalog)
+        #expect(context.diagnostics.isEmpty, "Unexpected diagnostics: \(context.diagnostics.map(\.summary))")
+        
+        let node = try #require(context.documentationCache["some-symbol-id"])
+        let pageImages = try #require(node.metadata?.pageImages)
+        #expect(pageImages.count == 2)
+        
+        let iconImage = pageImages.first { $0.purpose == .icon }
+        let cardImage = pageImages.first { $0.purpose == .card }
+        #expect(iconImage?.source.path == "icon-image")
+        #expect(cardImage?.source.path == "card-image")
+    }
+}

--- a/Tests/SwiftDocCTests/Semantics/SymbolTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/SymbolTests.swift
@@ -1212,7 +1212,6 @@ class SymbolTests: XCTestCase {
                   @DocumentationExtension(mergeBehavior: override)
                   @TechnologyRoot
                   @DisplayName(Title)
-                  @PageImage(source: test, purpose: icon)
                   @CallToAction(url: "https://example.com/sample.zip", purpose: download)
                   @PageKind(sampleCode)
                   @SupportedLanguage(swift)
@@ -1230,7 +1229,6 @@ class SymbolTests: XCTestCase {
                 "org.swift.docc.Metadata.InvalidDocumentationExtensionInDocumentationComment",
                 "org.swift.docc.Metadata.InvalidTechnologyRootInDocumentationComment",
                 "org.swift.docc.Metadata.InvalidDisplayNameInDocumentationComment",
-                "org.swift.docc.Metadata.InvalidPageImageInDocumentationComment",
                 "org.swift.docc.Metadata.InvalidCallToActionInDocumentationComment",
                 "org.swift.docc.Metadata.InvalidPageKindInDocumentationComment",
                 "org.swift.docc.Metadata.InvalidSupportedLanguageInDocumentationComment",


### PR DESCRIPTION
Bug/issue #, if applicable: #1403 

## Summary

Previously, @PageImage directives were rejected when used in /// documentation comments with a warning suggesting to use a documentation extension file instead. This change removes that restriction, allowing developers to specify page images directly in source code documentation comments.
This aligns `@PageImage` behavior with `@Available` , which is already supported in `///` documentation comments.

This PR continues the work started in #1412 (closed for inactivity), addressing the review feedback that was left there:
- New tests are written using Swift Testing per the updated contribution guidelines.
- Tests use DataFile(name: "...", data: Data()) to verify the image is actually picked up, instead of filtering out  "couldn't be found" warnings.

**Implementation:**
- Removed `validateUnsupportedMetadataDirective(for: pageImages)` call in `Metadata.validateForUseInDocumentationComment()`
- Removed clearing of the `pageImages` array for documentation comments
- Removed `@PageImage` from the existing `testEmitsWarningsForInvalidMetadataChildrenInDocumentationComments` test case (since it's no longer invalid)

## Dependencies

None.

## Testing

Steps:
1. Build the project with `swift build`
2. Run the new tests with `swift test --filter PageImageInDocCommentTests`
3. Run the affected existing tests with `swift test --filter SymbolTests`
4. Run the full test suite with `bin/test`
  
New test cases added in `Tests/SwiftDocCTests/Semantics/PageImageInDocCommentTests.swift`:
- `parsesPageImageDirectiveFromDocComment` — verifies a single `@PageImage` directive is correctly parsed from a documentation comment
- `parsesMultiplePageImageDirectivesFromDocComment` — verifies multiple `@PageImage` directives (`icon` + `card`) are correctly parsed

**Test results in Xcode:**
  
<img width="1236" height="997" alt="스크린샷 2026-05-20 오전 3 12 33" src="https://github.com/user-attachments/assets/ea0e5d72-3a34-47cd-a469-848dd3402c77" />

**Test results in terminal (`swift test --filter SymbolTests` + new tests):**
<img width="564" height="331" alt="image" src="https://github.com/user-attachments/assets/66e67e48-b888-46d3-9094-94222ad38886" />

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
