### PR TITLE
Fix typo in link disambiguation example in the documentation

### DIFF
--- a/Sources/docc/DocCDocumentation.docc/linking-to-symbols-and-other-content.md
+++ b/Sources/docc/DocCDocumentation.docc/linking-to-symbols-and-other-content.md
@@ -269,7 +269,7 @@ The following example shows a topic group with disambiguated symbol links to the
 
 - ``forecast(for:at:)-(DateInterval,_)``
 - ``forecast(for:at:)->MinuteByMinuteForecast``
-- ``forecast(for:at:)->(Date,_)->HourByHourForecast``
+- ``forecast(for:at:)-(Date,_)->HourByHourForecast``
 ```
 
 > Earlier Versions:


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://176918781

## Summary

This fixes a small but meaningful typo in the examples of type-based disambiguation. The third example (modified in this PR) is meant to use `-(...)` syntax for the parameter types and `->...` syntax for the return types. 

## Dependencies

None.

## Testing

This is a documentation only change. 

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- ~[ ] Added tests~
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
