### PR TITLE
[6.4] Print a deprecation message when running `docc process-archive index`

### DIFF
--- a/Sources/DocCCommandLine/ArgumentParsing/Subcommands/Index.swift
+++ b/Sources/DocCCommandLine/ArgumentParsing/Subcommands/Index.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -10,6 +10,7 @@
 
 public import ArgumentParser
 public import Foundation
+import SwiftDocC
 
 extension Docc {
     /// Indexes a documentation bundle.
@@ -37,12 +38,43 @@ extension Docc {
         }
 
         public func run() async throws {
+            Self.warnAboutDeprecation()
+            
             let indexAction = IndexAction(
                 archiveURL: documentationArchive.urlOrFallback,
                 outputURL: outputURL,
                 bundleIdentifier: bundleIdentifier
             )
             try await indexAction.performAndHandleResult()
+        }
+        
+        /// The file handle that the index command uses to write the warning about its deprecation.
+        ///
+        /// Provided as a static variable to allow for redirecting output in unit tests.
+        static var _errorLogHandle: LogHandle = .standardError
+        static var _diagnosticFormattingOptions: DiagnosticFormattingOptions = []
+        
+        private static func warnAboutDeprecation() {
+            let diagnostic = Diagnostic(
+                severity: .warning,
+                identifier: "DeprecatedIndexCommand",
+                summary: "The `index` command is deprecated and scheduled to be removed after the Swift 6.6 release; pass the `--emit-lmdb-index` flag to the `convert` command instead",
+                explanation: """
+                The `convert` command always creates a JSON representation of the navigation hierarchy for the on-page sidebar.
+                If you need an LMDB database representation of the same navigation hierarchy, \
+                pass the `--emit-lmdb-index` flag to the `convert` command _instead_ of running the `index` command on the output of the `convert` command.
+                
+                If you're building documentation using the Swift-DocC Plugin (`swift package generate-documentation`) it passes the `--emit-lmdb-index` flag to Swift-DocC by default, \
+                and requires the `--disable-indexing`/`--no-indexing` flag to opt out of that behavior. \
+                If you need the LMDB database representation of the same navigation hierarchy in the documentation output, \
+                don't pass the `--disable-indexing`/`--no-indexing` flag to `swift package generate-documentation`.
+                """
+            )
+            
+            print(
+                DiagnosticConsoleWriter.formattedDescription(for: diagnostic, options: _diagnosticFormattingOptions),
+                to: &_errorLogHandle
+            )
         }
     }
     

--- a/Tests/DocCCommandLineTests/ArgumentParsing/IndexSubcommandDeprecationMessageTests.swift
+++ b/Tests/DocCCommandLineTests/ArgumentParsing/IndexSubcommandDeprecationMessageTests.swift
@@ -1,0 +1,60 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2026 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+import Foundation
+@testable import DocCCommandLine
+@testable import SwiftDocC
+import ArgumentParser
+import DocCTestUtilities
+
+// This test uses `XCTestCase` so that it can call our `createTemporaryDirectory()` helper
+class IndexSubcommandDeprecationMessageTests: XCTestCase {
+    func testWarnsAboutDeprecationWhenRun() async throws {
+        // Set up the output for the deprecation warning
+        let originalErrorLogHandle = Docc.Index._errorLogHandle
+        let originalDiagnosticFormattingOptions = Docc.Index._diagnosticFormattingOptions
+        defer {
+            Docc.Index._errorLogHandle = originalErrorLogHandle
+            Docc.Index._diagnosticFormattingOptions = originalDiagnosticFormattingOptions
+        }
+        Docc.Index._diagnosticFormattingOptions = .formatConsoleOutputForTools
+        
+        // Create the minimal inputs to the command.
+        let archiveInput = try Folder(name: "Something.doccarchive") {
+            Folder(name: "data") {}
+        }.write(inside: createTemporaryDirectory())
+        
+        // Verify that both versions of the command print the deprecation message.
+        for indexCommandType in [
+            Docc.Index.self  as any AsyncParsableCommand.Type, // Verify the `docc process-archive index` subcommand
+            Docc._Index.self as any AsyncParsableCommand.Type, // Verify the hidden `docc index` command, previously left for backwards compatibility.
+        ] {
+            // Use a different log store for each command type
+            let logStorage = LogHandle.LogStorage()
+            Docc.Index._errorLogHandle = .memory(logStorage)
+            
+            // Verify that running the `index` command prints the deprecation message.
+            var command = try indexCommandType.parse([
+                archiveInput.path,
+                "--bundle-identifier", "org.swift.example",
+            ])
+            
+            try await command.run()
+            XCTAssertEqual(logStorage.text.trimmingCharacters(in: .newlines), """
+            warning: The `index` command is deprecated and scheduled to be removed after the Swift 6.6 release; pass the `--emit-lmdb-index` flag to the `convert` command instead [DeprecatedIndexCommand]
+            The `convert` command always creates a JSON representation of the navigation hierarchy for the on-page sidebar.
+            If you need an LMDB database representation of the same navigation hierarchy, pass the `--emit-lmdb-index` flag to the `convert` command _instead_ of running the `index` command on the output of the `convert` command.
+
+            If you're building documentation using the Swift-DocC Plugin (`swift package generate-documentation`) it passes the `--emit-lmdb-index` flag to Swift-DocC by default, and requires the `--disable-indexing`/`--no-indexing` flag to opt out of that behavior. If you need the LMDB database representation of the same navigation hierarchy in the documentation output, don't pass the `--disable-indexing`/`--no-indexing` flag to `swift package generate-documentation`.
+            """)
+        }
+    }
+}


### PR DESCRIPTION
- **Explanation**: As proposed in [this Swift Forums thread](https://forums.swift.org/t/pitch-deprecating-the-docc-process-archive-index-subcommand/86701); this prints a deprecation message when running both the `docc process-archive index` subcommand and the hidden `docc index` command that was previously left for backwards compatibility (before we had a process-archive group of commands).

  The reason for suggesting that we cherry pick this into the 6.4 release is to give any developer who uses this command (which we expect to be very few or none at all) but doesn't read the Swift Forums as much time as possible to both reach out about their use case and/or to transition to passing the the `--emit-lmdb-index` flag in their `docc convert` call instead.
- **Scope**: The `docc process-archive index` subcommand.
- **Issues**: rdar://177519864
- **Original PRs**: #1525
- **Risk**: Low. This only informs developer of a deprecation and upcoming removal of a niche command. It doesn't change any other behavior.
- **Testing**: All existing automated test pass. New tests verify that both variations of the `index` subcommand print the deprecation warning.
- **Reviewers**: @sofiaromorales 