### PR TITLE
Add early work-in-progress integration to output static HTML to enable more people to contribute to it 

### DIFF
--- a/Sources/DocCCommandLine/Action/Actions/Convert/ConvertAction.swift
+++ b/Sources/DocCCommandLine/Action/Actions/Convert/ConvertAction.swift
@@ -27,6 +27,7 @@ public struct ConvertAction: AsyncAction {
     let htmlTemplateDirectory: URL?
     
     private let emitDigest: Bool
+    private let outputFormat: Docc.Convert.OutputFormat
     let treatWarningsAsErrors: Bool
     let experimentalEnableCustomTemplates: Bool
     private let experimentalModifyCatalogWithGeneratedCuration: Bool
@@ -59,6 +60,7 @@ public struct ConvertAction: AsyncAction {
     /// 
     ///     A JSON representation is built and emitted regardless of this value.
     ///   - fileManager: The file manager that the convert action uses to create directories and write data to files.
+    ///   - outputFormat: The format that the convert action will output the documentation in when writing to the output location.
     ///   - documentationCoverageOptions: Indicates whether or not to generate coverage output and at what level.
     ///   - bundleDiscoveryOptions: Options to configure how the converter discovers documentation bundles.
     ///   - diagnosticLevel: The level above which diagnostics will be filtered out. This filter level is inclusive, i.e. if a level of `DiagnosticSeverity.information` is specified, diagnostics with a severity up to and including `.information` will be printed.
@@ -90,6 +92,7 @@ public struct ConvertAction: AsyncAction {
         buildIndex: Bool = false,
         fileManager: any FileManagerProtocol = FileManager.default,
         temporaryDirectory: URL,
+        outputFormat: Docc.Convert.OutputFormat = .json,
         documentationCoverageOptions: DocumentationCoverageOptions = .noCoverage,
         bundleDiscoveryOptions: BundleDiscoveryOptions = .init(),
         diagnosticLevel: String? = nil,
@@ -114,6 +117,7 @@ public struct ConvertAction: AsyncAction {
         self.targetDirectory = targetDirectory
         self.htmlTemplateDirectory = htmlTemplateDirectory
         self.emitDigest = emitDigest
+        self.outputFormat = outputFormat
         self.buildLMDBIndex = buildIndex
         self.fileManager = fileManager
         self.temporaryDirectory = temporaryDirectory

--- a/Sources/DocCCommandLine/Action/Actions/Convert/ConvertAction.swift
+++ b/Sources/DocCCommandLine/Action/Actions/Convert/ConvertAction.swift
@@ -349,7 +349,7 @@ public struct ConvertAction: AsyncAction {
                 targetFolder: temporaryFolder,
                 fileManager: fileManager,
                 customHeader: experimentalEnableCustomTemplates ? inputs.customHeader : nil,
-                customFooter: experimentalEnableCustomTemplates ? inputs.customFooter : nil,
+                customFooter: experimentalEnableCustomTemplates ? inputs.customFooter : nil
             )
         } else if includeContentInEachHTMLFile, let indexHTML {
             htmlConsumer = try FileWritingHTMLContentConsumer(

--- a/Sources/DocCCommandLine/Action/Actions/Convert/ConvertAction.swift
+++ b/Sources/DocCCommandLine/Action/Actions/Convert/ConvertAction.swift
@@ -13,6 +13,7 @@ package import Foundation
 @_spi(ExternalLinks) // SPI to set `context.linkResolver.dependencyArchives`
 public import SwiftDocC
 private import Markdown
+private import DocCHTML
 
 #if canImport(os)
 private import os
@@ -225,7 +226,17 @@ public struct ConvertAction: AsyncAction {
     
     func perform(logHandle: inout LogHandle) async throws -> (ActionResult, DocumentationContext) {
         // FIXME: Use `defer` again when the asynchronous defer-statement miscompilation (rdar://137774949) is fixed.
-        let temporaryFolder = try createTempFolder(with: htmlTemplateDirectory)
+        let temporaryFolder: URL
+        switch outputFormat {
+        case .json:
+            temporaryFolder = try createTempFolder(with: htmlTemplateDirectory)
+        case .experimentalHTML:
+            temporaryFolder = try createTempFolder(with: nil)
+            for file in DocCHTML.StaticResources.allFiles {
+                try fileManager.createFile(at: temporaryFolder.appendingPathComponent(file.filename), contents: file.data)
+            }
+        }
+        
         do {
             let result = try await _perform(logHandle: &logHandle, temporaryFolder: temporaryFolder)
             diagnosticEngine.flush()
@@ -276,7 +287,7 @@ public struct ConvertAction: AsyncAction {
 //        }
 
         let indexHTML: URL?
-        if let htmlTemplateDirectory {
+        if let htmlTemplateDirectory, outputFormat == .json {
             let indexHTMLUrl = temporaryFolder.appendingPathComponent(
                 HTMLTemplate.indexFileName.rawValue,
                 isDirectory: false

--- a/Sources/DocCCommandLine/Action/Actions/Convert/ConvertAction.swift
+++ b/Sources/DocCCommandLine/Action/Actions/Convert/ConvertAction.swift
@@ -343,8 +343,15 @@ public struct ConvertAction: AsyncAction {
             bundleID: inputs.id
         )
         
-        let htmlConsumer: FileWritingHTMLContentConsumer?
-        if includeContentInEachHTMLFile, let indexHTML {
+        let htmlConsumer: (any HTMLContentConsumer)?
+        if outputFormat == .experimentalHTML {
+            htmlConsumer = try FullPageHTMLContentConsumer(
+                targetFolder: temporaryFolder,
+                fileManager: fileManager,
+                customHeader: experimentalEnableCustomTemplates ? inputs.customHeader : nil,
+                customFooter: experimentalEnableCustomTemplates ? inputs.customFooter : nil,
+            )
+        } else if includeContentInEachHTMLFile, let indexHTML {
             htmlConsumer = try FileWritingHTMLContentConsumer(
                 targetFolder: temporaryFolder,
                 fileManager: fileManager,

--- a/Sources/DocCCommandLine/Action/Actions/Convert/FileWritingHTMLContentConsumer.swift
+++ b/Sources/DocCCommandLine/Action/Actions/Convert/FileWritingHTMLContentConsumer.swift
@@ -21,6 +21,7 @@ private import DocCHTML
 
 struct FileWritingHTMLContentConsumer: HTMLContentConsumer {
     var prettyPrintOutput: Bool
+    let _isPrimaryOutputFormat = false
     
     private struct HTMLTemplate {
         var original: String

--- a/Sources/DocCCommandLine/Action/Actions/Convert/FileWritingHTMLContentConsumer.swift
+++ b/Sources/DocCCommandLine/Action/Actions/Convert/FileWritingHTMLContentConsumer.swift
@@ -98,6 +98,7 @@ struct FileWritingHTMLContentConsumer: HTMLContentConsumer {
         }
     }
     private var htmlTemplate: HTMLTemplate
+    // FIXME: Extract the file writing (and directory creation) functionality from this RenderNode (JSON) specific type.
     private let fileWriter: JSONEncodingRenderNodeWriter
     
     init(

--- a/Sources/DocCCommandLine/Action/Actions/Convert/FullPageHTMLContentConsumer.swift
+++ b/Sources/DocCCommandLine/Action/Actions/Convert/FullPageHTMLContentConsumer.swift
@@ -25,8 +25,9 @@ private import DocCHTML
 struct FullPageHTMLContentConsumer: HTMLContentConsumer {
     let _isPrimaryOutputFormat = true
     
-    private var customHeader: XMLNode?
-    private var customFooter: XMLNode?
+    private let customHeader: XMLNode?
+    private let customFooter: XMLNode?
+    // FIXME: Extract the file writing (and directory creation) functionality from this RenderNode (JSON) specific type.
     private let fileWriter: JSONEncodingRenderNodeWriter
     
     init(

--- a/Sources/DocCCommandLine/Action/Actions/Convert/FullPageHTMLContentConsumer.swift
+++ b/Sources/DocCCommandLine/Action/Actions/Convert/FullPageHTMLContentConsumer.swift
@@ -1,0 +1,58 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2026 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+#if canImport(FoundationXML)
+// TODO: Consider other HTML rendering options as a future improvement (rdar://165755530)
+import FoundationXML
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+import SwiftDocC
+private import DocCHTML
+
+// I'm not convinced that this is the best long-term design for HTML as a primary output format.
+// It currently exist because the consumers are created in the DocCCommandLine target but the core logic is in SwiftDocC.
+// There might be a different internal abstraction where we don't need this type at all. (rdar://177867282)
+struct FullPageHTMLContentConsumer: HTMLContentConsumer {
+    let _isPrimaryOutputFormat = true
+    
+    private var customHeader: XMLNode?
+    private var customFooter: XMLNode?
+    private let fileWriter: JSONEncodingRenderNodeWriter
+    
+    init(
+        targetFolder: URL,
+        fileManager: some FileManagerProtocol,
+        customHeader: URL?,
+        customFooter: URL?
+    ) throws {
+        (self.customHeader, self.customFooter) = try HTMLRenderer.prepareForFullPage(customHeader: customHeader, customFooter: customFooter, fileManager: fileManager)
+        
+        self.fileWriter = JSONEncodingRenderNodeWriter(
+            targetFolder: targetFolder,
+            fileManager: fileManager,
+            transformForStaticHostingIndexHTML: nil
+        )
+    }
+    
+    func consume(
+        mainContent: XMLNode,
+        metadata: (title: String, description: String?),
+        forPage reference: ResolvedTopicReference
+    ) throws {
+        let page = HTMLRenderer.makeFullPage(mainContent: mainContent, metadata: metadata, for: reference, customHeader: customHeader, customFooter: customFooter)
+        
+        let htmlString = page.xmlString(options: .nodeCompactEmptyElement)
+        let relativeFilePath = NodeURLGenerator.fileSafeReferencePath(reference, lowercased: true) + "/index.html"
+        try fileWriter.write(Data(htmlString.utf8), toFileSafePath: relativeFilePath)
+    }
+}

--- a/Sources/DocCCommandLine/ArgumentParsing/ActionExtensions/ConvertAction+CommandInitialization.swift
+++ b/Sources/DocCCommandLine/ArgumentParsing/ActionExtensions/ConvertAction+CommandInitialization.swift
@@ -69,6 +69,7 @@ extension ConvertAction {
             currentPlatforms: parsedPlatforms,
             buildIndex: convert.featureFlags.emitLMDBIndex,
             temporaryDirectory: FileManager.default.temporaryDirectory,
+            outputFormat: convert.inputsAndOutputs.outputFormat,
             documentationCoverageOptions: DocumentationCoverageOptions(
                 from: convert.experimentalDocumentationCoverageOptions
             ),

--- a/Sources/DocCCommandLine/ArgumentParsing/Subcommands/Convert.swift
+++ b/Sources/DocCCommandLine/ArgumentParsing/Subcommands/Convert.swift
@@ -83,6 +83,10 @@ extension Docc {
                     }
                 }
             }
+            
+            /// The format that the convert action will output the documentation in when writing to the specific output location.
+            @Option(name: .long, help: .hidden)
+            var outputFormat: OutputFormat = .json
         }
         
         /// The path to the directory that all build output should be placed in.
@@ -612,6 +616,32 @@ extension Docc {
                 DiagnosticConsoleWriter.formattedDescription(for: diagnostic, options: _diagnosticFormattingOptions),
                 to: &_errorLogHandle
             )
+        }
+        
+        /// The possible output (file) formats that the convert action can use for the documentation output.
+        package enum OutputFormat: ExpressibleByArgument {
+            /// Output each page as a JSON file---in the format described in RenderNode.spec.json---to be consumed by Swift-DocC Render.
+            case json
+            /// Output each page as a static HTML file.
+            case experimentalHTML
+            
+            package init?(argument: String) {
+                switch argument {
+                    case "json": self = .json
+                    
+                    // This spelling is meant to indicate that this feature is not suitable for general use.
+                    // As this start to approach being complete enough to a viable alternative output format,
+                    // the plan is to rename this to only "experimental-html" and post a pitch about the broader feature to the Swift Forums.
+                    case "experimental-html-for-development":
+                        self = .experimentalHTML
+                    
+                    default: return nil
+                }
+            }
+            
+            package static var allValueStrings: [String] {
+                ["json", "experimental-html-for-development"]
+            }
         }
     }
 }

--- a/Sources/DocCCommandLine/CMakeLists.txt
+++ b/Sources/DocCCommandLine/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 This source file is part of the Swift open source project
 
-Copyright © 2014 - 2025 Apple Inc. and the Swift project authors
+Copyright © 2014 - 2026 Apple Inc. and the Swift project authors
 Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information
@@ -15,6 +15,7 @@ add_library(DocCCommandLine STATIC
   Action/Actions/Convert/ConvertFileWritingConsumer.swift
   Action/Actions/Convert/CoverageDataEntry+generateSummary.swift
   Action/Actions/Convert/FileWritingHTMLContentConsumer.swift
+  Action/Actions/Convert/FullPageHTMLContentConsumer.swift
   Action/Actions/Convert/Indexer.swift
   Action/Actions/Convert/JSONEncodingRenderNodeWriter.swift
   Action/Actions/CoverageAction.swift

--- a/Sources/DocCHTML/CMakeLists.txt
+++ b/Sources/DocCHTML/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 This source file is part of the Swift open source project
 
-Copyright © 2014 - 2025 Apple Inc. and the Swift project authors
+Copyright © 2014 - 2026 Apple Inc. and the Swift project authors
 Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information
@@ -18,6 +18,7 @@ add_library(DocCHTML STATIC
   MarkdownRenderer+Returns.swift
   MarkdownRenderer+Topics.swift
   MarkdownRenderer.swift
+  StaticResources.swift
   WordBreak.swift
   XMLNode+element.swift)
 target_link_libraries(DocCHTML PRIVATE

--- a/Sources/DocCHTML/MarkdownRenderer+Topics.swift
+++ b/Sources/DocCHTML/MarkdownRenderer+Topics.swift
@@ -97,7 +97,12 @@ package extension MarkdownRenderer {
         let items: [XMLNode]
         switch element.subheadings {
         case .single(.conceptual(let title)):
-            items = [.element(named: "p", children: [.text(title)])]
+            let item = XMLNode.element(named: "p", children: [.text(title)])
+            if goal == .richness {
+                // TODO: Pass information about the type of icon that the conceptual element should display.
+                item.addAttributes(["class": "api-collection"])
+            }
+            items = [item]
             
         case .single(.symbol(let fragments)):
             items = switch goal {

--- a/Sources/DocCHTML/StaticResources.swift
+++ b/Sources/DocCHTML/StaticResources.swift
@@ -1,0 +1,923 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2026 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+// This file defines data constants for resource files that make up Swift-DocC's base "template" for static HTML output.
+//
+// We're defining these data constants like this ourselves to workaround restrictions with `.embedInCode()` package resources.
+// https://github.com/swiftlang/swift-package-manager/issues/6969
+//
+// If we instead used real files in a subdirectory, we would need to handle them the same as the Swift-DocC Render template, meaning:
+// - DocC would need to find these resources at runtime and handle the case when the resources are missing.
+// - We would need to update the script that installs Swift-DocC into the Swift toolchain to copy these resources into a suitable location.
+// - In order to support local development workflows would need to support a runtime override of this resource location.
+//
+// Conceptually these two groups of files are very alike but practically there are two big differences between them:
+// - These resources for the static HTML output are defined and developed inside the Swift-DocC repo.
+// - These resources for the static HTML output are about two orders of magnitude smaller than the Swift-DocC Render template.
+// Thus, in order to facilitate easier development of the static HTML output, it makes sense to handle these resources differently, at least for now.
+
+package import struct Foundation.Data
+
+// When working with these resources, a decent workflow is to build some static HTML output and then in-place modify the copied resources in the output directory.
+// This way, you can make adjustments to the CSS or add a new icon and refresh the page to see the changes reflected as you make quick iterations.
+// If you're happy with your changes or if you need to make modifications to the static HTML that DocC outputs, you can copy the contents of the modified files back here.
+
+/// The group of resource files that make up DocC's base "template" for static HTML output.
+package enum StaticResources {
+    // This type is only responsible for naming the blobs of data. It's the caller's responsibility to work with the file system to write these files into the output location.
+    
+    package struct File {
+        package let filename: String
+        package let data: Data
+    }
+    
+    package static let allFiles = [
+        referenceStyleSheet,
+        // Page kind icons
+        apiCollectionIcon,
+        articleIcon,
+        moduleIcon,
+        // UI element icons
+        anchorIcon,
+        sidebarIcon,
+    ]
+    
+    // MARK: Stylesheets
+    
+    // For the future; the idea is that tutorial documentation would have its own stylesheet so that each page's `<head>` can link to only the style information that it needs.
+    
+    /// The style sheet that DocC uses to define the layout and appearance of "reference" documentation (symbols and articles).
+    static let referenceStyleSheet = File(filename: "reference.css", data: Data("""
+:root {
+  --color-header-text: #1d1d1f;
+  --color-code-background: #f7f7f7;
+  --color-secondary-label: #6e6e73;
+  
+  --color-grid: rgb(204, 204, 204);
+  
+  --color-fill-gray: #ccc;
+  --color-fill-gray-quaternary: #f0f0f0;
+  --color-fill-gray-secondary: #f5f5f5;
+  --color-fill-gray-tertiary: #f0f0f0;
+  
+  --color-badge-deprecated: #bf4800;
+  
+  --color-standard-blue: #06c;
+  --color-standard-gray: #afafaf;
+  --color-standard-green: #509ca3;
+  --color-standard-orange: #ff5a00;
+  --color-standard-purple: #bf6af7;
+  --color-standard-red: #d82797;
+  --color-standard-yellow: #ff9f2c;
+  
+  --color-figure-gray-secondary: rgb(102, 102, 102);
+  --color-figure-blue: rgb(51, 102, 255);
+  
+  --font-default: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  --font-mono: Menlo, monospace;
+}
+
+/* Hide and show language specific content by modifying these classes through JS */
+.swift-only {
+  display: unset;
+}
+.occ-only {
+  display: none;
+}
+
+* {
+  margin: 0;
+}
+
+body {
+  font-family: var(--font-default);
+  
+  font-synthesis: none;
+  -moz-font-feature-settings: 'kern';
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-align: start;
+  overflow-wrap: break-word;
+  
+  /* Default margin for stacked elements. */
+  --spacing-stacked-margin-small: 0.4em;
+
+  /* Default margin-top for subsequent elements. */
+  --spacing-stacked-margin-large: 0.8em;
+
+  /* Default margin for elements that require extra spacing */
+  --spacing-stacked-margin-xlarge: calc(var(--spacing-stacked-margin-large) * 2);
+
+  /* Default param spacing */
+  --spacing-param: 28px;
+
+  /* Default margin for Code Listing in Declaration */
+  --declaration-code-listing-margin: 30px 0 0 0;
+
+  /* Default padding for Code Blocks */
+  --code-block-style-elements-padding: 8px 14px;
+}
+
+section {
+  max-width: 820px;
+  margin: 0 auto;
+  
+  @media only screen and (max-width: 1250px) {
+    padding-left: 80px;
+    padding-right: 80px;
+  }
+  
+  @media only screen and (max-width: 735px) {
+    padding-left: 20px;
+    padding-right: 20px;
+  }
+  
+  @media only screen and (min-width: 1500px) {
+    max-width: 920px;
+  }
+}
+
+hr {
+  max-width: 820px;
+  margin: 0 auto;
+  
+  @media only screen and (max-width: 1250px) {
+    max-width: 660px;
+  }
+  
+  @media only screen and (max-width: 820px) {
+    margin: 0 80px;
+  }
+  
+  @media only screen and (max-width: 735px) {
+    margin: 0 20px;
+  }
+  
+  @media only screen and (min-width: 1500px) {
+    max-width: 920px;
+  }
+}
+
+section {
+  box-sizing: border-box;
+
+  padding-top: 40px;
+  padding-bottom: 40px;
+  
+  @media print {
+    padding-left: 80px;
+    padding-right: 80px;
+    max-width: none;
+  }
+}
+
+section + section {
+  /* avoid double padding between sections */
+  padding-top: 0;
+}
+
+hr {
+  border: none;
+  background: var(--color-grid);
+  height: 1px;
+}
+
+h1, h2, h3 {
+  font-weight: 400;
+}
+
+h4, h5, h6 {
+  font-weight: 600;
+}
+
+h1 {
+  font-size: 40px;
+  line-height: 44px;
+  margin-top: 1.6em;
+  
+  @media only screen and (max-width: 1250px) {
+    font-size: 32px;
+    line-height: 36px;
+  }
+  
+  @media only screen and (max-width: 735px) {
+    font-size: 28px;
+    line-height: 32px;
+  }
+}
+
+h2 {
+  font-size: 32px;
+  line-height: 36px;
+  margin-top: 1.6em;
+  
+  @media only screen and (max-width: 1250px) {
+    font-size: 28px;
+    line-height: 32px;
+  }
+  
+  @media only screen and (max-width: 735px) {
+    font-size: 24px;
+    line-height: 28px;
+  }
+}
+
+h3 {
+  /* Note that this is different inside a Topics/SeeAlso section */
+  font-size: 28px;
+  line-height: 32px;
+  padding-top: 36px;
+  
+  @media only screen and (max-width: 1250px) {
+    font-size: 24px;
+    line-height: 28px;
+  }
+  
+  @media only screen and (max-width: 735px) {
+    font-size: 21px;
+    line-height: 25px;
+  }
+}
+
+h4 {
+  font-size: 24px;
+  line-height: 28px;
+  
+  @media only screen and (max-width: 1250px) {
+    font-size: 21px;
+    line-height: 25px;
+  }
+}
+
+h5 {
+   font-size: 22px;
+   line-height: 26px;
+   
+   @media only screen and (max-width: 1250px) {
+     font-size: 20px;
+     line-height: 24px;
+   }
+   
+   @media only screen and (max-width: 735px) {
+     font-size: 18px;
+     line-height: 26px;
+   }
+}
+
+h6 {
+  font-size: 17px;
+  line-height: 25px;
+}
+
+a {
+  color: var(--color-figure-blue);
+}
+
+#eyebrow {
+  font-size: 21px;
+  line-height: 25px;
+  margin: 0;
+  margin-bottom: 15px;
+  color: var(--color-figure-gray-secondary);
+  
+  @media only screen and (max-width: 1250px) {
+    font-size: 19px;
+    line-height: 23px;
+  }
+}
+
+#breadcrumbs > ul {
+  padding: 0;
+  margin-bottom: 20px;
+  display: flex;
+  list-style-type: none;
+  
+  &>li {
+    font-size: 14px;
+    line-height: 20px;
+    a {
+      color: #000;
+    }
+    
+    &:not(:first-child):before {
+      content: "/";
+      width: 5px;
+      margin-inline: 5px;
+    }
+  }
+}
+
+#availability {
+  padding: 0;
+  margin-top: 15px;
+  margin-bottom: 20px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 11px;
+  list-style-type: none;
+  
+  align-items: center;
+  
+  &>li {
+    font-size: 14px;
+    line-height: 20px;
+    height: 20px;
+    
+    &:not(:last-child):after {
+      content: "";
+      display: inline-block;
+      height: 14px;
+      width: 1px;
+      position: relative;
+      top: 2px;
+      margin-left: 10px;
+      
+      background-color: black; /* TODO: dark mode */
+    }
+  }
+}
+
+h1, h2, h3, h4, h5, h6 {
+  padding-inline-end: 23px; /* for the hover icon */
+  
+  &> a {
+    text-decoration: none;
+    color: black; /* TODO: dark mode */
+    &:hover {
+      &:after {
+        margin-left: 7px;
+        content: url(anchor.svg)
+      }
+    }
+  }
+}
+
+#hero {
+  margin-bottom: 40px;
+  
+  position: relative;
+  overflow: clip;
+  
+  /* Draw the background in a pseudo element so that it can move behind the icon */
+  &::after {
+    content: "";
+    background: #f0f0f0;
+    
+    position: absolute;
+    top: 0;
+    left: 0;
+    
+    width: 100%;
+    height: 100%;
+    z-index: -2;
+  }
+}
+
+/* Add background icons for articles, API collections, and module pages */
+
+#hero.article:before {
+  background: url(article.svg);
+}
+
+#hero.api-collection:before {
+  background: url(api-collection.svg);
+}
+
+#hero.module:before {
+  background: url(module.svg);
+}
+
+#hero.article:before, #hero.api-collection:before, #hero.module:before {
+  content: "";
+  --icon-size: 250px;
+  
+  position: absolute;
+  top: calc(50% - var(--icon-size) / 2);
+  right: 25px;
+  opacity: 0.15;
+  z-index: -1;
+  
+  width: var(--icon-size);
+  height: var(--icon-size);
+  background-size: var(--icon-size) var(--icon-size);
+}
+
+section :first-child {
+  margin-top: 0;
+}
+
+/* Workaround some margin issues with H1 elements in the authored content. */
+#eyebrow + h1 {
+  margin-top: 0;
+}
+
+#abstract {
+  font-size: 21px;
+  line-height: 29px;
+  
+  margin-top: 12px;
+  
+  @media only screen and (max-width: 735px) {
+    font-size: 19px;
+    line-height: 27px;
+  }
+}
+
+#declaration, pre {
+  margin-top: 40px;
+  
+  background: var(--color-code-background);
+  border-color: var(--color-grid);
+  border-radius: 4px;
+  border-style: solid;
+  border-width: 1px;
+  padding: var(--code-block-style-elements-padding);
+  line-height: 25px;
+  
+  /* We probably don't need most of these colors because they don't appear in declarations */
+  --color-syntax-attributes: rgb(148, 113, 0);
+  --color-syntax-characters: rgb(39, 42, 216);
+  --color-syntax-comments: rgb(112, 127, 140);
+  --color-syntax-deletion: var(--color-figure-red);
+  --color-syntax-documentation-markup: rgb(80, 99, 117);
+  --color-syntax-documentation-markup-keywords: rgb(80, 99, 117);
+  --color-syntax-heading: rgb(186, 45, 162);
+  --color-syntax-highlighted: rgba(0, 113, 227, 0.2);
+  --color-syntax-keywords: rgb(173, 61, 164);
+  --color-syntax-marks: rgb(0, 0, 0);
+  --color-syntax-numbers: rgb(39, 42, 216);
+  --color-syntax-other-class-names: rgb(112, 61, 170);
+  --color-syntax-other-constants: rgb(75, 33, 176);
+  --color-syntax-other-declarations: rgb(4, 124, 176);
+  --color-syntax-other-function-and-method-names: rgb(75, 33, 176);
+  --color-syntax-other-instance-variables-and-globals: rgb(112, 61, 170);
+  --color-syntax-other-preprocessor-macros: rgb(120, 73, 42);
+  --color-syntax-other-type-names: rgb(112, 61, 170);
+  --color-syntax-param-internal-name: rgb(64, 64, 64);
+  --color-syntax-plain-text: rgb(0, 0, 0);
+  --color-syntax-preprocessor-statements: rgb(120, 73, 42);
+  --color-syntax-project-class-names: rgb(62, 128, 135);
+  --color-syntax-project-constants: rgb(45, 100, 105);
+  --color-syntax-project-function-and-method-names: rgb(45, 100, 105);
+  --color-syntax-project-instance-variables-and-globals: rgb(62, 128, 135);
+  --color-syntax-project-preprocessor-macros: rgb(120, 73, 42);
+  --color-syntax-project-type-names: rgb(62, 128, 135);
+  --color-syntax-strings: rgb(209, 47, 27);
+  --color-syntax-type-declarations: rgb(3, 99, 140);
+  --color-syntax-urls: rgb(19, 55, 255);
+  
+  &> code {
+    display: block;
+    
+    font-size: 15px;
+    line-height: 25px;
+    
+    .keyword, .attribute {
+      color: var(--color-syntax-keywords);
+    }
+    .internalParam {
+      color: var(--color-syntax-param-internal-name);
+    }
+    .typeIdentifier {
+      color: var(--color-syntax-other-type-names);
+      &:not(:hover) {
+        text-decoration: none;
+      }
+    }
+  }
+}
+
+pre {
+  margin-top: 2.1em;
+}
+
+p {
+  font-size: 17px;
+  line-height: 24px;
+  
+  margin-top: 0.8em;
+}
+
+/* Parameter and term definition lists */
+
+dl {
+  margin-top: 0.85em;
+  
+  dt {
+    font-weight: 600;
+    font-size: 17px;
+    line-height: 25px;
+    font-family: var(--font-mono);
+    padding-left: 17px;
+    padding-top: var(--spacing-param);
+    
+    &:first-child {
+      padding-top: 0;
+    }
+    
+    @media only screen and (max-width: 735px) {
+      padding-left: 0;
+    }
+  }
+  
+  dd {
+    padding-left: 34px;
+    
+    p {
+      margin: 0;
+      line-height: 23px;
+    }
+    
+    @media only screen and (max-width: 735px) {
+      padding-left: 0;
+    }
+  }
+}
+
+#Topics, #See-Also {
+  &> ul {
+    padding: 0;
+    &> li {
+      margin-top: 15px;
+      list-style: none;
+      &> a {
+        padding: 5px 0;
+        display: inline-flex;
+        
+        text-decoration: none;
+        font-size: 1rem;
+        
+        &:hover {
+          text-decoration: underline;
+        }
+        
+        &> code {
+          font-size: 17px;
+          line-height: 24px;
+          
+          
+          &>.decorator {
+            color: rgb(102, 102, 102);
+          }
+          &>.identifier {
+            color: var(--color-figure-blue);
+          }
+        }
+      }
+      &> p {
+        margin: 0;
+        margin-inline-start: 2.294em; /* it's defined like this in DocC Render */
+        line-height: 24px;
+      }
+      
+      /* Display icons for articles and API collections */
+      .api-collection, .article {
+        margin-top: 0px; /* avoid the top padding of other paragraphs */
+        
+        &:before {
+          margin-right: 20px;
+          margin-left: 4px;
+          width: 36px;
+          position: relative;
+          top: 2px;
+          content: url(api-collection.svg);
+        }
+      }
+      .article:before {
+        content: url(article.svg)
+      }
+    }
+  }
+  &> h3 {
+    font-size: 24px;
+    line-height: 28px;
+    padding-top: 39px;
+    
+    @media only screen and (max-width: 1250px) {
+      font-size: 21px;
+      line-height: 25px;
+    }
+  }
+  &> h2 {
+    margin-top: 0px;
+  }
+  &> p {
+    margin-top: 15px;
+  }
+}
+
+table {
+  margin-top: 1.6em;
+  margin-bottom: 1.6em;
+  
+  font-size: 17px;
+  line-height: 25px;
+  
+  border-collapse: collapse;
+  border-spacing: 0;
+  
+  th, td {
+    text-align: start;
+    padding: 10px;
+    
+    border: 1px solid #f0f0f0;
+  }
+  
+  /* No border on the outside of the table */
+  th {
+    border-top: none;
+  }
+  th:first-of-type {
+    border-left: none;
+  }
+  th:last-of-type {
+    border-right: none;
+  }
+  tr:last-of-type > td {
+    border-bottom: none;
+  }
+  
+  tr {
+    td:first-of-type {
+      border-left: none;
+    }
+    td:last-of-type {
+      border-right: none;
+    }
+  }
+}
+
+#Mentioned-In > ul {
+  padding: 0;
+  &> li {
+    margin-top: 10px;
+    list-style: none;
+    &> a {
+      padding: 5px 0;
+      display: inline-flex;
+      
+      text-decoration: none;
+      font-size: 17px;
+      
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+    &> p {
+      margin: 0;
+      margin-inline-start: 2.294em; /* it's defined like this in DocC Render */
+      line-height: 24px;
+    }
+    
+    /* Display an article icons*/
+    &:before {
+      margin-right: 8px;
+      margin-left: 2px;
+      width: 36px;
+      position: relative;
+      top: 2px;
+      content: url(article.svg);
+    }
+  }
+}
+
+/* Asides */
+
+blockquote {
+  background-color: rgb(245, 245, 245);
+  border: 0px solid rgb(102, 102, 102);
+  border-inline-start-width: 6px;
+  
+  border-radius: 4px;
+  padding: 16px;
+  
+  margin-top: 27px;
+  
+  .label {
+    font-weight: 600;
+    margin-top: 0;
+  }
+  
+  
+  &> p:nth-of-type(2) {
+    margin-top: 0.4em;
+  }
+}
+
+/* Links */
+a {
+  color: var(--color-figure-blue);
+}
+
+/* Inline Elements */
+
+b, strong {
+  font-weight: 600;
+}
+
+em, i, cite, dfn {
+  font-style: italic;
+}
+
+sup {
+  font-size: .6em;
+  vertical-align: top;
+  position: relative;
+  bottom: -.2em;
+  
+  h1 &,
+  h2 &,
+  h3 & {
+    font-size: .4em;
+  }
+  
+  a {
+    vertical-align: inherit;
+    color: inherit;
+    
+    &:hover {
+      color: var(--color-figure-blue);
+      text-decoration: none;
+    }
+  }
+}
+
+sub {
+  line-height: 1;
+}
+
+abbr {
+  border: 0;
+}
+
+code {
+  font-weight: inherit;
+  letter-spacing: 0;
+}
+
+/* Scroll the code inside of code blocks */
+pre {
+  overflow: auto;
+  -webkit-overflow-scrolling: auto;
+  white-space: pre;
+  overflow-wrap: normal;
+}
+
+body > header {
+  position: sticky;
+  top: 0;
+  width: 100%;
+  height: 52px;
+  z-index: 5;
+  
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  
+  border-bottom: 1px solid var(--color-grid);
+  line-height: 25px;
+  
+  /* Aim for a light visual effects appearance */
+  backdrop-filter: saturate(1.8) blur(20px);
+  background-color: rgba(255, 255, 255, 0.7);
+  
+  h2 {
+    float: left;
+    font-size: 21px;
+    line-height: 25px;
+    font-weight: 600;
+    margin-top: 0;
+    
+    &:before {
+      width: 30px;
+      display: inline-block;
+      content: url(sidebar.svg)
+    }
+    
+    margin-left: 22px;
+  }
+  
+  span {
+    float: right;
+    line-height: 18px;
+    font-size: 14px;
+    display: inline-block;
+    
+    margin-right: 22px;
+  }
+}
+
+body > footer {
+  width: 100%;
+  height: 63px;
+  
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  
+  border-top: 1px solid var(--color-grid);
+  line-height: 25px;
+  
+  fieldset {
+    legend {
+      /* This is copied from Swift-DocC Render to make the legend "invisible" without display:none */
+      position: absolute;
+      clip: rect(1px,1px,1px,1px);
+      clip-path: inset(0 0 99.9% 99.9%);
+      overflow: hidden;
+      height: 1px;
+      width: 1px;
+    }
+    
+    display: inline-flex;
+    --color: rgb(0, 0, 255);
+    
+    border: 1px solid var(--color);
+    border-radius: 4px;
+    padding: 1px;
+    
+    position: absolute;
+    right: 15%; /* FIXME: Position this properly */
+    
+    label {
+      margin: 0;
+      cursor: pointer;
+      
+      width: 42px;
+      text-align: center;
+      
+      color: var(--color);
+      font-size: 12px;
+      padding: 2px 6px;
+      line-height: 15px;
+      border-radius: 2px;
+      
+      box-sizing: border-box;
+      
+      &:has(input:checked) {
+        color: white;
+        background-color: var(--color);
+      }
+      
+      input {
+        display: none;
+      }
+    }
+  }
+}
+    
+""".utf8))
+    
+    // MARK: Icons
+
+    /// The icon that DocC displays for API collection pages and their references in curation or the navigation hierarchy.
+    static let apiCollectionIcon = File(filename: "api-collection.svg", data: Data("""
+<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="14px" height="14px" viewBox="0 0 14 14" fill="#666">
+  <path d="m1 1v12h12v-12zm11 11h-10v-10h10z"/>
+  <path d="m3 4h8v1h-8zm0 2.5h8v1h-8zm0 2.5h8v1h-8z"/>
+  <path d="m3 4h8v1h-8z"/>
+  <path d="m3 6.5h8v1h-8z"/>
+  <path d="m3 9h8v1h-8z"/>
+</svg>
+""".utf8))
+
+    /// The icon that DocC displays for article pages and their references in curation or the navigation hierarchy.
+    static let articleIcon = File(filename: "article.svg", data: Data("""
+<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="15px" height="15px" viewBox="0 0 14 14" fill="#666">
+  <path d="M8.033 1l3.967 4.015v7.985h-10v-12zM7.615 2h-4.615v10h8v-6.574z"></path>
+  <path d="M7 1h1v4h-1z"></path>
+  <path d="M7 5h5v1h-5z"></path>
+</svg>
+""".utf8))
+
+    /// The icon that DocC displays for module/framework pages and their references in curation or the navigation hierarchy.
+    static let moduleIcon = File(filename: "module.svg", data: Data("""
+<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="15px" height="15px" viewBox="0 0 14 14" fill="#666">
+  <path d="M3.39,9l3.16,1.84.47.28.47-.28L10.61,9l.45.26,1.08.63L7,12.91l-5.16-3,1.08-.64L3.39,9M7,0,0,4.1,2.47,5.55,0,7,2.47,8.44,0,9.9,7,14l7-4.1L11.53,8.45,14,7,11.53,5.56,14,4.1ZM7,7.12,5.87,6.45l-1.54-.9L3.39,5,1.85,4.1,7,1.08l5.17,3L10.6,5l-.93.55-1.54.91ZM7,10,3.39,7.9,1.85,7,3.4,6.09,4.94,7,7,8.2,9.06,7,10.6,6.1,12.15,7l-1.55.9Z"/>
+</svg>
+""".utf8))
+
+    /// The icon that DocC uses for the button to show and hide the on-page sidebar / navigation hierarchy.
+    static let sidebarIcon = File(filename: "sidebar.svg", data: Data("""
+<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="19px" height="19px" viewBox="0 -1 14 14">
+  <path d="M6.533 1.867h-6.533v10.267h14v-10.267zM0.933 11.2v-8.4h4.667v8.4zM13.067 11.2h-6.533v-8.4h6.533z M1.867 5.133h2.8v0.933h-2.8z M1.867 7.933h2.8v0.933h-2.8z" />
+</svg>
+
+""".utf8))
+
+    /// The icon that DocC displays, on-hover, next to headings that are links to themselves.
+    static let anchorIcon = File(filename: "anchor.svg", data: Data("""
+<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="16px" height="16px" viewBox="0 0 20 20" fill="#666">
+  <path d="M19.34,4.88L15.12,.66c-.87-.87-2.3-.87-3.17,0l-3.55,3.56-1.38,1.38-1.4,1.4c-.47,.47-.68,1.09-.64,1.7,.02,.29,.09,.58,.21,.84,.11,.23,.24,.44,.43,.63l4.22,4.22h0l.53-.53,.53-.53h0l-4.22-4.22c-.29-.29-.29-.77,0-1.06l1.4-1.4,.91-.91,.58-.58,.55-.55,2.9-2.9c.29-.29,.77-.29,1.06,0l4.22,4.22c.29,.29,.29,.77,0,1.06l-2.9,2.9c.14,.24,.24,.49,.31,.75,.08,.32,.11,.64,.09,.96l3.55-3.55c.87-.87,.87-2.3,0-3.17Z"/>
+  <path d="M14.41,9.82s0,0,0,0l-4.22-4.22h0l-.53,.53-.53,.53h0l4.22,4.22c.29,.29,.29,.77,0,1.06l-1.4,1.4-.91,.91-.58,.58-.55,.55h0l-2.9,2.9c-.29,.29-.77,.29-1.06,0L1.73,14.04c-.29-.29-.29-.77,0-1.06l2.9-2.9c-.14-.24-.24-.49-.31-.75-.08-.32-.11-.64-.09-.97L.68,11.93c-.87,.87-.87,2.3,0,3.17l4.22,4.22c.87,.87,2.3,.87,3.17,0l3.55-3.55,1.38-1.38,1.4-1.4c.47-.47,.68-1.09,.64-1.7-.02-.29-.09-.58-.21-.84-.11-.22-.24-.44-.43-.62Z"/>
+</svg>
+""".utf8))
+
+}

--- a/Sources/DocCHTML/StaticResources.swift
+++ b/Sources/DocCHTML/StaticResources.swift
@@ -363,18 +363,17 @@ h1, h2, h3, h4, h5, h6 {
   margin-bottom: 40px;
   
   position: relative;
-  overflow: clip;
+  clip-path: inset(0 -50%);
   
   /* Draw the background in a pseudo element so that it can move behind the icon */
-  &::after {
+  &:before {
     content: "";
     background: #f0f0f0;
     
     position: absolute;
     top: 0;
-    left: 0;
-    
-    width: 100%;
+    left: -50%;
+    width: 200%;
     height: 100%;
     z-index: -2;
   }
@@ -382,19 +381,19 @@ h1, h2, h3, h4, h5, h6 {
 
 /* Add background icons for articles, API collections, and module pages */
 
-#hero.article:before {
+#hero.article:after {
   background: url(article.svg);
 }
 
-#hero.api-collection:before {
+#hero.api-collection:after {
   background: url(api-collection.svg);
 }
 
-#hero.module:before {
+#hero.module:after {
   background: url(module.svg);
 }
 
-#hero.article:before, #hero.api-collection:before, #hero.module:before {
+#hero.article:after, #hero.api-collection:after, #hero.module:after {
   content: "";
   --icon-size: 250px;
   

--- a/Sources/DocCHTML/XMLNode+element.swift
+++ b/Sources/DocCHTML/XMLNode+element.swift
@@ -46,7 +46,7 @@ extension XMLNode {
 
 extension XMLElement {
     /// Adds the given attributes to the element.
-    func addAttributes(_ attributes: [String: String]) {
+    package func addAttributes(_ attributes: [String: String]) {
         let attributeNodes = attributes.sorted(by: { $0.key < $1.key }).map {
             XMLNode.attribute(withName: $0.key, stringValue: $0.value) as! XMLNode
         }

--- a/Sources/SwiftDocC/CMakeLists.txt
+++ b/Sources/SwiftDocC/CMakeLists.txt
@@ -178,6 +178,7 @@ add_library(SwiftDocC
   Model/Rendering/DocumentationContentRenderer.swift
   Model/Rendering/HTML/HTMLContentConsumer.swift
   Model/Rendering/HTML/HTMLRenderer.swift
+  Model/Rendering/HTML/HTMLRenderer+FullPage.swift
   Model/Rendering/LinkTitleResolver.swift
   "Model/Rendering/Navigation Tree/RenderHierarchy.swift"
   "Model/Rendering/Navigation Tree/RenderHierarchyChapter.swift"

--- a/Sources/SwiftDocC/Infrastructure/ConvertActionConverter.swift
+++ b/Sources/SwiftDocC/Infrastructure/ConvertActionConverter.swift
@@ -57,6 +57,7 @@ package enum ConvertActionConverter {
             return
         }
         
+        // FIXME: Don't create a (JSON) RenderContext when the output format is static HTML. (rdar://177867282)
         // Precompute the render context
         let renderContext = signposter.withIntervalSignpost("Build RenderContext", id: signposter.makeSignpostID()) {
             RenderContext(documentationContext: context)
@@ -87,7 +88,9 @@ package enum ConvertActionConverter {
                         let entity = try context.entity(with: identifier)
 
                         if let htmlContentConsumer {
-                            var renderer = HTMLRenderer(reference: identifier, context: context, goal: .conciseness, featureFlags: featureFlags)
+                            // TODO: Design a better way to indicate a primary output format and which "render" steps does and doesn't need (rdar://177867282)
+                            let isStaticHTMLOutput = htmlContentConsumer._isPrimaryOutputFormat
+                            var renderer = HTMLRenderer(reference: identifier, context: context, goal: isStaticHTMLOutput ? .richness : .conciseness, featureFlags: featureFlags)
                             
                             if let symbol = entity.semantic as? Symbol {
                                 let renderedPageInfo = renderer.renderSymbol(symbol)
@@ -95,6 +98,10 @@ package enum ConvertActionConverter {
                             } else if let article = entity.semantic as? Article {
                                 let renderedPageInfo = renderer.renderArticle(article)
                                 try htmlContentConsumer.consume(pageInfo: renderedPageInfo, forPage: identifier)
+                            }
+                            
+                            if isStaticHTMLOutput {
+                                return // Don't create a (JSON) render node for this page
                             }
                         }
 
@@ -128,6 +135,7 @@ package enum ConvertActionConverter {
                             break
                         }
                         
+                        // FIXME: Read all linkable entity information from the documentation node rather than the JSON render node. (rdar://177867335)
                         if emitDigest {
                             let nodeLinkSummaries = entity.externallyLinkableElementSummaries(context: context, renderNode: renderNode)
                             let nodeIndexingRecords = try renderNode.indexingRecords(onPage: identifier)

--- a/Sources/SwiftDocC/Model/Rendering/HTML/HTMLContentConsumer.swift
+++ b/Sources/SwiftDocC/Model/Rendering/HTML/HTMLContentConsumer.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2025 Apple Inc. and the Swift project authors
+ Copyright (c) 2025-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -37,4 +37,8 @@ package protocol HTMLContentConsumer {
         ),
         forPage reference: ResolvedTopicReference
     ) throws
+    
+    // This is not intended to be a long term design for determining which is the primary output format (rdar://177867282)
+    // We need to make sure that this short-term workaround isn't surfaced in any `public` API so that we retain the ability to make large design changes.
+    var _isPrimaryOutputFormat: Bool { get }
 }

--- a/Sources/SwiftDocC/Model/Rendering/HTML/HTMLRenderer+FullPage.swift
+++ b/Sources/SwiftDocC/Model/Rendering/HTML/HTMLRenderer+FullPage.swift
@@ -1,0 +1,116 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2026 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+#if canImport(FoundationXML)
+// TODO: Consider other HTML rendering options as a future improvement (rdar://165755530)
+import FoundationXML
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+private import DocCHTML
+
+extension HTMLRenderer {
+    /// Wraps the unique rendered documentation content and its metadata into a full-page document.
+    ///
+    /// - Parameters:
+    ///   - mainContent: The unique rendered documentation content for this page.
+    ///   - metadata: The title and plain text description to use as metadata for this page.
+    ///   - reference: The reference that the content and metadata is associated with.
+    /// - Returns: A full-page static HTML document.
+    static func makeFullPage(
+        mainContent: XMLNode,
+        metadata: (title: String, description: String?),
+        for reference: ResolvedTopicReference,
+        customHeader: XMLNode? = nil,
+        customFooter: XMLNode? = nil
+    ) -> XMLDocument {
+        // Use relative paths to shared assets like a style sheet or favicon.
+        let pathPrefixToArchiveRoot = String(repeating: "../", count: reference.url.pathComponents.count - 1)
+        
+        let head = XMLNode.element(named: "head", children: [
+            .element(named: "meta", attributes: ["charset": "utf-8"]),
+            .element(named: "meta", attributes: [
+                "name": "viewport",
+                "content": "width=device-width,initial-scale=1,viewport-fit=cover",
+            ]),
+            // FIXME: Add relative favicon links (rdar://177705447 (Include favicon images in the static HTML output))
+            .element(named: "link", attributes: [
+                "rel": "stylesheet",
+                "href": "\(pathPrefixToArchiveRoot)reference.css",
+            ]),
+            .element(named: "title", children: [.text(metadata.title)])
+        ])
+        if let description = metadata.description {
+            head.addChild(.element(named: "meta", attributes: [
+                "name": "description",
+                "content": description,
+            ]))
+        }
+        
+        // The full page body consists of 5 elements, in order;
+        let body = XMLNode.element(named: "body")
+        // 1. An optional custom header
+        if let customHeader {
+            body.addChild(customHeader)
+        }
+        
+        // 2. The default header
+        body.addChild(.element(named: "header", children: [
+            // FIXME: Make this a button that toggles the navigator sidebar (rdar://177705101)
+            // This is blocked by the sidebar requiring RenderNode input
+            .element(named: "h2", children: [.text("Documentation")]),
+            
+            // FIXME: Support switching between language representations of the page (rdar://177705327)
+            // The rough idea is to use <select> & <option> elements (when there are multiple languages)
+            // and to add some very minimal JavaScript to modify the display of the "swift-only" and "occ-only" CSS classes based on that selection.
+            .element(named: "span", children: [.text("Language: Swift")])
+        ]))
+        
+        // 3. The unique documentation content for this page
+        body.addChild(mainContent)
+        
+        // 4. The default footer
+        body.addChild(.element(named: "footer", children: [
+            // FIXME: Interacting with this radio group doesn't change the page's color scheme (rdar://177705056)
+            .element(named: "fieldset", children: [
+                .element(named: "legend", children: [.text("Select a color scheme preference")]),
+                
+                .element(named: "label", children: [
+                    .element(named: "input", attributes: ["type": "radio", "value": "light"]),
+                    .text("Light"),
+                ]),
+                .element(named: "label", children: [
+                    .element(named: "input", attributes: ["type": "radio", "value": "dark"]),
+                    .text("Dark"),
+                ]),
+                .element(named: "label", children: [
+                    .element(named: "input", attributes: ["type": "radio", "value": "auto", "checked": "true"]),
+                    .text("Auto"),
+                ]),
+            ], attributes: ["role": "radiogroup"])
+        ]))
+        
+        // 5. An optional custom footer
+        if let customFooter {
+            body.addChild(customFooter)
+        }
+        
+        // Specify the "html" doctype for the document
+        let documentTypeDefinition = XMLDTD()
+        documentTypeDefinition.name = "html"
+        let page = XMLDocument(rootElement: .element(named: "html", children: [head, body], attributes: ["lang": "en-US"]))
+        page.documentContentKind = .html
+        page.dtd = documentTypeDefinition
+        
+        return page
+    }
+}

--- a/Sources/SwiftDocC/Model/Rendering/HTML/HTMLRenderer+FullPage.swift
+++ b/Sources/SwiftDocC/Model/Rendering/HTML/HTMLRenderer+FullPage.swift
@@ -60,7 +60,7 @@ package extension HTMLRenderer {
         let body = XMLNode.element(named: "body")
         // 1. An optional custom header
         if let customHeader {
-            body.addChild(customHeader)
+            body.addChild(customHeader.copy() as! XMLNode)
         }
         
         // 2. The default header
@@ -101,7 +101,7 @@ package extension HTMLRenderer {
         
         // 5. An optional custom footer
         if let customFooter {
-            body.addChild(customFooter)
+            body.addChild(customFooter.copy() as! XMLNode)
         }
         
         // Specify the "html" doctype for the document

--- a/Sources/SwiftDocC/Model/Rendering/HTML/HTMLRenderer+FullPage.swift
+++ b/Sources/SwiftDocC/Model/Rendering/HTML/HTMLRenderer+FullPage.swift
@@ -85,15 +85,15 @@ package extension HTMLRenderer {
                 .element(named: "legend", children: [.text("Select a color scheme preference")]),
                 
                 .element(named: "label", children: [
-                    .element(named: "input", attributes: ["type": "radio", "value": "light"]),
+                    .element(named: "input", attributes: ["type": "radio", "name": "color-scheme", "value": "light"]),
                     .text("Light"),
                 ]),
                 .element(named: "label", children: [
-                    .element(named: "input", attributes: ["type": "radio", "value": "dark"]),
+                    .element(named: "input", attributes: ["type": "radio", "name": "color-scheme", "value": "dark"]),
                     .text("Dark"),
                 ]),
                 .element(named: "label", children: [
-                    .element(named: "input", attributes: ["type": "radio", "value": "auto", "checked": "true"]),
+                    .element(named: "input", attributes: ["type": "radio", "name": "color-scheme", "value": "auto", "checked": "true"]),
                     .text("Auto"),
                 ]),
             ], attributes: ["role": "radiogroup"])

--- a/Sources/SwiftDocC/Model/Rendering/HTML/HTMLRenderer+FullPage.swift
+++ b/Sources/SwiftDocC/Model/Rendering/HTML/HTMLRenderer+FullPage.swift
@@ -93,7 +93,7 @@ package extension HTMLRenderer {
                     .text("Dark"),
                 ]),
                 .element(named: "label", children: [
-                    .element(named: "input", attributes: ["type": "radio", "name": "color-scheme", "value": "auto", "checked": "true"]),
+                    .element(named: "input", attributes: ["type": "radio", "name": "color-scheme", "value": "auto", "checked": ""]),
                     .text("Auto"),
                 ]),
             ], attributes: ["role": "radiogroup"])

--- a/Sources/SwiftDocC/Model/Rendering/HTML/HTMLRenderer+FullPage.swift
+++ b/Sources/SwiftDocC/Model/Rendering/HTML/HTMLRenderer+FullPage.swift
@@ -10,15 +10,15 @@
 
 #if canImport(FoundationXML)
 // TODO: Consider other HTML rendering options as a future improvement (rdar://165755530)
-import FoundationXML
-import FoundationEssentials
+package import FoundationXML
+package import FoundationEssentials
 #else
-import Foundation
+package import Foundation
 #endif
 
 private import DocCHTML
 
-extension HTMLRenderer {
+package extension HTMLRenderer {
     /// Wraps the unique rendered documentation content and its metadata into a full-page document.
     ///
     /// - Parameters:
@@ -112,5 +112,28 @@ extension HTMLRenderer {
         page.dtd = documentTypeDefinition
         
         return page
+    }
+    
+    /// Prepares the provided custom header and footer files to be included in the full-page structure.
+    ///
+    /// - Parameters:
+    ///   - customHeader: A custom HTML file that the renderer will include as a header in the full-page output.
+    ///   - customFooter: A custom HTML file that the renderer will include as a footer in the full-page output.
+    ///   - fileManager: The file manager that the HTML renderer uses to read the custom header and footer files.
+    /// - Returns: The parsed custom header and parsed custom footer, ready to be included in the full-page output.
+    static func prepareForFullPage(
+        customHeader: URL?,
+        customFooter: URL?,
+        fileManager: some FileManagerProtocol
+    ) throws -> (customHeader: XMLNode?, customFooter: XMLNode?) {
+        func parse(contentsOf url: URL) throws -> XMLNode {
+            let content = String(decoding: try fileManager.contents(of: url), as: UTF8.self)
+            return try XMLElement(xmlString: content)
+        }
+        
+        return (
+            customHeader: try customHeader.map(parse(contentsOf:)),
+            customFooter: try customFooter.map(parse(contentsOf:))
+        )
     }
 }

--- a/Sources/SwiftDocC/Model/Rendering/HTML/HTMLRenderer.swift
+++ b/Sources/SwiftDocC/Model/Rendering/HTML/HTMLRenderer.swift
@@ -164,7 +164,11 @@ package struct HTMLRenderer {
         let node = context.documentationCache[reference]!
         
         let articleElement = XMLElement(name: "article")
-        let hero = XMLElement(name: "section")
+        let hero = XMLNode.element(named: "section")
+        if goal == .richness {
+            // Draw a background color for the hero section and an article/collection glyph
+            hero.addAttributes(["id": "hero", "class": article.topics == nil ? "article" : "api-collection"])
+        }
         articleElement.addChild(hero)
         
         // Breadcrumbs and Eyebrow
@@ -234,12 +238,20 @@ package struct HTMLRenderer {
         let articleElement = XMLElement(name: "article")
         let hero = XMLElement(name: "section")
         articleElement.addChild(hero)
+        let isModule = symbol.kind.identifier == .module
         
-        // Breadcrumbs and Eyebrow
-        hero.addChild(renderer.breadcrumbs(
-            references: (context.linkResolver.localResolver.breadcrumbs(of: reference, in: reference.sourceLanguage) ?? []).map { $0.url },
-            currentPageNames: node.makeNames(goal: goal)
-        ))
+        if isModule {
+            if goal == .richness {
+                // Draw a background color for the hero section and a module glyph
+                hero.addAttributes(["id": "hero", "class": "module"])
+            }
+        } else {
+            // Breadcrumbs and Eyebrow
+            hero.addChild(renderer.breadcrumbs(
+                references: (context.linkResolver.localResolver.breadcrumbs(of: reference, in: reference.sourceLanguage) ?? []).map { $0.url },
+                currentPageNames: node.makeNames(goal: goal)
+            ))
+        }
         addEyebrow(text: symbol.roleHeading, to: hero)
         
         // Title
@@ -297,6 +309,8 @@ package struct HTMLRenderer {
             }
         }
         
+        // TODO: Constraints
+        
         // Deprecation message
         if let deprecationMessage = symbol.deprecatedSummary?.content {
             addDeprecationSummary(markup: deprecationMessage, to: hero)
@@ -307,6 +321,8 @@ package struct HTMLRenderer {
             .values(goal: goal, by: { $0.parameters.elementsEqual($1.parameters, by: { $0.name == $1.name }) })
             .valuesByLanguage()
         {
+            separateSectionsIfNeeded(in: articleElement)
+            
             articleElement.addChildren(renderer.parameters(
                 parameterSections.mapValues { section in
                     section.parameters.map {
@@ -433,7 +449,11 @@ package struct HTMLRenderer {
     }
     
     private func separateSectionsIfNeeded(in element: XMLElement) {
-        guard goal == .richness, ((element.children ?? []).last as? XMLElement)?.name == "section" else {
+        guard goal == .richness,
+              let previous = (element.children ?? []).last as? XMLElement,
+              previous.name == "section",
+              previous.attribute(forName: "id")?.stringValue != "hero" // Avoid adding a `<hr>` element between then hero (with background) and the next section
+        else {
             return
         }
         

--- a/Sources/SwiftDocC/Model/Rendering/HTML/HTMLRenderer.swift
+++ b/Sources/SwiftDocC/Model/Rendering/HTML/HTMLRenderer.swift
@@ -37,20 +37,23 @@ private struct ContextLinkProvider: LinkProvider {
         
         // A helper function that transforms SymbolKit fragments into renderable identifier/decorator fragments
         func convert(_ fragments: [SymbolGraph.Symbol.DeclarationFragments.Fragment]) -> [LinkedElement.SymbolNameFragment] {
-            func convert(kind: SymbolGraph.Symbol.DeclarationFragments.Fragment.Kind) -> LinkedElement.SymbolNameFragment.Kind {
-                switch kind {
-                    case .identifier, .externalParameter: .identifier
-                    default:                              .decorator
+            func convert(_ fragment: SymbolGraph.Symbol.DeclarationFragments.Fragment) -> LinkedElement.SymbolNameFragment.Kind {
+                switch fragment.kind {
+                    case .identifier, .externalParameter,
+                         .keyword where fragment.spelling == "init":
+                            .identifier
+                    default:
+                            .decorator
                 }
             }
-            guard var current = fragments.first.map({ LinkedElement.SymbolNameFragment(text: $0.spelling, kind: convert(kind: $0.kind)) }) else {
+            guard var current = fragments.first.map({ LinkedElement.SymbolNameFragment(text: $0.spelling, kind: convert($0)) }) else {
                 return []
             }
             
             // Join together multiple fragments of the same identifier/decorator kind to produce a smaller output.
             var result: [LinkedElement.SymbolNameFragment] = []
             for fragment in fragments.dropFirst() {
-                let kind = convert(kind: fragment.kind)
+                let kind = convert(fragment)
                 if kind == current.kind  {
                     current.text += fragment.spelling
                 } else {

--- a/Sources/SwiftDocC/Model/Rendering/HTML/HTMLRenderer.swift
+++ b/Sources/SwiftDocC/Model/Rendering/HTML/HTMLRenderer.swift
@@ -119,7 +119,7 @@ private struct ContextLinkProvider: LinkProvider {
 // MARK: HTML Renderer
 
 /// A type that renders documentation pages into semantic HTML elements.
-struct HTMLRenderer {
+package struct HTMLRenderer {
     let reference: ResolvedTopicReference
     let context: DocumentationContext
     let goal: RenderGoal

--- a/Sources/SwiftDocC/Model/Rendering/HTML/HTMLRenderer.swift
+++ b/Sources/SwiftDocC/Model/Rendering/HTML/HTMLRenderer.swift
@@ -450,8 +450,6 @@ struct HTMLRenderer {
             ])
         )
     }
-    
-    // TODO: As a future enhancement, add another layer on top of this that creates complete HTML pages (both `<head>` and `<body>`) (rdar://165912669)
 }
 
 // MARK: Helpers

--- a/Tests/DocCCommandLineTests/ArgumentParsing/ConvertSubcommandTests.swift
+++ b/Tests/DocCCommandLineTests/ArgumentParsing/ConvertSubcommandTests.swift
@@ -619,6 +619,29 @@ class ConvertSubcommandFlagParsingTests {
         #expect(conflictingSeverity.diagnosticOptions.warningGroupsWithWarningSeverity == [],         "'First' is excluded from both lists")
     }
     
+    @Test
+    func parsingOutputFormat() throws {
+        // The feature is enabled when no flag is passed.
+        let noFlagConvert = try Docc.Convert.parse([])
+        #expect(noFlagConvert.inputsAndOutputs.outputFormat == .json)
+        
+        // It's allowed (but redundant) to explicitly specify "json" as the output format
+        let redundantJSONOutput = try Docc.Convert.parse(["--output-format", "json"])
+        #expect(redundantJSONOutput.inputsAndOutputs.outputFormat == .json)
+        
+        // At this stage, the static HTML output format is spelled very verbosely and explicitly to dissuade general usage (in addition to the option is hidden)
+        let htmlOutput = try Docc.Convert.parse(["--output-format", "experimental-html-for-development"])
+        #expect(htmlOutput.inputsAndOutputs.outputFormat == .experimentalHTML)
+        
+        // Any shorter and less explicit spelling raises an error.
+        #expect(throws: (any Error).self) {
+            try Docc.Convert.parse(["--output-format", "experimental-html"])
+        }
+        #expect(throws: (any Error).self) {
+            try Docc.Convert.parse(["--output-format", "html"])
+        }
+    }
+    
     // This test calls ``ConvertOptions.infoPlistFallbacks._unusedVersionForBackwardsCompatibility`` which is deprecated.
     // Deprecating the test silences the deprecation warning when running the tests. It doesn't skip the test.
     @available(*, deprecated) // We'll probably keep this deprecated property for a long time for backwards compatibility.

--- a/Tests/DocCCommandLineTests/FileWritingHTMLContentConsumerTests.swift
+++ b/Tests/DocCCommandLineTests/FileWritingHTMLContentConsumerTests.swift
@@ -216,9 +216,6 @@ final class FileWritingHTMLContentConsumerTests: XCTestCase {
             <noscript>
               <article>
                 <section>
-                  <ul>
-                    <li>ModuleName</li>
-                  </ul>
                   <p>Framework</p>
                   <h1>ModuleName</h1>
                   <p>Some <b>formatted</b> description of this module</p>

--- a/Tests/DocCHTMLTests/MarkdownRenderer+PageElementsTests.swift
+++ b/Tests/DocCHTMLTests/MarkdownRenderer+PageElementsTests.swift
@@ -741,7 +741,7 @@ struct MarkdownRenderer_PageElementsTests {
                 </li>
                 <li>
                   <a href="../../somearticle/index.html">
-                    <p>Some Article</p>
+                    <p class="api-collection">Some Article</p>
                   </a>
                   <p>Some <b>formatted</b>description of this <i>article</i>.</p>
                 </li>

--- a/Tests/SwiftDocCTests/Rendering/HTML/HTMLRenderer+FullPageTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/HTML/HTMLRenderer+FullPageTests.swift
@@ -144,8 +144,13 @@ func assert(_ html: XMLDocument, matches expectedHTML: String, sourceLocation: S
     func formatForTestComparison(_ xmlString: String) -> String {
         // This is overly simplified and won't result in "pretty" XML for general use but sufficient for test content comparisons
         xmlString
+            // Workaround document type differences
+            .replacingOccurrences(of: #"<?xml version="1.0" encoding="utf-8" standalone="no"?>"#, with: "")
+            .replacingOccurrences(of: #"<!DOCTYPE html PUBLIC "" "">"#, with: "<!DOCTYPE html>")
             // Put each tag on its own line
             .replacingOccurrences(of: ">", with: ">\n")
+            // Allow some meta tags to encode as void elements rather than self-closing elements
+            .replacingOccurrences(of: "\">", with: "\"/>")
             // Remove leading indentation
             .components(separatedBy: .newlines)
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
@@ -154,6 +159,8 @@ func assert(_ html: XMLDocument, matches expectedHTML: String, sourceLocation: S
             // Explicitly escape a few HTML characters that appear in the test content
             .replacingOccurrences(of: "–", with: "&#x2013;") // en-dash
             .replacingOccurrences(of: "—", with: "&#x2014;") // em-dash
+            // Shorten empty string attribute values
+            .replacingOccurrences(of: #"="""#, with: "")
     }
     
     let actualHTML: String = html.xmlString(options: .nodeCompactEmptyElement)

--- a/Tests/SwiftDocCTests/Rendering/HTML/HTMLRenderer+FullPageTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/HTML/HTMLRenderer+FullPageTests.swift
@@ -76,12 +76,6 @@ struct HTMLRenderFullPageTests {
     
     @Test
     func includesCustomHeaderAndFooterInFullPage() async throws {
-        let mainContent = XMLNode.element(named: "article", children: [
-            .element(named: "p", children: [
-                .text("Some documentation")
-            ])
-        ])
-        
         let customHeader = XMLNode.element(named: "header", children: [
             .text("A custom header")
         ])
@@ -89,50 +83,59 @@ struct HTMLRenderFullPageTests {
             .text("A custom footer")
         ])
         
-        let fullPage = HTMLRenderer.makeFullPage(
-            mainContent: mainContent,
-            metadata: (title: "Some title", nil),
-            for: reference,
-            customHeader: customHeader,
-            customFooter: customFooter
-        )
-        
-        assert(fullPage, matches: """
-        <!DOCTYPE html>
-        <html lang="en-US">
-          <head>
-            <meta charset="utf-8">
-            <meta content="width=device-width,initial-scale=1,viewport-fit=cover" name="viewport">
-            <link href="../../../../reference.css" rel="stylesheet">
-            <title>Some title</title>
-          </head>
-          <body>
-            <header>A custom header</header>
-            <header>
-              <h2>Documentation</h2>
-              <span>Language: Swift</span>
-            </header>
-            <article>
-              <p>Some documentation</p>
-            </article>
-            <footer>
-              <fieldset role="radiogroup">
-                <legend>Select a color scheme preference</legend>
-                <label>
-                  <input name="color-scheme" type="radio" value="light">
-                  Light</label>
-              <label>
-                <input name="color-scheme" type="radio" value="dark">
-                Dark</label>
-              <label>
-                <input checked name="color-scheme" type="radio" value="auto">
-                Auto</label>
-              </fieldset>
-            </footer>
-            <footer>A custom footer</footer>
-          </body>
-        </html>
-        """)
+        // Render the page a few times in parallel to verify that the custom header/footer nodes can be "reused".
+        [1,2,3].concurrentPerform { _ in    
+            let mainContent = XMLNode.element(named: "article", children: [
+                .element(named: "p", children: [
+                    .text("Some documentation")
+                ])
+            ])
+            
+            let fullPage = HTMLRenderer.makeFullPage(
+                mainContent: mainContent,
+                metadata: (title: "Some title", nil),
+                for: reference,
+                customHeader: customHeader,
+                customFooter: customFooter
+            )
+            
+            assert(fullPage, matches: """
+            <!DOCTYPE html>
+            <html lang="en-US">
+              <head>
+                <meta charset="utf-8">
+                <meta content="width=device-width,initial-scale=1,viewport-fit=cover" name="viewport">
+                <link href="../../../../reference.css" rel="stylesheet">
+                <title>Some title</title>
+              </head>
+              <body>
+                <header>A custom header</header>
+                <header>
+                  <h2>Documentation</h2>
+                  <span>Language: Swift</span>
+                </header>
+                <article>
+                  <p>Some documentation</p>
+                </article>
+                <footer>
+                  <fieldset role="radiogroup">
+                    <legend>Select a color scheme preference</legend>
+                    <label>
+                      <input name="color-scheme" type="radio" value="light">
+                      Light</label>
+                  <label>
+                    <input name="color-scheme" type="radio" value="dark">
+                    Dark</label>
+                  <label>
+                    <input checked name="color-scheme" type="radio" value="auto">
+                    Auto</label>
+                  </fieldset>
+                </footer>
+                <footer>A custom footer</footer>
+              </body>
+            </html>
+            """)
+        }
     }
 }
 

--- a/Tests/SwiftDocCTests/Rendering/HTML/HTMLRenderer+FullPageTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/HTML/HTMLRenderer+FullPageTests.swift
@@ -1,0 +1,161 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2026 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Testing
+#if canImport(FoundationXML)
+// TODO: Consider other HTML rendering options as a future improvement (rdar://165755530)
+import FoundationXML
+import FoundationEssentials
+#else
+import Foundation
+#endif
+import DocCHTML
+@testable import SwiftDocC
+import DocCTestUtilities
+
+struct HTMLRenderFullPageTests {
+    private let reference = ResolvedTopicReference(bundleID: "com.example", path: "/documentation/ModuleName/SomePage/someMethod(with:and:)", fragment: nil, sourceLanguage: .swift)
+    
+    @Test
+    func includesMainContentInFullPage() async throws {
+        let mainContent = XMLNode.element(named: "article", children: [
+            .element(named: "p", children: [
+                .text("Some documentation")
+            ])
+        ])
+        
+        let fullPage = HTMLRenderer.makeFullPage(
+            mainContent: mainContent,
+            metadata: (title: "Some title", description: "Some description"),
+            for: reference
+        )
+        
+        assert(fullPage, matches: """
+        <!DOCTYPE html>
+        <html lang="en-US">
+          <head>
+            <meta charset="utf-8">
+            <meta content="width=device-width,initial-scale=1,viewport-fit=cover" name="viewport">
+            <link href="../../../../reference.css" rel="stylesheet">
+            <title>Some title</title>
+            <meta content="Some description" name="description">
+          </head>
+          <body>
+            <header>
+              <h2>Documentation</h2>
+              <span>Language: Swift</span>
+            </header>
+            <article>
+              <p>Some documentation</p>
+            </article>
+            <footer>
+              <fieldset role="radiogroup">
+                <legend>Select a color scheme preference</legend>
+                <label>
+                  <input type="radio" value="light">
+                  Light</label>
+              <label>
+                <input type="radio" value="dark">
+                Dark</label>
+              <label>
+                <input checked type="radio" value="auto">
+                Auto</label>
+              </fieldset>
+            </footer>
+          </body>
+        </html>
+        """)
+    }
+    
+    @Test
+    func includesCustomHeaderAndFooterInFullPage() async throws {
+        let mainContent = XMLNode.element(named: "article", children: [
+            .element(named: "p", children: [
+                .text("Some documentation")
+            ])
+        ])
+        
+        let customHeader = XMLNode.element(named: "header", children: [
+            .text("A custom header")
+        ])
+        let customFooter = XMLNode.element(named: "footer", children: [
+            .text("A custom footer")
+        ])
+        
+        let fullPage = HTMLRenderer.makeFullPage(
+            mainContent: mainContent,
+            metadata: (title: "Some title", nil),
+            for: reference,
+            customHeader: customHeader,
+            customFooter: customFooter
+        )
+        
+        assert(fullPage, matches: """
+        <!DOCTYPE html>
+        <html lang="en-US">
+          <head>
+            <meta charset="utf-8">
+            <meta content="width=device-width,initial-scale=1,viewport-fit=cover" name="viewport">
+            <link href="../../../../reference.css" rel="stylesheet">
+            <title>Some title</title>
+          </head>
+          <body>
+            <header>A custom header</header>
+            <header>
+              <h2>Documentation</h2>
+              <span>Language: Swift</span>
+            </header>
+            <article>
+              <p>Some documentation</p>
+            </article>
+            <footer>
+              <fieldset role="radiogroup">
+                <legend>Select a color scheme preference</legend>
+                <label>
+                  <input type="radio" value="light">
+                  Light</label>
+              <label>
+                <input type="radio" value="dark">
+                Dark</label>
+              <label>
+                <input checked type="radio" value="auto">
+                Auto</label>
+              </fieldset>
+            </footer>
+            <footer>A custom footer</footer>
+          </body>
+        </html>
+        """)
+    }
+}
+
+// This workaround is modified from the similar code in FileWritingHTMLContentConsumerTests.swift
+func assert(_ html: XMLDocument, matches expectedHTML: String, sourceLocation: SourceLocation = #_sourceLocation) {
+    // XMLNode on macOS and Linux pretty print with different indentation.
+    // To compare the XML structure without getting false positive failures because of indentation and other formatting differences,
+    // we explicitly process each string into an easy-to-compare format.
+    func formatForTestComparison(_ xmlString: String) -> String {
+        // This is overly simplified and won't result in "pretty" XML for general use but sufficient for test content comparisons
+        xmlString
+            // Put each tag on its own line
+            .replacingOccurrences(of: ">", with: ">\n")
+            // Remove leading indentation
+            .components(separatedBy: .newlines)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: "\n")
+            // Explicitly escape a few HTML characters that appear in the test content
+            .replacingOccurrences(of: "–", with: "&#x2013;") // en-dash
+            .replacingOccurrences(of: "—", with: "&#x2014;") // em-dash
+    }
+    
+    let actualHTML: String = html.xmlString(options: .nodeCompactEmptyElement)
+    #expect(formatForTestComparison(actualHTML) == formatForTestComparison(expectedHTML), sourceLocation: sourceLocation)
+}

--- a/Tests/SwiftDocCTests/Rendering/HTML/HTMLRenderer+FullPageTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/HTML/HTMLRenderer+FullPageTests.swift
@@ -59,13 +59,13 @@ struct HTMLRenderFullPageTests {
               <fieldset role="radiogroup">
                 <legend>Select a color scheme preference</legend>
                 <label>
-                  <input type="radio" value="light">
+                  <input name="color-scheme" type="radio" value="light">
                   Light</label>
               <label>
-                <input type="radio" value="dark">
+                <input name="color-scheme" type="radio" value="dark">
                 Dark</label>
               <label>
-                <input checked type="radio" value="auto">
+                <input checked name="color-scheme" type="radio" value="auto">
                 Auto</label>
               </fieldset>
             </footer>
@@ -119,13 +119,13 @@ struct HTMLRenderFullPageTests {
               <fieldset role="radiogroup">
                 <legend>Select a color scheme preference</legend>
                 <label>
-                  <input type="radio" value="light">
+                  <input name="color-scheme" type="radio" value="light">
                   Light</label>
               <label>
-                <input type="radio" value="dark">
+                <input name="color-scheme" type="radio" value="dark">
                 Dark</label>
               <label>
-                <input checked type="radio" value="auto">
+                <input checked name="color-scheme" type="radio" value="auto">
                 Auto</label>
               </fieldset>
             </footer>


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://165912669

## Summary

> [!NOTE]
> The primary purpose of this PR is to put together enough scaffolding in place to allow people to contribute on improving the static HTML output; both in terms of refining the layout and appearance and in terms of adding HTML output for more page elements. As such, some pieces are a bit more rough than what I would normally include in a PR. However, I believe that those can be cleaned up over time and feel that there are worthwhile benefits to opening this area up to contributions sooner.

This is a collection of rough changes pieced together from a handful of explorations into static HTML output from on and off over the past few of months. 

Most of those changes (800+ lines) are in the form of CSS to adjust the layout and appearance of the minimal semantic HTML that DocC can already output. Some of this is pixel-perfect recreations of the DocC-Render appearance—with some rules taken directly from there—and some of this very quick, good enough, first versions. I'm certain that this stylesheet can be greatly improved over time. Notably; many of the defined variables are never used and the stylesheet doesn't define any dark appearance colors. There's an additional ~100 lines of SVG icons where the paths are taken directly from DocC-Render. In the long run we might be able to make some of these more readable and/or better aligned to pixels for their display sizes.

The code comment in [StaticResources.swift](https://github.com/swiftlang/swift-docc/compare/main...d-ronnqvist:swift-docc:experimental-html-output?expand=1#diff-db113cd4f84968d9630a84ddfa834d5e4b51585c7d70ae39e71826f4b809ee7b) gives a brief explanation of why I've opted for code constants in this PR; it's much simpler to reference and submit to toolchains and it's two orders of magnitude less data than the DocC-Render Template (~18kB instead of ~1.2MB). If this becomes a problem in the future we can go down the same route as the DocC-Render Template but until then I'd prefer to avoid that if possible.

In terms of long term intentional design, there are two parts among these changes that in the ballpark of what my long term plan:
- Separating the HTML document creation from its serialization makes it easier to test behaviors of the HTML output.
- I believe that a `--output-format` CLI option will be extensible both if we want to add more complete formats (for example ePUB) and if we want options to output only the metadata (linkable entities, indexing records, etc.) without outputting pages in any format.

and one part that needs future design work:
- I'm not sure how the `ConvertAction` and `ConvertActionConverter` can best communicate which output files are needed, which responsibilities belong in `DocCCommandLine` and which belong in `SwiftDocC`, and how to manage this complexity with future hypothetical output formats. As pointed out in a few code comments mentioning "rdar://177867282"; I don't have a clear picture yet for how we'd configure which parts of the "render" output that a given output format wants and where that logic is best handled. At this point it would take some time, and additional prototyping / exploration, to try and answer those questions, which would be time where it's difficult for people to contribute to this output. By ensuring that nothing of this temporary design leaks up into public API and by adding code comments on pieces that aren't meant to be long-lived, my plan is to refine this design over time, in parallel to people's refinements of the static HTML output.

> [!NOTE]
> My hope is that this can be merged—so that people can start contributing in this area—without requiring a pitch and discussion in the Swift Forums. There's really only the `--output-format` flag that is user-facing _but hidden_. If you feel that this needs to be discussed in the Swift Forums before merging; I'd ask you to think about if there's anything I could do to further hide or dissuade from using this output format that would make that unnecessary that need. 
>
> I plan on making a broader pitch for this—including ideas for how it will support the on-page sidebar (very minimally at first with additional features being added over time), custom theming, custom page components, etc.—once it's getting closer to the point of being usable. However, right now, I feel that it's too early to have that discussion. I haven't explored the on-page sidebar solutions in sufficient detail yet, so it will take a lot more research before I can have a full pitch available to discuss and I would very much like to facilitate people contributing to this feature before then.

Lastly, this PR contains a few miscellaneous page refinements (on-hover icons for headings, icons for API collections in curation, backgrounds for "hero" sections, a visual—but not working—page headings and page footer) from various explorations. I felt that it made sense to collect these as well so that people wouldn't need to redo work that I had already done.

---- 

To give a few examples of what this early work-in-progress pages look like today; here are a two examples from the Swift standard library (the first also showing the in-progress recreation of DocC-Render's response design):

<img width="70%" alt="swift-method" src="https://github.com/user-attachments/assets/e755a66d-55d9-47f5-a71e-2da744267f43" />
<img width="35%" alt="swift-method-responsive" src="https://github.com/user-attachments/assets/e5402fdb-f23b-4319-90a8-2fb2d3bfada1" />
<img width="70%"  alt="swift-module" src="https://github.com/user-attachments/assets/b7325b1f-8fe4-48f7-9212-e19d88185def" />


## Dependencies

None.

## Testing

- Build some reference documentation and pass `--output-format experimental-html-for-development`
- Navigate to one of the HTML pages inside the output location and open it directly (without starting a local web server)
  - You should see a page that looks very similar to the DocC-Render version of those pages (although without an on-page sidebar, and a few other features).
  
As mentioned above; these changes aren't primarily for people to _use_. Instead, they're intended for local development workflows where people can iterate on improving this static HTML output.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
