### PR TITLE
[6.4] Allow `@PageImage` in `///` documentation comments (#1523)

### DIFF
--- a/Sources/SwiftDocC/Semantics/Metadata/Metadata.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/Metadata.swift
@@ -231,7 +231,6 @@ public final class Metadata: Semantic, AutomaticDirectiveConvertible {
         validateUnsupportedMetadataDirective(for: titleHeading)
         validateUnsupportedMetadataDirective(for: redirects)
         validateUnsupportedMetadataDirective(for: supportedLanguages)
-        validateUnsupportedMetadataDirective(for: pageImages)
         
         documentationOptions = nil
         technologyRoot       = nil
@@ -242,6 +241,5 @@ public final class Metadata: Semantic, AutomaticDirectiveConvertible {
         titleHeading         = nil
         redirects            = nil
         supportedLanguages   = []
-        pageImages           = []
     }
 }

--- a/Tests/SwiftDocCTests/Semantics/PageImageInDocCommentTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/PageImageInDocCommentTests.swift
@@ -1,0 +1,89 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2026 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+import Testing
+import SymbolKit
+@testable import SwiftDocC
+import DocCTestUtilities
+
+struct PageImageInDocCommentTests {
+    
+    @Test
+    func parsesMultiplePageImageDirectivesFromDocComment() async throws {
+        let catalog = Folder(name: "unit-test.docc", content: [
+            JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(
+                moduleName: "ModuleName",
+                symbols: [
+                    makeSymbol(
+                        id: "some-symbol-id",
+                        kind: .class,
+                        pathComponents: ["SomeClass"],
+                        docComment: """
+                        The symbol's abstract.
+                            
+                        @Metadata {
+                            @PageImage(source: "icon-image", purpose: icon)
+                            @PageImage(source: "card-image", purpose: card)
+                        }
+                        """
+                    )
+                ]
+                )),
+            DataFile(name: "icon-image.png", data: Data()),
+            DataFile(name: "card-image.png", data: Data()),
+        ])
+        
+        let context = try await load(catalog: catalog)
+        #expect(context.diagnostics.isEmpty, "Unexpected diagnostics: \(context.diagnostics.map(\.summary))")
+        
+        let node = try #require(context.documentationCache["some-symbol-id"])
+        let pageImages = try #require(node.metadata?.pageImages)
+        #expect(pageImages.count == 2)
+        
+        let iconImage = pageImages.first { $0.purpose == .icon }
+        let cardImage = pageImages.first { $0.purpose == .card }
+        #expect(iconImage?.source.path == "icon-image")
+        #expect(cardImage?.source.path == "card-image")
+    }
+    
+    @Test
+    func emitsWarningForUnresolvedPageImageInDocComment() async throws {
+        let catalog = Folder(name: "unit-test.docc", content: [
+            JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(
+                moduleName: "ModuleName",
+                symbols: [
+                    makeSymbol(
+                        id: "some-symbol-id",
+                        kind: .class,
+                        pathComponents: ["SomeClass"],
+                        docComment: """
+                            The symbol's abstract.
+                            
+                            @Metadata {
+                                @PageImage(source: "card-image", purpose: card)
+                                @PageImage(source: "missing-image", purpose: icon)
+                            }
+                            """
+                    )
+                ]
+            )),
+            DataFile(name: "card-image.png", data: Data()),
+            // Intentionally no DataFile for "missing-image" the source can't be resolved.
+        ])
+        let context = try await load(catalog: catalog)
+        
+        #expect(context.diagnostics.count == 1)
+        let diagnostic = try #require(context.diagnostics.first)
+        #expect(diagnostic.identifier == "org.swift.docc.unresolvedResource")
+        #expect(diagnostic.severity == .warning)
+        #expect(diagnostic.summary == "Resource 'missing-image' couldn't be found")
+    }
+}

--- a/Tests/SwiftDocCTests/Semantics/SymbolTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/SymbolTests.swift
@@ -1212,7 +1212,6 @@ class SymbolTests: XCTestCase {
                   @DocumentationExtension(mergeBehavior: override)
                   @TechnologyRoot
                   @DisplayName(Title)
-                  @PageImage(source: test, purpose: icon)
                   @CallToAction(url: "https://example.com/sample.zip", purpose: download)
                   @PageKind(sampleCode)
                   @SupportedLanguage(swift)
@@ -1230,7 +1229,6 @@ class SymbolTests: XCTestCase {
                 "org.swift.docc.Metadata.InvalidDocumentationExtensionInDocumentationComment",
                 "org.swift.docc.Metadata.InvalidTechnologyRootInDocumentationComment",
                 "org.swift.docc.Metadata.InvalidDisplayNameInDocumentationComment",
-                "org.swift.docc.Metadata.InvalidPageImageInDocumentationComment",
                 "org.swift.docc.Metadata.InvalidCallToActionInDocumentationComment",
                 "org.swift.docc.Metadata.InvalidPageKindInDocumentationComment",
                 "org.swift.docc.Metadata.InvalidSupportedLanguageInDocumentationComment",


### PR DESCRIPTION
- **Explanation**: This change allows symbols to use `@PageImage` in in-source documentation comments. Before this symbols could only specify a `@PageImage` in a documentation extension file.
- **Scope**: Validation of `@PageImage` directives in in-source documentation comments.
- **Issues**: #1403 
- **Original PRs**: #1523 (by @YooGyeongMo)
- **Risk**: Low. 
- **Testing**: New tests verify bot that DocC doesn't warn about the `@PageImage` directive and that DocC resolves the image asset. All existing automated test pass. 
- **Reviewers**: @d-ronnqvist 