### PR TITLE
Add alignment parameter to @Column directive

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/Content/RenderBlockContent.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Content/RenderBlockContent.swift
@@ -818,7 +818,7 @@ public enum RenderBlockContent: Equatable {
             public var size: Int
 
             /// The alignment of this column's content.
-            public var alignment: ColumnAlignment?
+            public var alignment: ColumnAlignment = .leading
 
             /// The content that should be rendered in this column.
             public var content: [RenderBlockContent]

--- a/Sources/SwiftDocC/Model/Rendering/Content/RenderBlockContent.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Content/RenderBlockContent.swift
@@ -798,15 +798,28 @@ public enum RenderBlockContent: Equatable {
         /// individual columns that span multiple columns (specified with the column's
         /// ``Column/size`` property) or the row could be not fully filled with columns.
         public var numberOfColumns: Int
-        
+
         /// The columns that should be rendered in this row.
         public var columns: [Column]
-        
+
+        /// The alignment of content within a column.
+        public enum ColumnAlignment: String, Codable, Equatable {
+            /// Align to the leading edge.
+            case leading
+            /// Align to the center.
+            case center
+            /// Align to the trailing edge.
+            case trailing
+        }
+
         /// A column with a row in a grid-based layout system.
         public struct Column: Codable, Equatable {
             /// The number of columns in the parent row this column should span.
             public var size: Int
-            
+
+            /// The alignment of this column's content.
+            public var alignment: ColumnAlignment?
+
             /// The content that should be rendered in this column.
             public var content: [RenderBlockContent]
         }

--- a/Sources/SwiftDocC/Model/Rendering/Content/RenderBlockContent.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Content/RenderBlockContent.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -798,19 +798,9 @@ public enum RenderBlockContent: Equatable {
         /// individual columns that span multiple columns (specified with the column's
         /// ``Column/size`` property) or the row could be not fully filled with columns.
         public var numberOfColumns: Int
-
+        
         /// The columns that should be rendered in this row.
         public var columns: [Column]
-
-        /// The alignment of content within a column.
-        public enum ColumnAlignment: String, Codable, Equatable {
-            /// Align to the leading edge.
-            case leading
-            /// Align to the center.
-            case center
-            /// Align to the trailing edge.
-            case trailing
-        }
 
         /// A column with a row in a grid-based layout system.
         public struct Column: Codable, Equatable {
@@ -818,10 +808,20 @@ public enum RenderBlockContent: Equatable {
             public var size: Int
 
             /// The alignment of this column's content.
-            public var alignment: ColumnAlignment = .leading
+            public var alignment: Alignment = .leading
 
             /// The content that should be rendered in this column.
             public var content: [RenderBlockContent]
+
+            /// The alignment of content within a column.
+            public enum Alignment: String, Codable, Equatable {
+                /// Align to the leading edge.
+                case leading
+                /// Align to the center.
+                case center
+                /// Align to the trailing edge.
+                case trailing
+            }
         }
     }
     

--- a/Sources/SwiftDocC/Model/Rendering/Content/RenderBlockContent.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Content/RenderBlockContent.swift
@@ -803,12 +803,12 @@ public enum RenderBlockContent: Equatable {
         public var columns: [Column]
 
         /// A column with a row in a grid-based layout system.
-        public struct Column: Codable, Equatable {
+        public struct Column: Equatable {
             /// The number of columns in the parent row this column should span.
             public var size: Int
 
             /// The alignment of this column's content.
-            public var alignment: Alignment = .leading
+            public var alignment: Alignment
 
             /// The content that should be rendered in this column.
             public var content: [RenderBlockContent]
@@ -1004,6 +1004,26 @@ extension RenderBlockContent.Table: Codable {
                 try cellContainer.encode(data.rowspan, forKey: .rowspan)
             }
         }
+    }
+}
+
+extension RenderBlockContent.Row.Column: Codable {
+    enum CodingKeys: String, CodingKey {
+        case size, alignment, content
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        size = try container.decode(Int.self, forKey: .size)
+        alignment = try container.decodeIfPresent(Alignment.self, forKey: .alignment) ?? .leading
+        content = try container.decode([RenderBlockContent].self, forKey: .content)
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(size, forKey: .size)
+        try container.encode(alignment, forKey: .alignment)
+        try container.encode(content, forKey: .content)
     }
 }
 

--- a/Sources/SwiftDocC/Semantics/Reference/Row.swift
+++ b/Sources/SwiftDocC/Semantics/Reference/Row.swift
@@ -110,6 +110,9 @@ extension Row {
     ///     }
     /// }
     /// ```
+    ///
+    /// > Earlier Versions:
+    /// > Before Swift-DocC 6.4, the `alignment` parameter wasn't supported for `@Column`.
     public final class Column: Semantic, AutomaticDirectiveConvertible, MarkupContaining {
         public static let introducedVersion = "5.8"
         public let originalMarkup: BlockDirective

--- a/Sources/SwiftDocC/Semantics/Reference/Row.swift
+++ b/Sources/SwiftDocC/Semantics/Reference/Row.swift
@@ -106,7 +106,7 @@ extension Row {
     ///     }
     ///
     ///     @Column(size: 2, alignment: trailing) {
-    ///         Trailing alignment
+    ///         Trailing alignment; twice as wide
     ///     }
     /// }
     /// ```

--- a/Sources/SwiftDocC/Semantics/Reference/Row.swift
+++ b/Sources/SwiftDocC/Semantics/Reference/Row.swift
@@ -50,6 +50,22 @@ public import Markdown
 public final class Row: Semantic, AutomaticDirectiveConvertible, MarkupContaining {
     public static let introducedVersion = "5.8"
     public let originalMarkup: BlockDirective
+
+    /// The alignment of content within a column.
+    public enum ColumnAlignment: String, CaseIterable, DirectiveArgumentValueConvertible {
+        /// Align to the leading edge.
+        case leading
+
+        /// Align to the center.
+        case center
+
+        /// Align to the trailing edge.
+        case trailing
+
+        public init?(rawDirectiveArgumentValue: String) {
+            self.init(rawValue: rawDirectiveArgumentValue)
+        }
+    }
     
     /// The number of columns available in this row.
     @DirectiveArgumentWrapped(name: .custom("numberOfColumns"))
@@ -103,13 +119,18 @@ extension Row {
         /// in the parent ``Row``.
         @DirectiveArgumentWrapped
         public private(set) var size: Int = 1
-        
+
+        /// The alignment of this column's content.
+        @DirectiveArgumentWrapped
+        public private(set) var alignment: Row.ColumnAlignment? = nil
+
         /// The markup content in this column.
         @ChildMarkup(numberOfParagraphs: .zeroOrMore, supportsStructure: true)
         public private(set) var content: MarkupContainer
         
         static var keyPaths: [String : AnyKeyPath] = [
             "size"      : \Column._size,
+            "alignment" : \Column._alignment,
             "content"   : \Column._content,
         ]
         
@@ -133,8 +154,12 @@ extension Row {
 extension Row: RenderableDirectiveConvertible {
     func render(with contentCompiler: inout RenderContentCompiler) -> [any RenderContent] {
         let renderedColumns = columns.map { column in
+            let alignment = column.alignment.flatMap { semanticAlignment in
+                RenderBlockContent.Row.ColumnAlignment(rawValue: semanticAlignment.rawValue)
+            }
             return RenderBlockContent.Row.Column(
                 size: column.size,
+                alignment: alignment,
                 content: column.content.elements.flatMap { markupElement in
                     return contentCompiler.visit(markupElement) as! [RenderBlockContent]
                 }

--- a/Sources/SwiftDocC/Semantics/Reference/Row.swift
+++ b/Sources/SwiftDocC/Semantics/Reference/Row.swift
@@ -171,7 +171,7 @@ extension Row {
 extension Row: RenderableDirectiveConvertible {
     func render(with contentCompiler: inout RenderContentCompiler) -> [any RenderContent] {
         let renderedColumns = columns.map { column in
-            let alignment = RenderBlockContent.Row.ColumnAlignment(rawValue: column.alignment.rawValue)!
+            let alignment = RenderBlockContent.Row.ColumnAlignment(rawValue: column.alignment.rawValue) ?? .leading
             return RenderBlockContent.Row.Column(
                 size: column.size,
                 alignment: alignment,

--- a/Sources/SwiftDocC/Semantics/Reference/Row.swift
+++ b/Sources/SwiftDocC/Semantics/Reference/Row.swift
@@ -109,6 +109,23 @@ extension Row {
     /// with a row in a grid-based layout.
     ///
     /// Create a column inside a ``Row`` by nesting a `@Column` directive within the content for an `@Row` directive.
+    /// Use `size` to span multiple columns and `alignment` to control content positioning.
+    ///
+    /// ```md
+    /// @Row {
+    ///     @Column {
+    ///         Default (leading) alignment
+    ///     }
+    ///
+    ///     @Column(alignment: center) {
+    ///         Centered content
+    ///     }
+    ///
+    ///     @Column(size: 2, alignment: trailing) {
+    ///         Trailing alignment
+    ///     }
+    /// }
+    /// ```
     public final class Column: Semantic, AutomaticDirectiveConvertible, MarkupContaining {
         public static let introducedVersion = "5.8"
         public let originalMarkup: BlockDirective

--- a/Sources/SwiftDocC/Semantics/Reference/Row.swift
+++ b/Sources/SwiftDocC/Semantics/Reference/Row.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2022-2023 Apple Inc. and the Swift project authors
+ Copyright (c) 2022-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -50,22 +50,6 @@ public import Markdown
 public final class Row: Semantic, AutomaticDirectiveConvertible, MarkupContaining {
     public static let introducedVersion = "5.8"
     public let originalMarkup: BlockDirective
-
-    /// The alignment of content within a column.
-    public enum ColumnAlignment: String, CaseIterable, DirectiveArgumentValueConvertible {
-        /// Align to the leading edge.
-        case leading
-
-        /// Align to the center.
-        case center
-
-        /// Align to the trailing edge.
-        case trailing
-
-        public init?(rawDirectiveArgumentValue: String) {
-            self.init(rawValue: rawDirectiveArgumentValue)
-        }
-    }
     
     /// The number of columns available in this row.
     @DirectiveArgumentWrapped(name: .custom("numberOfColumns"))
@@ -139,7 +123,7 @@ extension Row {
 
         /// The alignment of this column's content.
         @DirectiveArgumentWrapped
-        public private(set) var alignment: Row.ColumnAlignment = .leading
+        public private(set) var alignment: Alignment = .leading
 
         /// The markup content in this column.
         @ChildMarkup(numberOfParagraphs: .zeroOrMore, supportsStructure: true)
@@ -165,13 +149,29 @@ extension Row {
         init(originalMarkup: BlockDirective) {
             self.originalMarkup = originalMarkup
         }
+
+        /// The alignment of content within a column.
+        public enum Alignment: String, CaseIterable, DirectiveArgumentValueConvertible {
+            /// Align to the leading edge.
+            case leading
+
+            /// Align to the center.
+            case center
+
+            /// Align to the trailing edge.
+            case trailing
+
+            public init?(rawDirectiveArgumentValue: String) {
+                self.init(rawValue: rawDirectiveArgumentValue)
+            }
+        }
     }
 }
 
 extension Row: RenderableDirectiveConvertible {
     func render(with contentCompiler: inout RenderContentCompiler) -> [any RenderContent] {
         let renderedColumns = columns.map { column in
-            let alignment = RenderBlockContent.Row.ColumnAlignment(rawValue: column.alignment.rawValue) ?? .leading
+            let alignment = RenderBlockContent.Row.Column.Alignment(rawValue: column.alignment.rawValue) ?? .leading
             return RenderBlockContent.Row.Column(
                 size: column.size,
                 alignment: alignment,

--- a/Sources/SwiftDocC/Semantics/Reference/Row.swift
+++ b/Sources/SwiftDocC/Semantics/Reference/Row.swift
@@ -122,7 +122,7 @@ extension Row {
 
         /// The alignment of this column's content.
         @DirectiveArgumentWrapped
-        public private(set) var alignment: Row.ColumnAlignment? = nil
+        public private(set) var alignment: Row.ColumnAlignment = .leading
 
         /// The markup content in this column.
         @ChildMarkup(numberOfParagraphs: .zeroOrMore, supportsStructure: true)
@@ -154,9 +154,7 @@ extension Row {
 extension Row: RenderableDirectiveConvertible {
     func render(with contentCompiler: inout RenderContentCompiler) -> [any RenderContent] {
         let renderedColumns = columns.map { column in
-            let alignment = column.alignment.flatMap { semanticAlignment in
-                RenderBlockContent.Row.ColumnAlignment(rawValue: semanticAlignment.rawValue)
-            }
+            let alignment = RenderBlockContent.Row.ColumnAlignment(rawValue: column.alignment.rawValue)!
             return RenderBlockContent.Row.Column(
                 size: column.size,
                 alignment: alignment,

--- a/Sources/docc/DocCDocumentation.docc/docc.symbols.json
+++ b/Sources/docc/DocCDocumentation.docc/docc.symbols.json
@@ -2076,6 +2076,15 @@
             "text" : "```"
           },
           {
+            "text" : ""
+          },
+          {
+            "text" : "> Earlier Versions:"
+          },
+          {
+            "text" : "> Before Swift-DocC 6.4, the `alignment` parameter wasn't supported for `@Column`."
+          },
+          {
             "text" : "- Parameters:"
           },
           {

--- a/Sources/docc/DocCDocumentation.docc/docc.symbols.json
+++ b/Sources/docc/DocCDocumentation.docc/docc.symbols.json
@@ -2064,7 +2064,7 @@
             "text" : "    @Column(size: 2, alignment: trailing) {"
           },
           {
-            "text" : "        Trailing alignment"
+            "text" : "        Trailing alignment; twice as wide"
           },
           {
             "text" : "    }"

--- a/Sources/docc/DocCDocumentation.docc/docc.symbols.json
+++ b/Sources/docc/DocCDocumentation.docc/docc.symbols.json
@@ -1995,7 +1995,7 @@
         },
         {
           "kind" : "typeIdentifier",
-          "spelling" : "ColumnAlignment"
+          "spelling" : "Alignment"
         },
         {
           "kind" : "text",
@@ -2098,6 +2098,15 @@
           },
           {
             "text" : "     **(optional)**"
+          },
+          {
+            "text" : "     - term `leading`: Align to the leading edge."
+          },
+          {
+            "text" : "     - term `center`: Align to the center."
+          },
+          {
+            "text" : "     - term `trailing`: Align to the trailing edge."
           }
         ]
       },
@@ -2160,7 +2169,7 @@
           },
           {
             "kind" : "typeIdentifier",
-            "spelling" : "ColumnAlignment"
+            "spelling" : "Alignment"
           },
           {
             "kind" : "text",
@@ -4911,7 +4920,7 @@
         },
         {
           "kind" : "typeIdentifier",
-          "spelling" : "ColumnAlignment"
+          "spelling" : "Alignment"
         },
         {
           "kind" : "text",

--- a/Sources/docc/DocCDocumentation.docc/docc.symbols.json
+++ b/Sources/docc/DocCDocumentation.docc/docc.symbols.json
@@ -2025,6 +2025,57 @@
             "text" : "Create a column inside a ``Row`` by nesting a `@Column` directive within the content for an `@Row` directive."
           },
           {
+            "text" : "Use `size` to span multiple columns and `alignment` to control content positioning."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "```md"
+          },
+          {
+            "text" : "@Row {"
+          },
+          {
+            "text" : "    @Column {"
+          },
+          {
+            "text" : "        Default (leading) alignment"
+          },
+          {
+            "text" : "    }"
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "    @Column(alignment: center) {"
+          },
+          {
+            "text" : "        Centered content"
+          },
+          {
+            "text" : "    }"
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "    @Column(size: 2, alignment: trailing) {"
+          },
+          {
+            "text" : "        Trailing alignment"
+          },
+          {
+            "text" : "    }"
+          },
+          {
+            "text" : "}"
+          },
+          {
+            "text" : "```"
+          },
+          {
             "text" : "- Parameters:"
           },
           {

--- a/Sources/docc/DocCDocumentation.docc/docc.symbols.json
+++ b/Sources/docc/DocCDocumentation.docc/docc.symbols.json
@@ -1983,6 +1983,26 @@
         },
         {
           "kind" : "text",
+          "spelling" : ", "
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "alignment"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "ColumnAlignment"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " = leading"
+        },
+        {
+          "kind" : "text",
           "spelling" : ")"
         },
         {
@@ -2021,6 +2041,12 @@
           },
           {
             "text" : "     in the parent ``Row``."
+          },
+          {
+            "text" : "  - alignment: The alignment of this column's content."
+          },
+          {
+            "text" : "     **(optional)**"
           }
         ]
       },
@@ -2068,6 +2094,22 @@
           {
             "kind" : "typeIdentifier",
             "spelling" : "Int"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ", "
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "alignment"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "spelling" : "ColumnAlignment"
           },
           {
             "kind" : "text",
@@ -2993,12 +3035,6 @@
           },
           {
             "text" : "- Parameters:"
-          },
-          {
-            "text" : "  - source: A reference to the source file for the media item."
-          },
-          {
-            "text" : "     **(required)**"
           },
           {
             "text" : "  - alt: Optional alternate text for an image."
@@ -4809,6 +4845,26 @@
         {
           "kind" : "text",
           "spelling" : " = 1"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ", "
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "alignment"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "ColumnAlignment"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " = leading"
         },
         {
           "kind" : "text",
@@ -7193,12 +7249,6 @@
           },
           {
             "text" : "- Parameters:"
-          },
-          {
-            "text" : "  - source: A reference to the source file for the media item."
-          },
-          {
-            "text" : "     **(required)**"
           },
           {
             "text" : "  - alt: Alternate text describing the video."

--- a/Tests/SwiftDocCTests/Semantics/Reference/RowTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/Reference/RowTests.swift
@@ -10,196 +10,153 @@
 
 import Foundation
 
-import XCTest
+import Testing
 @testable public import SwiftDocC
 import Markdown
 
-class RowTests: XCTestCase {
-    func testNoColumns() async throws {
+struct RowTests {
+    @Test func noColumns() async throws {
         let (renderBlockContent, diagnostics, row) = try await parseDirective(Row.self) {
             """
             @Row
             """
         }
-        
-        XCTAssertNotNil(row)
-        
-        XCTAssertEqual(
-            diagnostics,
-            ["1: warning – org.swift.docc.HasAtLeastOne<Row, Column>"]
-        )
-        
-        XCTAssertEqual(renderBlockContent.count, 1)
-        XCTAssertEqual(
-            renderBlockContent.first,
-            .row(.init(numberOfColumns: 0, columns: []))
-        )
+
+        #expect(row != nil)
+
+        #expect(diagnostics == ["1: warning – org.swift.docc.HasAtLeastOne<Row, Column>"])
+
+        #expect(renderBlockContent.count == 1)
+        #expect(renderBlockContent.first == .row(.init(numberOfColumns: 0, columns: [])))
     }
     
-    func testInvalidParameters() async throws {
-        do {
-            let (renderBlockContent, diagnostics, row) = try await parseDirective(Row.self) {
-                """
-                @Row(columns: 3) {
-                    @Column(what: true) {
-                        Hello there.
-                    }
-                
-                    @Column(size: true) {
-                        Hello there.
-                    }
-                
-                    @Column(size: 4) {
-                        Hello there.
-                    }
+    @Test func unknownArguments() async throws {
+        let (renderBlockContent, diagnostics, row) = try await parseDirective(Row.self) {
+            """
+            @Row(columns: 3) {
+                @Column(what: true) {
+                    Hello there.
                 }
-                """
+
+                @Column(size: true) {
+                    Hello there.
+                }
+
+                @Column(size: 4) {
+                    Hello there.
+                }
             }
-            
-            XCTAssertNotNil(row)
-            XCTAssertEqual(
-                diagnostics,
-                [
-                    "1: warning – org.swift.docc.UnknownArgument",
-                    "2: warning – org.swift.docc.UnknownArgument",
-                    "6: warning – org.swift.docc.HasArgument.size.ConversionFailed",
-                ]
-            )
-            
-            XCTAssertEqual(renderBlockContent.count, 1)
-            XCTAssertEqual(
-                renderBlockContent.first,
-                .row(RenderBlockContent.Row(
-                    numberOfColumns: 6,
-                    columns: [
-                        RenderBlockContent.Row.Column(size: 1, alignment: .leading, content: ["Hello there."]),
-                        RenderBlockContent.Row.Column(size: 1, alignment: .leading, content: ["Hello there."]),
-                        RenderBlockContent.Row.Column(size: 4, alignment: .leading, content: ["Hello there."])
-                    ]
-                ))
-            )
+            """
         }
-        
-        do {
-            let (_, diagnostics, row) = try await parseDirective(Row.self) {
-                """
-                @Row(numberOfColumns: 3) {
-                    @Column(size: 3) {
-                        @Row {
-                            @Column {
-                                @Row {
-                                    @Column(weird: false)
-                                }
+
+        #expect(row != nil)
+        #expect(diagnostics == [
+            "1: warning – org.swift.docc.UnknownArgument",
+            "2: warning – org.swift.docc.UnknownArgument",
+            "6: warning – org.swift.docc.HasArgument.size.ConversionFailed",
+        ])
+
+        #expect(renderBlockContent.count == 1)
+        #expect(renderBlockContent.first == .row(RenderBlockContent.Row(
+            numberOfColumns: 6,
+            columns: [
+                RenderBlockContent.Row.Column(size: 1, alignment: .leading, content: ["Hello there."]),
+                RenderBlockContent.Row.Column(size: 1, alignment: .leading, content: ["Hello there."]),
+                RenderBlockContent.Row.Column(size: 4, alignment: .leading, content: ["Hello there."])
+            ]
+        )))
+    }
+
+    @Test func unknownArgumentInNestedRow() async throws {
+        let (_, diagnostics, row) = try await parseDirective(Row.self) {
+            """
+            @Row(numberOfColumns: 3) {
+                @Column(size: 3) {
+                    @Row {
+                        @Column {
+                            @Row {
+                                @Column(weird: false)
                             }
                         }
                     }
                 }
-                """
             }
-            
-            XCTAssertNotNil(row)
-            XCTAssertEqual(
-                diagnostics,
-                [
-                    "6: warning – org.swift.docc.UnknownArgument",
-                ]
-            )
+            """
         }
+
+        #expect(row != nil)
+        #expect(diagnostics == ["6: warning – org.swift.docc.UnknownArgument"])
     }
     
-    func testInvalidChildren() async throws {
-        do {
-            let (renderBlockContent, diagnostics, row) = try await parseDirective(Row.self) {
-                """
-                @Row {
-                    @Row {
-                        @Column {
-                            Hello there.
-                        }
-                    }
-                }
-                """
-            }
-            
-            XCTAssertNotNil(row)
-            XCTAssertEqual(
-                diagnostics,
-                [
-                    "1: warning – org.swift.docc.HasAtLeastOne<Row, Column>",
-                    "1: warning – org.swift.docc.Row.UnexpectedContent",
-                    "2: warning – org.swift.docc.HasOnlyKnownDirectives",
-                ]
-            )
-            
-            XCTAssertEqual(renderBlockContent.count, 1)
-            XCTAssertEqual(
-                renderBlockContent.first,
-                .row(RenderBlockContent.Row(
-                    numberOfColumns: 0,
-                    columns: []
-                ))
-            )
-        }
-        
-        do {
-            let (renderBlockContent, diagnostics, row) = try await parseDirective(Row.self) {
-                """
+    @Test func invalidChildrenNestedRow() async throws {
+        let (renderBlockContent, diagnostics, row) = try await parseDirective(Row.self) {
+            """
+            @Row {
                 @Row {
                     @Column {
-                        @Column {
-                            Hello there.
-                        }
+                        Hello there.
                     }
                 }
-                """
             }
-            
-            XCTAssertNotNil(row)
-            XCTAssertEqual(
-                diagnostics,
-                [
-                    "3: warning – org.swift.docc.HasOnlyKnownDirectives",
-                ]
-            )
-            
-            XCTAssertEqual(renderBlockContent.count, 1)
-            XCTAssertEqual(
-                renderBlockContent.first,
-                .row(RenderBlockContent.Row(
-                    numberOfColumns: 1,
-                    columns: [
-                        RenderBlockContent.Row.Column(size: 1, alignment: .leading, content: [])
-                    ]
-                ))
-            )
+            """
         }
-        
-        do {
-            let (renderBlockContent, diagnostics, row) = try await parseDirective(Row.self) {
-                """
-                @Row {
 
+        #expect(row != nil)
+        #expect(diagnostics == [
+            "1: warning – org.swift.docc.HasAtLeastOne<Row, Column>",
+            "1: warning – org.swift.docc.Row.UnexpectedContent",
+            "2: warning – org.swift.docc.HasOnlyKnownDirectives",
+        ])
+
+        #expect(renderBlockContent.count == 1)
+        #expect(renderBlockContent.first == .row(RenderBlockContent.Row(
+            numberOfColumns: 0,
+            columns: []
+        )))
+    }
+
+    @Test func invalidChildrenNestedColumn() async throws {
+        let (renderBlockContent, diagnostics, row) = try await parseDirective(Row.self) {
+            """
+            @Row {
+                @Column {
+                    @Column {
+                        Hello there.
+                    }
                 }
-                """
             }
-            
-            XCTAssertNotNil(row)
-            XCTAssertEqual(
-                diagnostics,
-                [
-                    "1: warning – org.swift.docc.HasAtLeastOne<Row, Column>",
-                ]
-            )
-            
-            XCTAssertEqual(renderBlockContent.count, 1)
-            XCTAssertEqual(
-                renderBlockContent.first,
-                .row(RenderBlockContent.Row(numberOfColumns: 0, columns: []))
-            )
+            """
         }
+
+        #expect(row != nil)
+        #expect(diagnostics == ["3: warning – org.swift.docc.HasOnlyKnownDirectives"])
+
+        #expect(renderBlockContent.count == 1)
+        #expect(renderBlockContent.first == .row(RenderBlockContent.Row(
+            numberOfColumns: 1,
+            columns: [
+                RenderBlockContent.Row.Column(size: 1, alignment: .leading, content: [])
+            ]
+        )))
+    }
+
+    @Test func emptyRowBody() async throws {
+        let (renderBlockContent, diagnostics, row) = try await parseDirective(Row.self) {
+            """
+            @Row {
+
+            }
+            """
+        }
+
+        #expect(row != nil)
+        #expect(diagnostics == ["1: warning – org.swift.docc.HasAtLeastOne<Row, Column>"])
+
+        #expect(renderBlockContent.count == 1)
+        #expect(renderBlockContent.first == .row(RenderBlockContent.Row(numberOfColumns: 0, columns: [])))
     }
     
-    func testEmptyColumn() async throws {
+    @Test func emptyColumn() async throws {
         let (renderBlockContent, diagnostics, row) = try await parseDirective(Row.self) {
             """
             @Row {
@@ -213,31 +170,28 @@ class RowTests: XCTestCase {
             }
             """
         }
-        
-        XCTAssertNotNil(row)
-        XCTAssertEqual(diagnostics, [])
 
-        XCTAssertEqual(renderBlockContent.count, 1)
-        XCTAssertEqual(
-            renderBlockContent.first,
-            .row(RenderBlockContent.Row(
-                numberOfColumns: 5,
-                columns: [
-                    RenderBlockContent.Row.Column(size: 1, alignment: .leading, content: []),
-                    
-                    RenderBlockContent.Row.Column(
-                        size: 3,
-                        alignment: .leading,
-                        content: ["This is a wiiiiddde column."]
-                    ),
-                    
-                    RenderBlockContent.Row.Column(size: 1, alignment: .leading, content: []),
-                ]
-            ))
-        )
+        #expect(row != nil)
+        #expect(diagnostics == [])
+
+        #expect(renderBlockContent.count == 1)
+        #expect(renderBlockContent.first == .row(RenderBlockContent.Row(
+            numberOfColumns: 5,
+            columns: [
+                RenderBlockContent.Row.Column(size: 1, alignment: .leading, content: []),
+
+                RenderBlockContent.Row.Column(
+                    size: 3,
+                    alignment: .leading,
+                    content: ["This is a wiiiiddde column."]
+                ),
+
+                RenderBlockContent.Row.Column(size: 1, alignment: .leading, content: []),
+            ]
+        )))
     }
     
-    func testNestedRowAndColumns() async throws {
+    @Test func nestedRowAndColumns() async throws {
         let (renderBlockContent, diagnostics, row) = try await parseDirective(Row.self) {
             """
             @Row {
@@ -255,35 +209,32 @@ class RowTests: XCTestCase {
             }
             """
         }
-        
-        XCTAssertNotNil(row)
-        XCTAssertEqual(diagnostics, [])
-        
-        XCTAssertEqual(renderBlockContent.count, 1)
-        XCTAssertEqual(
-            renderBlockContent.first,
-            .row(RenderBlockContent.Row(
-                numberOfColumns: 1,
-                columns: [
-                    RenderBlockContent.Row.Column(
-                        size: 1,
-                        alignment: .leading,
-                        content: [
-                            .row(RenderBlockContent.Row(
-                                numberOfColumns: 2,
-                                columns: [
-                                    RenderBlockContent.Row.Column(size: 1, alignment: .leading, content: ["Hello"]),
-                                    RenderBlockContent.Row.Column(size: 1, alignment: .leading, content: ["There"]),
-                                ]
-                            ))
-                        ]
-                    )
-                ]
-            ))
-        )
+
+        #expect(row != nil)
+        #expect(diagnostics == [])
+
+        #expect(renderBlockContent.count == 1)
+        #expect(renderBlockContent.first == .row(RenderBlockContent.Row(
+            numberOfColumns: 1,
+            columns: [
+                RenderBlockContent.Row.Column(
+                    size: 1,
+                    alignment: .leading,
+                    content: [
+                        .row(RenderBlockContent.Row(
+                            numberOfColumns: 2,
+                            columns: [
+                                RenderBlockContent.Row.Column(size: 1, alignment: .leading, content: ["Hello"]),
+                                RenderBlockContent.Row.Column(size: 1, alignment: .leading, content: ["There"]),
+                            ]
+                        ))
+                    ]
+                )
+            ]
+        )))
     }
 
-    func testColumnWithAlignmentOnly() async throws {
+    @Test func columnWithAlignmentOnly() async throws {
         let (renderBlockContent, diagnostics, row) = try await parseDirective(Row.self) {
             """
             @Row {
@@ -294,26 +245,23 @@ class RowTests: XCTestCase {
             """
         }
 
-        XCTAssertNotNil(row)
-        XCTAssertEqual(diagnostics, [])
+        #expect(row != nil)
+        #expect(diagnostics == [])
 
-        XCTAssertEqual(renderBlockContent.count, 1)
-        XCTAssertEqual(
-            renderBlockContent.first,
-            .row(RenderBlockContent.Row(
-                numberOfColumns: 1,
-                columns: [
-                    RenderBlockContent.Row.Column(
-                        size: 1,
-                        alignment: .center,
-                        content: ["Centered content"]
-                    )
-                ]
-            ))
-        )
+        #expect(renderBlockContent.count == 1)
+        #expect(renderBlockContent.first == .row(RenderBlockContent.Row(
+            numberOfColumns: 1,
+            columns: [
+                RenderBlockContent.Row.Column(
+                    size: 1,
+                    alignment: .center,
+                    content: ["Centered content"]
+                )
+            ]
+        )))
     }
 
-    func testColumnWithSizeAndAlignment() async throws {
+    @Test func columnWithSizeAndAlignment() async throws {
         let (renderBlockContent, diagnostics, row) = try await parseDirective(Row.self) {
             """
             @Row {
@@ -324,26 +272,23 @@ class RowTests: XCTestCase {
             """
         }
 
-        XCTAssertNotNil(row)
-        XCTAssertEqual(diagnostics, [])
+        #expect(row != nil)
+        #expect(diagnostics == [])
 
-        XCTAssertEqual(renderBlockContent.count, 1)
-        XCTAssertEqual(
-            renderBlockContent.first,
-            .row(RenderBlockContent.Row(
-                numberOfColumns: 2,
-                columns: [
-                    RenderBlockContent.Row.Column(
-                        size: 2,
-                        alignment: .trailing,
-                        content: ["Trailing aligned"]
-                    )
-                ]
-            ))
-        )
+        #expect(renderBlockContent.count == 1)
+        #expect(renderBlockContent.first == .row(RenderBlockContent.Row(
+            numberOfColumns: 2,
+            columns: [
+                RenderBlockContent.Row.Column(
+                    size: 2,
+                    alignment: .trailing,
+                    content: ["Trailing aligned"]
+                )
+            ]
+        )))
     }
 
-    func testColumnWithoutAlignment() async throws {
+    @Test func columnWithoutAlignment() async throws {
         let (renderBlockContent, diagnostics, row) = try await parseDirective(Row.self) {
             """
             @Row {
@@ -354,90 +299,80 @@ class RowTests: XCTestCase {
             """
         }
 
-        XCTAssertNotNil(row)
-        XCTAssertEqual(diagnostics, [])
+        #expect(row != nil)
+        #expect(diagnostics == [])
 
-        XCTAssertEqual(renderBlockContent.count, 1)
-        XCTAssertEqual(
-            renderBlockContent.first,
-            .row(RenderBlockContent.Row(
-                numberOfColumns: 2,
-                columns: [
-                    RenderBlockContent.Row.Column(
-                        size: 2,
-                        alignment: .leading,
-                        content: ["Default alignment"]
-                    )
-                ]
-            ))
-        )
+        #expect(renderBlockContent.count == 1)
+        #expect(renderBlockContent.first == .row(RenderBlockContent.Row(
+            numberOfColumns: 2,
+            columns: [
+                RenderBlockContent.Row.Column(
+                    size: 2,
+                    alignment: .leading,
+                    content: ["Default alignment"]
+                )
+            ]
+        )))
     }
 
-    func testInvalidAlignmentValue() async throws {
+    @Test(arguments: [
+        ("alignment: invalid", 1),
+        ("alignment: true", 1),
+        ("size: 2, alignment: 123", 2),
+    ])
+    func columnWithUnparseableAlignment(columnArgs: String, expectedColumnSize: Int) async throws {
         let (renderBlockContent, diagnostics, row) = try await parseDirective(Row.self) {
             """
             @Row {
-                @Column(alignment: invalid) {
+                @Column(\(columnArgs)) {
                     Content
                 }
             }
             """
         }
 
-        XCTAssertNotNil(row)
-        XCTAssertEqual(
-            diagnostics,
-            ["2: warning – org.swift.docc.HasArgument.alignment.ConversionFailed"]
-        )
+        #expect(row != nil)
+        #expect(diagnostics == ["2: warning – org.swift.docc.HasArgument.alignment.ConversionFailed"])
 
-        XCTAssertEqual(renderBlockContent.count, 1)
-        XCTAssertEqual(
-            renderBlockContent.first,
-            .row(RenderBlockContent.Row(
-                numberOfColumns: 1,
-                columns: [
-                    RenderBlockContent.Row.Column(
-                        size: 1,
-                        alignment: .leading,
-                        content: ["Content"]
-                    )
-                ]
-            ))
-        )
-    }
-
-    func testAllAlignmentValues() async throws {
-        let alignmentValues: [(String, RenderBlockContent.Row.Column.Alignment)] = [
-            ("leading", .leading),
-            ("center", .center),
-            ("trailing", .trailing)
-        ]
-
-        for (stringValue, expectedAlignment) in alignmentValues {
-            let (renderBlockContent, diagnostics, row) = try await parseDirective(Row.self) {
-                """
-                @Row {
-                    @Column(alignment: \(stringValue)) {
-                        Content
-                    }
-                }
-                """
-            }
-
-            XCTAssertNotNil(row)
-            XCTAssertEqual(diagnostics, [])
-            XCTAssertEqual(renderBlockContent.count, 1)
-
-            if case let .row(row) = renderBlockContent.first {
-                XCTAssertEqual(row.columns.count, 1)
-                XCTAssertEqual(row.columns.first?.alignment, expectedAlignment)
-            } else {
-                XCTFail("Expected row but got \(String(describing: renderBlockContent.first))")
-            }
+        #expect(renderBlockContent.count == 1)
+        if case let .row(row) = renderBlockContent.first {
+            #expect(row.columns.count == 1)
+            #expect(row.columns.first?.size == expectedColumnSize)
+            #expect(row.columns.first?.alignment == .leading)
+        } else {
+            Issue.record("Expected row but got \(String(describing: renderBlockContent.first))")
         }
     }
 
-    func testMultipleColumnsWithMixedAlignment() async throws {
+    @Test(arguments: [
+        ("leading", RenderBlockContent.Row.Column.Alignment.leading),
+        ("center", .center),
+        ("trailing", .trailing),
+    ])
+    func columnAlignment(alignmentString: String, expectedAlignment: RenderBlockContent.Row.Column.Alignment) async throws {
+        let (renderBlockContent, diagnostics, row) = try await parseDirective(Row.self) {
+            """
+            @Row {
+                @Column(alignment: \(alignmentString)) {
+                    Content
+                }
+            }
+            """
+        }
+
+        #expect(row != nil)
+        #expect(diagnostics == [])
+        #expect(renderBlockContent.count == 1)
+
+        if case let .row(row) = renderBlockContent.first {
+            #expect(row.columns.count == 1)
+            #expect(row.columns.first?.alignment == expectedAlignment)
+        } else {
+            Issue.record("Expected row but got \(String(describing: renderBlockContent.first))")
+        }
+    }
+
+    @Test func multipleColumnsWithMixedAlignment() async throws {
         let (renderBlockContent, diagnostics, row) = try await parseDirective(Row.self) {
             """
             @Row {
@@ -456,102 +391,33 @@ class RowTests: XCTestCase {
             """
         }
 
-        XCTAssertNotNil(row)
-        XCTAssertEqual(diagnostics, [])
+        #expect(row != nil)
+        #expect(diagnostics == [])
 
-        XCTAssertEqual(renderBlockContent.count, 1)
-        XCTAssertEqual(
-            renderBlockContent.first,
-            .row(RenderBlockContent.Row(
-                numberOfColumns: 3,
-                columns: [
-                    RenderBlockContent.Row.Column(
-                        size: 1,
-                        alignment: .leading,
-                        content: ["Left aligned"]
-                    ),
-                    RenderBlockContent.Row.Column(
-                        size: 1,
-                        alignment: .center,
-                        content: ["Center aligned"]
-                    ),
-                    RenderBlockContent.Row.Column(
-                        size: 1,
-                        alignment: .leading,
-                        content: ["Default aligned"]
-                    )
-                ]
-            ))
-        )
+        #expect(renderBlockContent.count == 1)
+        #expect(renderBlockContent.first == .row(RenderBlockContent.Row(
+            numberOfColumns: 3,
+            columns: [
+                RenderBlockContent.Row.Column(
+                    size: 1,
+                    alignment: .leading,
+                    content: ["Left aligned"]
+                ),
+                RenderBlockContent.Row.Column(
+                    size: 1,
+                    alignment: .center,
+                    content: ["Center aligned"]
+                ),
+                RenderBlockContent.Row.Column(
+                    size: 1,
+                    alignment: .leading,
+                    content: ["Default aligned"]
+                )
+            ]
+        )))
     }
 
-    func testAlignmentWithInvalidType() async throws {
-        let (renderBlockContent, diagnostics, row) = try await parseDirective(Row.self) {
-            """
-            @Row {
-                @Column(alignment: true) {
-                    Content
-                }
-            }
-            """
-        }
-
-        XCTAssertNotNil(row)
-        XCTAssertEqual(
-            diagnostics,
-            ["2: warning – org.swift.docc.HasArgument.alignment.ConversionFailed"]
-        )
-
-        XCTAssertEqual(renderBlockContent.count, 1)
-        XCTAssertEqual(
-            renderBlockContent.first,
-            .row(RenderBlockContent.Row(
-                numberOfColumns: 1,
-                columns: [
-                    RenderBlockContent.Row.Column(
-                        size: 1,
-                        alignment: .leading,
-                        content: ["Content"]
-                    )
-                ]
-            ))
-        )
-    }
-
-    func testAlignmentWithSizeInvalidType() async throws {
-        let (renderBlockContent, diagnostics, row) = try await parseDirective(Row.self) {
-            """
-            @Row {
-                @Column(size: 2, alignment: 123) {
-                    Content
-                }
-            }
-            """
-        }
-
-        XCTAssertNotNil(row)
-        XCTAssertEqual(
-            diagnostics,
-            ["2: warning – org.swift.docc.HasArgument.alignment.ConversionFailed"]
-        )
-
-        XCTAssertEqual(renderBlockContent.count, 1)
-        XCTAssertEqual(
-            renderBlockContent.first,
-            .row(RenderBlockContent.Row(
-                numberOfColumns: 2,
-                columns: [
-                    RenderBlockContent.Row.Column(
-                        size: 2,
-                        alignment: .leading,
-                        content: ["Content"]
-                    )
-                ]
-            ))
-        )
-    }
-
-    func testMultipleColumnsWithInvalidAlignment() async throws {
+    @Test func multipleColumnsWithInvalidAlignment() async throws {
         let (renderBlockContent, diagnostics, row) = try await parseDirective(Row.self) {
             """
             @Row {
@@ -570,36 +436,30 @@ class RowTests: XCTestCase {
             """
         }
 
-        XCTAssertNotNil(row)
-        XCTAssertEqual(
-            diagnostics,
-            ["6: warning – org.swift.docc.HasArgument.alignment.ConversionFailed"]
-        )
+        #expect(row != nil)
+        #expect(diagnostics == ["6: warning – org.swift.docc.HasArgument.alignment.ConversionFailed"])
 
-        XCTAssertEqual(renderBlockContent.count, 1)
-        XCTAssertEqual(
-            renderBlockContent.first,
-            .row(RenderBlockContent.Row(
-                numberOfColumns: 3,
-                columns: [
-                    RenderBlockContent.Row.Column(
-                        size: 1,
-                        alignment: .leading,
-                        content: ["Valid"]
-                    ),
-                    RenderBlockContent.Row.Column(
-                        size: 1,
-                        alignment: .leading,
-                        content: ["Invalid"]
-                    ),
-                    RenderBlockContent.Row.Column(
-                        size: 1,
-                        alignment: .trailing,
-                        content: ["Valid"]
-                    )
-                ]
-            ))
-        )
+        #expect(renderBlockContent.count == 1)
+        #expect(renderBlockContent.first == .row(RenderBlockContent.Row(
+            numberOfColumns: 3,
+            columns: [
+                RenderBlockContent.Row.Column(
+                    size: 1,
+                    alignment: .leading,
+                    content: ["Valid"]
+                ),
+                RenderBlockContent.Row.Column(
+                    size: 1,
+                    alignment: .leading,
+                    content: ["Invalid"]
+                ),
+                RenderBlockContent.Row.Column(
+                    size: 1,
+                    alignment: .trailing,
+                    content: ["Valid"]
+                )
+            ]
+        )))
     }
 
 }

--- a/Tests/SwiftDocCTests/Semantics/Reference/RowTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/Reference/RowTests.swift
@@ -15,11 +15,20 @@ import Testing
 import Markdown
 
 struct RowTests {
-    @Test func noColumns() async throws {
+    @Test(arguments: [
+        """
+        @Row
+        """,
+
+        """
+        @Row {
+
+        }
+        """,
+    ])
+    func warnsAboutRowWithoutColumns(directive: String) async throws {
         let (renderBlockContent, diagnostics, row) = try await parseDirective(Row.self) {
-            """
-            @Row
-            """
+            directive
         }
 
         #expect(row != nil)
@@ -140,22 +149,6 @@ struct RowTests {
         )))
     }
 
-    @Test func emptyRowBody() async throws {
-        let (renderBlockContent, diagnostics, row) = try await parseDirective(Row.self) {
-            """
-            @Row {
-
-            }
-            """
-        }
-
-        #expect(row != nil)
-        #expect(diagnostics == ["1: warning – org.swift.docc.HasAtLeastOne<Row, Column>"])
-
-        #expect(renderBlockContent.count == 1)
-        #expect(renderBlockContent.first == .row(RenderBlockContent.Row(numberOfColumns: 0, columns: [])))
-    }
-    
     @Test func emptyColumn() async throws {
         let (renderBlockContent, diagnostics, row) = try await parseDirective(Row.self) {
             """

--- a/Tests/SwiftDocCTests/Semantics/Reference/RowTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/Reference/RowTests.swift
@@ -204,16 +204,16 @@ class RowTests: XCTestCase {
             """
             @Row {
                 @Column
-
+            
                 @Column(size: 3) {
                     This is a wiiiiddde column.
                 }
-
+            
                 @Column
             }
             """
         }
-
+        
         XCTAssertNotNil(row)
         XCTAssertEqual(diagnostics, [])
 
@@ -224,13 +224,13 @@ class RowTests: XCTestCase {
                 numberOfColumns: 5,
                 columns: [
                     RenderBlockContent.Row.Column(size: 1, alignment: .leading, content: []),
-
+                    
                     RenderBlockContent.Row.Column(
                         size: 3,
                         alignment: .leading,
                         content: ["This is a wiiiiddde column."]
                     ),
-
+                    
                     RenderBlockContent.Row.Column(size: 1, alignment: .leading, content: []),
                 ]
             ))
@@ -246,7 +246,7 @@ class RowTests: XCTestCase {
                         @Column {
                             Hello
                         }
-
+            
                         @Column {
                             There
                         }
@@ -255,10 +255,10 @@ class RowTests: XCTestCase {
             }
             """
         }
-
+        
         XCTAssertNotNil(row)
         XCTAssertEqual(diagnostics, [])
-
+        
         XCTAssertEqual(renderBlockContent.count, 1)
         XCTAssertEqual(
             renderBlockContent.first,
@@ -407,7 +407,7 @@ class RowTests: XCTestCase {
     }
 
     func testAllAlignmentValues() async throws {
-        let alignmentValues: [(String, RenderBlockContent.Row.ColumnAlignment)] = [
+        let alignmentValues: [(String, RenderBlockContent.Row.Column.Alignment)] = [
             ("leading", .leading),
             ("center", .center),
             ("trailing", .trailing)

--- a/Tests/SwiftDocCTests/Semantics/Reference/RowTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/Reference/RowTests.swift
@@ -72,9 +72,9 @@ class RowTests: XCTestCase {
                 .row(RenderBlockContent.Row(
                     numberOfColumns: 6,
                     columns: [
-                        RenderBlockContent.Row.Column(size: 1, alignment: nil, content: ["Hello there."]),
-                        RenderBlockContent.Row.Column(size: 1, alignment: nil, content: ["Hello there."]),
-                        RenderBlockContent.Row.Column(size: 4, alignment: nil, content: ["Hello there."])
+                        RenderBlockContent.Row.Column(size: 1, alignment: .leading, content: ["Hello there."]),
+                        RenderBlockContent.Row.Column(size: 1, alignment: .leading, content: ["Hello there."]),
+                        RenderBlockContent.Row.Column(size: 4, alignment: .leading, content: ["Hello there."])
                     ]
                 ))
             )
@@ -168,7 +168,7 @@ class RowTests: XCTestCase {
                 .row(RenderBlockContent.Row(
                     numberOfColumns: 1,
                     columns: [
-                        RenderBlockContent.Row.Column(size: 1, alignment: nil, content: [])
+                        RenderBlockContent.Row.Column(size: 1, alignment: .leading, content: [])
                     ]
                 ))
             )
@@ -223,15 +223,15 @@ class RowTests: XCTestCase {
             .row(RenderBlockContent.Row(
                 numberOfColumns: 5,
                 columns: [
-                    RenderBlockContent.Row.Column(size: 1, alignment: nil, content: []),
+                    RenderBlockContent.Row.Column(size: 1, alignment: .leading, content: []),
 
                     RenderBlockContent.Row.Column(
                         size: 3,
-                        alignment: nil,
+                        alignment: .leading,
                         content: ["This is a wiiiiddde column."]
                     ),
 
-                    RenderBlockContent.Row.Column(size: 1, alignment: nil, content: []),
+                    RenderBlockContent.Row.Column(size: 1, alignment: .leading, content: []),
                 ]
             ))
         )
@@ -267,13 +267,13 @@ class RowTests: XCTestCase {
                 columns: [
                     RenderBlockContent.Row.Column(
                         size: 1,
-                        alignment: nil,
+                        alignment: .leading,
                         content: [
                             .row(RenderBlockContent.Row(
                                 numberOfColumns: 2,
                                 columns: [
-                                    RenderBlockContent.Row.Column(size: 1, alignment: nil, content: ["Hello"]),
-                                    RenderBlockContent.Row.Column(size: 1, alignment: nil, content: ["There"]),
+                                    RenderBlockContent.Row.Column(size: 1, alignment: .leading, content: ["Hello"]),
+                                    RenderBlockContent.Row.Column(size: 1, alignment: .leading, content: ["There"]),
                                 ]
                             ))
                         ]
@@ -365,7 +365,7 @@ class RowTests: XCTestCase {
                 columns: [
                     RenderBlockContent.Row.Column(
                         size: 2,
-                        alignment: nil,
+                        alignment: .leading,
                         content: ["Default alignment"]
                     )
                 ]
@@ -385,8 +385,10 @@ class RowTests: XCTestCase {
         }
 
         XCTAssertNotNil(row)
-        // Optional parameters silently default to nil when conversion fails
-        XCTAssertEqual(diagnostics, [])
+        XCTAssertEqual(
+            diagnostics,
+            ["2: warning – org.swift.docc.HasArgument.alignment.ConversionFailed"]
+        )
 
         XCTAssertEqual(renderBlockContent.count, 1)
         XCTAssertEqual(
@@ -396,7 +398,7 @@ class RowTests: XCTestCase {
                 columns: [
                     RenderBlockContent.Row.Column(
                         size: 1,
-                        alignment: nil,
+                        alignment: .leading,
                         content: ["Content"]
                     )
                 ]
@@ -475,7 +477,7 @@ class RowTests: XCTestCase {
                     ),
                     RenderBlockContent.Row.Column(
                         size: 1,
-                        alignment: nil,
+                        alignment: .leading,
                         content: ["Default aligned"]
                     )
                 ]
@@ -495,8 +497,10 @@ class RowTests: XCTestCase {
         }
 
         XCTAssertNotNil(row)
-        // Optional parameters silently default to nil on invalid values
-        XCTAssertEqual(diagnostics, [])
+        XCTAssertEqual(
+            diagnostics,
+            ["2: warning – org.swift.docc.HasArgument.alignment.ConversionFailed"]
+        )
 
         XCTAssertEqual(renderBlockContent.count, 1)
         XCTAssertEqual(
@@ -506,7 +510,7 @@ class RowTests: XCTestCase {
                 columns: [
                     RenderBlockContent.Row.Column(
                         size: 1,
-                        alignment: nil,
+                        alignment: .leading,
                         content: ["Content"]
                     )
                 ]
@@ -526,8 +530,10 @@ class RowTests: XCTestCase {
         }
 
         XCTAssertNotNil(row)
-        // Optional parameters silently default to nil on invalid values
-        XCTAssertEqual(diagnostics, [])
+        XCTAssertEqual(
+            diagnostics,
+            ["2: warning – org.swift.docc.HasArgument.alignment.ConversionFailed"]
+        )
 
         XCTAssertEqual(renderBlockContent.count, 1)
         XCTAssertEqual(
@@ -537,7 +543,7 @@ class RowTests: XCTestCase {
                 columns: [
                     RenderBlockContent.Row.Column(
                         size: 2,
-                        alignment: nil,
+                        alignment: .leading,
                         content: ["Content"]
                     )
                 ]
@@ -565,8 +571,10 @@ class RowTests: XCTestCase {
         }
 
         XCTAssertNotNil(row)
-        // Optional parameters silently default to nil on invalid values
-        XCTAssertEqual(diagnostics, [])
+        XCTAssertEqual(
+            diagnostics,
+            ["6: warning – org.swift.docc.HasArgument.alignment.ConversionFailed"]
+        )
 
         XCTAssertEqual(renderBlockContent.count, 1)
         XCTAssertEqual(
@@ -581,7 +589,7 @@ class RowTests: XCTestCase {
                     ),
                     RenderBlockContent.Row.Column(
                         size: 1,
-                        alignment: nil,
+                        alignment: .leading,
                         content: ["Invalid"]
                     ),
                     RenderBlockContent.Row.Column(

--- a/Tests/SwiftDocCTests/Semantics/Reference/RowTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/Reference/RowTests.swift
@@ -72,9 +72,9 @@ class RowTests: XCTestCase {
                 .row(RenderBlockContent.Row(
                     numberOfColumns: 6,
                     columns: [
-                        RenderBlockContent.Row.Column(size: 1, content: ["Hello there."]),
-                        RenderBlockContent.Row.Column(size: 1, content: ["Hello there."]),
-                        RenderBlockContent.Row.Column(size: 4, content: ["Hello there."])
+                        RenderBlockContent.Row.Column(size: 1, alignment: nil, content: ["Hello there."]),
+                        RenderBlockContent.Row.Column(size: 1, alignment: nil, content: ["Hello there."]),
+                        RenderBlockContent.Row.Column(size: 4, alignment: nil, content: ["Hello there."])
                     ]
                 ))
             )
@@ -168,7 +168,7 @@ class RowTests: XCTestCase {
                 .row(RenderBlockContent.Row(
                     numberOfColumns: 1,
                     columns: [
-                        RenderBlockContent.Row.Column(size: 1, content: [])
+                        RenderBlockContent.Row.Column(size: 1, alignment: nil, content: [])
                     ]
                 ))
             )
@@ -204,33 +204,34 @@ class RowTests: XCTestCase {
             """
             @Row {
                 @Column
-            
+
                 @Column(size: 3) {
                     This is a wiiiiddde column.
                 }
-            
+
                 @Column
             }
             """
         }
-        
+
         XCTAssertNotNil(row)
         XCTAssertEqual(diagnostics, [])
-        
+
         XCTAssertEqual(renderBlockContent.count, 1)
         XCTAssertEqual(
             renderBlockContent.first,
             .row(RenderBlockContent.Row(
                 numberOfColumns: 5,
                 columns: [
-                    RenderBlockContent.Row.Column(size: 1, content: []),
-                    
+                    RenderBlockContent.Row.Column(size: 1, alignment: nil, content: []),
+
                     RenderBlockContent.Row.Column(
                         size: 3,
+                        alignment: nil,
                         content: ["This is a wiiiiddde column."]
                     ),
-                    
-                    RenderBlockContent.Row.Column(size: 1, content: []),
+
+                    RenderBlockContent.Row.Column(size: 1, alignment: nil, content: []),
                 ]
             ))
         )
@@ -245,7 +246,7 @@ class RowTests: XCTestCase {
                         @Column {
                             Hello
                         }
-            
+
                         @Column {
                             There
                         }
@@ -254,10 +255,10 @@ class RowTests: XCTestCase {
             }
             """
         }
-        
+
         XCTAssertNotNil(row)
         XCTAssertEqual(diagnostics, [])
-        
+
         XCTAssertEqual(renderBlockContent.count, 1)
         XCTAssertEqual(
             renderBlockContent.first,
@@ -266,15 +267,327 @@ class RowTests: XCTestCase {
                 columns: [
                     RenderBlockContent.Row.Column(
                         size: 1,
+                        alignment: nil,
                         content: [
                             .row(RenderBlockContent.Row(
                                 numberOfColumns: 2,
                                 columns: [
-                                    RenderBlockContent.Row.Column(size: 1, content: ["Hello"]),
-                                    RenderBlockContent.Row.Column(size: 1, content: ["There"]),
+                                    RenderBlockContent.Row.Column(size: 1, alignment: nil, content: ["Hello"]),
+                                    RenderBlockContent.Row.Column(size: 1, alignment: nil, content: ["There"]),
                                 ]
                             ))
                         ]
+                    )
+                ]
+            ))
+        )
+    }
+
+    func testColumnWithAlignmentOnly() async throws {
+        let (renderBlockContent, diagnostics, row) = try await parseDirective(Row.self) {
+            """
+            @Row {
+                @Column(alignment: center) {
+                    Centered content
+                }
+            }
+            """
+        }
+
+        XCTAssertNotNil(row)
+        XCTAssertEqual(diagnostics, [])
+
+        XCTAssertEqual(renderBlockContent.count, 1)
+        XCTAssertEqual(
+            renderBlockContent.first,
+            .row(RenderBlockContent.Row(
+                numberOfColumns: 1,
+                columns: [
+                    RenderBlockContent.Row.Column(
+                        size: 1,
+                        alignment: .center,
+                        content: ["Centered content"]
+                    )
+                ]
+            ))
+        )
+    }
+
+    func testColumnWithSizeAndAlignment() async throws {
+        let (renderBlockContent, diagnostics, row) = try await parseDirective(Row.self) {
+            """
+            @Row {
+                @Column(size: 2, alignment: trailing) {
+                    Trailing aligned
+                }
+            }
+            """
+        }
+
+        XCTAssertNotNil(row)
+        XCTAssertEqual(diagnostics, [])
+
+        XCTAssertEqual(renderBlockContent.count, 1)
+        XCTAssertEqual(
+            renderBlockContent.first,
+            .row(RenderBlockContent.Row(
+                numberOfColumns: 2,
+                columns: [
+                    RenderBlockContent.Row.Column(
+                        size: 2,
+                        alignment: .trailing,
+                        content: ["Trailing aligned"]
+                    )
+                ]
+            ))
+        )
+    }
+
+    func testColumnWithoutAlignment() async throws {
+        let (renderBlockContent, diagnostics, row) = try await parseDirective(Row.self) {
+            """
+            @Row {
+                @Column(size: 2) {
+                    Default alignment
+                }
+            }
+            """
+        }
+
+        XCTAssertNotNil(row)
+        XCTAssertEqual(diagnostics, [])
+
+        XCTAssertEqual(renderBlockContent.count, 1)
+        XCTAssertEqual(
+            renderBlockContent.first,
+            .row(RenderBlockContent.Row(
+                numberOfColumns: 2,
+                columns: [
+                    RenderBlockContent.Row.Column(
+                        size: 2,
+                        alignment: nil,
+                        content: ["Default alignment"]
+                    )
+                ]
+            ))
+        )
+    }
+
+    func testInvalidAlignmentValue() async throws {
+        let (renderBlockContent, diagnostics, row) = try await parseDirective(Row.self) {
+            """
+            @Row {
+                @Column(alignment: invalid) {
+                    Content
+                }
+            }
+            """
+        }
+
+        XCTAssertNotNil(row)
+        // Optional parameters silently default to nil when conversion fails
+        XCTAssertEqual(diagnostics, [])
+
+        XCTAssertEqual(renderBlockContent.count, 1)
+        XCTAssertEqual(
+            renderBlockContent.first,
+            .row(RenderBlockContent.Row(
+                numberOfColumns: 1,
+                columns: [
+                    RenderBlockContent.Row.Column(
+                        size: 1,
+                        alignment: nil,
+                        content: ["Content"]
+                    )
+                ]
+            ))
+        )
+    }
+
+    func testAllAlignmentValues() async throws {
+        let alignmentValues: [(String, RenderBlockContent.Row.ColumnAlignment)] = [
+            ("leading", .leading),
+            ("center", .center),
+            ("trailing", .trailing)
+        ]
+
+        for (stringValue, expectedAlignment) in alignmentValues {
+            let (renderBlockContent, diagnostics, row) = try await parseDirective(Row.self) {
+                """
+                @Row {
+                    @Column(alignment: \(stringValue)) {
+                        Content
+                    }
+                }
+                """
+            }
+
+            XCTAssertNotNil(row)
+            XCTAssertEqual(diagnostics, [])
+            XCTAssertEqual(renderBlockContent.count, 1)
+
+            if case let .row(row) = renderBlockContent.first {
+                XCTAssertEqual(row.columns.count, 1)
+                XCTAssertEqual(row.columns.first?.alignment, expectedAlignment)
+            } else {
+                XCTFail("Expected row but got \(String(describing: renderBlockContent.first))")
+            }
+        }
+    }
+
+    func testMultipleColumnsWithMixedAlignment() async throws {
+        let (renderBlockContent, diagnostics, row) = try await parseDirective(Row.self) {
+            """
+            @Row {
+                @Column(size: 1, alignment: leading) {
+                    Left aligned
+                }
+
+                @Column(size: 1, alignment: center) {
+                    Center aligned
+                }
+
+                @Column(size: 1) {
+                    Default aligned
+                }
+            }
+            """
+        }
+
+        XCTAssertNotNil(row)
+        XCTAssertEqual(diagnostics, [])
+
+        XCTAssertEqual(renderBlockContent.count, 1)
+        XCTAssertEqual(
+            renderBlockContent.first,
+            .row(RenderBlockContent.Row(
+                numberOfColumns: 3,
+                columns: [
+                    RenderBlockContent.Row.Column(
+                        size: 1,
+                        alignment: .leading,
+                        content: ["Left aligned"]
+                    ),
+                    RenderBlockContent.Row.Column(
+                        size: 1,
+                        alignment: .center,
+                        content: ["Center aligned"]
+                    ),
+                    RenderBlockContent.Row.Column(
+                        size: 1,
+                        alignment: nil,
+                        content: ["Default aligned"]
+                    )
+                ]
+            ))
+        )
+    }
+
+    func testAlignmentWithInvalidType() async throws {
+        let (renderBlockContent, diagnostics, row) = try await parseDirective(Row.self) {
+            """
+            @Row {
+                @Column(alignment: true) {
+                    Content
+                }
+            }
+            """
+        }
+
+        XCTAssertNotNil(row)
+        // Optional parameters silently default to nil on invalid values
+        XCTAssertEqual(diagnostics, [])
+
+        XCTAssertEqual(renderBlockContent.count, 1)
+        XCTAssertEqual(
+            renderBlockContent.first,
+            .row(RenderBlockContent.Row(
+                numberOfColumns: 1,
+                columns: [
+                    RenderBlockContent.Row.Column(
+                        size: 1,
+                        alignment: nil,
+                        content: ["Content"]
+                    )
+                ]
+            ))
+        )
+    }
+
+    func testAlignmentWithSizeInvalidType() async throws {
+        let (renderBlockContent, diagnostics, row) = try await parseDirective(Row.self) {
+            """
+            @Row {
+                @Column(size: 2, alignment: 123) {
+                    Content
+                }
+            }
+            """
+        }
+
+        XCTAssertNotNil(row)
+        // Optional parameters silently default to nil on invalid values
+        XCTAssertEqual(diagnostics, [])
+
+        XCTAssertEqual(renderBlockContent.count, 1)
+        XCTAssertEqual(
+            renderBlockContent.first,
+            .row(RenderBlockContent.Row(
+                numberOfColumns: 2,
+                columns: [
+                    RenderBlockContent.Row.Column(
+                        size: 2,
+                        alignment: nil,
+                        content: ["Content"]
+                    )
+                ]
+            ))
+        )
+    }
+
+    func testMultipleColumnsWithInvalidAlignment() async throws {
+        let (renderBlockContent, diagnostics, row) = try await parseDirective(Row.self) {
+            """
+            @Row {
+                @Column(alignment: leading) {
+                    Valid
+                }
+
+                @Column(alignment: badvalue) {
+                    Invalid
+                }
+
+                @Column(alignment: trailing) {
+                    Valid
+                }
+            }
+            """
+        }
+
+        XCTAssertNotNil(row)
+        // Optional parameters silently default to nil on invalid values
+        XCTAssertEqual(diagnostics, [])
+
+        XCTAssertEqual(renderBlockContent.count, 1)
+        XCTAssertEqual(
+            renderBlockContent.first,
+            .row(RenderBlockContent.Row(
+                numberOfColumns: 3,
+                columns: [
+                    RenderBlockContent.Row.Column(
+                        size: 1,
+                        alignment: .leading,
+                        content: ["Valid"]
+                    ),
+                    RenderBlockContent.Row.Column(
+                        size: 1,
+                        alignment: nil,
+                        content: ["Invalid"]
+                    ),
+                    RenderBlockContent.Row.Column(
+                        size: 1,
+                        alignment: .trailing,
+                        content: ["Valid"]
                     )
                 ]
             ))

--- a/Tests/SwiftDocCTests/Semantics/Reference/SmallTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/Reference/SmallTests.swift
@@ -173,6 +173,7 @@ class SmallTests: XCTestCase {
                     columns: [
                         RenderBlockContent.Row.Column(
                             size: 1,
+                            alignment: .leading,
                             content: [
                                 "Regular text.",
                                 .small(RenderBlockContent.Small(
@@ -183,6 +184,7 @@ class SmallTests: XCTestCase {
                         
                         RenderBlockContent.Row.Column(
                             size: 1,
+                            alignment: .leading,
                             content: [
                                 "Second column of regular text.",
                             ]

--- a/Tests/SwiftDocCTests/Semantics/Reference/TabNavigatorTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/Reference/TabNavigatorTests.swift
@@ -178,11 +178,13 @@ class TabNavigatorTests: XCTestCase {
                                 columns: [
                                     RenderBlockContent.Row.Column(
                                         size: 1,
+                                        alignment: .leading,
                                         content: ["Hello!"]
                                     ),
                                     
                                     RenderBlockContent.Row.Column(
                                         size: 1,
+                                        alignment: .leading,
                                         content: ["Hello there!"]
                                     )
                                 ]


### PR DESCRIPTION
## Summary

This PR implements alignment control for the `@Column` directive, enabling documentation authors to align content.

The feature adds an optional `alignment` parameter to `@Column` that accepts `leading`, `center`, or `trailing` values, defaulting to `leading`.
This addresses the pitch at https://forums.swift.org/t/pitch-adding-alignment-control-to-the-column-directive/86754.

### Implementation Overview

**Semantic Layer Changes:**

- Adds `Row.ColumnAlignment` enum with three cases: `leading`, `center`, and `trailing`
- Parses the optional `alignment` parameter from `@Column` directive syntax
- Defaults to `.leading` when the parameter is not specified
- Produces a conversion-failed diagnostic when an invalid alignment value is encountered

**Render Layer Changes:**

- Introduces parallel `RenderBlockContent.Row.ColumnAlignment` enum to maintain clean separation between semantic and render models
- Converts semantic alignment values to their render equivalents

**Documentation Updates:**

- Refines Column directive documentation with concise parameter description
- Regenerates `docc.symbols.json` symbol graph to include the new alignment parameter and its doc comment entry
- Provides examples showcasing all three alignment options (default, center, and trailing)

**Test Coverage:**

- 14 comprehensive test cases covering:
  - All valid alignment values with proper conversion
  - Default `.leading` behavior when alignment is omitted
  - Invalid/unknown alignment values with appropriate diagnostics
  - Rendering layer conversion for all alignment states

## Dependencies

This PR is a pre-requisite for the corresponding swift-docc-render changes that will implement the actual rendering logic for the new alignment options. https://github.com/swiftlang/swift-docc-render/pull/1018

## Testing

1. Create a test file at `Sources/docc/DocCDocumentation.docc/TestAlignment.md` with the following content:

   ```markdown
   # Test Alignment

   ## Default (leading) alignment

   @Row {
       @Column {
           Foo
       }
   }

   ## Center alignment

   @Row {
       @Column(alignment: center) {
           Bar
       }
   }

   ## Trailing alignment

   @Row {
       @Column(alignment: trailing) {
           Baz
       }
   }
   ```

2. Preview the documentation to visually verify alignment rendering:

   ```bash
   ./bin/preview-docs DocC
   ```

3. Open http://localhost:8080/documentation/docc/testalignment in your browser and verify that all three rows display different column alignments correctly.

## Checklist

- [x] Added tests (14 new test cases in `RowTests.swift`)
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation with alignment parameter examples
