### PR TITLE
Update LinkCompletionToolsTests to Swift Testing

### DIFF
--- a/Tests/SwiftDocCTests/Infrastructure/Symbol Link Resolution/LinkCompletionToolsTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/Symbol Link Resolution/LinkCompletionToolsTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2024-2025 Apple Inc. and the Swift project authors
+ Copyright (c) 2024-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -9,22 +9,22 @@
 */
 
 import Foundation
-import XCTest
+import Testing
 @testable import SwiftDocC
 
-class LinkCompletionToolsTests: XCTestCase {
-    func testParsingLinkStrings() {
+struct LinkCompletionToolsTests {
+    @Test
+    func parsingLinkStrings() {
         func assertParsing(
             _ linkString: String,
             equal expected: [(name: String, disambiguation: LinkCompletionTools.ParsedDisambiguation)],
-            file: StaticString = #filePath,
-            line: UInt = #line
+            sourceLocation: SourceLocation = #_sourceLocation
         ) {
             let got = LinkCompletionTools.parse(linkString: linkString)
-            XCTAssertEqual(got.count, expected.count, "Incorrect number of link components", file: file, line: line)
+            #expect(got.count == expected.count, "Incorrect number of link components", sourceLocation: sourceLocation)
             for (index, (got, expected)) in zip(got, expected).enumerated() {
-                XCTAssertEqual(got.name, expected.name, "Incorrect base name for link component #\(index)", file: file, line: line)
-                XCTAssertEqual(got.disambiguation, expected.disambiguation, "Incorrect disambiguation for link component #\(index)", file: file, line: line)
+                #expect(got.name == expected.name, "Incorrect base name for link component #\(index)", sourceLocation: sourceLocation)
+                #expect(got.disambiguation == expected.disambiguation, "Incorrect disambiguation for link component #\(index)", sourceLocation: sourceLocation)
             }
         }
         
@@ -90,47 +90,48 @@ class LinkCompletionToolsTests: XCTestCase {
         ])
     }
     
-    func testFilteringSymbols() {
+    @Test
+    func matchingSymbolsToDisambiguation() {
         let symbol = LinkCompletionTools.SymbolInformation(kind: "func.op", symbolIDHash: "vt1x", parameterTypes: ["Int", "String"], returnTypes: ["Bool"])
         
-        XCTAssert(symbol.matches(.none))
-        XCTAssert(symbol.matches(.kindAndOrHash(kind: "func.op", hash: nil)))
-        XCTAssert(symbol.matches(.kindAndOrHash(kind: nil, hash: "vt1x")))
-        XCTAssert(symbol.matches(.kindAndOrHash(kind: "func.op", hash: "vt1x")))
-        XCTAssert(symbol.matches(.typeSignature(parameterTypes: ["_", "_"], returnTypes: ["_"])))
-        XCTAssert(symbol.matches(.typeSignature(parameterTypes: ["_", "_"], returnTypes: ["Bool"])))
-        XCTAssert(symbol.matches(.typeSignature(parameterTypes: ["Int", "_"], returnTypes: ["_"])))
-        XCTAssert(symbol.matches(.typeSignature(parameterTypes: ["_", "String"], returnTypes: ["_"])))
-        XCTAssert(symbol.matches(.typeSignature(parameterTypes: ["Int", "String"], returnTypes: ["_"])))
-        XCTAssert(symbol.matches(.typeSignature(parameterTypes: ["Int", "String"], returnTypes: ["Bool"])))
+        #expect(symbol.matches(.none))
+        #expect(symbol.matches(.kindAndOrHash(kind: "func.op", hash: nil)))
+        #expect(symbol.matches(.kindAndOrHash(kind: nil, hash: "vt1x")))
+        #expect(symbol.matches(.kindAndOrHash(kind: "func.op", hash: "vt1x")))
+        #expect(symbol.matches(.typeSignature(parameterTypes: ["_", "_"], returnTypes: ["_"])))
+        #expect(symbol.matches(.typeSignature(parameterTypes: ["_", "_"], returnTypes: ["Bool"])))
+        #expect(symbol.matches(.typeSignature(parameterTypes: ["Int", "_"], returnTypes: ["_"])))
+        #expect(symbol.matches(.typeSignature(parameterTypes: ["_", "String"], returnTypes: ["_"])))
+        #expect(symbol.matches(.typeSignature(parameterTypes: ["Int", "String"], returnTypes: ["_"])))
+        #expect(symbol.matches(.typeSignature(parameterTypes: ["Int", "String"], returnTypes: ["Bool"])))
         
-        XCTAssertFalse(symbol.matches(.kindAndOrHash(kind: "method", hash: nil)))
-        XCTAssertFalse(symbol.matches(.kindAndOrHash(kind: nil, hash: "pfi6")))
-        XCTAssertFalse(symbol.matches(.typeSignature(parameterTypes: [], returnTypes: [])))
-        XCTAssertFalse(symbol.matches(.typeSignature(parameterTypes: ["_"], returnTypes: ["_"])))
-        XCTAssertFalse(symbol.matches(.typeSignature(parameterTypes: ["_"], returnTypes: ["_", "_"])))
-        XCTAssertFalse(symbol.matches(.typeSignature(parameterTypes: ["Bool", "_"], returnTypes: ["_"])))
-        XCTAssertFalse(symbol.matches(.typeSignature(parameterTypes: ["_", "Bool"], returnTypes: ["_"])))
-        XCTAssertFalse(symbol.matches(.typeSignature(parameterTypes: ["_", "_"], returnTypes: ["Int"])))
-        XCTAssertFalse(symbol.matches(.typeSignature(parameterTypes: ["String", "Int"], returnTypes: ["Bool"])))
+        #expect(false == symbol.matches(.kindAndOrHash(kind: "method", hash: nil)))
+        #expect(false == symbol.matches(.kindAndOrHash(kind: nil, hash: "pfi6")))
+        #expect(false == symbol.matches(.typeSignature(parameterTypes: [], returnTypes: [])))
+        #expect(false == symbol.matches(.typeSignature(parameterTypes: ["_"], returnTypes: ["_"])))
+        #expect(false == symbol.matches(.typeSignature(parameterTypes: ["_"], returnTypes: ["_", "_"])))
+        #expect(false == symbol.matches(.typeSignature(parameterTypes: ["Bool", "_"], returnTypes: ["_"])))
+        #expect(false == symbol.matches(.typeSignature(parameterTypes: ["_", "Bool"], returnTypes: ["_"])))
+        #expect(false == symbol.matches(.typeSignature(parameterTypes: ["_", "_"], returnTypes: ["Int"])))
+        #expect(false == symbol.matches(.typeSignature(parameterTypes: ["String", "Int"], returnTypes: ["Bool"])))
     }
     
-    func testUSRHashing() {
-        for id in ["some", "unique", "symbol", "identifiers"] {
-            XCTAssertEqual(LinkCompletionTools.SymbolInformation.hash(uniqueSymbolID: id), id.stableHashString)
-        }
+    @Test(arguments: ["some", "unique", "symbol", "identifiers"])
+    func hashingSymbolIDs(_ symbolID: String) {
+        #expect(LinkCompletionTools.SymbolInformation.hash(uniqueSymbolID: symbolID) == symbolID.stableHashString)
     }
     
-    func testSuggestDisambiguation() {
+    @Test
+    func suggestsMinimalDisambiguationForCollidingSymbols() {
         let enumCase = LinkCompletionTools.SymbolInformation(kind: "enum.case", symbolIDHash: "lhk2x", parameterTypes: nil, returnTypes: nil)
         let property = LinkCompletionTools.SymbolInformation(kind: "property", symbolIDHash: "j56x", parameterTypes: nil, returnTypes: nil)
         
-        XCTAssertEqual(LinkCompletionTools.suggestedDisambiguation(forCollidingSymbols: [enumCase]), [""])
-        XCTAssertEqual(LinkCompletionTools.suggestedDisambiguation(forCollidingSymbols: [property]), [""])
+        #expect(LinkCompletionTools.suggestedDisambiguation(forCollidingSymbols: [enumCase]) == [""])
+        #expect(LinkCompletionTools.suggestedDisambiguation(forCollidingSymbols: [property]) == [""])
         
-        XCTAssertEqual(LinkCompletionTools.suggestedDisambiguation(forCollidingSymbols: [
+        #expect(LinkCompletionTools.suggestedDisambiguation(forCollidingSymbols: [
             enumCase, property
-        ]), [
+        ]) == [
             "-enum.case", "-property"
         ])
         
@@ -138,86 +139,87 @@ class LinkCompletionToolsTests: XCTestCase {
         let operator2 = LinkCompletionTools.SymbolInformation(kind: "func.op", symbolIDHash: "pfi6", parameterTypes: ["Wrapped", "Wrapped"], returnTypes: ["Wrapped"])
         let method = LinkCompletionTools.SymbolInformation(kind: "method", symbolIDHash: "w7ti9", parameterTypes: ["Int", "String"], returnTypes: [])
         
-        XCTAssertEqual(LinkCompletionTools.suggestedDisambiguation(forCollidingSymbols: [
+        #expect(LinkCompletionTools.suggestedDisambiguation(forCollidingSymbols: [
             operator1, operator2, method,
-        ]), [
+        ]) == [
             "->Bool", "->Wrapped", "-method",
         ])
         
         var operator3 = operator1
         operator3.symbolIDHash = "da50"
         
-        XCTAssertEqual(LinkCompletionTools.suggestedDisambiguation(forCollidingSymbols: [
+        #expect(LinkCompletionTools.suggestedDisambiguation(forCollidingSymbols: [
             operator1, operator2, operator3,
-        ]), [
+        ]) == [
             "-vt1x", "->Wrapped", "-da50",
         ])
         
         operator3.parameterTypes = ["Int", "Double"]
         
-        XCTAssertEqual(LinkCompletionTools.suggestedDisambiguation(forCollidingSymbols: [
+        #expect(LinkCompletionTools.suggestedDisambiguation(forCollidingSymbols: [
             operator1, operator2, operator3,
-        ]), [
+        ]) == [
             "-(_,String)", "->Wrapped", "-(_,Double)",
         ])
     }
     
-    func testDisambiguationSuffixStrings() {
+    @Test
+    func formattingDisambiguationSuffixStrings() {
         typealias Disambiguation = LinkCompletionTools.ParsedDisambiguation
         
-        XCTAssertEqual(Disambiguation.none.suffix,"")
+        #expect(Disambiguation.none.suffix == "")
         
-        XCTAssertEqual(Disambiguation.kindAndOrHash(kind: "class", hash: nil).suffix,
-                       "-class")
-        XCTAssertEqual(Disambiguation.kindAndOrHash(kind: nil, hash: "z3jl").suffix,
-                       "-z3jl")
+        #expect(Disambiguation.kindAndOrHash(kind: "class", hash: nil).suffix
+                == "-class")
+        #expect(Disambiguation.kindAndOrHash(kind: nil, hash: "z3jl").suffix
+                == "-z3jl")
         
-        XCTAssertEqual(Disambiguation.typeSignature(parameterTypes: [], returnTypes: nil).suffix,
-                       "-()")
-        XCTAssertEqual(Disambiguation.typeSignature(parameterTypes: ["Int"], returnTypes: nil).suffix,
-                       "-(Int)")
-        XCTAssertEqual(Disambiguation.typeSignature(parameterTypes: ["Int", "_", "String"], returnTypes: nil).suffix,
-                       "-(Int,_,String)")
+        #expect(Disambiguation.typeSignature(parameterTypes: [], returnTypes: nil).suffix
+                == "-()")
+        #expect(Disambiguation.typeSignature(parameterTypes: ["Int"], returnTypes: nil).suffix
+                == "-(Int)")
+        #expect(Disambiguation.typeSignature(parameterTypes: ["Int", "_", "String"], returnTypes: nil).suffix
+                == "-(Int,_,String)")
         
-        XCTAssertEqual(Disambiguation.typeSignature(parameterTypes: nil, returnTypes: []).suffix,
-                       "->()")
-        XCTAssertEqual(Disambiguation.typeSignature(parameterTypes: nil, returnTypes: ["Int"]).suffix,
-                       "->Int")
-        XCTAssertEqual(Disambiguation.typeSignature(parameterTypes: nil, returnTypes: ["Int", "_", "String"]).suffix,
-                       "->(Int,_,String)")
+        #expect(Disambiguation.typeSignature(parameterTypes: nil, returnTypes: []).suffix
+                == "->()")
+        #expect(Disambiguation.typeSignature(parameterTypes: nil, returnTypes: ["Int"]).suffix
+                == "->Int")
+        #expect(Disambiguation.typeSignature(parameterTypes: nil, returnTypes: ["Int", "_", "String"]).suffix
+                == "->(Int,_,String)")
         
-        XCTAssertEqual(Disambiguation.typeSignature(parameterTypes: ["_", "Bool"], returnTypes: []).suffix,
-                       "-(_,Bool)->()")
-        XCTAssertEqual(Disambiguation.typeSignature(parameterTypes: ["_", "Bool"], returnTypes: ["Int"]).suffix,
-                       "-(_,Bool)->Int")
-        XCTAssertEqual(Disambiguation.typeSignature(parameterTypes: ["_", "Bool"], returnTypes: ["Int", "_", "String"]).suffix,
-                       "-(_,Bool)->(Int,_,String)")
+        #expect(Disambiguation.typeSignature(parameterTypes: ["_", "Bool"], returnTypes: []).suffix
+                == "-(_,Bool)->()")
+        #expect(Disambiguation.typeSignature(parameterTypes: ["_", "Bool"], returnTypes: ["Int"]).suffix
+                == "-(_,Bool)->Int")
+        #expect(Disambiguation.typeSignature(parameterTypes: ["_", "Bool"], returnTypes: ["Int", "_", "String"]).suffix
+                == "-(_,Bool)->(Int,_,String)")
     }
     
-    func testParsingDisambiguationSuffixStrings() throws {
-        for disambiguationSuffixString in [
-            "",
-            "-class",
-            "-z3jl",
-            
-            "-()",
-            "-(Int)",
-            "-(Int,_,String)",
-            
-            "->()",
-            "->Int",
-            "->(Int,_,String)",
-            
-            "-(_,Bool)->()",
-            "-(_,Bool)->Int",
-            "-(_,Bool)->(Int,_,String)",
-        ] {
-            let parsedLinkComponent = try XCTUnwrap(LinkCompletionTools.parse(linkString: "SymbolName\(disambiguationSuffixString)").first)
-            XCTAssertEqual(parsedLinkComponent.disambiguation.suffix, disambiguationSuffixString)
-        }
+    @Test(arguments: [
+        "",
+        "-class",
+        "-z3jl",
+        
+        "-()",
+        "-(Int)",
+        "-(Int,_,String)",
+        
+        "->()",
+        "->Int",
+        "->(Int,_,String)",
+        
+        "-(_,Bool)->()",
+        "-(_,Bool)->Int",
+        "-(_,Bool)->(Int,_,String)",
+    ])
+    func parsingDisambiguationSuffixStrings(_ disambiguationSuffixString: String) throws {
+        let parsedLinkComponent = try #require(LinkCompletionTools.parse(linkString: "SymbolName\(disambiguationSuffixString)").first)
+        #expect(parsedLinkComponent.disambiguation.suffix == disambiguationSuffixString)
     }
 
-    func testSuggestingBothParameterAndReturnTypesInTheSameDisambiguation() {
+    @Test
+    func suggestingBothParameterAndReturnTypesInTheSameDisambiguation() {
         let overloads = [
             (parameters: ["Int"],  returns: []),      // (Int)  -> Void
             (parameters: ["Bool"], returns: []),      // (Bool) -> Void
@@ -231,14 +233,15 @@ class LinkCompletionToolsTests: XCTestCase {
             )
         }
         
-        XCTAssertEqual(LinkCompletionTools.suggestedDisambiguation(forCollidingSymbols: overloads), [
+        #expect(LinkCompletionTools.suggestedDisambiguation(forCollidingSymbols: overloads) == [
             "-(Int)->()", // Only parameter type would be ambiguous with 3rd overload & only return type would be ambiguous with 2nd overload.
             "-(Bool)",    // The only overload with a `Bool` value
             "->_",        // The only overload that returns something
         ])
     }
     
-    func testRemovesWhitespaceFromTypeSignatureDisambiguation() {
+    @Test
+    func removesWhitespaceFromTypeSignatureDisambiguation() {
         let overloads = [
             // The caller included whitespace in these closure type spellings but the DocC disambiguation won't include this whitespace.
             (parameters: ["(Int) -> Int"],  returns: []), // ((Int)  -> Int)  -> Void
@@ -252,7 +255,7 @@ class LinkCompletionToolsTests: XCTestCase {
             )
         }
         
-        XCTAssertEqual(LinkCompletionTools.suggestedDisambiguation(forCollidingSymbols: overloads), [
+        #expect(LinkCompletionTools.suggestedDisambiguation(forCollidingSymbols: overloads) == [
             // Both parameters require the only parameter type as disambiguation. The suggested disambiguation shouldn't contain extra whitespace.
             "-((Int)->Int)",
             "-((Bool)->())",

--- a/Tests/SwiftDocCTests/Infrastructure/Symbol Link Resolution/LinkCompletionToolsTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/Symbol Link Resolution/LinkCompletionToolsTests.swift
@@ -164,6 +164,20 @@ struct LinkCompletionToolsTests {
     }
     
     @Test
+    func suggestsProvidedHashesAsDisambiguationEvenWhenInvalidHashes() {
+        let invalidHashes = [
+            "1+2+3",         // "+" is not allowed in a symbol ID hash
+            "ABCDE",         // uppercase letters are not allowed in a symbol ID hash
+            "somelongstring" // symbol ID hashes cannot be longer than 5 characters
+        ]
+        
+        let collidingSymbols = invalidHashes.map {
+            LinkCompletionTools.SymbolInformation(kind: "class", symbolIDHash: $0, parameterTypes: nil, returnTypes: nil)
+        }
+        #expect(LinkCompletionTools.suggestedDisambiguation(forCollidingSymbols: collidingSymbols) == invalidHashes.map { "-\($0)" })
+    }
+    
+    @Test
     func formattingDisambiguationSuffixStrings() {
         typealias Disambiguation = LinkCompletionTools.ParsedDisambiguation
         


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

This updates the `LinkCompletionTools` tests to use Swift Testing and adds one test to cover a behavior of the current implementation to guard against potential future regressions.

## Dependencies

None

## Testing

Nothing in particular. This isn't a user-facing change.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
