### PR TITLE
Don't warn about DeprecationSummary when symbol is partially deprecated

### DIFF
--- a/Sources/SwiftDocC/Model/DocumentationNode.swift
+++ b/Sources/SwiftDocC/Model/DocumentationNode.swift
@@ -930,7 +930,7 @@ public struct DocumentationNode {
             .union(availabilityFromDirectives.available.map(\.platform.rawValue))
             .subtracting(deprecatedDomainNames)
         
-        guard isUnconditionallyAvailable || !availableDomainNames.isEmpty || deprecatedDomainNames.isEmpty else {
+        guard deprecatedDomainNames.isEmpty, isUnconditionallyAvailable || !availableDomainNames.isEmpty else {
             return
         }
         
@@ -1022,7 +1022,7 @@ public struct DocumentationNode {
                 // Not sure what solution we can offer for unconditional available symbols in languages other than Swift and C-family languages.
             }
         } else {
-            let platformNamesDescription = availableDomainNames.sorted().map(\.singleQuoted).list(finalConjunction: .and)
+            let platformNamesDescription = availableDomainNames.sorted().map(\.singleQuoted).list(finalConjunction: .or)
             if let inSourceAttributeDescription {
                 solutions.append(Solution(
                     summary: "Add \(inSourceAttributeDescription)\(availableDomainNames.count > 1 ? "s" : "") marking \(platformNamesDescription) as deprecated API",

--- a/Sources/SwiftDocC/Model/DocumentationNode.swift
+++ b/Sources/SwiftDocC/Model/DocumentationNode.swift
@@ -987,11 +987,21 @@ public struct DocumentationNode {
             explanation = makeExplanation(availabilityDescription: longAvailabilityDescription)
         }
         
+        func offsetIfNeeded(_ range: SourceRange) -> SourceRange {
+            guard range.source == inSourceDocumentationChunk?.url, let offset = inSourceDocumentationChunk?.offset else {
+                return range
+            }
+            // Diagnostics from an in-source documentation comment need to be offset based on the location of that documentation comment.
+            var range = range
+            range.offsetWithRange(offset)
+            return range
+        }
+        
         let notes: [Diagnostic.Note] = metadata?.availability.compactMap { availability -> Diagnostic.Note? in
             guard availability.deprecated == nil, let range = availability.originalMarkup.range, let source = range.source else {
                 return nil
             }
-            return .init(source: source, range: range, message: "Marked available for '\(availability.platform.rawValue)' here")
+            return .init(source: source, range: offsetIfNeeded(range), message: "Marked available for '\(availability.platform.rawValue)' here")
         } ?? []
         
         
@@ -1025,7 +1035,7 @@ public struct DocumentationNode {
             ))
         }
         
-        let range = deprecationSummaryDirective.range
+        let range = deprecationSummaryDirective.range.map(offsetIfNeeded)
         engine.emit(
             Diagnostic(
                 source: range?.source,

--- a/Tests/SwiftDocCTests/Model/AvailabilityTests.swift
+++ b/Tests/SwiftDocCTests/Model/AvailabilityTests.swift
@@ -1271,7 +1271,9 @@ struct AvailabilityTests {
             }
         }
         let context = try await load(catalog: catalog)
-        #expect(context.diagnostics.map(\.identifier) == ["DeprecationSummaryForAvailableSymbol"], "Unexpected problems: \(context.diagnostics.map(\.summary))")
+        try withKnownIssue("The DeprecationSummary validation doesn't know about default availability from the Info.plist", {
+            #expect(context.diagnostics.map(\.identifier) == ["DeprecationSummaryForAvailableSymbol"], "Unexpected problems: \(context.diagnostics.map(\.summary))")
+        }, when: { availabilitySource == .infoPlist })
         let node = try #require(context.documentationCache["some-symbol-id"])
         let converter = DocumentationContextConverter(context: context, renderContext: .init(documentationContext: context))
         let renderNode = try #require(converter.renderNode(for: node))

--- a/Tests/SwiftDocCTests/Model/DeprecationSummaryTests.swift
+++ b/Tests/SwiftDocCTests/Model/DeprecationSummaryTests.swift
@@ -155,6 +155,16 @@ struct DeprecationSummaryTests {
         let renderNode = converter.convert(node)
         
         #expect(renderNode.deprecationSummary?.firstParagraph == [.text("Some description, from the directive, of why this protocol is deprecated.")])
+        
+        let range  = try #require(diagnostic.range)
+        switch directiveLocation {
+        case .extensionFile:
+            #expect(range.lowerBound.line   ==  5)
+            #expect(range.lowerBound.column ==  1)
+        case .inSourceComment:
+            #expect(range.lowerBound.line   == 14)
+            #expect(range.lowerBound.column == 18)
+        }
     }
     
     @Test(arguments: DirectiveLocation.allCases)

--- a/Tests/SwiftDocCTests/Model/DeprecationSummaryTests.swift
+++ b/Tests/SwiftDocCTests/Model/DeprecationSummaryTests.swift
@@ -128,7 +128,9 @@ struct DeprecationSummaryTests {
                     Some in-source documentation with a deprecation summary for this type alias
                     
                     \(directiveLocation == .inSourceComment ? Self.deprecationSummaryDirective : "")
-                    """, availability: []) // No availability attributes for this symbol
+                    """, availability: [
+                        .init(domainName: nil, introduced: nil, deprecated: nil) // Unconditionally available for all versions of all platforms
+                    ])
             ])),
             
             TextFile(name: "SomeTypeAlias.md", utf8Content: """
@@ -168,7 +170,7 @@ struct DeprecationSummaryTests {
     }
     
     @Test(arguments: DirectiveLocation.allCases)
-    func warnsAboutDeprecationSummaryIfSymbolIsOnlyPartiallyDeprecated(_ directiveLocation: DirectiveLocation) async throws {
+    func warnsAboutDeprecationSummaryIfSymbolIsExplicitlyAvailable(_ directiveLocation: DirectiveLocation) async throws {
         let catalog = Folder(name: "unit-test.docc", content: [
             JSONFile(name: "SomeModule.symbols.json", content: makeSymbolGraph(moduleName: "SomeModule", symbols: [
                 makeSymbol(id: "some-symbol-id", kind: .typealias, pathComponents: ["SomeTypeAlias"], docComment: """
@@ -176,9 +178,8 @@ struct DeprecationSummaryTests {
                     
                     \(directiveLocation == .inSourceComment ? Self.deprecationSummaryDirective : "")
                     """, availability: [
-                        Self.makeInSourceAvailabilityInfo(domain: "FirstPlatform",                                                   deprecated: .init(major: 4, minor: 5, patch: 6)),
-                        Self.makeInSourceAvailabilityInfo(domain: "SecondPlatform", introduced: .init(major: 1, minor: 2, patch: 3), deprecated: nil),
-                        Self.makeInSourceAvailabilityInfo(domain: "ThirdPlatform",  introduced: nil,                                 deprecated: nil),
+                        Self.makeInSourceAvailabilityInfo(domain: "FirstPlatform",  introduced: .init(major: 1, minor: 2, patch: 3), deprecated: nil),
+                        Self.makeInSourceAvailabilityInfo(domain: "SecondPlatform", introduced: nil,                                 deprecated: nil),
                     ])
             ])),
             
@@ -197,8 +198,8 @@ struct DeprecationSummaryTests {
                 "Unexpected problems: \(context.diagnostics.map(\.summary))")
         
         let diagnostic = try #require(context.diagnostics.first)
-        #expect(diagnostic.summary == "Type alias 'SomeTypeAlias' is available for SecondPlatform and ThirdPlatform")
-        #expect(diagnostic.explanation == "This type alias has attributes that mark it as available for 'SecondPlatform' 1.2.3 onwards and all versions of 'ThirdPlatform'.")
+        #expect(diagnostic.summary == "Type alias 'SomeTypeAlias' is available for FirstPlatform and SecondPlatform")
+        #expect(diagnostic.explanation == "This type alias has attributes that mark it as available for 'FirstPlatform' 1.2.3 onwards and all versions of 'SecondPlatform'.")
         
         // Verify that DocC still displays the deprecation text, despite the symbol being available.
         let node = try #require(context.documentationCache["some-symbol-id"])
@@ -206,6 +207,33 @@ struct DeprecationSummaryTests {
         let renderNode = converter.convert(node)
         
         #expect(renderNode.deprecationSummary?.firstParagraph == [.text("Some description, from the directive, of why this protocol is deprecated.")])
+    }
+    
+    @Test(arguments: DirectiveLocation.allCases)
+    func doesNotWarnAboutDeprecationSummaryIfSymbolIsPartiallyDeprecated(_ directiveLocation: DirectiveLocation) async throws {
+        let catalog = Folder(name: "unit-test.docc", content: [
+            JSONFile(name: "SomeModule.symbols.json", content: makeSymbolGraph(moduleName: "SomeModule", symbols: [
+                makeSymbol(id: "some-symbol-id", kind: .typealias, pathComponents: ["SomeTypeAlias"], docComment: """
+                    Some in-source documentation with a deprecation summary for this type alias
+                    
+                    \(directiveLocation == .inSourceComment ? Self.deprecationSummaryDirective : "")
+                    """, availability: [
+                        Self.makeInSourceAvailabilityInfo(domain: "FirstPlatform",  introduced: nil,                                 deprecated: .init(major: 4, minor: 5, patch: 6)),
+                        Self.makeInSourceAvailabilityInfo(domain: "SecondPlatform", introduced: .init(major: 1, minor: 2, patch: 3), deprecated: nil),
+                    ])
+            ])),
+            
+            TextFile(name: "SomeTypeAlias.md", utf8Content: """
+            # ``SomeTypeAlias``
+            
+            Some additional documentation for this type alias.
+            
+            \(directiveLocation == .extensionFile ? Self.deprecationSummaryDirective : "")
+            """)
+        ])
+        
+        let context = try await load(catalog: catalog)
+        #expect(context.diagnostics.map(\.identifier) == [], "Unexpected problems: \(context.diagnostics.map(\.summary))")
     }
     
     @Test(arguments: DirectiveLocation.allCases, [
@@ -259,7 +287,7 @@ struct DeprecationSummaryTests {
         \(Self.deprecationSummaryDirective)
         @Metadata {
           @Available(PlatformB, introduced: "2.3.4")
-          @Available(PlatformD, introduced: "3.4.5")
+          @Available(PlatformC, introduced: "3.4.5")
         }
         """
         
@@ -270,9 +298,8 @@ struct DeprecationSummaryTests {
                     
                     \(directiveLocation == .inSourceComment ? directives : "")
                     """, availability: [
-                        Self.makeInSourceAvailabilityInfo(domain: "PlatformA",                                                  deprecated: .init(major: 4, minor: 5, patch: 6)),
+                        Self.makeInSourceAvailabilityInfo(domain: "PlatformA",                                                  deprecated: nil),
                         Self.makeInSourceAvailabilityInfo(domain: "PlatformB", introduced: .init(major: 1, minor: 2, patch: 3), deprecated: nil),
-                        Self.makeInSourceAvailabilityInfo(domain: "PlatformC", introduced: nil,                                 deprecated: nil),
                     ])
             ])),
             
@@ -291,8 +318,8 @@ struct DeprecationSummaryTests {
                 "Unexpected problems: \(context.diagnostics.map(\.summary))")
         
         let diagnostic = try #require(context.diagnostics.first)
-        #expect(diagnostic.summary == "Type alias 'SomeTypeAlias' is available for PlatformB, PlatformC, and PlatformD")
-        #expect(diagnostic.explanation == "This type alias has attributes that mark it as available for 'PlatformB' 2.3.4 onwards, all versions of 'PlatformC', and 'PlatformD' 3.4.5 onwards.")
+        #expect(diagnostic.summary == "Type alias 'SomeTypeAlias' is available for PlatformA, PlatformB, and PlatformC")
+        #expect(diagnostic.explanation == "This type alias has attributes that mark it as available for 'PlatformA' 1.2.3 onwards, 'PlatformB' 2.3.4 onwards, and 'PlatformC' 3.4.5 onwards.")
         
         // Verify that the notes refer to the Available directives
         let expectedSource = switch directiveLocation {
@@ -302,7 +329,7 @@ struct DeprecationSummaryTests {
         #expect(diagnostic.notes.map(\.source.path) == [expectedSource, expectedSource])
         #expect(diagnostic.notes.map(\.message) == [
             "Marked available for 'PlatformB' here",
-            "Marked available for 'PlatformD' here",
+            "Marked available for 'PlatformC' here",
         ])
         
         // Verify that the solutions suggest marking the available platforms as deprecated using both attributes (preferred) and directives
@@ -313,62 +340,15 @@ struct DeprecationSummaryTests {
         }
         #expect(diagnostic.solutions.count == (expectedSourceAttribute != nil ? 2 : 1))
         if let expectedSourceAttribute {
-            #expect(diagnostic.solutions.first?.summary == "Add \(expectedSourceAttribute) marking 'PlatformB', 'PlatformC', and 'PlatformD' as deprecated API")
+            #expect(diagnostic.solutions.first?.summary == "Add \(expectedSourceAttribute) marking 'PlatformA', 'PlatformB', or 'PlatformC' as deprecated API")
         }
-        #expect(diagnostic.solutions.last?.summary == "Add Available directives marking 'PlatformB', 'PlatformC', and 'PlatformD' as deprecated only in documentation")
+        #expect(diagnostic.solutions.last?.summary == "Add Available directives marking 'PlatformA', 'PlatformB', or 'PlatformC' as deprecated only in documentation")
         // Verify that DocC still displays the deprecation text, despite the symbol being available.
         let node = try #require(context.documentationCache["some-symbol-id"])
         let converter = DocumentationNodeConverter(context: context)
         let renderNode = converter.convert(node)
         
         #expect(renderNode.deprecationSummary?.firstParagraph == [.text("Some description, from the directive, of why this protocol is deprecated.")])
-    }
-    
-    @Test(arguments: DirectiveLocation.allCases)
-    func warningListsDeprecatedPlatformWhenSymbolHasUnconditionalAvailability(_ directiveLocation: DirectiveLocation) async throws {
-        let directives = """
-        \(Self.deprecationSummaryDirective)
-        @Metadata {
-          @Available(PlatformB, introduced: "2.3.4", deprecated: "4.5.6")
-        }
-        """
-        
-        let catalog = Folder(name: "unit-test.docc", content: [
-            JSONFile(name: "SomeModule.symbols.json", content: makeSymbolGraph(moduleName: "SomeModule", symbols: [
-                makeSymbol(id: "some-symbol-id", kind: .typealias,  pathComponents: ["SomeTypeAlias"], docComment: """
-                    Some in-source documentation with a deprecation summary for this type alias
-                    
-                    \(directiveLocation == .inSourceComment ? directives : "")
-                    """, availability: [
-                        Self.makeInSourceAvailabilityInfo(domain: nil,         introduced: nil, deprecated: nil), // Available on all platforms except where explicitly marked as deprecated
-                        Self.makeInSourceAvailabilityInfo(domain: "PlatformA", introduced: nil, deprecated: .init(major: 3, minor: 4, patch: 5)),
-                    ])
-            ])),
-            
-            TextFile(name: "SomeTypeAlias.md", utf8Content: """
-            # ``SomeTypeAlias``
-            
-            Some additional documentation for this type alias.
-               
-            \(directiveLocation == .extensionFile ? directives : "")
-            """)
-        ])
-        
-        let context = try await load(catalog: catalog)
-        // Verify the warning
-        #expect(context.diagnostics.map(\.identifier) == ["DeprecationSummaryForAvailableSymbol"],
-                "Unexpected problems: \(context.diagnostics.map(\.summary))")
-        
-        let diagnostic = try #require(context.diagnostics.first)
-        #expect(diagnostic.summary == "Type alias 'SomeTypeAlias' is available for all platforms, except PlatformA and PlatformB")
-        #expect(diagnostic.explanation == "This type alias has attributes that mark it as available for all platforms, except PlatformA and PlatformB.")
-        
-        #expect(diagnostic.notes.map(\.message) == [], "Only deprecated platforms, not available ones, are defined in Available directives")
-        
-        // Verify that the solutions suggest modifying the wildcard availability attribute
-        #expect(diagnostic.solutions.count == 1)
-        let solution = try #require(diagnostic.solutions.first)
-        #expect(solution.summary == "Update wildcard '@available()' attribute with a deprecated version or unconditional deprecation")
     }
     
     @Test

--- a/Tests/SwiftDocCTests/Semantics/SymbolTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/SymbolTests.swift
@@ -1264,7 +1264,7 @@ class SymbolTests: XCTestCase {
             extensionFileContent: nil
         )
         
-        XCTAssertEqual(diagnostics.map(\.identifier), ["DeprecationSummaryForAvailableSymbol"], "Unexpected diagnostics: \(diagnostics.map(\.summary))")
+        XCTAssert(diagnostics.isEmpty, "Unexpected diagnostics: \(diagnostics.map(\.summary))")
         
         XCTAssertEqual(
             (node.semantic as? Symbol)?


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://178260666

## Summary

This updates the warning about using a `DeprecationSummary` directive for an available symbol to _not_ raise that warning if the symbol is deprecated for _any_ of its available platforms. This matches the general behavior where a symbol is considered deprecated if it's deprecated for _any_ platform (as opposed to for _all_ platforms).

This also fixes a bug where the source location of `DeprecationSummary` didn't account for the start location of a symbol's documentation comment, resulting in the warning displaying somewhere very early in the same file (potentially very far from the markup that caused the warning—and possibly not even in any documentation comment).

## Dependencies

None.

## Testing

- Add a `DeprecationSummary` directive for a symbol that's marked as available for one platform. 
  - DocC should warn about the use of that directive for an available symbol
- Add another `@availability` annotation that marks the symbol as deprecated for some _other_ platform.
  -  DocC should no longer warn about the use of that directive, because the symbol is deprecated for _one_ of its platforms.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
