### PR TITLE
Fix versionless Catalyst fallback availability

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -173,6 +173,9 @@ public class DocumentationContext {
     /// The unsuccessful links are tracked so that the context doesn't attempt to re-resolve the unsuccessful links during rendering which runs concurrently for each page.
     var externallyResolvedLinks = [ValidatedURL: TopicReferenceResolutionResult]()
     
+    /// The set of symbol graph platforms registered for each module.
+    private(set) var registeredPlatformsPerModule: [String: Set<PlatformName>] = [:]
+    
     /// A temporary structure to hold a semantic value that hasn't yet had its links resolved.
     ///
     /// These temporary values are only expected to exist while the documentation is being built. Once the documentation bundles have been fully registered and the topic graph
@@ -2030,6 +2033,7 @@ public class DocumentationContext {
             try signposter.withIntervalSignpost("Load symbols", id: signposter.makeSignpostID()) {
                 try autoreleasepool {
                     try symbolGraphLoader.loadAll()
+                    registeredPlatformsPerModule = symbolGraphLoader.platformsFoundInSymbolGraphsByModule
                 }
             }
             try shouldContinueRegistration()

--- a/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphLoader.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphLoader.swift
@@ -25,6 +25,7 @@ struct SymbolGraphLoader {
     private(set) var snippetSymbolGraphs: [URL: SymbolKit.SymbolGraph] = [:]
     private(set) var unifiedGraphs: [String: SymbolKit.UnifiedSymbolGraph] = [:]
     private(set) var graphLocations: [String: [SymbolKit.GraphCollector.GraphKind]] = [:]
+    private(set) var platformsFoundInSymbolGraphsByModule: [String: Set<PlatformName>] = [:]
     private let dataProvider: any DataProvider
     private let bundle: DocumentationBundle
     private let symbolGraphTransformer: ((inout SymbolGraph) -> ())?
@@ -148,11 +149,12 @@ struct SymbolGraphLoader {
                 defaultUnavailablePlatforms = unavailablePlatforms.map(\.platformName)
                 defaultAvailableInformation = availablePlatforms
             }
-            
             let platformsFoundInSymbolGraphs: [PlatformName] = unifiedGraph.moduleData.compactMap {
                 guard let platformName = $0.value.platform.name else { return nil }
                 return PlatformName(operatingSystemName: platformName)
             }
+            
+            platformsFoundInSymbolGraphsByModule[unifiedGraph.moduleName] = Set(platformsFoundInSymbolGraphs)
 
             addMissingAvailability(
                 unifiedGraph: &unifiedGraph,

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -1376,7 +1376,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
                 }
                 
                 func addFallbackIfNeeded(named name: String) {
-                    guard information[name] == nil, !unavailableDefaultPlatformNames.contains(name) else {
+                    guard information[name]?.introduced == nil, !unavailableDefaultPlatformNames.contains(name) else {
                         return
                     }
                     var copy = iOSAvailability

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -1384,6 +1384,8 @@ public struct RenderNodeTranslator: SemanticVisitor {
                     information[name] = copy
                 }
                 addFallbackIfNeeded(named: PlatformName.iPadOS.displayName)
+                
+                // FIXME: Move this logic out of the rendering code (rdar://172280267)
                 let catalystSGFExists = context.registeredPlatformsPerModule[moduleName.symbolName]?.contains(.catalyst) ?? false
                 let symbolExistsInCatalystSymbolGraph = information[PlatformName.catalyst.displayName] != nil
                 

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -1384,7 +1384,16 @@ public struct RenderNodeTranslator: SemanticVisitor {
                     information[name] = copy
                 }
                 addFallbackIfNeeded(named: PlatformName.iPadOS.displayName)
-                addFallbackIfNeeded(named: PlatformName.catalyst.displayName)
+                let symbolAvailabilityContainsMacCatalyst = inSourceAvailability.availability.contains(where: {
+                    $0.domain?.rawValue == SymbolGraph.Symbol.Availability.Domain.macCatalyst
+                })
+                let catalystSGFExists = context.registeredPlatformsPerModule[moduleName.symbolName]?.contains(.catalyst) ?? false
+                
+                // Only inherit iOS if the Catalyst SGF don't define availability
+                // or if there's no catalyst SGF at all.
+                if symbolAvailabilityContainsMacCatalyst || !catalystSGFExists {
+                    addFallbackIfNeeded(named: PlatformName.catalyst.displayName)
+                }
             }
             
             // Lastly, remove any inferred or default information for platforms that were marked explicitly unavailable.

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -1384,14 +1384,14 @@ public struct RenderNodeTranslator: SemanticVisitor {
                     information[name] = copy
                 }
                 addFallbackIfNeeded(named: PlatformName.iPadOS.displayName)
-                let symbolAvailabilityContainsMacCatalyst = inSourceAvailability.availability.contains(where: {
-                    $0.domain?.rawValue == SymbolGraph.Symbol.Availability.Domain.macCatalyst
-                })
                 let catalystSGFExists = context.registeredPlatformsPerModule[moduleName.symbolName]?.contains(.catalyst) ?? false
+                let symbolExistsInCatalystSymbolGraph = information[PlatformName.catalyst.displayName] != nil
                 
-                // Only inherit iOS if the Catalyst SGF don't define availability
-                // or if there's no catalyst SGF at all.
-                if symbolAvailabilityContainsMacCatalyst || !catalystSGFExists {
+                // Catalyst only inherits iOS availability if the symbol don't specify in-source
+                // availability or if there's none Mac Catalyst symbol graph.
+                // If the symbol is not present in the Catalyst SGF then is not availble for this
+                // platform.
+                if (catalystSGFExists && symbolExistsInCatalystSymbolGraph) || !catalystSGFExists  {
                     addFallbackIfNeeded(named: PlatformName.catalyst.displayName)
                 }
             }

--- a/Tests/SwiftDocCTests/Model/AvailabilityTests.swift
+++ b/Tests/SwiftDocCTests/Model/AvailabilityTests.swift
@@ -350,6 +350,153 @@ struct AvailabilityTests {
         #expect(renderPlatforms.first(where: { $0.name == "Mac Catalyst" })?.introduced ==  "6.5")
     }
     
+    @Test
+    func catalystInheritsAvailabilityIfDefaulAvailabilityIsVersionless() async throws {
+        let catalog = Folder(name: "unit-test.docc") {
+            for (domainName, environment, introducedVersion) in [
+                ("iOS",         nil,      SymbolGraph.SemanticVersion(major: 12, minor: 0, patch: 0)),
+                ("macCatalyst", "macabi", nil)
+            ] {
+                JSONFile(name: "ModuleName-\(domainName).symbols.json", content: makeSymbolGraph(moduleName: "ModuleName", platform: .init(operatingSystem: .init(name: "ios"), environment: environment), symbols: [
+                    makeSymbol(id: "some-symbol-id", kind: .class, pathComponents: ["SomeClass"], availability: [
+                        .init(domainName: domainName, introduced: introducedVersion, deprecated: nil)
+                    ])
+                ]))
+            }
+            InfoPlist(defaultAvailability: ["ModuleName": [
+                .init(platformName: .iOS, platformVersion: nil),
+                .init(platformName: .iPadOS, platformVersion: nil),
+                .init(platformName: .catalyst, platformVersion: nil)
+            ]])
+        }
+        let context = try await load(catalog: catalog)
+        let node = try #require(context.documentationCache["some-symbol-id"])
+        let converter = DocumentationContextConverter(context: context, renderContext: .init(documentationContext: context))
+        let renderNode = try #require(converter.renderNode(for: node))
+        
+        let renderPlatforms = try #require(renderNode.metadata.platforms)
+        #expect(renderPlatforms.compactMap(\.name) == ["iOS", "iPadOS", "Mac Catalyst"])
+        
+        #expect(renderPlatforms.first(where: { $0.name == "iOS"          })?.introduced == "12.0")
+        #expect(renderPlatforms.first(where: { $0.name == "iPadOS"       })?.introduced == "12.0")
+        #expect(renderPlatforms.first(where: { $0.name == "Mac Catalyst" })?.introduced ==  "12.0")
+    }
+    
+    @Test
+    func catalystDoesNotInheritsAvailabilityIfItsNotVersionless() async throws {
+        let catalog = Folder(name: "unit-test.docc") {
+            for (domainName, environment, introducedVersion) in [
+                ("iOS",         nil,      SymbolGraph.SemanticVersion(major: 12, minor: 0, patch: 0)),
+                ("macCatalyst", "macabi", SymbolGraph.SemanticVersion(major: 1, minor: 2, patch: 3))
+            ] {
+                JSONFile(name: "ModuleName-\(domainName).symbols.json", content: makeSymbolGraph(moduleName: "ModuleName", platform: .init(operatingSystem: .init(name: "ios"), environment: environment), symbols: [
+                    makeSymbol(id: "some-symbol-id", kind: .class, pathComponents: ["SomeClass"], availability: [
+                        .init(domainName: domainName, introduced: introducedVersion, deprecated: nil)
+                    ])
+                ]))
+            }
+            InfoPlist(defaultAvailability: ["ModuleName": [
+                .init(platformName: .iOS, platformVersion: nil),
+                .init(platformName: .iPadOS, platformVersion: nil),
+                .init(platformName: .catalyst, platformVersion: nil)
+            ]])
+        }
+        let context = try await load(catalog: catalog)
+        let node = try #require(context.documentationCache["some-symbol-id"])
+        let converter = DocumentationContextConverter(context: context, renderContext: .init(documentationContext: context))
+        let renderNode = try #require(converter.renderNode(for: node))
+        
+        let renderPlatforms = try #require(renderNode.metadata.platforms)
+        #expect(renderPlatforms.compactMap(\.name) == ["iOS", "iPadOS", "Mac Catalyst"])
+        
+        #expect(renderPlatforms.first(where: { $0.name == "iOS"          })?.introduced == "12.0")
+        #expect(renderPlatforms.first(where: { $0.name == "iPadOS"       })?.introduced == "12.0")
+        #expect(renderPlatforms.first(where: { $0.name == "Mac Catalyst" })?.introduced ==  "1.2.3")
+    }
+    
+    @Test
+    func catalystDoesNotInheritsAvailabilityIfItHasDefaultAvailability() async throws {
+        let catalog = Folder(name: "unit-test.docc") {
+            for (domainName, environment, introducedVersion) in [
+                ("iOS",         nil,      SymbolGraph.SemanticVersion(major: 12, minor: 0, patch: 0)),
+                ("macCatalyst", "macabi", nil)
+            ] {
+                JSONFile(name: "ModuleName-\(domainName).symbols.json", content: makeSymbolGraph(moduleName: "ModuleName", platform: .init(operatingSystem: .init(name: "ios"), environment: environment), symbols: [
+                    makeSymbol(id: "some-symbol-id", kind: .class, pathComponents: ["SomeClass"], availability: [
+                        .init(domainName: domainName, introduced: introducedVersion, deprecated: nil)
+                    ])
+                ]))
+            }
+            InfoPlist(defaultAvailability: ["ModuleName": [
+                .init(platformName: .iOS, platformVersion: nil),
+                .init(platformName: .iPadOS, platformVersion: nil),
+                .init(platformName: .catalyst, platformVersion: "1.2.3")
+            ]])
+        }
+        let context = try await load(catalog: catalog)
+        let node = try #require(context.documentationCache["some-symbol-id"])
+        let converter = DocumentationContextConverter(context: context, renderContext: .init(documentationContext: context))
+        let renderNode = try #require(converter.renderNode(for: node))
+        
+        let renderPlatforms = try #require(renderNode.metadata.platforms)
+        #expect(renderPlatforms.compactMap(\.name) == ["iOS", "iPadOS", "Mac Catalyst"])
+        
+        #expect(renderPlatforms.first(where: { $0.name == "iOS"          })?.introduced == "12.0")
+        #expect(renderPlatforms.first(where: { $0.name == "iPadOS"       })?.introduced == "12.0")
+        #expect(renderPlatforms.first(where: { $0.name == "Mac Catalyst" })?.introduced ==  "1.2.3")
+    }
+    
+    @Test
+    func catalystInheritsAvailabilityIfITheresNoCatalystSGF() async throws {
+        let catalog = Folder(name: "unit-test.docc") {
+            JSONFile(name: "ModuleName-ios.symbols.json", content: makeSymbolGraph(moduleName: "ModuleName", platform: .init(operatingSystem: .init(name: "ios"), environment: nil), symbols: [
+                makeSymbol(id: "some-symbol-id", kind: .class, pathComponents: ["SomeClass"], availability: [
+                    .init(domainName: "ios", introduced: SymbolGraph.SemanticVersion(major: 12, minor: 0, patch: 0), deprecated: nil)
+                ])
+            ]))
+            InfoPlist(defaultAvailability: ["ModuleName": [
+                .init(platformName: .iOS, platformVersion: nil),
+                .init(platformName: .iPadOS, platformVersion: nil),
+                .init(platformName: .catalyst, platformVersion: nil)
+            ]])
+        }
+        let context = try await load(catalog: catalog)
+        let node = try #require(context.documentationCache["some-symbol-id"])
+        let converter = DocumentationContextConverter(context: context, renderContext: .init(documentationContext: context))
+        let renderNode = try #require(converter.renderNode(for: node))
+        
+        let renderPlatforms = try #require(renderNode.metadata.platforms)
+        #expect(renderPlatforms.compactMap(\.name) == ["iOS", "iPadOS", "Mac Catalyst"])
+        
+        #expect(renderPlatforms.first(where: { $0.name == "iOS"          })?.introduced == "12.0")
+        #expect(renderPlatforms.first(where: { $0.name == "iPadOS"       })?.introduced == "12.0")
+        #expect(renderPlatforms.first(where: { $0.name == "Mac Catalyst" })?.introduced ==  "12.0")
+    }
+    
+    @Test
+    func catalystDoesNotInheritsAvailabilityIfItDoesntExistsInCatalystSGF() async throws {
+        let catalog = Folder(name: "unit-test.docc") {
+            JSONFile(name: "ModuleName-Catalyst.symbols.json", content: makeSymbolGraph(moduleName: "ModuleName", platform: .init(operatingSystem: .init(name: "ios"), environment: "macabi"), symbols: []))
+            JSONFile(name: "ModuleName-ios.symbols.json", content: makeSymbolGraph(moduleName: "ModuleName", platform: .init(operatingSystem: .init(name: "ios"), environment: nil), symbols: [
+                makeSymbol(id: "some-symbol-id", kind: .class, pathComponents: ["SomeClass"], availability: [
+                    .init(domainName: "ios", introduced: SymbolGraph.SemanticVersion(major: 12, minor: 0, patch: 0), deprecated: nil)
+                ])
+            ]))
+            InfoPlist(defaultAvailability: ["ModuleName": [
+                .init(platformName: .iOS, platformVersion: nil),
+                .init(platformName: .iPadOS, platformVersion: nil),
+                .init(platformName: .catalyst, platformVersion: nil)
+            ]])
+        }
+        let context = try await load(catalog: catalog)
+        let node = try #require(context.documentationCache["some-symbol-id"])
+        let converter = DocumentationContextConverter(context: context, renderContext: .init(documentationContext: context))
+        let renderNode = try #require(converter.renderNode(for: node))
+        
+        let renderPlatforms = try #require(renderNode.metadata.platforms)
+        #expect(renderPlatforms.compactMap(\.name) == ["iOS", "iPadOS"])
+    }
+    
     // MARK: Default Availability
     
     @Test

--- a/Tests/SwiftDocCTests/Rendering/SymbolAvailabilityTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/SymbolAvailabilityTests.swift
@@ -116,4 +116,5 @@ class SymbolAvailabilityTests: XCTestCase {
         ])
     }
     
+
 }

--- a/Tests/SwiftDocCTests/Rendering/SymbolAvailabilityTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/SymbolAvailabilityTests.swift
@@ -115,5 +115,4 @@ class SymbolAvailabilityTests: XCTestCase {
             // The availability items that are obsolete are not rendered in the final documentation.
         ])
     }
-    
 }

--- a/Tests/SwiftDocCTests/Rendering/SymbolAvailabilityTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/SymbolAvailabilityTests.swift
@@ -116,5 +116,4 @@ class SymbolAvailabilityTests: XCTestCase {
         ])
     }
     
-
 }


### PR DESCRIPTION
<!--
If you're opening a PR to cherry-pick a change for a release branch, use this template instead:
https://github.com/apple/swift-docc/blob/main/.github/PULL_REQUEST_TEMPLATE/CHERRY_PICK.md
-->

Bug/issue #, if applicable:  178528216

## Summary

1. Mac Catalyst was not applying the inheritance behaviour with iOS
when there was a default availability defined for the platform.

In the case were the default availability does not defines an
introduced version, but there's a version available we can inherit
from, use the inherited version instead of keeping the availability
as versionless.

This only applies for MacCatalyst and iPadOS as there are the only
platforms that have the inheritance mechanism from iOS.

2. Don't inherit from iOS when the symbol is not available in Catalyst

When a Catalyst symbol graph is provided for a module, that graph is the
source of truth for which symbols are available on Catalyst. Symbols
absent from the Catalyst graph should not silently inherit availability
from iOS, since the symbol isn't actually available on Catalyst.

## Dependencies

N/A

## Testing

To test manually:

1. Preview the attached catalog without the fix
2. Assert the Catalyst version is not there for the Greet symbol
3. Apply this diff
4. Assert that the iOS version gets correctly inherited by Mac Catalyst platform

[dummyCatalog.docc.zip](https://github.com/user-attachments/files/28559503/dummyCatalog.docc.zip)

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran the `./bin/test` script and it succeeded
- [X] Updated documentation if necessary
