### PR TITLE
Use GitHub Actions for CI workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/scripts/prebuild.ps1
+++ b/.github/scripts/prebuild.ps1
@@ -1,0 +1,38 @@
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2026 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+#
+
+param (
+    [switch]$SkipAndroid,
+    [switch]$InstallCMake
+)
+
+# winget isn't easily made available in containers, so use chocolatey
+Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
+
+if ($InstallCMake) {
+    choco install -y cmake --installargs 'ADD_CMAKE_TO_PATH=System' --apply-install-arguments-to-dependencies
+    choco install -y ninja
+
+    Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1
+    refreshenv
+
+    # Let swiftc find the path to link.exe in the CMake smoke test
+    $env:Path += ";$(Split-Path -Path "$(& "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" "-latest" -products Microsoft.VisualStudio.Product.BuildTools -find VC\Tools\MSVC\*\bin\HostX64\x64\link.exe)" -Parent)"
+}
+
+if (-not $SkipAndroid) {
+    choco install -y android-ndk
+
+    Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1
+    refreshenv
+
+    # Work around a bug in the package causing the env var to be set incorrectly
+    $env:ANDROID_NDK_ROOT = $env:ANDROID_NDK_ROOT.replace('-windows.zip','')
+}

--- a/.github/scripts/prebuild.sh
+++ b/.github/scripts/prebuild.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2026 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+#
+
+set -e
+
+if [[ $(uname) == Darwin ]] ; then
+    if [[ "$INSTALL_CMAKE" == "1" ]] ; then
+        mkdir -p "$RUNNER_TOOL_CACHE"
+        if ! command -v cmake >/dev/null 2>&1 ; then
+            curl -fsSLO https://github.com/Kitware/CMake/releases/download/v4.1.2/cmake-4.1.2-macos-universal.tar.gz
+            echo '3be85f5b999e327b1ac7d804cbc9acd767059e9f603c42ec2765f6ab68fbd367 cmake-4.1.2-macos-universal.tar.gz' > cmake-4.1.2-macos-universal.tar.gz.sha256
+            sha256sum -c cmake-4.1.2-macos-universal.tar.gz.sha256
+            tar -xf cmake-4.1.2-macos-universal.tar.gz
+            ln -s "$PWD/cmake-4.1.2-macos-universal/CMake.app/Contents/bin/cmake" "$RUNNER_TOOL_CACHE/cmake"
+        fi
+        if ! command -v ninja >/dev/null 2>&1 ; then
+            curl -fsSLO https://github.com/ninja-build/ninja/releases/download/v1.13.1/ninja-mac.zip
+            echo 'da7797794153629aca5570ef7c813342d0be214ba84632af886856e8f0063dd9 ninja-mac.zip' > ninja-mac.zip.sha256
+            sha256sum -c ninja-mac.zip.sha256
+            unzip ninja-mac.zip
+            rm -f ninja-mac.zip
+            mv ninja "$RUNNER_TOOL_CACHE/ninja"
+        fi
+    fi
+elif command -v apt-get >/dev/null 2>&1 ; then # bookworm, noble, jammy
+    export DEBIAN_FRONTEND=noninteractive
+
+    apt-get update -y
+
+    # Build dependencies
+    apt-get install -y libsqlite3-dev libncurses-dev
+
+    # Debug symbols
+    apt-get install -y libc6-dbg
+
+    if [[ "$INSTALL_CMAKE" == "1" ]] ; then
+        apt-get install -y cmake ninja-build
+    fi
+
+    # Android NDK
+    dpkg_architecture="$(dpkg --print-architecture)"
+    if [[ "$SKIP_ANDROID" != "1" ]] && [[ "$dpkg_architecture" == amd64 ]] ; then
+        eval "$(cat /etc/os-release)"
+        case "$VERSION_CODENAME" in
+            bookworm|jammy)
+                : # Not available
+                ;;
+            noble)
+                apt-get install -y google-android-ndk-r26c-installer
+                ;;
+            *)
+                echo "Unable to fetch Android NDK for unknown Linux distribution: $VERSION_CODENAME" >&2
+                exit 1
+        esac
+    else
+        echo "Skipping Android NDK installation on $dpkg_architecture" >&2
+    fi
+elif command -v dnf >/dev/null 2>&1 ; then # rhel-ubi9
+    dnf update -y
+
+    # Build dependencies
+    dnf install -y sqlite-devel ncurses-devel
+
+    # Debug symbols
+    dnf debuginfo-install -y glibc
+elif command -v yum >/dev/null 2>&1 ; then # amazonlinux2
+    yum update -y
+
+    # Build dependencies
+    yum install -y sqlite-devel ncurses-devel
+
+    # Debug symbols
+    yum install -y yum-utils
+    debuginfo-install -y glibc
+fi

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,54 @@
+name: Pull request
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tests:
+    name: Test
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.11
+    with:
+      linux_host_archs: '["x86_64", "aarch64"]'
+      linux_swift_versions: '["nightly-main", "nightly-6.3"]'
+      windows_swift_versions: '["nightly-main", "nightly-6.3"]'
+      # The Windows CI runs are disabled due to issues with file names on Windows.
+      # The CMake build tests for Windows are also not present at the moment.
+      # They can be enabled in the future once Windows CI is fixed.
+      # Related PRs:
+      #
+      # - File names: https://github.com/swiftlang/swift-docc/pull/668
+      # - CMake: https://github.com/swiftlang/swift-docc/pull/1115
+      enable_windows_checks: false
+      enable_macos_checks: true
+  soundness:
+    name: Soundness
+    uses: swiftlang/github-workflows/.github/workflows/soundness.yml@0.0.11
+    with:
+      license_header_check_project_name: "Swift"
+      # The license header check is disabled as it requires a large number of changes.
+      license_header_check_enabled: false
+      # The unacceptable language check is disabled due to conflict with
+      # DocC's own unacceptable language check tests.
+      unacceptable_language_check_enabled: false
+      # The format check is disabled as this project does not conform to swift-format.
+      # More discussion is needed before enabling this check.
+      format_check_enabled: false
+      # The docs check is disabled as it requires a large number of changes.
+      docs_check_enabled: false
+      # The Python lint check is buggy due to flake8's default ignore list
+      # being overridden by the config in the workflow definition. The check
+      # needs to remain disabled until the fix is merged and released:
+      #
+      # https://github.com/swiftlang/github-workflows/pull/279
+      python_lint_check_enabled: false
+      # The YAML issue templates are structurally valid but unformatted.
+      # This linter will be enabled in a follow-up PR.
+      yamllint_check_enabled: false

--- a/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
@@ -1828,6 +1828,14 @@ Root
     }
     
     func testNavigatorIndexAsReadOnlyFile() async throws {
+        #if !os(Windows)
+        // Skip this test if running as root (e.g. inside a CI container).
+        // The kernel bypasses POSIX permission checks for the root user, so
+        // the file is always readable, even if the permissions are set to 000.
+        // This means the assertion in the last line will not succeed.
+        try XCTSkipIf(getuid() == 0, "POSIX permission checks are bypassed for the root user")
+        #endif
+
         let (_, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         let converter = DocumentationNodeConverter(context: context)
         


### PR DESCRIPTION
This patch introduces configuration for GitHub Actions, and adds a number of CI jobs that trigger on pull requests. Most of the information related to the workflow comes from the org-wide repository at https://github.com/swiftlang/github-workflows.

This is a subset of the changes proposed in #1414:

- The unacceptable language check has been disabled since it requires more discussion, and the workaround to make the check ignore words breaks the build.
- The trailing whitespace check has been omitted since it is unrelated to GHA support, and requires more discussion.