### PR TITLE
[6.4] Don't warn about DeprecationSummary when symbol is partially deprecated

### DIFF
--- a/Sources/DocCTestUtilities/SymbolGraphCreation.swift
+++ b/Sources/DocCTestUtilities/SymbolGraphCreation.swift
@@ -196,7 +196,7 @@ package func makeSymbolKind(_ kindID: SymbolGraph.Symbol.KindIdentifier) -> Symb
 
 package extension SymbolGraph.Symbol.Availability.AvailabilityItem {
     init(
-        domainName: String,
+        domainName: String?,
         introduced: SymbolGraph.SemanticVersion?,
         deprecated: SymbolGraph.SemanticVersion?,
         obsoleted: SymbolGraph.SemanticVersion? = nil,
@@ -207,7 +207,7 @@ package extension SymbolGraph.Symbol.Availability.AvailabilityItem {
         willEventuallyBeDeprecated:   Bool = false
     ) {
         self.init(
-            domain: .init(rawValue: domainName),
+            domain: domainName.map { .init(rawValue: $0) },
             introducedVersion: introduced,
             deprecatedVersion: deprecated,
             obsoletedVersion: obsoleted,

--- a/Sources/SwiftDocC/Model/DocumentationNode.swift
+++ b/Sources/SwiftDocC/Model/DocumentationNode.swift
@@ -930,7 +930,7 @@ public struct DocumentationNode {
             .union(availabilityFromDirectives.available.map(\.platform.rawValue))
             .subtracting(deprecatedDomainNames)
         
-        guard isUnconditionallyAvailable || !availableDomainNames.isEmpty || deprecatedDomainNames.isEmpty else {
+        guard deprecatedDomainNames.isEmpty, isUnconditionallyAvailable || !availableDomainNames.isEmpty else {
             return
         }
         
@@ -987,11 +987,21 @@ public struct DocumentationNode {
             explanation = makeExplanation(availabilityDescription: longAvailabilityDescription)
         }
         
+        func offsetIfNeeded(_ range: SourceRange) -> SourceRange {
+            guard range.source == inSourceDocumentationChunk?.url, let offset = inSourceDocumentationChunk?.offset else {
+                return range
+            }
+            // Diagnostics from an in-source documentation comment need to be offset based on the location of that documentation comment.
+            var range = range
+            range.offsetWithRange(offset)
+            return range
+        }
+        
         let notes: [Diagnostic.Note] = metadata?.availability.compactMap { availability -> Diagnostic.Note? in
             guard availability.deprecated == nil, let range = availability.originalMarkup.range, let source = range.source else {
                 return nil
             }
-            return .init(source: source, range: range, message: "Marked available for '\(availability.platform.rawValue)' here")
+            return .init(source: source, range: offsetIfNeeded(range), message: "Marked available for '\(availability.platform.rawValue)' here")
         } ?? []
         
         
@@ -1012,7 +1022,7 @@ public struct DocumentationNode {
                 // Not sure what solution we can offer for unconditional available symbols in languages other than Swift and C-family languages.
             }
         } else {
-            let platformNamesDescription = availableDomainNames.sorted().map(\.singleQuoted).list(finalConjunction: .and)
+            let platformNamesDescription = availableDomainNames.sorted().map(\.singleQuoted).list(finalConjunction: .or)
             if let inSourceAttributeDescription {
                 solutions.append(Solution(
                     summary: "Add \(inSourceAttributeDescription)\(availableDomainNames.count > 1 ? "s" : "") marking \(platformNamesDescription) as deprecated API",
@@ -1025,7 +1035,7 @@ public struct DocumentationNode {
             ))
         }
         
-        let range = deprecationSummaryDirective.range
+        let range = deprecationSummaryDirective.range.map(offsetIfNeeded)
         engine.emit(
             Diagnostic(
                 source: range?.source,

--- a/Tests/SwiftDocCTests/Model/AvailabilityTests.swift
+++ b/Tests/SwiftDocCTests/Model/AvailabilityTests.swift
@@ -1402,7 +1402,9 @@ struct AvailabilityTests {
             }
         }
         let context = try await load(catalog: catalog)
-        #expect(context.diagnostics.map(\.identifier) == ["DeprecationSummaryForAvailableSymbol"], "Unexpected problems: \(context.diagnostics.map(\.summary))")
+        try withKnownIssue("The DeprecationSummary validation doesn't know about default availability from the Info.plist", {
+            #expect(context.diagnostics.map(\.identifier) == ["DeprecationSummaryForAvailableSymbol"], "Unexpected problems: \(context.diagnostics.map(\.summary))")
+        }, when: { availabilitySource == .infoPlist })
         let node = try #require(context.documentationCache["some-symbol-id"])
         
         let converter = DocumentationContextConverter(context: context, renderContext: .init(documentationContext: context))

--- a/Tests/SwiftDocCTests/Model/DeprecationSummaryTests.swift
+++ b/Tests/SwiftDocCTests/Model/DeprecationSummaryTests.swift
@@ -128,7 +128,9 @@ struct DeprecationSummaryTests {
                     Some in-source documentation with a deprecation summary for this type alias
                     
                     \(directiveLocation == .inSourceComment ? Self.deprecationSummaryDirective : "")
-                    """, availability: []) // No availability attributes for this symbol
+                    """, availability: [
+                        .init(domainName: nil, introduced: nil, deprecated: nil) // Unconditionally available for all versions of all platforms
+                    ])
             ])),
             
             TextFile(name: "SomeTypeAlias.md", utf8Content: """
@@ -155,10 +157,20 @@ struct DeprecationSummaryTests {
         let renderNode = converter.convert(node)
         
         #expect(renderNode.deprecationSummary?.firstParagraph == [.text("Some description, from the directive, of why this protocol is deprecated.")])
+        
+        let range  = try #require(diagnostic.range)
+        switch directiveLocation {
+        case .extensionFile:
+            #expect(range.lowerBound.line   ==  5)
+            #expect(range.lowerBound.column ==  1)
+        case .inSourceComment:
+            #expect(range.lowerBound.line   == 14)
+            #expect(range.lowerBound.column == 18)
+        }
     }
     
     @Test(arguments: DirectiveLocation.allCases)
-    func warnsAboutDeprecationSummaryIfSymbolIsOnlyPartiallyDeprecated(_ directiveLocation: DirectiveLocation) async throws {
+    func warnsAboutDeprecationSummaryIfSymbolIsExplicitlyAvailable(_ directiveLocation: DirectiveLocation) async throws {
         let catalog = Folder(name: "unit-test.docc", content: [
             JSONFile(name: "SomeModule.symbols.json", content: makeSymbolGraph(moduleName: "SomeModule", symbols: [
                 makeSymbol(id: "some-symbol-id", kind: .typealias, pathComponents: ["SomeTypeAlias"], docComment: """
@@ -166,9 +178,8 @@ struct DeprecationSummaryTests {
                     
                     \(directiveLocation == .inSourceComment ? Self.deprecationSummaryDirective : "")
                     """, availability: [
-                        Self.makeInSourceAvailabilityInfo(domain: "FirstPlatform",                                                   deprecated: .init(major: 4, minor: 5, patch: 6)),
-                        Self.makeInSourceAvailabilityInfo(domain: "SecondPlatform", introduced: .init(major: 1, minor: 2, patch: 3), deprecated: nil),
-                        Self.makeInSourceAvailabilityInfo(domain: "ThirdPlatform",  introduced: nil,                                 deprecated: nil),
+                        Self.makeInSourceAvailabilityInfo(domain: "FirstPlatform",  introduced: .init(major: 1, minor: 2, patch: 3), deprecated: nil),
+                        Self.makeInSourceAvailabilityInfo(domain: "SecondPlatform", introduced: nil,                                 deprecated: nil),
                     ])
             ])),
             
@@ -187,8 +198,8 @@ struct DeprecationSummaryTests {
                 "Unexpected problems: \(context.diagnostics.map(\.summary))")
         
         let diagnostic = try #require(context.diagnostics.first)
-        #expect(diagnostic.summary == "Type alias 'SomeTypeAlias' is available for SecondPlatform and ThirdPlatform")
-        #expect(diagnostic.explanation == "This type alias has attributes that mark it as available for 'SecondPlatform' 1.2.3 onwards and all versions of 'ThirdPlatform'.")
+        #expect(diagnostic.summary == "Type alias 'SomeTypeAlias' is available for FirstPlatform and SecondPlatform")
+        #expect(diagnostic.explanation == "This type alias has attributes that mark it as available for 'FirstPlatform' 1.2.3 onwards and all versions of 'SecondPlatform'.")
         
         // Verify that DocC still displays the deprecation text, despite the symbol being available.
         let node = try #require(context.documentationCache["some-symbol-id"])
@@ -196,6 +207,33 @@ struct DeprecationSummaryTests {
         let renderNode = converter.convert(node)
         
         #expect(renderNode.deprecationSummary?.firstParagraph == [.text("Some description, from the directive, of why this protocol is deprecated.")])
+    }
+    
+    @Test(arguments: DirectiveLocation.allCases)
+    func doesNotWarnAboutDeprecationSummaryIfSymbolIsPartiallyDeprecated(_ directiveLocation: DirectiveLocation) async throws {
+        let catalog = Folder(name: "unit-test.docc", content: [
+            JSONFile(name: "SomeModule.symbols.json", content: makeSymbolGraph(moduleName: "SomeModule", symbols: [
+                makeSymbol(id: "some-symbol-id", kind: .typealias, pathComponents: ["SomeTypeAlias"], docComment: """
+                    Some in-source documentation with a deprecation summary for this type alias
+                    
+                    \(directiveLocation == .inSourceComment ? Self.deprecationSummaryDirective : "")
+                    """, availability: [
+                        Self.makeInSourceAvailabilityInfo(domain: "FirstPlatform",  introduced: nil,                                 deprecated: .init(major: 4, minor: 5, patch: 6)),
+                        Self.makeInSourceAvailabilityInfo(domain: "SecondPlatform", introduced: .init(major: 1, minor: 2, patch: 3), deprecated: nil),
+                    ])
+            ])),
+            
+            TextFile(name: "SomeTypeAlias.md", utf8Content: """
+            # ``SomeTypeAlias``
+            
+            Some additional documentation for this type alias.
+            
+            \(directiveLocation == .extensionFile ? Self.deprecationSummaryDirective : "")
+            """)
+        ])
+        
+        let context = try await load(catalog: catalog)
+        #expect(context.diagnostics.map(\.identifier) == [], "Unexpected problems: \(context.diagnostics.map(\.summary))")
     }
     
     @Test(arguments: DirectiveLocation.allCases, [
@@ -249,7 +287,7 @@ struct DeprecationSummaryTests {
         \(Self.deprecationSummaryDirective)
         @Metadata {
           @Available(PlatformB, introduced: "2.3.4")
-          @Available(PlatformD, introduced: "3.4.5")
+          @Available(PlatformC, introduced: "3.4.5")
         }
         """
         
@@ -260,9 +298,8 @@ struct DeprecationSummaryTests {
                     
                     \(directiveLocation == .inSourceComment ? directives : "")
                     """, availability: [
-                        Self.makeInSourceAvailabilityInfo(domain: "PlatformA",                                                  deprecated: .init(major: 4, minor: 5, patch: 6)),
+                        Self.makeInSourceAvailabilityInfo(domain: "PlatformA",                                                  deprecated: nil),
                         Self.makeInSourceAvailabilityInfo(domain: "PlatformB", introduced: .init(major: 1, minor: 2, patch: 3), deprecated: nil),
-                        Self.makeInSourceAvailabilityInfo(domain: "PlatformC", introduced: nil,                                 deprecated: nil),
                     ])
             ])),
             
@@ -281,8 +318,8 @@ struct DeprecationSummaryTests {
                 "Unexpected problems: \(context.diagnostics.map(\.summary))")
         
         let diagnostic = try #require(context.diagnostics.first)
-        #expect(diagnostic.summary == "Type alias 'SomeTypeAlias' is available for PlatformB, PlatformC, and PlatformD")
-        #expect(diagnostic.explanation == "This type alias has attributes that mark it as available for 'PlatformB' 2.3.4 onwards, all versions of 'PlatformC', and 'PlatformD' 3.4.5 onwards.")
+        #expect(diagnostic.summary == "Type alias 'SomeTypeAlias' is available for PlatformA, PlatformB, and PlatformC")
+        #expect(diagnostic.explanation == "This type alias has attributes that mark it as available for 'PlatformA' 1.2.3 onwards, 'PlatformB' 2.3.4 onwards, and 'PlatformC' 3.4.5 onwards.")
         
         // Verify that the notes refer to the Available directives
         let expectedSource = switch directiveLocation {
@@ -292,7 +329,7 @@ struct DeprecationSummaryTests {
         #expect(diagnostic.notes.map(\.source.path) == [expectedSource, expectedSource])
         #expect(diagnostic.notes.map(\.message) == [
             "Marked available for 'PlatformB' here",
-            "Marked available for 'PlatformD' here",
+            "Marked available for 'PlatformC' here",
         ])
         
         // Verify that the solutions suggest marking the available platforms as deprecated using both attributes (preferred) and directives
@@ -303,62 +340,15 @@ struct DeprecationSummaryTests {
         }
         #expect(diagnostic.solutions.count == (expectedSourceAttribute != nil ? 2 : 1))
         if let expectedSourceAttribute {
-            #expect(diagnostic.solutions.first?.summary == "Add \(expectedSourceAttribute) marking 'PlatformB', 'PlatformC', and 'PlatformD' as deprecated API")
+            #expect(diagnostic.solutions.first?.summary == "Add \(expectedSourceAttribute) marking 'PlatformA', 'PlatformB', or 'PlatformC' as deprecated API")
         }
-        #expect(diagnostic.solutions.last?.summary == "Add Available directives marking 'PlatformB', 'PlatformC', and 'PlatformD' as deprecated only in documentation")
+        #expect(diagnostic.solutions.last?.summary == "Add Available directives marking 'PlatformA', 'PlatformB', or 'PlatformC' as deprecated only in documentation")
         // Verify that DocC still displays the deprecation text, despite the symbol being available.
         let node = try #require(context.documentationCache["some-symbol-id"])
         let converter = DocumentationNodeConverter(context: context)
         let renderNode = converter.convert(node)
         
         #expect(renderNode.deprecationSummary?.firstParagraph == [.text("Some description, from the directive, of why this protocol is deprecated.")])
-    }
-    
-    @Test(arguments: DirectiveLocation.allCases)
-    func warningListsDeprecatedPlatformWhenSymbolHasUnconditionalAvailability(_ directiveLocation: DirectiveLocation) async throws {
-        let directives = """
-        \(Self.deprecationSummaryDirective)
-        @Metadata {
-          @Available(PlatformB, introduced: "2.3.4", deprecated: "4.5.6")
-        }
-        """
-        
-        let catalog = Folder(name: "unit-test.docc", content: [
-            JSONFile(name: "SomeModule.symbols.json", content: makeSymbolGraph(moduleName: "SomeModule", symbols: [
-                makeSymbol(id: "some-symbol-id", kind: .typealias,  pathComponents: ["SomeTypeAlias"], docComment: """
-                    Some in-source documentation with a deprecation summary for this type alias
-                    
-                    \(directiveLocation == .inSourceComment ? directives : "")
-                    """, availability: [
-                        Self.makeInSourceAvailabilityInfo(domain: nil,         introduced: nil, deprecated: nil), // Available on all platforms except where explicitly marked as deprecated
-                        Self.makeInSourceAvailabilityInfo(domain: "PlatformA", introduced: nil, deprecated: .init(major: 3, minor: 4, patch: 5)),
-                    ])
-            ])),
-            
-            TextFile(name: "SomeTypeAlias.md", utf8Content: """
-            # ``SomeTypeAlias``
-            
-            Some additional documentation for this type alias.
-               
-            \(directiveLocation == .extensionFile ? directives : "")
-            """)
-        ])
-        
-        let context = try await load(catalog: catalog)
-        // Verify the warning
-        #expect(context.diagnostics.map(\.identifier) == ["DeprecationSummaryForAvailableSymbol"],
-                "Unexpected problems: \(context.diagnostics.map(\.summary))")
-        
-        let diagnostic = try #require(context.diagnostics.first)
-        #expect(diagnostic.summary == "Type alias 'SomeTypeAlias' is available for all platforms, except PlatformA and PlatformB")
-        #expect(diagnostic.explanation == "This type alias has attributes that mark it as available for all platforms, except PlatformA and PlatformB.")
-        
-        #expect(diagnostic.notes.map(\.message) == [], "Only deprecated platforms, not available ones, are defined in Available directives")
-        
-        // Verify that the solutions suggest modifying the wildcard availability attribute
-        #expect(diagnostic.solutions.count == 1)
-        let solution = try #require(diagnostic.solutions.first)
-        #expect(solution.summary == "Update wildcard '@available()' attribute with a deprecated version or unconditional deprecation")
     }
     
     @Test

--- a/Tests/SwiftDocCTests/Semantics/SymbolTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/SymbolTests.swift
@@ -1264,7 +1264,7 @@ class SymbolTests: XCTestCase {
             extensionFileContent: nil
         )
         
-        XCTAssertEqual(diagnostics.map(\.identifier), ["DeprecationSummaryForAvailableSymbol"], "Unexpected diagnostics: \(diagnostics.map(\.summary))")
+        XCTAssert(diagnostics.isEmpty, "Unexpected diagnostics: \(diagnostics.map(\.summary))")
         
         XCTAssertEqual(
             (node.semantic as? Symbol)?


### PR DESCRIPTION
- **Explanation**: This corrects the source location of the DocC warning when `@DeprecationSummary` is used for a symbol that's not deprecated _and_ doesn't raise that warning if the symbol is deprecated for _any_ platform for consistency with other deprecation behaviors.
- **Scope**: The DocC warning for when `@DeprecationSummary` is used for a symbol that's not deprecated.
- **Issues**: rdar://178260666
- **Original PRs**: #1533
- **Risk**: Low. 
- **Testing**: New tests verify the correct source location of this warning and that DocC doesn't raise the warning when the symbol is partially deprecated. All existing automated test pass. Manually verified with the project that originally reported this issue.
- **Reviewers**: @snprajwal 