### PR TITLE
[6.4] Fix bug where discussion before deprecation summary directive is dropped

### DIFF
--- a/Sources/SwiftDocC/Model/DocumentationMarkup.swift
+++ b/Sources/SwiftDocC/Model/DocumentationMarkup.swift
@@ -175,21 +175,6 @@ struct DocumentationMarkup {
                 }
             }
             
-            // Parse content into a discussion section and assorted tags
-            let parseDiscussion: ([any Markup])-> (discussion: DiscussionSection, tags: TaggedListItemExtractor) = { children in
-                // Extract tags
-                var extractor = TaggedListItemExtractor()
-                let content: [any Markup]
-                
-                if let remainder = extractor.visit(markup.withUncheckedChildren(children)) {
-                    content = Array(remainder.children)
-                } else {
-                    content = []
-                }
-                
-                return (discussion: DiscussionSection(content: content), tags: extractor)
-            }
-            
             // Parse a discussion, if found
             if currentSection == .discussion {
                 // Scanning for the first discussion content child
@@ -296,6 +281,21 @@ struct DocumentationMarkup {
                 }
             }
         }
+    }
+
+    /// Parses content into a discussion section and assorted tags.
+    private func parseDiscussion(_ children: [any Markup]) -> (discussion: DiscussionSection, tags: TaggedListItemExtractor) {
+        // Extract tags
+        var extractor = TaggedListItemExtractor()
+        let content: [any Markup]
+
+        if let remainder = extractor.visit(markup.withUncheckedChildren(children)) {
+            content = Array(remainder.children)
+        } else {
+            content = []
+        }
+
+        return (discussion: DiscussionSection(content: content), tags: extractor)
     }
 }
 

--- a/Sources/SwiftDocC/Model/DocumentationMarkup.swift
+++ b/Sources/SwiftDocC/Model/DocumentationMarkup.swift
@@ -149,6 +149,9 @@ struct DocumentationMarkup {
                Self.allowedSectionsForDeprecationSummary.contains(currentSection)
             {
                 deprecation = MarkupContainer(directive.children)
+                if isLastChild, currentSection == .discussion, let discussionIndex {
+                    finalizeDiscussion(over: markup.children(at: discussionIndex ..< index))
+                }
                 continue
             }
             

--- a/Sources/SwiftDocC/Model/DocumentationMarkup.swift
+++ b/Sources/SwiftDocC/Model/DocumentationMarkup.swift
@@ -204,16 +204,12 @@ struct DocumentationMarkup {
                 if let heading = child as? Heading, heading.level == 2 {
                     switch heading.plainText {
                     case TopicsSection.title:
-                        let (discussion, tags) = parseDiscussion(markup.children(at: discussionIndex ..< index))
-                        discussionSection = discussion
-                        discussionTags = tags
+                        finalizeDiscussion(over: markup.children(at: discussionIndex ..< index))
                         currentSection = .topics
                         continue
                         
                     case SeeAlsoSection.title:
-                        let (discussion, tags) = parseDiscussion(markup.children(at: discussionIndex ..< index))
-                        discussionSection = discussion
-                        discussionTags = tags
+                        finalizeDiscussion(over: markup.children(at: discussionIndex ..< index))
                         currentSection = .seeAlso
                         continue
                     default: break
@@ -222,9 +218,7 @@ struct DocumentationMarkup {
                 
                 // If at end of content, parse discussion
                 if isLastChild {
-                    let (discussion, tags) = parseDiscussion(markup.children(at: discussionIndex ... index))
-                    discussionSection = discussion
-                    discussionTags = tags
+                    finalizeDiscussion(over: markup.children(at: discussionIndex ... index))
                 }
             }
             
@@ -296,6 +290,13 @@ struct DocumentationMarkup {
         }
 
         return (discussion: DiscussionSection(content: content), tags: extractor)
+    }
+
+    /// Parses the given children as the discussion section and stores the result.
+    private mutating func finalizeDiscussion(over children: [any Markup]) {
+        let (discussion, tags) = parseDiscussion(children)
+        discussionSection = discussion
+        discussionTags = tags
     }
 }
 

--- a/Tests/SwiftDocCTests/Model/DocumentationMarkupTests.swift
+++ b/Tests/SwiftDocCTests/Model/DocumentationMarkupTests.swift
@@ -353,6 +353,15 @@ class DocumentationMarkupTests: XCTestCase {
             """
             let model = DocumentationMarkup(markup: Document(parsing: source, options: .parseBlockDirectives))
             XCTAssertEqual(expected, model.deprecation?.elements.map({ $0.format() }).joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines))
+            XCTAssertEqual(
+                """
+                Paragraph
+                └─ Text "My discussion content."
+                """,
+                model.discussionSection?.content
+                    .map({ $0.detachedFromParent.debugDescription() })
+                    .joined(separator: "\n")
+            )
         }
         
         // Deprecation in the topics


### PR DESCRIPTION
- **Explanation**: Fixes a bug where discussion content gets dropped when followed by a deprecation summary.
- **Scope**: Documentation pages for symbols that have a deprecation summary.
- **Issue**: rdar://178653799
- **Original PR**: https://github.com/swiftlang/swift-docc/pull/1539
- **Risk**: Low
- **Testing**: Verified via automated testing and manual testing.
- **Reviewer**: @snprajwal 