### PR TITLE
Migrate URL and String utility tests to Swift Testing

### DIFF
--- a/Tests/SwiftDocCTests/Utility/Language/EnglishLanguageTests.swift
+++ b/Tests/SwiftDocCTests/Utility/Language/EnglishLanguageTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -9,21 +9,27 @@
 */
 
 import Foundation
-import XCTest
+import Testing
 @testable import SwiftDocC
 
-class EnglishLanguageTests: XCTestCase {
-    func testEnglishListOptions() throws {
-        XCTAssertEqual([], NativeLanguage.english.listSeparators(itemsCount: 0, listType: .options), "Didn't return empty separator list for empty input list.")
-        XCTAssertEqual([], NativeLanguage.english.listSeparators(itemsCount: 1, listType: .options), "Didn't return empty separator list for 1 items input list.")
-        XCTAssertEqual([" or "], NativeLanguage.english.listSeparators(itemsCount: 2, listType: .options), "Didn't return single separator for 2 items input list.")
-        XCTAssertEqual([", ", ", or "], NativeLanguage.english.listSeparators(itemsCount: 3, listType: .options), "Didn't return expected separators for 3 items input list.")
+struct EnglishLanguageTests {
+    @Test(arguments: [
+        (0, []),
+        (1, []),
+        (2, [" or "]),
+        (3, [", ", ", or "]),
+    ])
+    func usesOrSeparatorForOptionsLists(itemsCount: Int, expected: [String]) {
+        #expect(NativeLanguage.english.listSeparators(itemsCount: itemsCount, listType: .options) == expected)
     }
-
-    func testEnglishListUnion() throws {
-        XCTAssertEqual([], NativeLanguage.english.listSeparators(itemsCount: 0, listType: .union), "Didn't return empty separator list for empty input list.")
-        XCTAssertEqual([], NativeLanguage.english.listSeparators(itemsCount: 1, listType: .union), "Didn't return empty separator list for 1 items input list.")
-        XCTAssertEqual([" and "], NativeLanguage.english.listSeparators(itemsCount: 2, listType: .union), "Didn't return single separator for 2 items input list.")
-        XCTAssertEqual([", ", ", and "], NativeLanguage.english.listSeparators(itemsCount: 3, listType: .union), "Didn't return expected separators for 3 items input list.")
+    
+    @Test(arguments: [
+        (0, []),
+        (1, []),
+        (2, [" and "]),
+        (3, [", ", ", and "]),
+    ])
+    func usesAndSeparatorForUnionLists(itemsCount: Int, expected: [String]) {
+        #expect(NativeLanguage.english.listSeparators(itemsCount: itemsCount, listType: .union) == expected)
     }
 }

--- a/Tests/SwiftDocCTests/Utility/SemanticVersion+ComparableTests.swift
+++ b/Tests/SwiftDocCTests/Utility/SemanticVersion+ComparableTests.swift
@@ -1,36 +1,25 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import XCTest
+import Testing
 import SymbolKit
 
-class SemanticVersion_ComparableTests: XCTestCase {
-    private typealias Version = SymbolGraph.SemanticVersion
+struct SemanticVersion_ComparableTests {
+    typealias Version = SymbolGraph.SemanticVersion
     
-    func test() {
-        // Patch difference
-        XCTAssertLessThan(
-            Version(major: 1, minor: 1, patch: 1),
-            Version(major: 1, minor: 1, patch: 2)
-        )
-        
-        // Minor difference
-        XCTAssertLessThan(
-            Version(major: 1, minor: 1, patch: 3),
-            Version(major: 1, minor: 2, patch: 1)
-        )
-        
-        // Major difference
-        XCTAssertLessThan(
-            Version(major: 1, minor: 3, patch: 1),
-            Version(major: 2, minor: 1, patch: 2)
-        )
+    @Test(arguments: [
+        (Version(major: 1, minor: 1, patch: 1), Version(major: 1, minor: 1, patch: 2)),
+        (Version(major: 1, minor: 1, patch: 3), Version(major: 1, minor: 2, patch: 1)),
+        (Version(major: 1, minor: 3, patch: 1), Version(major: 2, minor: 1, patch: 2)),
+    ])
+    func comparesByMajorThenMinorThenPatch(smaller: Version, larger: Version) {
+        #expect(smaller < larger)
     }
 }

--- a/Tests/SwiftDocCTests/Utility/String+CapitalizationTests.swift
+++ b/Tests/SwiftDocCTests/Utility/String+CapitalizationTests.swift
@@ -1,71 +1,63 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import XCTest
+import Testing
 @testable import SwiftDocC
 
-class String_CapitalizationTests: XCTestCase {
+struct String_CapitalizationTests {
     
-    func testAllLowerCase() {
-        let testString = "hello world"
-        XCTAssertEqual("Hello world", testString.capitalizingFirstWord())
+    @Test
+    func capitalizesFirstLetterOfLowercaseString() {
+        #expect("hello world".capitalizingFirstWord() == "Hello world")
     }
     
-    func testAllLowerCaseWithPunctuation() {
-        let testString1 = "hello, world"
-        let testString2 = "twenty-one"
-        let testString3 = "hello! world"
-        let testString4 = "hello: world"
-        let testString5 = "l'ocean world"
-        XCTAssertEqual("Hello, world", testString1.capitalizingFirstWord())
-        XCTAssertEqual("Twenty-One", testString2.capitalizingFirstWord())
-        XCTAssertEqual("Hello! world", testString3.capitalizingFirstWord())
-        XCTAssertEqual("Hello: world", testString4.capitalizingFirstWord())
-        XCTAssertEqual("L'ocean world", testString5.capitalizingFirstWord())
+    @Test
+    func leavesWordsContainingBacktickUnchanged() {
+        #expect("h`ello world".capitalizingFirstWord() == "h`ello world")
     }
     
-    func testInvalidPunctuation() {
-        let testString = "h`ello world"
-        XCTAssertEqual(testString, testString.capitalizingFirstWord())
+    @Test
+    func preservesWordsWithInternalCapitalization() {
+        #expect("iPad iOS visionOS".capitalizingFirstWord() == "iPad iOS visionOS")
     }
     
-    func testHasUppercase() {
-        let testString = "iPad iOS visionOS"
-        XCTAssertEqual(testString, testString.capitalizingFirstWord())
+    @Test(arguments: [
+        ("hello, world", "Hello, world"),
+        ("twenty-one", "Twenty-One"),
+        ("hello! world", "Hello! world"),
+        ("hello: world", "Hello: world"),
+        ("l'ocean world", "L'ocean world"),
+    ])
+    func capitalizesEachWordSeparatedByPunctuation(input: String, expected: String) {
+        #expect(input.capitalizingFirstWord() == expected)
     }
     
-    func testWhiteSpaces() {
-        let testString1 = "       has many spaces"
-        let testString2 = "     has a tab"
-        let testString3 = "         has many spaces     "
-        XCTAssertEqual("       Has many spaces", testString1.capitalizingFirstWord())
-        XCTAssertEqual("     Has a tab", testString2.capitalizingFirstWord())
-        XCTAssertEqual("         Has many spaces     ", testString3.capitalizingFirstWord())
+    @Test(arguments: [
+        ("       has many spaces", "       Has many spaces"),
+        ("     has a tab", "     Has a tab"),
+        ("         has many spaces     ", "         Has many spaces     "),
+    ])
+    func preservesLeadingAndTrailingWhitespace(input: String, expected: String) {
+        #expect(input.capitalizingFirstWord() == expected)
     }
     
-    
-    func testDifferentAlphabets() {
-        let testString1 = "l'amérique du nord"
-        let testString2 = "ça va?"
-        let testString3 = "à"
-        let testString4 = "チーズ"
-        let testString5 = "牛奶"
-        let testString6 = "i don't like 牛奶"
-        let testString7 = "牛奶 is tasty"
-        XCTAssertEqual("L'amérique du nord", testString1.capitalizingFirstWord())
-        XCTAssertEqual("Ça va?", testString2.capitalizingFirstWord())
-        XCTAssertEqual("À", testString3.capitalizingFirstWord())
-        XCTAssertEqual("チーズ", testString4.capitalizingFirstWord())
-        XCTAssertEqual("牛奶", testString5.capitalizingFirstWord())
-        XCTAssertEqual("I don't like 牛奶", testString6.capitalizingFirstWord())
-        XCTAssertEqual("牛奶 is tasty", testString7.capitalizingFirstWord())
+    @Test(arguments: [
+        ("l'amérique du nord", "L'amérique du nord"),
+        ("ça va?", "Ça va?"),
+        ("à", "À"),
+        ("チーズ", "チーズ"),
+        ("牛奶", "牛奶"),
+        ("i don't like 牛奶", "I don't like 牛奶"),
+        ("牛奶 is tasty", "牛奶 is tasty"),
+    ])
+    func capitalizesAcrossDifferentScripts(input: String, expected: String) {
+        #expect(input.capitalizingFirstWord() == expected)
     }
-    
 }

--- a/Tests/SwiftDocCTests/Utility/String+HashingTests.swift
+++ b/Tests/SwiftDocCTests/Utility/String+HashingTests.swift
@@ -1,35 +1,41 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import XCTest
+import Testing
 @testable import SwiftDocC
 
-class String_HashingTests: XCTestCase {
+struct String_HashingTests {
     
-    func testFNV1aHash() {
-        // Test that the results are stable for the given inputs
+    @Test(arguments: [
+        ("", "146ys"),
+        ("Hello", "1if00"),
+        ("Lorem ipsum dolor sit amet, consectetur adipiscing elit.", "3c6o6"),
+        ("/mykit/myclass/myfunc", "4y7c"),
+    ])
+    func stableHashStringIsDeterministicAcrossInvocations(input: String, expected: String) {
+        // Repeat the call to verify the result is stable for the given input.
         for _ in (0...100) {
-            XCTAssertEqual("146ys", "".stableHashString)
-            XCTAssertEqual("1if00", "Hello".stableHashString)
-            XCTAssertEqual("3c6o6", "Lorem ipsum dolor sit amet, consectetur adipiscing elit.".stableHashString)
-            XCTAssertEqual("4y7c", "/mykit/myclass/myfunc".stableHashString)
+            #expect(input.stableHashString == expected)
         }
     }
     
-    func testUSRHash() {
-        // Test that the results are stable for the given inputs
+    @Test(arguments: [
+        ("", "ztntfp"),
+        ("s:5SideKit0A5ClassC10elementT", "1kf2iw4"),
+        ("s:5SideKit0A5ClassC10value_int", "n3jy95"),
+        (veryLongUSR, "1m0yasz"),
+    ])
+    func usrHashIsDeterministicAcrossInvocations(usr: String, expected: String) {
+        // Repeat the call to verify the result is stable for the given input.
         for _ in (0...100) {
-            XCTAssertEqual("ztntfp", ExternalIdentifier.usr("").hash)
-            XCTAssertEqual("1kf2iw4", ExternalIdentifier.usr("s:5SideKit0A5ClassC10elementT").hash)
-            XCTAssertEqual("n3jy95", ExternalIdentifier.usr("s:5SideKit0A5ClassC10value_int").hash)
-            XCTAssertEqual("1m0yasz", ExternalIdentifier.usr(veryLongUSR).hash)
+            #expect(ExternalIdentifier.usr(usr).hash == expected)
         }
     }
 }

--- a/Tests/SwiftDocCTests/Utility/String+Slash.swift
+++ b/Tests/SwiftDocCTests/Utility/String+Slash.swift
@@ -1,27 +1,33 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import XCTest
+import Testing
 @testable import SwiftDocC
 
-class String_SlashTests: XCTestCase {
+struct String_SlashTests {
     
-    func testPrependingSlash() {
-        XCTAssertEqual("/", "".prependingLeadingSlash)
-        XCTAssertEqual("/path", "path".prependingLeadingSlash)
-        XCTAssertEqual("/path", "/path".prependingLeadingSlash)
+    @Test(arguments: [
+        ("", "/"),
+        ("path", "/path"),
+        ("/path", "/path"),
+    ])
+    func prependsLeadingSlashWhenMissing(input: String, expected: String) {
+        #expect(input.prependingLeadingSlash == expected)
     }
-
-    func testRemovingSlash() {
-        XCTAssertEqual("", "/".removingLeadingSlash)
-        XCTAssertEqual("path", "/path".removingLeadingSlash)
-        XCTAssertEqual("path", "path".removingLeadingSlash)
+    
+    @Test(arguments: [
+        ("/", ""),
+        ("/path", "path"),
+        ("path", "path"),
+    ])
+    func removesLeadingSlashWhenPresent(input: String, expected: String) {
+        #expect(input.removingLeadingSlash == expected)
     }
 }

--- a/Tests/SwiftDocCTests/Utility/String+SplittingTests.swift
+++ b/Tests/SwiftDocCTests/Utility/String+SplittingTests.swift
@@ -1,27 +1,24 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import XCTest
+import Testing
 @testable import SwiftDocC
 
-class String_SplittingTests: XCTestCase {
+struct String_SplittingTests {
     
-    func testSplitsAStringWithNoTrailingNewlines() {
-        XCTAssertEqual("hello\nworld".splitByNewlines, ["hello", "world"])
-    }
-    
-    func testSplitsAStringWithOneTrailingNewline() {
-        XCTAssertEqual("hello\nworld\n".splitByNewlines, ["hello", "world"])
-    }
-    
-    func testSplitsAStringWithTwoTrailingNewlines() {
-        XCTAssertEqual("hello\nworld\n\n".splitByNewlines, ["hello", "world", ""])
+    @Test(arguments: [
+        ("hello\nworld", ["hello", "world"]),
+        ("hello\nworld\n", ["hello", "world"]),
+        ("hello\nworld\n\n", ["hello", "world", ""]),
+    ])
+    func splitsByNewlinesAndDropsSingleTrailingNewline(input: String, expected: [String]) {
+        #expect(input.splitByNewlines == expected)
     }
 }

--- a/Tests/SwiftDocCTests/Utility/String+WhitespaceTests.swift
+++ b/Tests/SwiftDocCTests/Utility/String+WhitespaceTests.swift
@@ -1,61 +1,49 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import XCTest
+import Testing
 @testable import SwiftDocC
 
-class String_WhitespaceTests: XCTestCase {
+struct String_WhitespaceTests {
     
-    func testVariousSeparators() {
-        XCTAssertEqual("Words separated by spaces".replacingWhitespaceAndPunctuation(with: "-"),
-                       "Words-separated-by-spaces")
-        XCTAssertEqual("Words_separated_by_underscores".replacingWhitespaceAndPunctuation(with: "-"),
-                       "Words-separated-by-underscores")
-        XCTAssertEqual("Words'separated'by'single'quotes".replacingWhitespaceAndPunctuation(with: "-"),
-                       "Words-separated-by-single-quotes")
-        XCTAssertEqual("Words:separated:by:colons".replacingWhitespaceAndPunctuation(with: "-"),
-                       "Words-separated-by-colons")
-        XCTAssertEqual("Words/separated/by/forward/slashes".replacingWhitespaceAndPunctuation(with: "-"),
-                       "Words-separated-by-forward-slashes")
-        XCTAssertEqual("Mixig various'separator_characters:between/words".replacingWhitespaceAndPunctuation(with: "-"),
-                       "Mixig-various-separator-characters-between-words")
+    @Test(arguments: [
+        ("Words separated by spaces", "Words-separated-by-spaces"),
+        ("Words_separated_by_underscores", "Words-separated-by-underscores"),
+        ("Words'separated'by'single'quotes", "Words-separated-by-single-quotes"),
+        ("Words:separated:by:colons", "Words-separated-by-colons"),
+        ("Words/separated/by/forward/slashes", "Words-separated-by-forward-slashes"),
+        ("Mixig various'separator_characters:between/words", "Mixig-various-separator-characters-between-words"),
+    ])
+    func replacesEachSeparatorCharacterWithGivenString(input: String, expected: String) {
+        #expect(input.replacingWhitespaceAndPunctuation(with: "-") == expected)
     }
     
-    func testMultipleSeparators() {
-        XCTAssertEqual("Words   separated by    multiple  spaces".replacingWhitespaceAndPunctuation(with: "-"),
-                       "Words-separated-by-multiple-spaces")
-        XCTAssertEqual("Words___separated_by____multiple__underscrores".replacingWhitespaceAndPunctuation(with: "-"),
-                       "Words-separated-by-multiple-underscrores")
-        
-        XCTAssertEqual("Words: with, various. punctuation! as - separators".replacingWhitespaceAndPunctuation(with: "-"),
-                       "Words-with-various-punctuation-as-separators")
+    @Test(arguments: [
+        ("Words   separated by    multiple  spaces", "Words-separated-by-multiple-spaces"),
+        ("Words___separated_by____multiple__underscrores", "Words-separated-by-multiple-underscrores"),
+        ("Words: with, various. punctuation! as - separators", "Words-with-various-punctuation-as-separators"),
+    ])
+    func collapsesConsecutiveSeparators(input: String, expected: String) {
+        #expect(input.replacingWhitespaceAndPunctuation(with: "-") == expected)
     }
     
-    func testTrimmingWhitespace() {
-        XCTAssertEqual("".removingLeadingWhitespace(), "")
-        XCTAssertEqual("".removingTrailingWhitespace(), "")
-        
-        XCTAssertEqual("ABC".removingLeadingWhitespace(), "ABC")
-        XCTAssertEqual("ABC".removingTrailingWhitespace(), "ABC")
-        
-        XCTAssertEqual("\t ABC\t ".removingLeadingWhitespace(), "ABC\t ", "Removing leading whitespace doesn't remove trailing whitespace")
-        XCTAssertEqual("\t ABC\t ".removingTrailingWhitespace(), "\t ABC", "Removing trailing whitespace doesn't remove leading whitespace")
-        
-        XCTAssertEqual("\t ".removingLeadingWhitespace(), "", "All characters are whitespace")
-        XCTAssertEqual("\t ".removingTrailingWhitespace(), "", "All characters are whitespace")
-        
-        XCTAssertEqual("\n ABC \n".removingLeadingWhitespace(), "ABC \n", "Newline is considered a whitespace character")
-        XCTAssertEqual("\n ABC \n".removingTrailingWhitespace(), "\n ABC", "Newline is considered a whitespace character")
-        
-        XCTAssertEqual("start ABC end".removingLeadingWhitespace(), "start ABC end", "Only removes whitespace at the start and end of the string")
-        XCTAssertEqual("start ABC end".removingTrailingWhitespace(), "start ABC end", "Only removes whitespace at the start and end of the string")
+    @Test(arguments: [
+        ("", "", ""),
+        ("ABC", "ABC", "ABC"),
+        ("\t ABC\t ", "ABC\t ", "\t ABC"),
+        ("\t ", "", ""),
+        ("\n ABC \n", "ABC \n", "\n ABC"),
+        ("start ABC end", "start ABC end", "start ABC end"),
+    ])
+    func trimsLeadingAndTrailingWhitespaceIndependently(input: String, expectedLeading: String, expectedTrailing: String) {
+        #expect(input.removingLeadingWhitespace() == expectedLeading)
+        #expect(input.removingTrailingWhitespace() == expectedTrailing)
     }
 }
-

--- a/Tests/SwiftDocCTests/Utility/URL+IsAbsoluteWebURLTests.swift
+++ b/Tests/SwiftDocCTests/Utility/URL+IsAbsoluteWebURLTests.swift
@@ -1,26 +1,25 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2022-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+import Foundation
 @testable import SwiftDocC
-import XCTest
+import Testing
 
-class URL_IsAbsoluteWebURLTests: XCTestCase {
-    func testisAbsoluteWebURL() throws {
-        let localURL = URL(fileURLWithPath: "/Users/username/Documents/Some Folder/Some Document.txt")
-        let topReferenceURL = try XCTUnwrap(URL(string: "doc://swift-doc"))
-        let webURL = try XCTUnwrap(URL(string: "swift.org"))
-        let absoluteWebURL = try XCTUnwrap(URL(string: "https://swift.org"))
-
-        XCTAssertEqual(localURL.isAbsoluteWebURL, false)
-        XCTAssertEqual(topReferenceURL.isAbsoluteWebURL, false)
-        XCTAssertEqual(webURL.isAbsoluteWebURL, false)
-        XCTAssertEqual(absoluteWebURL.isAbsoluteWebURL, true)
+struct URL_IsAbsoluteWebURLTests {
+    @Test(arguments: [
+        (URL(fileURLWithPath: "/Users/username/Documents/Some Folder/Some Document.txt"), false),
+        (URL(string: "doc://swift-doc")!, false),
+        (URL(string: "swift.org")!, false),
+        (URL(string: "https://swift.org")!, true),
+    ])
+    func recognizesAbsoluteWebURLs(url: URL, isAbsoluteWebURL: Bool) {
+        #expect(url.isAbsoluteWebURL == isAbsoluteWebURL)
     }
 }

--- a/Tests/SwiftDocCTests/Utility/URL+RelativeTests.swift
+++ b/Tests/SwiftDocCTests/Utility/URL+RelativeTests.swift
@@ -1,70 +1,63 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import XCTest
+import Foundation
+import Testing
 @testable import SwiftDocC
 
-class URL_RelativeTests: XCTestCase {
-
-    func testPathsRelativeToParents() {
+struct URL_RelativeTests {
+    
+    @Test(arguments: [
+        ("/Users/username/Documents/Some Folder/", "Some Document.txt"),
+        ("/Users/username/Documents/", "Some Folder/Some Document.txt"),
+        ("/Users/username/", "Documents/Some Folder/Some Document.txt"),
+        ("/Users/", "username/Documents/Some Folder/Some Document.txt"),
+        ("/", "Users/username/Documents/Some Folder/Some Document.txt"),
+    ])
+    func usesPlainSuffixWhenStartingPointIsAncestor(startingPath: String, expected: String) {
         let url = URL(fileURLWithPath: "/Users/username/Documents/Some Folder/Some Document.txt")
-
-        XCTAssertEqual(url.relative(to: URL(fileURLWithPath: "/Users/username/Documents/Some Folder/"))?.path,
-                       "Some Document.txt")
-        XCTAssertEqual(url.relative(to: URL(fileURLWithPath: "/Users/username/Documents/"))?.path,
-                       "Some Folder/Some Document.txt")
-        XCTAssertEqual(url.relative(to: URL(fileURLWithPath: "/Users/username/"))?.path,
-                       "Documents/Some Folder/Some Document.txt")
-        XCTAssertEqual(url.relative(to: URL(fileURLWithPath: "/Users/"))?.path,
-                       "username/Documents/Some Folder/Some Document.txt")
-        XCTAssertEqual(url.relative(to: URL(fileURLWithPath: "/"))?.path,
-                       "Users/username/Documents/Some Folder/Some Document.txt")
+        #expect(url.relative(to: URL(fileURLWithPath: startingPath))?.path == expected)
     }
-
-    func testPathsRelativeToChildren() {
+    
+    @Test(arguments: [
+        ("/Users/username/Documents/Some/Nested/Folders/", "../../../../Some File.txt"),
+        ("/Users/username/Documents/Some/Nested/", "../../../Some File.txt"),
+        ("/Users/username/Documents/Some/", "../../Some File.txt"),
+        ("/Users/username/Documents/", "../Some File.txt"),
+    ])
+    func usesParentReferencesWhenStartingPointIsDeeper(startingPath: String, expected: String) {
         let url = URL(fileURLWithPath: "/Users/username/Some File.txt")
-
-        XCTAssertEqual(url.relative(to: URL(fileURLWithPath: "/Users/username/Documents/Some/Nested/Folders/"))?.path,
-                       "../../../../Some File.txt")
-        XCTAssertEqual(url.relative(to: URL(fileURLWithPath: "/Users/username/Documents/Some/Nested/"))?.path,
-                       "../../../Some File.txt")
-        XCTAssertEqual(url.relative(to: URL(fileURLWithPath: "/Users/username/Documents/Some/"))?.path,
-                       "../../Some File.txt")
-        XCTAssertEqual(url.relative(to: URL(fileURLWithPath: "/Users/username/Documents/"))?.path,
-                       "../Some File.txt")
+        #expect(url.relative(to: URL(fileURLWithPath: startingPath))?.path == expected)
     }
-
-    func testPathsRelativeToSiblingsChildren() {
+    
+    @Test(arguments: [
+        ("/Users/username/Desktop/", "../Documents/Some Document.txt"),
+        ("/Users/username/Desktop/Some/", "../../Documents/Some Document.txt"),
+        ("/Users/username/Desktop/Some/Nested/", "../../../Documents/Some Document.txt"),
+        ("/Users/username/Desktop/Some/Nested/Folders/", "../../../../Documents/Some Document.txt"),
+    ])
+    func combinesParentReferencesAndForwardPathForUnrelatedSubtree(startingPath: String, expected: String) {
         let url = URL(fileURLWithPath: "/Users/username/Documents/Some Document.txt")
-
-        XCTAssertEqual(url.relative(to: URL(fileURLWithPath: "/Users/username/Desktop/"))?.path,
-                       "../Documents/Some Document.txt")
-        XCTAssertEqual(url.relative(to: URL(fileURLWithPath: "/Users/username/Desktop/Some/"))?.path,
-                       "../../Documents/Some Document.txt")
-        XCTAssertEqual(url.relative(to: URL(fileURLWithPath: "/Users/username/Desktop/Some/Nested/"))?.path,
-                       "../../../Documents/Some Document.txt")
-        XCTAssertEqual(url.relative(to: URL(fileURLWithPath: "/Users/username/Desktop/Some/Nested/Folders/"))?.path,
-                       "../../../../Documents/Some Document.txt")
+        #expect(url.relative(to: URL(fileURLWithPath: startingPath))?.path == expected)
     }
-
-    func testPathsRelativeToSelf() {
+    
+    @Test
+    func returnsEmptyPathWhenStartingPointIsSelf() {
         let url = URL(fileURLWithPath: "/Users/username/Documents/Some Document.txt")
-
-        XCTAssertEqual(url.relative(to: url)?.path, "")
+        #expect(url.relative(to: url)?.path == "")
     }
-
-    func testPathsRelativeToSibling() {
+    
+    @Test
+    func usesSingleParentReferenceForSibling() {
         let url = URL(fileURLWithPath: "/Users/username/Documents/Some Document.txt")
-
-        XCTAssertEqual(url.relative(to: URL(fileURLWithPath: "/Users/username/Documents/Another Document.txt"))?.path,
-                       "../Some Document.txt")
+        #expect(url.relative(to: URL(fileURLWithPath: "/Users/username/Documents/Another Document.txt"))?.path
+                == "../Some Document.txt")
     }
-
 }

--- a/Tests/SwiftDocCTests/Utility/URL+WithoutHostAndSchemeTests.swift
+++ b/Tests/SwiftDocCTests/Utility/URL+WithoutHostAndSchemeTests.swift
@@ -1,25 +1,27 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import XCTest
+import Foundation
+import Testing
 @testable import SwiftDocC
 
-class URL_withoutHostAndPortAndSchemeTests: XCTestCase {
+struct URL_withoutHostAndPortAndSchemeTests {
 
-    func test() {
+    @Test
+    func removesHostPortAndScheme() {
         let url = URL(string: "http://host.name:8888/path/to/something#fragment")!
 
         let withoutHostAndPortAndScheme = url.withoutHostAndPortAndScheme()
-        XCTAssertEqual(withoutHostAndPortAndScheme.absoluteString, "/path/to/something#fragment")
+        #expect(withoutHostAndPortAndScheme.absoluteString == "/path/to/something#fragment")
         
         // Removing the host and scheme from a URL without those shouldn't change anything.
-        XCTAssertEqual(withoutHostAndPortAndScheme.withoutHostAndPortAndScheme().absoluteString, "/path/to/something#fragment")
+        #expect(withoutHostAndPortAndScheme.withoutHostAndPortAndScheme().absoluteString == "/path/to/something#fragment")
     }
 }


### PR DESCRIPTION
Bug/issue #, if applicable: N/A

## Summary

Migrates utility tests for URL and String utilities to Swift Testing.

## Dependencies

N/A

## Testing

No functional change

## Checklist

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
