### PR TITLE
Use `XCTSkipIf(true, ...)` instead of `XCTSkip`

### DIFF
--- a/Tests/DocCCommandLineTests/Utility/LogHandleTests.swift
+++ b/Tests/DocCCommandLineTests/Utility/LogHandleTests.swift
@@ -18,7 +18,7 @@ class LogHandleTests: XCTestCase {
     /// - Bug: rdar://73462272
     func testWriteToStandardOutput() throws {
 #if os(Windows)
-        throw XCTSkip("cannot reassign file handles on Windows")
+        try XCTSkipIf(true, "cannot reassign file handles on Windows")
 #else
         let pipe = Pipe()
 
@@ -58,7 +58,7 @@ class LogHandleTests: XCTestCase {
 
     func testFlushesStandardOutput() throws {
 #if os(Windows)
-        throw XCTSkip("cannot reassign file handles on Windows")
+        try XCTSkipIf(true, "cannot reassign file handles on Windows")
 #else
         let pipe = Pipe()
 
@@ -79,7 +79,7 @@ class LogHandleTests: XCTestCase {
 
     func testFlushesStandardError() throws {
 #if os(Windows)
-        throw XCTSkip("cannot reassign file handles on Windows")
+        try XCTSkipIf(true, "cannot reassign file handles on Windows")
 #else
         let pipe = Pipe()
 

--- a/Tests/SwiftDocCTests/Converter/RenderNodeCodableTests.swift
+++ b/Tests/SwiftDocCTests/Converter/RenderNodeCodableTests.swift
@@ -103,7 +103,7 @@ class RenderNodeCodableTests: XCTestCase {
     
     func testSortedKeys() throws {
         guard #available(macOS 10.13, iOS 11.0, watchOS 4.0, tvOS 11.0, *) else {
-            throw XCTSkip("Skipped on platforms that don't support JSONEncoder.OutputFormatting.sortedKeys")
+            try XCTSkipIf(true, "Skipped on platforms that don't support JSONEncoder.OutputFormatting.sortedKeys")
         }
 
         // When prettyPrint is enabled, keys are sorted

--- a/Tests/SwiftDocCTests/DocumentationService/ConvertService/ConvertServiceTests.swift
+++ b/Tests/SwiftDocCTests/DocumentationService/ConvertService/ConvertServiceTests.swift
@@ -1498,7 +1498,7 @@ class ConvertServiceTests: XCTestCase {
     
     func testReturnsRenderReferenceStoreWhenRequestedForOnDiskBundleWithUncuratedArticles() async throws {
         #if os(Linux)
-        throw XCTSkip("""
+        try XCTSkipIf(true, """
         Skipped on Linux due to an issue in Foundation.Codable where dictionaries are sometimes getting encoded as \
         arrays. (github.com/apple/swift/issues/57363)
         """)
@@ -1627,7 +1627,7 @@ class ConvertServiceTests: XCTestCase {
     
     func testNoRenderReferencesToNonLinkableNodes() async throws {
         #if os(Linux)
-        throw XCTSkip("""
+        try XCTSkipIf(true, """
         Skipped on Linux due to an issue in Foundation.Codable where dictionaries are sometimes getting encoded as \
         arrays. (github.com/apple/swift/issues/57363)
         """)
@@ -1669,7 +1669,7 @@ class ConvertServiceTests: XCTestCase {
     
     func testReturnsRenderReferenceStoreWhenRequestedForOnDiskBundleWithCuratedArticles() async throws {
         #if os(Linux)
-        throw XCTSkip("""
+        try XCTSkipIf(true, """
         Skipped on Linux due to an issue in Foundation.Codable where dictionaries are sometimes getting encoded as \
         arrays. (github.com/apple/swift/issues/57363)
         """)


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

There are certain tests that have known issues. We skip these tests with `throw XCTSkip(<reason>)`. However, the Swift compiler determines that this method is guaranteed to throw, and complains that no code after this line will be executed. These warnings add noise when building tests and make it harder to view genuine warnings for newly introduced tests or changes to existing tests.

This patch replaces the usage of `throw XCTSkip(<reason>)` with `try XCTSkipIf(true, <reason>)`. The latter is functionally identical, but silences the compiler warnings.

## Dependencies

N/A

## Testing

N/A

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
