### PR TITLE
Replace legacy bundle in link render context and chapter tests

### DIFF
--- a/Tests/SwiftDocCTests/Converter/RenderContextTests.swift
+++ b/Tests/SwiftDocCTests/Converter/RenderContextTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -11,10 +11,17 @@
 import Foundation
 import XCTest
 @testable import SwiftDocC
+import DocCTestUtilities
 
 class RenderContextTests: XCTestCase {
     func testCreatesRenderReferences() async throws {
-        let (_, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let catalog = Folder(name: "unit-test.docc") {
+            JSONFile(symbolGraph: makeSymbolGraph(moduleName: "MyKit", symbols: [
+                makeSymbol(id: "s:6MyKit5MyClassC", kind: .class, pathComponents: ["MyClass"]),
+            ]))
+            DataFile(name: "image.png", data: Data())
+        }
+        let (_, context) = try await loadBundle(catalog: catalog)
         let renderContext = RenderContext(documentationContext: context)
         
         // Verify render references are created for all topics

--- a/Tests/SwiftDocCTests/Rendering/LinkTitleResolverTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/LinkTitleResolverTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -11,17 +11,20 @@
 import Foundation
 import XCTest
 @testable import SwiftDocC
+import DocCTestUtilities
 
 class LinkTitleResolverTests: XCTestCase {
     func testSymbolTitleResolving() async throws {
-        let (_, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
-        let resolver = LinkTitleResolver(context: context, source: nil)
-        guard let reference = context.knownIdentifiers.filter({ ref -> Bool in
-            return ref.path.hasSuffix("MyProtocol")
-        }).first else {
-            XCTFail("Did not find MyProtocol in Test Bundle")
-            return
+        let catalog = Folder(name: "unit-test.docc") {
+            JSONFile(symbolGraph: makeSymbolGraph(moduleName: "MyKit", symbols: [
+                makeSymbol(id: "s:6MyKit10MyProtocolP", kind: .protocol, pathComponents: ["MyProtocol"]),
+            ]))
         }
+        let (_, context) = try await loadBundle(catalog: catalog)
+        let resolver = LinkTitleResolver(context: context, source: nil)
+        let reference = try XCTUnwrap(context.knownIdentifiers.first(where: { ref in
+            ref.path.hasSuffix("MyProtocol")
+        }), "Did not find MyProtocol in test catalog")
         let myProtocolNode = try context.entity(with: reference)
         
         // Tests title resolving for symbols

--- a/Tests/SwiftDocCTests/Semantics/ChapterTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/ChapterTests.swift
@@ -8,9 +8,11 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+import Foundation
 import XCTest
 @testable import SwiftDocC
 import Markdown
+import DocCTestUtilities
 
 class ChapterTests: XCTestCase {
     func testEmpty() async throws {
@@ -82,15 +84,46 @@ class ChapterTests: XCTestCase {
     }
     
     func testDuplicateTutorialReferences() async throws {
-        let (_, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        // The catalog contains two `@TutorialReference` directives in a single chapter
+        // that resolve to the same tutorial: "doc:TestTutorial" and "doc:/TestTutorial".
+        // Even though they're spelled differently, they should be treated as duplicates.
+        let catalog = Folder(name: "unit-test.docc") {
+            TextFile(name: "TestOverview.tutorial", utf8Content: """
+            @Tutorials(name: "Technology X") {
+               @Intro(title: "Technology X") {
+                  You'll learn all about Technology X.
+               }
+               @Volume(name: "Volume 1") {
+                  @Chapter(name: "Chapter 1") {
+                     @Image(source: image.png, alt: image)
+                     @TutorialReference(tutorial: "doc:TestTutorial")
+                     @TutorialReference(tutorial: "doc:/TestTutorial")
+                  }
+               }
+            }
+            """)
+            TextFile(name: "TestTutorial.tutorial", utf8Content: """
+            @Tutorial(time: 1) {
+               @Intro(title: "Tutorial") {
+                  An intro.
+               }
+               @Section(title: "Section") {
+                  @ContentAndMedia {
+                     Content.
+                  }
+                  @Steps {
+                     @Step {
+                        Do something.
+                        @Image(source: image.png, alt: image)
+                     }
+                  }
+               }
+            }
+            """)
+            DataFile(name: "image.png", data: Data())
+        }
+        let (_, context) = try await loadBundle(catalog: catalog)
         
-        /*
-         The test bundle contains the duplicate tutorial references in TestOverview:
-         - @TutorialReference(tutorial: "doc:TestTutorial")
-         - @TutorialReference(tutorial: "doc:/TestTutorial")
-         
-         Although these are spelled differently, they resolve to the same tutorial, so they are treated as duplicates.
-         */
         let duplicateDiagnostic = context.diagnostics.filter { $0.identifier == "org.swift.docc.Chapter.Duplicate\(TutorialReference.self)" }
         XCTAssertEqual(1, duplicateDiagnostic.count)
     }


### PR DESCRIPTION
Bug/issue #, if applicable: N/A

## Summary

Replaces uses of the `LegacyBundle_DoNotUseInNewTests` fixture in render context and link resolver tests. There's no strong relationship between those tests, I just bundled them together since they were easier to migrate.

## Dependencies

None.

## Testing

No functional changes.

## Checklist

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary