### PR TITLE
Replace legacy bundle in tutorial reference, resources, and URL tests

### DIFF
--- a/Tests/SwiftDocCTests/Infrastructure/PresentationURLGeneratorTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/PresentationURLGeneratorTests.swift
@@ -15,23 +15,24 @@ import DocCCommon
 
 class PresentationURLGeneratorTests: XCTestCase {
     func testInternalURLs() async throws {
-        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let context = try await makeEmptyContext()
+        let bundleID = context.inputs.id
         let generator = PresentationURLGenerator(context: context, baseURL: URL(string: "https://host:1024/webPrefix")!)
         
         // Test resolved tutorial reference
-        let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/tutorials/Test-Bundle/TestTutorial", sourceLanguage: .swift)
+        let reference = ResolvedTopicReference(bundleID: bundleID, path: "/tutorials/Test-Bundle/TestTutorial", sourceLanguage: .swift)
         XCTAssertEqual(generator.presentationURLForReference(reference).absoluteString, "https://host:1024/webPrefix/tutorials/test-bundle/testtutorial")
         
         // Test resolved symbol reference
-        let symbol = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit/MyClass", sourceLanguage: .swift)
+        let symbol = ResolvedTopicReference(bundleID: bundleID, path: "/documentation/MyKit/MyClass", sourceLanguage: .swift)
         XCTAssertEqual(generator.presentationURLForReference(symbol).absoluteString, "https://host:1024/webPrefix/documentation/mykit/myclass")
         
         // Test root
-        let root = ResolvedTopicReference(bundleID: bundle.id, path: "/", sourceLanguage: .swift)
+        let root = ResolvedTopicReference(bundleID: bundleID, path: "/", sourceLanguage: .swift)
         XCTAssertEqual(generator.presentationURLForReference(root).absoluteString, "https://host:1024/webPrefix/documentation")
         
         // Fragment
-        let fragment = ResolvedTopicReference(bundleID: bundle.id, path: "/path", fragment: "test URL! FRAGMENT", sourceLanguage: .swift)
+        let fragment = ResolvedTopicReference(bundleID: bundleID, path: "/path", fragment: "test URL! FRAGMENT", sourceLanguage: .swift)
         XCTAssertEqual(generator.presentationURLForReference(fragment).absoluteString, "https://host:1024/webPrefix/path#test-URL-FRAGMENT")
     }
 }

--- a/Tests/SwiftDocCTests/Semantics/ResourcesTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/ResourcesTests.swift
@@ -17,7 +17,7 @@ class ResourcesTests: XCTestCase {
         let source = "@\(Resources.directiveName)"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (_, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let context = try await makeEmptyContext()
         var diagnostics = [Diagnostic]()
         let resources = Resources(from: directive, source: nil, for: context.inputs, featureFlags: context.configuration.featureFlags, diagnostics: &diagnostics)
         XCTAssertNil(resources)
@@ -64,7 +64,7 @@ class ResourcesTests: XCTestCase {
 """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (_, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let context = try await makeEmptyContext()
         var diagnostics = [Diagnostic]()
         let resources = Resources(from: directive, source: nil, for: context.inputs, featureFlags: context.configuration.featureFlags, diagnostics: &diagnostics)
         XCTAssertNotNil(resources)
@@ -117,7 +117,7 @@ Resources @1:1-29:2
 """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (_, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let context = try await makeEmptyContext()
         var diagnostics = [Diagnostic]()
         let resources = Resources(from: directive, source: nil, for: context.inputs, featureFlags: context.configuration.featureFlags, diagnostics: &diagnostics)
         XCTAssertNotNil(resources)

--- a/Tests/SwiftDocCTests/Semantics/TutorialArticleTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/TutorialArticleTests.swift
@@ -21,7 +21,7 @@ class TutorialArticleTests: XCTestCase {
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (_, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let context = try await makeEmptyContext()
         
         if let directive {
             var diagnostics = [Diagnostic]()
@@ -57,7 +57,7 @@ class TutorialArticleTests: XCTestCase {
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (_, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let context = try await makeEmptyContext()
         
         if let directive {
             var diagnostics = [Diagnostic]()
@@ -107,7 +107,7 @@ TutorialArticle @1:1-13:2
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (_, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let context = try await makeEmptyContext()
         
         if let directive {
             var diagnostics = [Diagnostic]()

--- a/Tests/SwiftDocCTests/Semantics/TutorialReferenceTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/TutorialReferenceTests.swift
@@ -19,7 +19,7 @@ class TutorialReferenceTests: XCTestCase {
 """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (_, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let context = try await makeEmptyContext()
         var diagnostics = [Diagnostic]()
         let tutorialReference = TutorialReference(from: directive, source: nil, for: context.inputs, featureFlags: context.configuration.featureFlags, diagnostics: &diagnostics)
         XCTAssertNil(tutorialReference)
@@ -37,7 +37,7 @@ class TutorialReferenceTests: XCTestCase {
 """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (_, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let context = try await makeEmptyContext()
         var diagnostics = [Diagnostic]()
         let tutorialReference = TutorialReference(from: directive, source: nil, for: context.inputs, featureFlags: context.configuration.featureFlags, diagnostics: &diagnostics)
         XCTAssertNotNil(tutorialReference)
@@ -57,7 +57,7 @@ class TutorialReferenceTests: XCTestCase {
         """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (_, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let context = try await makeEmptyContext()
         var diagnostics = [Diagnostic]()
         let tutorialReference = TutorialReference(from: directive, source: nil, for: context.inputs, featureFlags: context.configuration.featureFlags, diagnostics: &diagnostics)
         XCTAssertNil(tutorialReference)

--- a/Tests/SwiftDocCTests/Semantics/TutorialTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/TutorialTests.swift
@@ -21,7 +21,7 @@ class TutorialTests: XCTestCase {
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (_, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let context = try await makeEmptyContext()
         
         if let directive {
             var diagnostics = [Diagnostic]()


### PR DESCRIPTION
Bug/issue #, if applicable: N/A

## Summary

Replaces uses of the `LegacyBundle_DoNotUseInNewTests` fixture in tutorial reference, resources, tutorial, tutorial article, and presentation URL generator tests that didn't need to use it in the first place.

## Dependencies

None.

## Testing

No functional changes.

## Checklist

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary