### PR TITLE
Replace legacy bundle in server tests

### DIFF
--- a/Sources/SwiftDocC/Servers/DocumentationSchemeHandler.swift
+++ b/Sources/SwiftDocC/Servers/DocumentationSchemeHandler.swift
@@ -29,20 +29,26 @@ public class DocumentationSchemeHandler: NSObject {
     var fileServer: FileServer
     
     /// The default file provider to serve content from memory.
-    var memoryProvider = MemoryFileServerProvider()
+    var memoryProvider: MemoryFileServerProvider
     
     /**
      Initializes a `DocumentationSchemeHandler` with content coming from a folder.
      */
-    public init(withTemplateURL templateURL:URL) {
+    public convenience init(withTemplateURL templateURL: URL) {
+        self.init(withTemplateURL: templateURL, fileManager: FileManager.default)
+    }
+    
+    package init(withTemplateURL templateURL: URL, fileManager: any FileManagerProtocol) {
         fileServer = FileServer(baseURL: URL(string: DocumentationSchemeHandler.fullScheme)!)
-        let templateProvider = FileSystemServerProvider(directoryPath: templateURL.path)!
+        memoryProvider = MemoryFileServerProvider(fileManager: fileManager)
+        let templateProvider = FileSystemServerProvider(directoryPath: templateURL.path, fileManager: fileManager)!
         fileServer.register(provider: templateProvider)
         fileServer.register(provider: memoryProvider, subPath: "/data")
     }
     
     public override init() {
         fileServer = FileServer(baseURL: URL(string: DocumentationSchemeHandler.fullScheme)!)
+        memoryProvider = MemoryFileServerProvider()
         fileServer.register(provider: memoryProvider)
     }
     

--- a/Sources/SwiftDocC/Servers/FileServer.swift
+++ b/Sources/SwiftDocC/Servers/FileServer.swift
@@ -182,17 +182,23 @@ public protocol FileServerProvider {
 public class FileSystemServerProvider: FileServerProvider {
     
     private(set) var directoryURL: URL
+    private let fileManager: any FileManagerProtocol
     
-    public init?(directoryPath: String) {
-        guard FileManager.default.directoryExists(atPath: directoryPath) else {
+    public convenience init?(directoryPath: String) {
+        self.init(directoryPath: directoryPath, fileManager: FileManager.default)
+    }
+    
+    package init?(directoryPath: String, fileManager: any FileManagerProtocol) {
+        guard fileManager.directoryExists(atPath: directoryPath) else {
             return nil
         }
         self.directoryURL = URL(fileURLWithPath: directoryPath)
+        self.fileManager = fileManager
     }
     
     public func data(for path: String) -> Data? {
         let finalURL = directoryURL.appendingPathComponent(path)
-        return try? Data(contentsOf: finalURL)
+        return try? fileManager.contents(of: finalURL)
     }
     
 }
@@ -202,7 +208,19 @@ public class MemoryFileServerProvider: FileServerProvider {
     /// Files to serve based on relative path.
     private var files = [String: Data]()
     
-    public init() {}
+    private let fileManager: any FileManagerProtocol
+
+    /// Creates a memory file server provider with the default file manager.
+    public convenience init() {
+        self.init(fileManager: FileManager.default)
+    }
+
+    /// Creates a memory file server provider with the given file manager.
+    ///
+    /// - Parameter fileManager: The file manager that the provider uses to read files added with ``addFiles(inFolder:inSubPath:recursive:)``.
+    package init(fileManager: any FileManagerProtocol) {
+        self.fileManager = fileManager
+    }
     
     
     /// Add a file to the file server.
@@ -241,18 +259,16 @@ public class MemoryFileServerProvider: FileServerProvider {
     ///   - destination: The destination directory in the file server to add the files to.
     ///   - recursive: Whether or not to recursively add files from the source directory.
     public func addFiles(inFolder source: String, inSubPath destination: String = "", recursive: Bool = true) {
-        var isDirectory: ObjCBool = false
-        guard FileManager.default.fileExists(atPath: source, isDirectory: &isDirectory) else { return }
-        guard isDirectory.boolValue else { return }
+        guard fileManager.directoryExists(atPath: source) else { return }
         
         let trimmedSubPath = destination.trimmingCharacters(in: slashCharSet)
-        let enumerator = FileManager.default.enumerator(atPath: source)!
+        let sourceURL = URL(fileURLWithPath: source)
         
-        for file in enumerator {
-            guard let file = file as? String else { fatalError("Enumerator returned an unexpected type.") }
-            guard let data = try? Data(contentsOf: URL(fileURLWithPath: source).appendingPathComponent(file)) else { continue }
-            if recursive == false && file.contains("/") { continue } // skip if subfolder and recursive is disabled
-            addFile(path: "/\(trimmedSubPath)/\(file)", data: data)
+        for fileURL in fileManager.recursiveFiles(startingPoint: sourceURL, options: []) {
+            let relativePath = fileURL.path.removingPrefix(sourceURL.path).removingPrefix("/")
+            if recursive == false && relativePath.contains("/") { continue }
+            guard let data = try? fileManager.contents(of: fileURL) else { continue }
+            addFile(path: "/\(trimmedSubPath)/\(relativePath)", data: data)
         }
     }
     

--- a/Tests/SwiftDocCTests/Servers/DocumentationSchemeHandlerTests.swift
+++ b/Tests/SwiftDocCTests/Servers/DocumentationSchemeHandlerTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -15,17 +15,21 @@ import FoundationNetworking
 
 import XCTest
 @testable import SwiftDocC
+import DocCTestUtilities
 
 fileprivate let baseURL = URL(string: "test://")!
 fileprivate let helloWorldHTML = "<html><header><title>Hello Title</title></header><body>Hello world</body></html>".data(using: .utf8)!
 
 class DocumentationSchemeHandlerTests: XCTestCase {
-    let templateURL = Bundle.module.url(
-        forResource: "LegacyBundle_DoNotUseInNewTests", withExtension: "docc", subdirectory: "Test Bundles")!
     
-    func testDocumentationSchemeHandler() {
+    func testDocumentationSchemeHandler() throws {
         #if !os(Linux) && !os(Android) && !os(Windows) && !os(FreeBSD) && !os(OpenBSD)
-        let topicSchemeHandler = DocumentationSchemeHandler(withTemplateURL: templateURL)
+        let (fileSystem, templateURL) = try makeTestFileSystemWith {
+            Folder(name: "images") {
+                DataFile(name: "figure1.jpg", data: Data())
+            }
+        }
+        let topicSchemeHandler = DocumentationSchemeHandler(withTemplateURL: templateURL, fileManager: fileSystem)
         
         let request = URLRequest(url:  baseURL.appendingPathComponent("/images/figure1.jpg"))
         
@@ -49,9 +53,14 @@ class DocumentationSchemeHandlerTests: XCTestCase {
         #endif
     }
     
-    func testSetData() {
+    func testSetData() throws {
         #if !os(Linux) && !os(Android) && !os(Windows) && !os(FreeBSD) && !os(OpenBSD)
-        let topicSchemeHandler = DocumentationSchemeHandler(withTemplateURL: templateURL)
+        let (fileSystem, templateURL) = try makeTestFileSystemWith {
+            Folder(name: "images") {
+                DataFile(name: "figure1.jpg", data: Data())
+            }
+        }
+        let topicSchemeHandler = DocumentationSchemeHandler(withTemplateURL: templateURL, fileManager: fileSystem)
         
         let data = "hello!".data(using: .utf8)!
         topicSchemeHandler.setData(data: ["a.txt": data])

--- a/Tests/SwiftDocCTests/Servers/FileServerTests.swift
+++ b/Tests/SwiftDocCTests/Servers/FileServerTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -15,6 +15,7 @@ import FoundationNetworking
 
 import XCTest
 @testable import SwiftDocC
+import DocCTestUtilities
 
 fileprivate let baseURL = URL(string: "test://")!
 fileprivate let helloWorldHTML = "<html><header><title>Hello Title</title></header><body>Hello world</body></html>".data(using: .utf8)!
@@ -65,12 +66,16 @@ class FileServerTests: XCTestCase {
         XCTAssertNil(retrieved, "\(baseURL.appendingPathComponent("/invalid/").absoluteString) should return nil, but returned \(String(describing: retrieved))")
     }
     
-    func testAddingFilesInFolder() {
-        let folder = Bundle.module.url(
-            forResource: "LegacyBundle_DoNotUseInNewTests", withExtension: "docc", subdirectory: "Test Bundles")!
-        
-        let memoryFileProvider = MemoryFileServerProvider()
-        memoryFileProvider.addFiles(inFolder: folder.path)
+    func testAddingFilesInFolder() throws {
+        let (fileSystem, folderURL) = try makeTestFileSystemWith {
+            DataFile(name: "figure1.png", data: Data())
+            Folder(name: "images") {
+                DataFile(name: "figure1.jpg", data: Data())
+            }
+        }
+
+        let memoryFileProvider = MemoryFileServerProvider(fileManager: fileSystem)
+        memoryFileProvider.addFiles(inFolder: folderURL.path)
         
         let fileServer = FileServer(baseURL: baseURL)
         fileServer.register(provider: memoryFileProvider)
@@ -80,11 +85,9 @@ class FileServerTests: XCTestCase {
     }
     
     func testAddingRemovingFromPath() {
-        let folder = Bundle.module.url(
-            forResource: "LegacyBundle_DoNotUseInNewTests", withExtension: "docc", subdirectory: "Test Bundles")!
-        
         let memoryFileProvider = MemoryFileServerProvider()
-        memoryFileProvider.addFiles(inFolder: folder.path)
+        memoryFileProvider.addFile(path: "/figure1.png", data: Data())
+        memoryFileProvider.addFile(path: "/images/figure1.jpg", data: Data())
         
         let fileServer = FileServer(baseURL: baseURL)
         fileServer.register(provider: memoryFileProvider)
@@ -96,11 +99,15 @@ class FileServerTests: XCTestCase {
         XCTAssertNil(fileServer.data(for: baseURL.appendingPathComponent("/images/figure1.jpg")))
     }
     
-    func testDiskServerProvider() {
-        let folder = Bundle.module.url(
-            forResource: "LegacyBundle_DoNotUseInNewTests", withExtension: "docc", subdirectory: "Test Bundles")!.path
-        
-        guard let fileSystemFileProvider = FileSystemServerProvider(directoryPath: folder) else {
+    func testDiskServerProvider() throws {
+        let (fileSystem, folderURL) = try makeTestFileSystemWith {
+            DataFile(name: "figure1.png", data: Data())
+            Folder(name: "images") {
+                DataFile(name: "figure1.jpg", data: Data())
+            }
+        }
+
+        guard let fileSystemFileProvider = FileSystemServerProvider(directoryPath: folderURL.path, fileManager: fileSystem) else {
             XCTFail("Provided folder is not valid, it cannot be served.")
             return
         }
@@ -112,11 +119,15 @@ class FileServerTests: XCTestCase {
         XCTAssertNotNil(fileServer.data(for: baseURL.appendingPathComponent("/figure1.png")))
     }
     
-    func testSubPathProvider() {
-        let folder = Bundle.module.url(
-            forResource: "LegacyBundle_DoNotUseInNewTests", withExtension: "docc", subdirectory: "Test Bundles")!.path
-        
-        guard let fileSystemFileProvider = FileSystemServerProvider(directoryPath: folder) else {
+    func testSubPathProvider() throws {
+        let (fileSystem, folderURL) = try makeTestFileSystemWith {
+            DataFile(name: "figure1.png", data: Data())
+            Folder(name: "images") {
+                DataFile(name: "figure1.jpg", data: Data())
+            }
+        }
+
+        guard let fileSystemFileProvider = FileSystemServerProvider(directoryPath: folderURL.path, fileManager: fileSystem) else {
             XCTFail("Provided folder is not valid, it cannot be served.")
             return
         }
@@ -145,11 +156,8 @@ class FileServerTests: XCTestCase {
     }
     
     func testResponse() {
-        let folder = Bundle.module.url(
-            forResource: "LegacyBundle_DoNotUseInNewTests", withExtension: "docc", subdirectory: "Test Bundles")!
-        
         let memoryFileProvider = MemoryFileServerProvider()
-        memoryFileProvider.addFiles(inFolder: folder.path)
+        memoryFileProvider.addFile(path: "/images/figure1.jpg", data: Data())
         
         let fileServer = FileServer(baseURL: baseURL)
         fileServer.register(provider: memoryFileProvider)


### PR DESCRIPTION
Bug/issue #, if applicable: N/A

## Summary

Replaces uses of the `LegacyBundle_DoNotUseInNewTests` fixture in the file server tests with an in-memory file system. To enable this, the file server providers were made injectable with a `FileManagerProtocol`.

## Dependencies

None.

## Testing

No functional changes.

## Checklist

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary