### PR TITLE
Ensure image filenames are consistently represented in markdown output

### DIFF
--- a/Sources/SwiftDocC/Model/MarkdownOutput/Translation/MarkdownOutputMarkdownWalker.swift
+++ b/Sources/SwiftDocC/Model/MarkdownOutput/Translation/MarkdownOutputMarkdownWalker.swift
@@ -141,16 +141,16 @@ extension MarkdownOutputMarkupWalker {
             return
         }
         let unescaped = source.removingPercentEncoding ?? source
-        if let resolved = context.resolveAsset(named: unescaped, in: identifier, withType: .image),
-           let first = resolved.variants.first?.value,
-           first.isFileURL
-        {
-            let filename = first.lastPathComponent
-            markdown.append("![\(image.altText ?? "")](images/\(context.inputs.id)/\(filename))")
-        } else {
-            markdown.append(image.format())
+        if let resolved = context.resolveAsset(named: unescaped, in: identifier, withType: .image) {
+            for traits in DataTraitCollection.allCases {
+                if let match = resolved.variants[traits], match.isFileURL {
+                    let filename = match.lastPathComponent
+                    markdown.append("![\(image.altText ?? "")](images/\(context.inputs.id)/\(filename))")
+                    return
+                }
+            }
         }
-                    
+        markdown.append(image.format())
     }
        
     mutating func visitCodeBlock(_ codeBlock: CodeBlock) {

--- a/Tests/SwiftDocCTests/Rendering/Markdown/MarkdownOutputTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/Markdown/MarkdownOutputTests.swift
@@ -553,7 +553,7 @@ struct MarkdownOutputTests {
                 """),
             Folder(name: "Resources", content: [
                 Folder(name: "Images", content: [
-                    CopyOfFile(original: imageURL)
+                    DataFile(name: "image.png", data: Data())
                 ])
             ])
         ])
@@ -565,7 +565,7 @@ struct MarkdownOutputTests {
         #expect(node.markdown.contains("![Unresolved Image](unresolved.png)"))
     }
     
-    @Test("Runs multiple times to check consistent output", arguments: 1...10)
+    @Test(arguments: 1...10)
     func imagesUseSameVariantOverMultipleRuns(run: Int) async throws {
         
         let imageURL = try #require(Bundle.module.url(forResource: "image", withExtension: "png", subdirectory: "Test Resources"), "Could not find test image")
@@ -578,11 +578,11 @@ struct MarkdownOutputTests {
             """),
             Folder(name: "Resources", content: [
                 Folder(name: "Images", content: [
-                    CopyOfFile(original: imageURL, newName: "image.png"),
-                    CopyOfFile(original: imageURL, newName: "image@2x.png"),
-                    CopyOfFile(original: imageURL, newName: "image~dark@2x.png"),
-                    CopyOfFile(original: imageURL, newName: "image@3x.png"),
-                    CopyOfFile(original: imageURL, newName: "image~dark@2x.png")
+                    DataFile(name: "image.png",         data: Data()),
+                    DataFile(name: "image@2x.png",      data: Data()),
+                    DataFile(name: "image~dark@2x.png", data: Data()),
+                    DataFile(name: "image@3x.png",      data: Data()),
+                    DataFile(name: "image~dark@2x.png", data: Data()),
                 ])
             ])
         ])

--- a/Tests/SwiftDocCTests/Rendering/Markdown/MarkdownOutputTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/Markdown/MarkdownOutputTests.swift
@@ -539,13 +539,12 @@ struct MarkdownOutputTests {
         
     @Test
     func imagesUseArchiveRelativePathsForLocalFiles() async throws {
+        
+        let imageURL = try #require(Bundle.module.url(forResource: "image", withExtension: "png", subdirectory: "Test Resources"), "Could not find test image")
+        
         let catalog = catalog(files: [
             TextFile(name: "ImageArticle.md", utf8Content: """
                 # Images
-                
-                Shows how images are represented in markdown output
-                
-                ## Overview
                 
                 ![Alternative Title](image.png)
                 ![](image.png)
@@ -554,7 +553,7 @@ struct MarkdownOutputTests {
                 """),
             Folder(name: "Resources", content: [
                 Folder(name: "Images", content: [
-                    CopyOfFile(original: Bundle.module.url(forResource: "image", withExtension: "png", subdirectory: "Test Resources")!)
+                    CopyOfFile(original: imageURL)
                 ])
             ])
         ])
@@ -564,6 +563,32 @@ struct MarkdownOutputTests {
         #expect(node.markdown.contains("![](images/MarkdownOutput/image.png"))
         #expect(node.markdown.contains("![Web Image](https://www.example.com/webimage.png)"))
         #expect(node.markdown.contains("![Unresolved Image](unresolved.png)"))
+    }
+    
+    @Test("Runs multiple times to check consistent output", arguments: 1...10)
+    func imagesUseSameVariantOverMultipleRuns(run: Int) async throws {
+        
+        let imageURL = try #require(Bundle.module.url(forResource: "image", withExtension: "png", subdirectory: "Test Resources"), "Could not find test image")
+        
+        let catalog = catalog(files: [
+            TextFile(name: "ImageVariants.md", utf8Content: """
+            # Image variants
+            
+            ![Image Title](image.png)
+            """),
+            Folder(name: "Resources", content: [
+                Folder(name: "Images", content: [
+                    CopyOfFile(original: imageURL, newName: "image.png"),
+                    CopyOfFile(original: imageURL, newName: "image@2x.png"),
+                    CopyOfFile(original: imageURL, newName: "image~dark@2x.png"),
+                    CopyOfFile(original: imageURL, newName: "image@3x.png"),
+                    CopyOfFile(original: imageURL, newName: "image~dark@2x.png")
+                ])
+            ])
+        ])
+        
+        let (node, _) = try await markdownOutput(catalog: catalog, path: "ImageVariants")
+        #expect(node.markdown.contains("![Image Title](images/MarkdownOutput/image.png)"), "Expected to choose the first variant matching in order of DataTraitCollection.allCases.")
     }
     
     @Test

--- a/Tests/SwiftDocCTests/Rendering/Markdown/MarkdownOutputTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/Markdown/MarkdownOutputTests.swift
@@ -539,9 +539,6 @@ struct MarkdownOutputTests {
         
     @Test
     func imagesUseArchiveRelativePathsForLocalFiles() async throws {
-        
-        let imageURL = try #require(Bundle.module.url(forResource: "image", withExtension: "png", subdirectory: "Test Resources"), "Could not find test image")
-        
         let catalog = catalog(files: [
             TextFile(name: "ImageArticle.md", utf8Content: """
                 # Images
@@ -551,11 +548,11 @@ struct MarkdownOutputTests {
                 ![Web Image](https://www.example.com/webimage.png)
                 ![Unresolved Image](unresolved.png)
                 """),
-            Folder(name: "Resources", content: [
-                Folder(name: "Images", content: [
+            Folder(name: "Resources") {
+                Folder(name: "Images") {
                     DataFile(name: "image.png", data: Data())
-                ])
-            ])
+                }
+            }
         ])
         
         let (node, _) = try await markdownOutput(catalog: catalog, path: "ImageArticle")
@@ -566,25 +563,22 @@ struct MarkdownOutputTests {
     }
     
     @Test(arguments: 1...10)
-    func imagesUseSameVariantOverMultipleRuns(run: Int) async throws {
-        
-        let imageURL = try #require(Bundle.module.url(forResource: "image", withExtension: "png", subdirectory: "Test Resources"), "Could not find test image")
-        
+    func imagesUseSameVariantOverMultipleRuns(run: Int) async throws {      
         let catalog = catalog(files: [
             TextFile(name: "ImageVariants.md", utf8Content: """
             # Image variants
             
             ![Image Title](image.png)
             """),
-            Folder(name: "Resources", content: [
-                Folder(name: "Images", content: [
-                    DataFile(name: "image.png",         data: Data()),
-                    DataFile(name: "image@2x.png",      data: Data()),
-                    DataFile(name: "image~dark@2x.png", data: Data()),
-                    DataFile(name: "image@3x.png",      data: Data()),
-                    DataFile(name: "image~dark@2x.png", data: Data()),
-                ])
-            ])
+            Folder(name: "Resources") {
+                Folder(name: "Images") {
+                    DataFile(name: "image.png",         data: Data())
+                    DataFile(name: "image@2x.png",      data: Data())
+                    DataFile(name: "image~dark@2x.png", data: Data())
+                    DataFile(name: "image@3x.png",      data: Data())
+                    DataFile(name: "image~dark@2x.png", data: Data())
+                }
+            }
         ])
         
         let (node, _) = try await markdownOutput(catalog: catalog, path: "ImageVariants")


### PR DESCRIPTION
Bug/issue #, if applicable: 179367117

## Summary

When multiple variants of an image file are present in resources (e.g. @2x, ~dark ), the filename included in the markdown output was not consistent from run to run. 

Fixed by always using the first variant that matches a trait from `DataTraitCollection.allCases`. 

## Dependencies

N/A

## Testing

Steps:

1. Create a DocC catalog with multiple variants of an image, and include the image in a documentation page.
2. Repeatedly generate markdown output using `docc convert` with the `--enable-experimental-markdown-output` flag on
3. The filename displayed in the markdown output may vary from run to run. 

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary N/A
