### PR TITLE
Render the `@Small` directive in the static HTML output

### DIFF
--- a/Sources/DocCHTML/MarkdownRenderer.swift
+++ b/Sources/DocCHTML/MarkdownRenderer.swift
@@ -741,8 +741,13 @@ package struct MarkdownRenderer<Provider: LinkProvider> {
     
     // MARK: Directives
     
-    func visit(_: BlockDirective) -> XMLNode {
-        .text("") // TODO: Support the block directives that appear as in-page content (rdar://165755944)
+    func visit(_ directive: BlockDirective) -> XMLNode {
+        switch directive.name {
+        case "Small":
+            return .element(named: "small", children: visit(directive.children))
+        default:
+            return .text("") // TODO: Support the block directives that appear as in-page content (rdar://165755944)
+        }
     }
     
     // TODO: Support rendering Doxygen tags. (rdar://165755750)

--- a/Sources/DocCHTML/MarkdownRenderer.swift
+++ b/Sources/DocCHTML/MarkdownRenderer.swift
@@ -744,7 +744,12 @@ package struct MarkdownRenderer<Provider: LinkProvider> {
     func visit(_ directive: BlockDirective) -> XMLNode {
         switch directive.name {
         case "Small":
-            return .element(named: "small", children: visit(directive.children))
+            // <small> is phrasing content and should be wrapped by <p>,
+            // per the HTML spec - not the other way around
+            let content = directive.children.flatMap { child -> [XMLNode] in
+                (child as? Paragraph).map { visit($0.children) } ?? [visit(child)]
+            }
+            return .element(named: "p", children: [.element(named: "small", children: content)])
         default:
             return .text("") // TODO: Support the block directives that appear as in-page content (rdar://165755944)
         }

--- a/Tests/DocCHTMLTests/MarkdownRendererTests.swift
+++ b/Tests/DocCHTMLTests/MarkdownRendererTests.swift
@@ -292,24 +292,14 @@ struct MarkdownRendererTests {
     }
     
     @Test
-    func renderingSmallDirectives() async throws {
+    func renderingSmallDirective() async throws {
         assert(
             rendering: """
             @Small {
                 Licensed under Apache License v2.0
             }
             """,
-            parseOptions: [.parseSymbolLinks, .parseBlockDirectives],
-            matches: "<small><p>Licensed under Apache License v2.0</p></small>")
-        
-        assert(
-            rendering: """
-            @Row {
-                empty
-            }
-            """,
-            parseOptions: [.parseSymbolLinks, .parseBlockDirectives],
-            matches: "")
+            matches: "<p><small>Licensed under Apache License v2.0</small></p>")
     }
     
     @Test
@@ -620,7 +610,6 @@ struct MarkdownRendererTests {
     
     private func assert(
         rendering markdownContent: String,
-        parseOptions: ParseOptions = .parseSymbolLinks,
         elementToReturn: LinkedElement? = nil,
         assetToReturn: LinkedAsset? = nil,
         fallbackLinkTextToReturn: String? = nil,
@@ -637,7 +626,7 @@ struct MarkdownRendererTests {
                 fallbackLinkTextToReturn: fallbackLinkTextToReturn
             )
         )
-        let htmlNodes = Document(parsing: markdownContent, options: parseOptions).children.map { renderer.visit($0) }
+        let htmlNodes = Document(parsing: markdownContent, options: [.parseSymbolLinks, .parseBlockDirectives]).children.map { renderer.visit($0) }
         htmlNodes.assertMatches(prettyFormatted: prettyFormatted, expectedXMLString: expectedHTML, sourceLocation: sourceLocation)
     }
     

--- a/Tests/DocCHTMLTests/MarkdownRendererTests.swift
+++ b/Tests/DocCHTMLTests/MarkdownRendererTests.swift
@@ -292,6 +292,27 @@ struct MarkdownRendererTests {
     }
     
     @Test
+    func renderingSmallDirectives() async throws {
+        assert(
+            rendering: """
+            @Small {
+                Licensed under Apache License v2.0
+            }
+            """,
+            parseOptions: [.parseSymbolLinks, .parseBlockDirectives],
+            matches: "<small><p>Licensed under Apache License v2.0</p></small>")
+        
+        assert(
+            rendering: """
+            @Row {
+                empty
+            }
+            """,
+            parseOptions: [.parseSymbolLinks, .parseBlockDirectives],
+            matches: "")
+    }
+    
+    @Test
     func renderingCodeBlocks() async throws {
         assert(
             rendering: """
@@ -599,6 +620,7 @@ struct MarkdownRendererTests {
     
     private func assert(
         rendering markdownContent: String,
+        parseOptions: ParseOptions = .parseSymbolLinks,
         elementToReturn: LinkedElement? = nil,
         assetToReturn: LinkedAsset? = nil,
         fallbackLinkTextToReturn: String? = nil,
@@ -615,7 +637,7 @@ struct MarkdownRendererTests {
                 fallbackLinkTextToReturn: fallbackLinkTextToReturn
             )
         )
-        let htmlNodes = Document(parsing: markdownContent, options: .parseSymbolLinks).children.map { renderer.visit($0) }
+        let htmlNodes = Document(parsing: markdownContent, options: parseOptions).children.map { renderer.visit($0) }
         htmlNodes.assertMatches(prettyFormatted: prettyFormatted, expectedXMLString: expectedHTML, sourceLocation: sourceLocation)
     }
     


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://165755944

## Summary

The static HTML renderer (`DocCHTML`) previously discarded all block directives, producing empty output for them. This PR adds rendering for the `@Small` directive, wrapping its content in an HTML `<small>` element.

### Before
  ```swift
  func visit(_: BlockDirective) -> XMLNode {
      .text("") // all block directives produced empty output
  }
```
### After
```swift
  func visit(_ directive: BlockDirective) -> XMLNode {
      switch directive.name {
      case "Small":
          return .element(named: "small", children: visit(directive.children))
      default:
          return .text("") // other block directives still TODO (rdar://165755944)
      }
  }
```
This is a first step toward supporting block directives in the static HTML output; other directives (`@Row`, `@Image`, etc.) remain as a follow-up.

### Open question
`@Small` content is wrapped in a paragraph, so the output is `<small><p>…</p></small>`. I kept the paragraph for now - happy to unwrap it to inline content if reviewers prefer.

## Dependencies

None.

## Testing

Steps:
1. Build a documentation catalog that uses the `@Small` directive.
2. Run docc convert with --output-format experimental-html-for-development.
3. The `@Small` content now appears inside a <small> element in the generated HTML.

Unit tests covering both `@Small` rendering and the unchanged behavior of other directives are included.
I added a `parseOptions` parameter (defaulting to the existing `.parseSymbolLinks`) to the test helper so directive rendering can be tested; existing tests are unaffected.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary
