### PR TITLE
fix(diagnostics): correct markdown link fix-it ranges

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -1241,7 +1241,12 @@ public class DocumentationContext {
                     }
                     
                     // Present a diagnostic specific to documentation extension files but get the solutions and notes from the general unresolved link problem.
-                    let unresolvedLinkDiagnostic = unresolvedReferenceDiagnostic(source: documentationExtension.source, range: link.range, severity: .warning, errorInfo: errorInfo, fromSymbolLink: link is SymbolLink)
+                    let unresolvedLinkDiagnostic = unresolvedReferenceDiagnostic(
+                        source: documentationExtension.source,
+                        link: link,
+                        severity: .warning,
+                        errorInfo: errorInfo
+                    )
                     
                     diagnosticEngine.emit(
                         Diagnostic(source: documentationExtension.source, severity: .warning, range: link.range, identifier: "org.swift.docc.SymbolUnmatched", summary: "No symbol matched \(destination.singleQuoted). \(errorInfo.message).", notes: unresolvedLinkDiagnostic.notes, solutions: unresolvedLinkDiagnostic.solutions)

--- a/Sources/SwiftDocC/Semantics/MarkupReferenceResolver.swift
+++ b/Sources/SwiftDocC/Semantics/MarkupReferenceResolver.swift
@@ -49,7 +49,13 @@ struct MarkupReferenceResolver: MarkupRewriter {
     // This property offers a customization point for when we need to try resolving links in other contexts than the current one to provide more precise diagnostics.
     var diagnosticForUnresolvedReference: ((_ unresolvedReference: UnresolvedTopicReference, _ range: SourceRange?, _ fromSymbolLink: Bool, _ underlyingErrorMessage: String) -> Diagnostic?)? = nil
 
-    private mutating func resolve(reference: TopicReference, range: SourceRange?, severity: DiagnosticSeverity, fromSymbolLink: Bool = false) -> ResolvedTopicReference? {
+    private mutating func resolve(
+        reference: TopicReference,
+        link: any AnyLink,
+        severity: DiagnosticSeverity,
+        fromSymbolLink: Bool = false
+    ) -> ResolvedTopicReference? {
+        let range = link.range
         switch context.resolve(reference, in: rootReference, fromSymbolLink: fromSymbolLink) {
         case .success(let resolved):
             // If the linked node is part of the topic graph,
@@ -74,7 +80,7 @@ struct MarkupReferenceResolver: MarkupRewriter {
             if let articleNotInHierarchy = context.uncuratedArticles[context.inputs.articlesDocumentationRootReference.appendingPathOfReference(unresolved)] {
                 diagnostics.append(makeUnfindableArticleDiagnostic(source: range?.source, severity: severity, range: range, articleNotInHierarchy: articleNotInHierarchy, rootPageNames: context.sortedRootPageNames()))
             } else {
-                diagnostics.append(unresolvedReferenceDiagnostic(source: range?.source, range: range, severity: severity, errorInfo: error, fromSymbolLink: fromSymbolLink))
+                diagnostics.append(unresolvedReferenceDiagnostic(source: range?.source, link: link, severity: severity, errorInfo: error))
             }
             return nil
         }
@@ -113,7 +119,7 @@ struct MarkupReferenceResolver: MarkupRewriter {
             return link // Create a non-topic link
         }
         let unresolved = TopicReference.unresolved(.init(topicURL: url))
-        guard let resolvedURL = resolve(reference: unresolved, range: link.range, severity: .warning) else {
+        guard let resolvedURL = resolve(reference: unresolved, link: link, severity: .warning) else {
             return link
         }
         var link = link
@@ -126,27 +132,24 @@ struct MarkupReferenceResolver: MarkupRewriter {
         return link
     }
 
-    mutating func resolveAbsoluteSymbolLink(unresolvedDestination: String, elementRange range: SourceRange?) -> ResolvedTopicReference? {
-        if let cached = context.referenceIndex[unresolvedDestination] {
-            guard context.topicGraph.isLinkable(cached) == true else {
-                diagnostics.append(disabledLinkDestinationDiagnostic(reference: cached, range: range, severity: .warning))
-                return nil
-            }
-            return cached
-        }
-
-        // We don't require a scheme here as the link can be a relative one, e.g. ``SwiftUI/View``.
-        let url = ValidatedURL(parsingExact: unresolvedDestination)?.requiring(scheme: ResolvedTopicReference.urlScheme) ?? ValidatedURL(symbolPath: unresolvedDestination)
-        return resolve(reference: .unresolved(.init(topicURL: url)), range: range, severity: .warning, fromSymbolLink: true)
-    }
-    
     mutating func visitSymbolLink(_ symbolLink: SymbolLink) -> (any Markup)? {
         guard let destination = symbolLink.destination else {
             return symbolLink
         }
         
         var symbolLink = symbolLink
-        if let resolved = resolveAbsoluteSymbolLink(unresolvedDestination: destination, elementRange: symbolLink.range) {
+        if let cached = context.referenceIndex[destination] {
+            guard context.topicGraph.isLinkable(cached) == true else {
+                diagnostics.append(disabledLinkDestinationDiagnostic(reference: cached, range: symbolLink.range, severity: .warning))
+                return symbolLink
+            }
+            symbolLink.destination = cached.absoluteString
+            return symbolLink
+        }
+
+        // We don't require a scheme here as the link can be a relative one, e.g. ``SwiftUI/View``.
+        let url = ValidatedURL(parsingExact: destination)?.requiring(scheme: ResolvedTopicReference.urlScheme) ?? ValidatedURL(symbolPath: destination)
+        if let resolved = resolve(reference: .unresolved(.init(topicURL: url)), link: symbolLink, severity: .warning, fromSymbolLink: true) {
             symbolLink.destination = resolved.absoluteString
         }
         

--- a/Sources/SwiftDocC/Semantics/ReferenceResolver.swift
+++ b/Sources/SwiftDocC/Semantics/ReferenceResolver.swift
@@ -12,33 +12,60 @@ import Foundation
 import Markdown
 private import SymbolKit
 
-func unresolvedReferenceDiagnostic(source: URL?, range: SourceRange?, severity: DiagnosticSeverity, errorInfo: TopicReferenceResolutionErrorInfo, fromSymbolLink: Bool) -> Diagnostic {
+private func unresolvedReferenceDiagnostic(
+    source: URL?,
+    range: SourceRange?,
+    severity: DiagnosticSeverity,
+    errorInfo: TopicReferenceResolutionErrorInfo
+) -> Diagnostic {
     let referenceSourceRange: SourceRange? = range.map { range in
         // FIXME: Finding the range for the link's destination is better suited for Swift-Markdown
         // https://github.com/apple/swift-markdown/issues/109
-        if fromSymbolLink {
-            // Inset the range by 2 at the start and end to skip both "``".
-            return SourceLocation(line: range.lowerBound.line, column: range.lowerBound.column+2, source: range.lowerBound.source) ..< SourceLocation(line: range.upperBound.line, column: range.upperBound.column-2, source: range.upperBound.source)
-        } else {
-            // FIXME: This assumes that the link uses the `<doc:my/reference>` syntax.
-            // Links that use the [link text](doc:my/reference) syntax will have incorrect suggestion replacements.
-            // https://github.com/swiftlang/swift-docc/issues/470
-            
-            // Inset the range by 5 at the start and by 1 at the end to skip "<doc:" at the start and ">" at the end.
-            return SourceLocation(line: range.lowerBound.line, column: range.lowerBound.column+5, source: range.lowerBound.source) ..< SourceLocation(line: range.upperBound.line, column: range.upperBound.column-1, source: range.upperBound.source)
-        }
+        // Inset the range by 5 at the start and by 1 at the end to skip "<doc:" at the start and ">" at the end.
+        return SourceLocation(line: range.lowerBound.line, column: range.lowerBound.column+5, source: range.lowerBound.source) ..< SourceLocation(line: range.upperBound.line, column: range.upperBound.column-1, source: range.upperBound.source)
     }
     
+    return unresolvedReferenceDiagnostic(
+        source: source,
+        range: range,
+        referenceSourceRange: referenceSourceRange,
+        severity: severity,
+        errorInfo: errorInfo
+    )
+}
+
+func unresolvedReferenceDiagnostic(
+    source: URL?,
+    link: any AnyLink,
+    severity: DiagnosticSeverity,
+    errorInfo: TopicReferenceResolutionErrorInfo
+) -> Diagnostic {
+    return unresolvedReferenceDiagnostic(
+        source: source,
+        range: link.range,
+        referenceSourceRange: link.referenceBodySourceRange,
+        severity: severity,
+        errorInfo: errorInfo
+    )
+}
+
+private func unresolvedReferenceDiagnostic(
+    source: URL?,
+    range: SourceRange?,
+    referenceSourceRange: SourceRange?,
+    severity: DiagnosticSeverity,
+    errorInfo: TopicReferenceResolutionErrorInfo
+) -> Diagnostic {
     var solutions: [Solution] = []
     var notes: [Diagnostic.Note] = []
     if let referenceSourceRange {
         if let note = errorInfo.note, let source {
             notes.append(.init(source: source, range: referenceSourceRange, message: note))
         }
-        
+
         solutions.append(contentsOf: errorInfo.solutions(referenceSourceRange: referenceSourceRange))
     }
-    
+
     let diagnosticRange: SourceRange?
     if var rangeAdjustment = errorInfo.rangeAdjustment, let referenceSourceRange {
         rangeAdjustment.offsetWithRange(referenceSourceRange)
@@ -52,7 +79,7 @@ func unresolvedReferenceDiagnostic(source: URL?, range: SourceRange?, severity: 
     } else {
         diagnosticRange = referenceSourceRange
     }
-    
+
     return Diagnostic(source: source, severity: severity, range: diagnosticRange, identifier: "org.swift.docc.unresolvedTopicReference", summary: errorInfo.message, notes: notes, solutions: solutions)
 }
 
@@ -114,7 +141,7 @@ struct ReferenceResolver: SemanticVisitor {
             if let articleNotInHierarchy = context.uncuratedArticles[context.inputs.documentationRootReference.appendingPathOfReference(unresolved)] {
                 diagnostics.append(makeUnfindableArticleDiagnostic(source: range?.source, severity: severity, range: range, articleNotInHierarchy: articleNotInHierarchy, rootPageNames: context.sortedRootPageNames()))
             } else {
-                diagnostics.append(unresolvedReferenceDiagnostic(source: range?.source, range: range, severity: severity, errorInfo: error, fromSymbolLink: false))
+                diagnostics.append(unresolvedReferenceDiagnostic(source: range?.source, range: range, severity: severity, errorInfo: error))
             }
             return .failure(unresolved, error)
         }

--- a/Sources/SwiftDocC/Utility/MarkupExtensions/SourceRangeExtensions.swift
+++ b/Sources/SwiftDocC/Utility/MarkupExtensions/SourceRangeExtensions.swift
@@ -48,3 +48,66 @@ extension SourceRange {
         return location ..< location
     }
 }
+
+extension AnyLink {
+    var referenceBodySourceRange: SourceRange? {
+        guard let destination, let range else {
+            return nil
+        }
+
+        if self is SymbolLink {
+            // Inset the range by 2 at the start and end to skip both "``".
+            return SourceLocation(
+                line: range.lowerBound.line,
+                column: range.lowerBound.column + 2,
+                source: range.lowerBound.source
+            ) ..< SourceLocation(
+                line: range.upperBound.line,
+                column: range.upperBound.column - 2,
+                source: range.upperBound.source
+            )
+        }
+
+        guard let link = self as? Link else {
+            return nil
+        }
+
+        let topicScheme = "\(ResolvedTopicReference.urlScheme):"
+        guard destination.hasPrefix(topicScheme) else {
+            return nil
+        }
+
+        let isAngleBracketAutolink = link.isAutolink
+            && range.lowerBound.line == range.upperBound.line
+            && range.upperBound.column - range.lowerBound.column == destination.count + 2
+        if isAngleBracketAutolink {
+            return SourceLocation(
+                line: range.lowerBound.line,
+                column: range.lowerBound.column + 1 + topicScheme.count,
+                source: range.lowerBound.source
+            ) ..< SourceLocation(
+                line: range.upperBound.line,
+                column: range.upperBound.column - 1,
+                source: range.upperBound.source
+            )
+        }
+
+        guard range.lowerBound.line == range.upperBound.line else {
+            return nil
+        }
+
+        let titleSourceLength = link.title.map { $0.count + 3 } ?? 0
+        let destinationEndColumn = range.upperBound.column - 1 - titleSourceLength
+        let destinationStartColumn = destinationEndColumn - destination.count
+
+        return SourceLocation(
+            line: range.upperBound.line,
+            column: destinationStartColumn + topicScheme.count,
+            source: range.upperBound.source
+        ) ..< SourceLocation(
+            line: range.upperBound.line,
+            column: destinationEndColumn,
+            source: range.upperBound.source
+        )
+    }
+}

--- a/Tests/SwiftDocCTests/Semantics/Reference/MarkdownLinkFixitTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/Reference/MarkdownLinkFixitTests.swift
@@ -1,0 +1,92 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2026 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Markdown
+import Testing
+@testable import SwiftDocC
+
+struct MarkdownLinkFixitTests {
+    @Test(arguments: [
+        LinkFixItCase(
+            source: "<doc:MyClass/init()>",
+            expected: "<doc:MyClass/init()-33vaw>"
+        ),
+        LinkFixItCase(
+            source: "[custom title](doc:MyClass/init())",
+            expected: "[custom title](doc:MyClass/init()-33vaw)"
+        ),
+        LinkFixItCase(
+            source: "[custom title](doc:MyClass/init() \"Initializer\")",
+            expected: "[custom title](doc:MyClass/init()-33vaw \"Initializer\")"
+        ),
+        LinkFixItCase(
+            source: "[doc:MyClass/init()](doc:MyClass/init())",
+            expected: "[doc:MyClass/init()](doc:MyClass/init()-33vaw)"
+        ),
+        LinkFixItCase(
+            source: "``MyClass/init()``",
+            expected: "``MyClass/init()-33vaw``"
+        ),
+    ])
+    func fixItReplacementRangesUseAuthoredReferenceBody(testCase: LinkFixItCase) throws {
+        let link = try #require(firstLink(in: testCase.source))
+        let diagnostic = unresolvedReferenceDiagnostic(
+            source: nil,
+            link: link,
+            severity: .warning,
+            errorInfo: TopicReferenceResolutionErrorInfo(
+                "Test diagnostic",
+                solutions: [
+                    Solution(summary: "Insert '-33vaw'", replacements: [
+                        .init(
+                            range: .makeRelativeRange(startColumn: "MyClass/init()".count, length: 0),
+                            replacement: "-33vaw"
+                        )
+                    ])
+                ]
+            ),
+        )
+
+        let solution = try #require(diagnostic.solutions.first)
+        #expect(try solution.applyTo(testCase.source) == testCase.expected)
+    }
+
+    private func firstLink(in source: String) -> (any AnyLink)? {
+        let document = Document(parsing: source, options: [.parseSymbolLinks])
+        let links = links(in: document)
+        return links.first { link in
+            (link as? Link)?.isAutolink == false
+        } ?? links.first
+    }
+
+    private func links(in markup: any Markup) -> [any AnyLink] {
+        var result: [any AnyLink] = []
+        if let link = markup as? any AnyLink {
+            result.append(link)
+        }
+
+        for index in 0..<markup.childCount {
+            if let child = markup.child(at: index) {
+                result.append(contentsOf: links(in: child))
+            }
+        }
+
+        return result
+    }
+}
+
+struct LinkFixItCase: CustomStringConvertible, Sendable {
+    var source: String
+    var expected: String
+
+    var description: String {
+        source
+    }
+}


### PR DESCRIPTION
Fixes: #470

## Summary

This fixes unresolved reference fix-it replacement ranges for references authored with regular Markdown link syntax, such as `[custom title](doc:MyClass/init())`.

Previously, unresolved reference diagnostics inferred replacement ranges as if non-symbol links were always written using `<doc:...>` autolink syntax. For Markdown links, that could offset the suggested replacement into the link text or surrounding punctuation.

This change routes link diagnostics through parsed `AnyLink` markup when available and computes the source range for the authored reference body. It keeps the raw range-based fallback for semantic references that don't have parsed link markup.

It also adds a Swift Testing regression that applies fix-it replacements to authored source for:

- `<doc:MyClass/init()>`
- `[custom title](doc:MyClass/init())`
- `[custom title](doc:MyClass/init() "Initializer")`
- `[doc:MyClass/init()](doc:MyClass/init())`
- ``MyClass/init()``

## Dependencies

None.

## Testing

- `swift test --filter MarkdownLinkFixitTests`
- `swift test --filter ReferenceResolverTests`
- `swift test --filter MarkupReferenceResolverTests`
- `swift test --filter SymbolTests.testUnresolvedReferenceWarningsInDocumentationExtension`

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- ~[ ] Ran the `./bin/test` script and it succeeded~ Ran the focused tests listed above.
- ~[ ] Updated documentation if necessary~ This is an implementation-only bug fix.