### PR TITLE
Drop unnamed symbols when loading symbol graph

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphLoader.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphLoader.swift
@@ -69,7 +69,25 @@ struct SymbolGraphLoader {
                 let data = try dataProvider.contents(of: symbolGraphURL)
 
                 var symbolGraph: SymbolGraph = try FastSymbolGraphJSONDecoder.decode(SymbolGraph.self, from: data)
-                
+
+                // Clang can sometimes erroneously emit anonymous structs and unions without a title in the symbol graph.
+                // This typically occurs for anonymous types nested within public types, making them technically public
+                // but functionally private since they cannot be referenced in any way by any consumers of that header.
+                // This causes issues in a few different places for DocC:
+                //
+                // - Their pages can't be navigated to because their URL path end with a leading slash.
+                //   The corresponding static hosting 'index.html' copy also overrides the container's index.html file because
+                //   its file path has two slashes, for example "/documentation/ModuleName/ContainerName//index.html".
+                // - In cases where the symbol is top-level, its URL path conflicts with the root page of the framework,
+                //   leading to incorrect content being rendered.
+                //
+                // In order to avoid these issues, symbols without valid non-empty path components are dropped.
+                let droppedIDs = symbolGraph.symbols.compactMap { $0.value.pathComponents.contains("") ? $0.key : nil }
+                if !droppedIDs.isEmpty {
+                    for id in droppedIDs { symbolGraph.symbols.removeValue(forKey: id) }
+                    symbolGraph.relationships.removeAll { droppedIDs.contains($0.source) || droppedIDs.contains($0.target) }
+                }
+
                 symbolGraphTransformer?(&symbolGraph)
 
                 let (moduleName, isMainSymbolGraph) = Self.moduleNameFor(symbolGraph, at: symbolGraphURL)

--- a/Tests/SwiftDocCTests/Infrastructure/SymbolGraph/SymbolGraphLoaderTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/SymbolGraph/SymbolGraphLoaderTests.swift
@@ -211,6 +211,34 @@ struct SymbolGraphLoaderTests {
         #expect(loader.unifiedGraphs.first?.value.metadata.first?.value.formatVersion.description == "9.9.9")
     }
     
+    @Test
+    func dropsSymbolsWithEmptyPathComponents() throws {
+        let validParent = makeSymbol(id: "valid-parent-id", kind: .class, pathComponents: ["ClassName"])
+        let validChild = makeSymbol(id: "valid-child-id", kind: .func, pathComponents: ["methodName"])
+        let anonParent = makeSymbol(id: "anon-parent-id", kind: .struct, pathComponents: [""])
+        let anonChild = makeSymbol(id: "anon-child-id", kind: .property, pathComponents: ["", "fieldName"])
+
+        let validRelationship = SymbolGraph.Relationship(
+            source: "valid-child-id", target: "valid-parent-id", kind: .memberOf, targetFallback: nil
+        )
+        let invalidRelationship = SymbolGraph.Relationship(
+            source: "anon-child-id", target: "anon-parent-id", kind: .memberOf, targetFallback: nil
+        )
+
+        var loader = try makeLoader {
+            JSONFile(symbolGraph: makeSymbolGraph(
+                moduleName: "TestModule",
+                symbols: [validParent, validChild, anonParent, anonChild],
+                relationships: [validRelationship, invalidRelationship]
+            ))
+        }
+        try loader.loadAll()
+
+        let graph = try #require(loader.symbolGraphs.values.first)
+        #expect(Set(graph.symbols.keys) == ["valid-parent-id", "valid-child-id"], "Symbols with empty path component segments should be dropped")
+        #expect(graph.relationships.map(\.source) == ["valid-child-id"], "Relationships referencing dropped symbols should be removed")
+    }
+
     private func makeLoader(@FileBuilder content: () -> [any File]) throws -> SymbolGraphLoader {
         let (fileSystem, folderURL) = try makeTestFileSystemWith(content: content)
         


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://180902381

## Summary

Clang can sometimes erroneously emit anonymous structs and unions without a title in the symbol graph. This typically occurs for anonymous types nested within public types, making them technically public but functionally private since they cannot be referenced in any way by any consumers of that header. This patch updates the symbol graph loader to drop these symbols to avoid a variety of issues caused by registering them.

## Dependencies

N/A

## Testing

1. Create a symbol graph containing an unnamed struct or union. Optionally, add a relationship making this type a child of a named container type.
2. Build documentation with this symbol graph in an archive.
3. Notice that the root page (or the container page if the type was nested) breaks.
4. With this patch, the page renders correctly.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
