### PR TITLE
Enable unacceptable language check

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -35,9 +35,10 @@ jobs:
       license_header_check_project_name: "Swift"
       # The license header check is disabled as it requires a large number of changes.
       license_header_check_enabled: false
-      # The unacceptable language check is disabled due to conflict with
-      # DocC's own unacceptable language check tests.
-      unacceptable_language_check_enabled: false
+      # There are some words in typical programming jargon that are a part of the default list.
+      # The list of words checked by this job is restricted below to prevent raising issues for
+      # words that are contextually acceptable to use in this repository.
+      unacceptable_language_check_word_list: "blacklist whitelist slave master"  # ignore-unacceptable-language
       # The format check is disabled as this project does not conform to swift-format.
       # More discussion is needed before enabling this check.
       format_check_enabled: false

--- a/.unacceptablelanguageignore
+++ b/.unacceptablelanguageignore
@@ -1,0 +1,2 @@
+Sources/SwiftDocC/Checker/Checkers/NonInclusiveLanguageChecker.swift
+Tests/SwiftDocCTests/Checker/Checkers/NonInclusiveLanguageCheckerTests.swift

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 FROM swift:5.9-focal
 
 # Set up the current build user in the same way done in the Swift.org CI system: 
-# https://github.com/apple/swift-docker/blob/main/swift-ci/master/ubuntu/20.04/Dockerfile.
+# https://github.com/apple/swift-docker/blob/main/swift-ci/main/ubuntu/20.04/Dockerfile.
 
 RUN groupadd -g 998 build-user && \
   useradd -m -r -u 42 -g build-user build-user

--- a/bin/check-source
+++ b/bin/check-source
@@ -28,6 +28,7 @@ unacceptable_terms=(
     -e blacklis[t]
     -e whitelis[t]
     -e slav[e]
+    -e maste[r]
 )
 # Ignore the NonInclusiveLanguageChecker source and tests
 if git grep --color=never -i "${unacceptable_terms[@]}" -- :/**/^NonInclusiveLanguageChecker*.swift > /dev/null; then


### PR DESCRIPTION
The soundness check suite provides an unacceptable language check. This was previously disabled due to the default list containing a number of words that DocC uses in various places in a non-offensive and contextually appropriate manner. This patch enables this check and restricts the list of words to the ones checked by DocC's own unacceptable language check. It also updates DocC's check to identify usage of the word "master".