### PR TITLE
Encode the JSON keys sorted for a stable output between runs

### DIFF
--- a/Sources/SwiftDocC/Converter/RenderNode+Coding.swift
+++ b/Sources/SwiftDocC/Converter/RenderNode+Coding.swift
@@ -113,12 +113,10 @@ public enum RenderJSONEncoder {
     ) -> JSONEncoder {
         let encoder = JSONEncoder()
         
-        if prettyPrint {
-            if #available(macOS 10.13, iOS 11.0, watchOS 4.0, tvOS 11.0, *) {
-                encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-            } else {
-                encoder.outputFormatting = [.prettyPrinted]
-            }
+        encoder.outputFormatting = if prettyPrint {
+            [.prettyPrinted, .sortedKeys]
+        } else {
+            [.sortedKeys]
         }
         
         if emitVariantOverrides {

--- a/Sources/SwiftDocC/Infrastructure/Communication/Foundation/JSON.swift
+++ b/Sources/SwiftDocC/Infrastructure/Communication/Foundation/JSON.swift
@@ -58,11 +58,7 @@ indirect enum JSON: Codable {
 extension JSON: CustomDebugStringConvertible {
     var debugDescription: String {
         let encoder = JSONEncoder()
-        if #available(macOS 10.13, iOS 11.0, watchOS 4.0, tvOS 11.0, *) {
-            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-        } else {
-            encoder.outputFormatting = [.prettyPrinted]
-        }
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         
         do {
             let data = try encoder.encode(self)

--- a/Tests/SwiftDocCTests/Converter/RenderNodeCodableTests.swift
+++ b/Tests/SwiftDocCTests/Converter/RenderNodeCodableTests.swift
@@ -110,9 +110,9 @@ class RenderNodeCodableTests: XCTestCase {
         let encoderPretty = RenderJSONEncoder.makeEncoder(prettyPrint: true)
         XCTAssertTrue(encoderPretty.outputFormatting.contains(.sortedKeys))
 
-        // When prettyPrint is disabled, keys are not sorted
+        // When prettyPrint is disabled, keys are still sorted
         let encoderNotPretty = RenderJSONEncoder.makeEncoder(prettyPrint: false)
-        XCTAssertFalse(encoderNotPretty.outputFormatting.contains(.sortedKeys))
+        XCTAssertTrue(encoderNotPretty.outputFormatting.contains(.sortedKeys))
     }
 
     func testEncodesVariantOverridesSetAsProperty() throws {

--- a/Tests/SwiftDocCTests/Converter/RenderNodeCodableTests.swift
+++ b/Tests/SwiftDocCTests/Converter/RenderNodeCodableTests.swift
@@ -102,10 +102,6 @@ class RenderNodeCodableTests: XCTestCase {
     }
     
     func testSortedKeys() throws {
-        guard #available(macOS 10.13, iOS 11.0, watchOS 4.0, tvOS 11.0, *) else {
-            try XCTSkipIf(true, "Skipped on platforms that don't support JSONEncoder.OutputFormatting.sortedKeys")
-        }
-
         // When prettyPrint is enabled, keys are sorted
         let encoderPretty = RenderJSONEncoder.makeEncoder(prettyPrint: true)
         XCTAssertTrue(encoderPretty.outputFormatting.contains(.sortedKeys))

--- a/Tests/SwiftDocCTests/Model/RenderNodeSerializationTests.swift
+++ b/Tests/SwiftDocCTests/Model/RenderNodeSerializationTests.swift
@@ -330,9 +330,7 @@ class RenderNodeSerializationTests: XCTestCase {
 
     func encode(renderNode: RenderNode) throws -> Data {
         let encoder = JSONEncoder()
-        if #available(OSX 10.13, *) {
-            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-        }
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         
         return try encoder.encode(renderNode)
     }


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://92189849

## Summary

This revives https://github.com/swiftlang/swift-docc/pull/158/changes and sorts keys in the RenderNode JSON.

## Dependencies

None.

## Testing

Build documentation for some project twice and diff the JSON output from both runs. The JSON keys in all files in the `/data` subdirectory of the archive output should be sorted in both runs, resulting in the same output for both runs.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] ~Added~ Updated tests
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~ 
