### PR TITLE
Check if symbol exists in Mac Catalyst SGF.

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -1336,6 +1336,10 @@ public struct RenderNodeTranslator: SemanticVisitor {
             renderAvailabilities(from: $0.availability, currentPlatforms: currentPlatforms)
         } ?? .init()
         
+        // FIXME: Move this logic out of the rendering code (rdar://172280267)
+        let catalystSGFExists = context.registeredPlatformsPerModule[moduleName.symbolName]?.contains(.catalyst) ?? false
+        let symbolExistsInCatalystSymbolGraph = documentationNode.unifiedSymbol?.allSelectors.contains(where: { $0.platform?.lowercased() == PlatformName.catalyst.rawValue.lowercased() }) ?? false
+        
         node.metadata.platformsVariants = VariantCollection<[AvailabilityRenderItem]?>(from: symbol.availabilityVariants) { _, inSourceAvailability in
             // Different sources of availability information are added in-order to compute the complete availability information.
 
@@ -1385,13 +1389,10 @@ public struct RenderNodeTranslator: SemanticVisitor {
                 }
                 addFallbackIfNeeded(named: PlatformName.iPadOS.displayName)
                 
-                // FIXME: Move this logic out of the rendering code (rdar://172280267)
-                let catalystSGFExists = context.registeredPlatformsPerModule[moduleName.symbolName]?.contains(.catalyst) ?? false
-                let symbolExistsInCatalystSymbolGraph = information[PlatformName.catalyst.displayName] != nil
                 
                 // Catalyst only inherits iOS availability if the symbol don't specify in-source
-                // availability or if there's none Mac Catalyst symbol graph.
-                // If the symbol is not present in the Catalyst SGF then is not availble for this
+                // availability or if there's no Mac Catalyst symbol graph.
+                // If the symbol is not present in the Catalyst SGF then is not available for this
                 // platform.
                 if (catalystSGFExists && symbolExistsInCatalystSymbolGraph) || !catalystSGFExists  {
                     addFallbackIfNeeded(named: PlatformName.catalyst.displayName)

--- a/Tests/SwiftDocCTests/Model/AvailabilityTests.swift
+++ b/Tests/SwiftDocCTests/Model/AvailabilityTests.swift
@@ -536,6 +536,28 @@ struct AvailabilityTests {
         #expect(renderPlatforms.compactMap(\.name) == ["iOS", "iPadOS"])
     }
     
+    @Test
+    func catalystInheritsWhenTheresNoInSourceCatalystAvailabilityButSymbolInCatalystSGF() async throws {
+        let catalog = Folder(name: "unit-test.docc") {
+            JSONFile(name: "ModuleName-Catalyst.symbols.json", content: makeSymbolGraph(moduleName: "ModuleName", platform: .init(operatingSystem: .init(name: "ios"), environment: "macabi"), symbols: [
+                makeSymbol(id: "some-symbol-id", kind: .class, pathComponents: ["SomeClass"], availability: [
+                    .init(domainName: "ios", introduced: SymbolGraph.SemanticVersion(major: 12, minor: 0, patch: 0), deprecated: nil)
+                ])
+            ]))
+        }
+        let context = try await load(catalog: catalog)
+        let node = try #require(context.documentationCache["some-symbol-id"])
+        let converter = DocumentationContextConverter(context: context, renderContext: .init(documentationContext: context))
+        let renderNode = try #require(converter.renderNode(for: node))
+        
+        let renderPlatforms = try #require(renderNode.metadata.platforms)
+        #expect(renderPlatforms.compactMap(\.name) == ["iOS", "iPadOS", "Mac Catalyst"])
+        
+        #expect(renderPlatforms.first(where: { $0.name == "iOS"          })?.introduced == "12.0")
+        #expect(renderPlatforms.first(where: { $0.name == "iPadOS"       })?.introduced == "12.0")
+        #expect(renderPlatforms.first(where: { $0.name == "Mac Catalyst" })?.introduced ==  "12.0")
+    }
+    
     // MARK: Default Availability
     
     @Test


### PR DESCRIPTION

<!--
If you are opening a pull request against a release branch, see
https://www.swift.org/contributing#release-branch-pull-requests
-->

Bug/issue #, if applicable: 181019790

## Summary

Fix logic introduced in `0273800`[1] that checks for the existance of a symbol in the Catalyst Symbol Graph.

The old logic checked for the existance for the catalyst platform in the in-source availability, instead of in the catalyst SGF.

The new logic checks the existence of the symbol by looking into the selectors of the unified symbol for the appearance of the MacCatalyst platform.

---

[1] https://github.com/swiftlang/swift-docc/commit/027380080d2cce30fccf884afabe22bd922e2f83

## Dependencies

N/A

## Testing

To test manually:

1. Preview the attached catalog without the fix
2. Assert the Catalyst platform is not there for the Greet symbol
3. Apply this diff
4. Assert that the iOS version gets correctly inherited by Mac Catalyst platform

[dummyCatalogCatalyst.docc.zip](https://github.com/user-attachments/files/29709593/dummyCatalogCatalyst.docc.zip)

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran the `./bin/test` script and it succeeded
- [] Updated documentation if necessary (N/A)
