### PR TITLE
[3/n] Minimally integrate custom HTML formatter 

### DIFF
--- a/Sources/DocCCommandLine/Action/Actions/Convert/ConvertAction.swift
+++ b/Sources/DocCCommandLine/Action/Actions/Convert/ConvertAction.swift
@@ -348,6 +348,7 @@ public struct ConvertAction: AsyncAction {
             htmlConsumer = try FullPageHTMLContentConsumer(
                 targetFolder: temporaryFolder,
                 fileManager: fileManager,
+                prettyPrint: shouldPrettyPrintOutputJSON, // Use the same configuration as the JSON output to make it convenient for the developer.
                 customHeader: experimentalEnableCustomTemplates ? inputs.customHeader : nil,
                 customFooter: experimentalEnableCustomTemplates ? inputs.customFooter : nil
             )

--- a/Sources/DocCCommandLine/Action/Actions/Convert/FileWritingHTMLContentConsumer.swift
+++ b/Sources/DocCCommandLine/Action/Actions/Convert/FileWritingHTMLContentConsumer.swift
@@ -38,7 +38,7 @@ struct FileWritingHTMLContentConsumer: HTMLContentConsumer {
             
             // Ensure that the index.html file has at least a `<head>` and a `<body>`.
             guard var beforeEndOfHead  = content.utf8.firstRange(of: "</head>".utf8)?.lowerBound,
-                  var afterStartOfBody = content.range(of: "<body[^>]*>", options: .regularExpression)?.upperBound
+                  var afterStartOfBody = content.range(of: "<body[^>]*>\n?", options: .regularExpression)?.upperBound
             else {
                 struct MissingRequiredTagsError: DescribedError {
                     let errorDescription = "Missing required `<head>` and `<body>` elements in \"index.html\" file."
@@ -55,10 +55,10 @@ struct FileWritingHTMLContentConsumer: HTMLContentConsumer {
             {
                 titleReplacementRange = titleStart ..< titleEnd
             } else {
-                content.insert(contentsOf: "<title></title>", at: beforeEndOfHead)
-                content.utf8.formIndex(&beforeEndOfHead,  offsetBy: "<title></title>".utf8.count)
-                content.utf8.formIndex(&afterStartOfBody, offsetBy: "<title></title>".utf8.count)
-                let titleInside = content.utf8.index(beforeEndOfHead, offsetBy: -"</title>".utf8.count)
+                content.insert(contentsOf: "<title></title>\n", at: beforeEndOfHead)
+                content.utf8.formIndex(&beforeEndOfHead,  offsetBy: "<title></title>\n".utf8.count)
+                content.utf8.formIndex(&afterStartOfBody, offsetBy: "<title></title>\n".utf8.count)
+                let titleInside = content.utf8.index(beforeEndOfHead, offsetBy: -"</title>\n".utf8.count)
                 titleReplacementRange = titleInside ..< titleInside
             }
             
@@ -67,7 +67,7 @@ struct FileWritingHTMLContentConsumer: HTMLContentConsumer {
             {
                 contentReplacementRange = noScriptStart ..< noScriptEnd
             } else {
-                content.insert(contentsOf: "<noscript></noscript>", at: afterStartOfBody)
+                content.insert(contentsOf: "<noscript></noscript>\n", at: afterStartOfBody)
                 let noScriptInside = content.utf8.index(afterStartOfBody, offsetBy: "<noscript>".utf8.count)
                 contentReplacementRange = noScriptInside ..< noScriptInside
             }
@@ -92,7 +92,7 @@ struct FileWritingHTMLContentConsumer: HTMLContentConsumer {
                 let metaDescription = XMLNode.element(named: "meta", attributes: ["name": "description", "content": plainDescription])
                 copy.replaceSubrange(descriptionReplacementRange, with: metaDescription.rendered(prettyPrinted: prettyPrint))
             }
-            copy.replaceSubrange(titleReplacementRange,   with: title)
+            copy.replaceSubrange(titleReplacementRange, with: title)
             
             return copy
         }
@@ -153,7 +153,15 @@ struct FileWritingHTMLContentConsumer: HTMLContentConsumer {
 
 private extension XMLNode {
     func rendered(prettyPrinted: Bool) -> String {
-        if prettyPrinted {
+        if let htmlNode = HTMLNode(from: self) {
+            let data = HTMLFormatter.format(htmlNode, options: prettyPrinted ? .prettyPrint : [])
+            return String(decoding: data, as: UTF8.self)
+        }
+         
+        assertionFailure("Failed to convert XMLNode \(name ?? "<no tag>") to an HTMLNode")
+        
+        // Fallback to the XMLNode string formatting for now.
+        return if prettyPrinted {
             xmlString(options: [.nodePrettyPrint, .nodeCompactEmptyElement])
         } else {
             xmlString(options: .nodeCompactEmptyElement)

--- a/Sources/DocCCommandLine/Action/Actions/Convert/FileWritingHTMLContentConsumer.swift
+++ b/Sources/DocCCommandLine/Action/Actions/Convert/FileWritingHTMLContentConsumer.swift
@@ -38,7 +38,7 @@ struct FileWritingHTMLContentConsumer: HTMLContentConsumer {
             
             // Ensure that the index.html file has at least a `<head>` and a `<body>`.
             guard var beforeEndOfHead  = content.utf8.firstRange(of: "</head>".utf8)?.lowerBound,
-                  var afterStartOfBody = content.range(of: "<body[^>]*>\n?", options: .regularExpression)?.upperBound
+                  var afterStartOfBody = content.range(of: "<body[^>]*>", options: .regularExpression)?.upperBound
             else {
                 struct MissingRequiredTagsError: DescribedError {
                     let errorDescription = "Missing required `<head>` and `<body>` elements in \"index.html\" file."

--- a/Sources/DocCCommandLine/Action/Actions/Convert/FullPageHTMLContentConsumer.swift
+++ b/Sources/DocCCommandLine/Action/Actions/Convert/FullPageHTMLContentConsumer.swift
@@ -27,16 +27,20 @@ struct FullPageHTMLContentConsumer: HTMLContentConsumer {
     
     private let customHeader: XMLNode?
     private let customFooter: XMLNode?
+    private let prettyPrint: Bool
+    
     // FIXME: Extract the file writing (and directory creation) functionality from this RenderNode (JSON) specific type.
     private let fileWriter: JSONEncodingRenderNodeWriter
     
     init(
         targetFolder: URL,
         fileManager: some FileManagerProtocol,
+        prettyPrint: Bool,
         customHeader: URL?,
         customFooter: URL?
     ) throws {
         (self.customHeader, self.customFooter) = try HTMLRenderer.prepareForFullPage(customHeader: customHeader, customFooter: customFooter, fileManager: fileManager)
+        self.prettyPrint = prettyPrint
         
         self.fileWriter = JSONEncodingRenderNodeWriter(
             targetFolder: targetFolder,
@@ -52,8 +56,9 @@ struct FullPageHTMLContentConsumer: HTMLContentConsumer {
     ) throws {
         let page = HTMLRenderer.makeFullPage(mainContent: mainContent, metadata: metadata, for: reference, customHeader: customHeader, customFooter: customFooter)
         
-        let htmlString = page.xmlString(options: .nodeCompactEmptyElement)
+        let htmlData = HTMLFormatter.format(page, options: prettyPrint ? .prettyPrint : [])
+        
         let relativeFilePath = NodeURLGenerator.fileSafeReferencePath(reference, lowercased: true) + "/index.html"
-        try fileWriter.write(Data(htmlString.utf8), toFileSafePath: relativeFilePath)
+        try fileWriter.write(htmlData, toFileSafePath: relativeFilePath)
     }
 }

--- a/Sources/DocCHTML/CMakeLists.txt
+++ b/Sources/DocCHTML/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(DocCHTML STATIC
   HTMLFormatter.swift
   HTMLNode.swift
   HTMLNode+Attributes.swift
+  HTMLNode+fromXMLNode.swift
   HTMLNode+Tags.swift
   LinkProvider.swift
   MarkdownRenderer+Availability.swift

--- a/Sources/DocCHTML/HTMLFormatter.swift
+++ b/Sources/DocCHTML/HTMLFormatter.swift
@@ -265,8 +265,10 @@ package struct HTMLFormatter {
             //    ```
             
             let hasAttributeReasonToPresentOnSeparateLine = switch tag {
-                case .a, .td, .th: attributes.count > 1
-                default:           !attributes.isEmpty
+                case .a, .td, .th, .dt, .span:
+                    attributes.count > 1
+                default:
+                    !attributes.isEmpty
             }
             let firstContents = contents.first! // verified to be non-empty above
             let shouldPresentContentsOnSeparateLine = contents.count > 1 || !firstContents._isText || hasAttributeReasonToPresentOnSeparateLine
@@ -385,7 +387,7 @@ package struct HTMLFormatter {
     private mutating func _format(attributes: [HTMLNode.Attribute]) {
         for attribute in attributes {
             buffer.append(.init(ascii: " "))
-            _append(attribute.name)
+            buffer.append(contentsOf: attribute.name.utf8)
             
             var value = attribute.value
             guard !value.isEmpty else { continue }

--- a/Sources/DocCHTML/HTMLFormatter.swift
+++ b/Sources/DocCHTML/HTMLFormatter.swift
@@ -295,10 +295,13 @@ package struct HTMLFormatter {
                 // It's necessary to know what element comes next in the container (if any) to determine when it's allowed to omit the end tag.
                 childState.nextElementTag = nextIndex < contents.endIndex ? contents[nextIndex]._tag : nil
                 
-                // If the previous element presented on its own line and the current line is text, add a line break before the text as well.
-                if childState.presentOnCurrentLine || !child._isText {
+                let presentOnCurrentLine = shouldPresentInline(for: child)
+                if presentOnCurrentLine && !childState.presentOnCurrentLine {
+                    // If the previous element presented on its own line but this element presents on the same line, add a "trailing" line break after the previous element.
+                    appendLineBreakAndIndentation(depth: childState.depth)
                     childState.presentOnCurrentLine = shouldPresentInline(for: child)
                 }
+                childState.presentOnCurrentLine = presentOnCurrentLine
                 
                 // Whitespace is significant inside `<pre>` elements; so we switch to formatting that sub-hierarchy _without_ pretty printing.
                 if child._tag == .pre {

--- a/Sources/DocCHTML/HTMLFormatter.swift
+++ b/Sources/DocCHTML/HTMLFormatter.swift
@@ -300,7 +300,6 @@ package struct HTMLFormatter {
                 if presentOnCurrentLine && !childState.presentOnCurrentLine {
                     // If the previous element presented on its own line but this element presents on the same line, add a "trailing" line break after the previous element.
                     appendLineBreakAndIndentation(depth: childState.depth)
-                    childState.presentOnCurrentLine = shouldPresentInline(for: child)
                 }
                 childState.presentOnCurrentLine = presentOnCurrentLine
                 

--- a/Sources/DocCHTML/HTMLFormatter.swift
+++ b/Sources/DocCHTML/HTMLFormatter.swift
@@ -244,7 +244,8 @@ package struct HTMLFormatter {
             //
             // Additionally the formatter has two special case behaviors that aims to make slight readability refinements for certain content:
             //
-            // 1. Anchors (`<a>`) and table cells (`<td>` or `<th>`) with at most one attribute still displays plain textual contents on the same line. For example:
+            // 1. Anchors (`<a>`), table cells (`<td>` or `<th>`), definition terms (`<dt>`), and `<span>` elements with at most one attribute still displays plain textual contents on the same line.
+            // This arbitrary set of elements make for slight readability refinements for some patterns that occur in formatted documentation. For example:
             //    ```
             //    <a href="something">Some text</a>
             //    ```

--- a/Sources/DocCHTML/HTMLNode+Attributes.swift
+++ b/Sources/DocCHTML/HTMLNode+Attributes.swift
@@ -11,7 +11,7 @@
 extension HTMLNode {
     /// An attribute that can be applies to one or more HTML elements.
     package struct Attribute {
-        let name: StaticString
+        let name: String
         let value: String
         
         /// A short, abbreviated description of a `<th>` element's content.

--- a/Sources/DocCHTML/HTMLNode+fromXMLNode.swift
+++ b/Sources/DocCHTML/HTMLNode+fromXMLNode.swift
@@ -1,0 +1,58 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2026 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+#if canImport(FoundationXML)
+// TODO: Consider other HTML rendering options as a future improvement (rdar://165755530)
+package import FoundationXML
+#else
+package import Foundation
+#endif
+
+/// Creates a new HTML from an XMLNode, or returns `nil` if the XMLNode doesn't represent an HTML element.
+package extension HTMLNode {
+    init?(from xmlNode: XMLNode) {
+        if let element = xmlNode as? XMLElement {
+            guard let name = xmlNode.name,
+                  let tag = HTMLNode._Tag(rawValue: name.lowercased())
+            else {
+                return nil
+            }
+            
+            let attributes = element.attributes?.compactMap {
+                HTMLNode.Attribute($0)
+            } ?? []
+            
+            if tag.isVoid {
+                self = ._voidElement(tag, attributes: attributes)
+            } else {
+                let contents = xmlNode.children?.compactMap {
+                    HTMLNode(from: $0)
+                } ?? []
+                self = ._element(tag, attributes: attributes, contents: contents)
+            }
+        } else if xmlNode.kind == .text, let text = xmlNode.stringValue {
+            self = .text(text)
+        } else {
+            return nil
+        }
+    }
+}
+
+private extension HTMLNode.Attribute {
+    init?(_ attribute: XMLNode) {
+        assert(attribute.kind == .attribute)
+        guard let name = attribute.name?.lowercased() else {
+            return nil
+        }
+        
+        self.name = name
+        self.value = attribute.stringValue ?? ""
+    }
+}

--- a/Sources/DocCHTML/HTMLNode+fromXMLNode.swift
+++ b/Sources/DocCHTML/HTMLNode+fromXMLNode.swift
@@ -15,7 +15,7 @@ package import FoundationXML
 package import Foundation
 #endif
 
-/// Creates a new HTML from an XMLNode, or returns `nil` if the XMLNode doesn't represent an HTML element.
+/// Creates a new HTML node from an XMLNode, or returns `nil` if the XMLNode doesn't represent an HTML element.
 package extension HTMLNode {
     init?(from xmlNode: XMLNode) {
         if let element = xmlNode as? XMLElement {

--- a/Sources/DocCHTML/HTMLNode.swift
+++ b/Sources/DocCHTML/HTMLNode.swift
@@ -59,7 +59,7 @@ package struct HTMLNode: Sendable {
     }
 }
 
-private extension HTMLNode._Tag {
+extension HTMLNode._Tag {
     var isVoid: Bool {
         switch self {
             case .base, .link, .meta,                  // Metadata

--- a/Sources/SwiftDocC/Model/Rendering/HTML/HTMLRenderer+FullPage.swift
+++ b/Sources/SwiftDocC/Model/Rendering/HTML/HTMLRenderer+FullPage.swift
@@ -16,7 +16,7 @@ package import FoundationEssentials
 package import Foundation
 #endif
 
-private import DocCHTML
+package import DocCHTML
 
 package extension HTMLRenderer {
     /// Wraps the unique rendered documentation content and its metadata into a full-page document.
@@ -32,7 +32,7 @@ package extension HTMLRenderer {
         for reference: ResolvedTopicReference,
         customHeader: XMLNode? = nil,
         customFooter: XMLNode? = nil
-    ) -> XMLDocument {
+    ) -> HTMLNode {
         // Use relative paths to shared assets like a style sheet or favicon.
         let pathPrefixToArchiveRoot = String(repeating: "../", count: reference.url.pathComponents.count - 1)
         
@@ -106,14 +106,9 @@ package extension HTMLRenderer {
             body.addChild(customFooter.copy() as! XMLNode)
         }
         
-        // Specify the "html" doctype for the document
-        let documentTypeDefinition = XMLDTD()
-        documentTypeDefinition.name = "html"
-        let page = XMLDocument(rootElement: .element(named: "html", children: [head, body], attributes: ["lang": "en-US"]))
-        page.documentContentKind = .html
-        page.dtd = documentTypeDefinition
+        let root = XMLNode.element(named: "html", children: [head, body], attributes: ["lang": "en-US"])
         
-        return page
+        return HTMLNode(from: root) ?? html(contents: [])
     }
     
     /// Prepares the provided custom header and footer files to be included in the full-page structure.

--- a/Tests/DocCCommandLineTests/FileWritingHTMLContentConsumerTests.swift
+++ b/Tests/DocCCommandLineTests/FileWritingHTMLContentConsumerTests.swift
@@ -1,25 +1,24 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2025 Apple Inc. and the Swift project authors
+ Copyright (c) 2025-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-
 import Foundation
 @testable import DocCCommandLine
 import SwiftDocC
 import SymbolKit
-import XCTest
+import Testing
 import DocCTestUtilities
 
-final class FileWritingHTMLContentConsumerTests: XCTestCase {
-    
-    func testWritesContentInsideHTMLTemplate() async throws {
-        let catalog = Folder(name: "ModuleName.docc", content: [
+struct FileWritingHTMLContentConsumerTests {
+    @Test
+    func writesContentInsideHTMLTemplate() async throws {
+        let catalog = Folder(name: "ModuleName.docc") {
             TextFile(name: "SomeArticle.md", utf8Content: """
             # Some article
             
@@ -40,9 +39,9 @@ final class FileWritingHTMLContentConsumerTests: XCTestCase {
             ## See Also
             
             - ``SomeClass``
-            """),
+            """)
             
-            JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(moduleName: "ModuleName", symbols: [
+            JSONFile(symbolGraph: makeSymbolGraph(moduleName: "ModuleName", symbols: [
                 makeSymbol(id: "some-class-id", kind: .class, pathComponents: ["SomeClass"], docComment: """
                 Some in-source description of this class.
                 """, declaration: [
@@ -117,7 +116,7 @@ final class FileWritingHTMLContentConsumerTests: XCTestCase {
             ], relationships: [
                 .init(source: "some-method-id", target: "some-class-id",    kind: .memberOf,   targetFallback: nil),
                 .init(source: "some-class-id",  target: "some-protocol-id", kind: .conformsTo, targetFallback: nil)
-            ])),
+            ]))
             
             TextFile(name: "ModuleName.md", utf8Content: """
             # ``ModuleName``
@@ -133,7 +132,7 @@ final class FileWritingHTMLContentConsumerTests: XCTestCase {
             - <doc:SomeArticle>
             - ``SomeClass``
             """)
-        ])
+        }
         
         let htmlTemplate = TextFile(name: "index.html", utf8Content: """
         <html>
@@ -152,17 +151,17 @@ final class FileWritingHTMLContentConsumerTests: XCTestCase {
         </html>
         """)
         
-        let fileSystem = try TestFileSystem(folders: [
-            Folder(name: "path", content: [
-                Folder(name: "to", content: [
+        let fileSystem = try TestFileSystem {
+            Folder(name: "path") {
+                Folder(name: "to") {
                     catalog
-                ])
-            ]),
-            Folder(name: "template", content: [
+                }
+            }
+            Folder(name: "template") {
                 htmlTemplate
-            ]),
-            Folder(name: "output-dir", content: [])
-        ])
+            }
+            Folder(name: "output-dir") {}
+        }
         
         let (inputs, dataProvider) = try DocumentationContext.InputsProvider(fileManager: fileSystem)
             .inputsAndDataProvider(startingPoint: URL(fileURLWithPath: "/path/to/\(catalog.name)"), options: .init())
@@ -188,7 +187,7 @@ final class FileWritingHTMLContentConsumerTests: XCTestCase {
         )
         
         // Because the TestOutputConsumer below, doesn't create any files, we only expect the HTML files in the output directory
-        XCTAssertEqual(fileSystem.dump(subHierarchyFrom: "/output-dir"), """
+        #expect(fileSystem.dump(subHierarchyFrom: "/output-dir") == """
         output-dir/
         ╰─ documentation/
            ╰─ modulename/
@@ -210,46 +209,49 @@ final class FileWritingHTMLContentConsumerTests: XCTestCase {
             <link rel="icon" href="/favicon.ico" />
             <title>ModuleName</title>
             <script>var baseUrl = "/"</script>
-            <meta content="Some formatted description of this module" name="description"/>
-          </head>
+          <meta content="Some formatted description of this module" name="description"></head>
           <body>
-            <noscript>
-              <article>
-                <section>
-                  <hgroup>
-                    <p>Framework</p>
-                    <h1>ModuleName</h1>
-                  </hgroup>
-                  <p>Some <b>formatted</b> description of this module</p>
-                </section>
-                <h2>Topics</h2>
-                <h3>Something custom</h3>
-                <p>A custom <i>formatted</i> description of this topic section</p>
-                <ul>
-                  <li>
-                    <a href="somearticle/index.html">
-                      <p>Some article</p>
-                    </a>
-                    <p>This is a <i>formatted</i> article.</p>
-                  </li>
-                  <li>
-                    <a href="someclass/index.html">
-                      <code>class SomeClass</code>
-                    </a>
-                    <p>Some in-source description of this class.</p>
-                  </li>
-                </ul>
-                <h3>Protocols</h3>
-                <ul>
-                  <li>
-                    <a href="someprotocol/index.html">
-                      <code>protocol SomeProtocol</code>
-                    </a>
-                    <p>Some in-source description of this protocol.</p>
-                  </li>
-                </ul>
-              </article>
-            </noscript>
+            <noscript><article>
+          <section>
+            <hgroup>
+              <p>Framework</p>
+              <h1>ModuleName</h1>
+            </hgroup>
+            <p>
+              Some <b>formatted</b> description of this module
+            </p>
+          </section>
+          <h2>Topics</h2>
+          <h3>Something custom</h3>
+          <p>
+            A custom <i>formatted</i> description of this topic section
+          </p>
+          <ul>
+            <li>
+              <a href="somearticle/index.html">
+                <p>Some article</p>
+              </a>
+              <p>
+                This is a <i>formatted</i> article.
+              </p>
+            </li>
+            <li>
+              <a href="someclass/index.html">
+                <code>class SomeClass</code>
+              </a>
+              <p>Some in-source description of this class.</p>
+            </li>
+          </ul>
+          <h3>Protocols</h3>
+          <ul>
+            <li>
+              <a href="someprotocol/index.html">
+                <code>protocol SomeProtocol</code>
+              </a>
+              <p>Some in-source description of this protocol.</p>
+            </li>
+          </ul>
+        </article></noscript>
             <div id="app"></div>
           </body>
         </html>
@@ -262,54 +264,49 @@ final class FileWritingHTMLContentConsumerTests: XCTestCase {
             <link rel="icon" href="/favicon.ico" />
             <title>SomeClass</title>
             <script>var baseUrl = "/"</script>
-            <meta content="Some in-source description of this class." name="description"/>
-          </head>
+          <meta content="Some in-source description of this class." name="description"></head>
           <body>
-            <noscript>
-              <article>
-                <section>
-                  <ul>
-                    <li>
-                      <a href="../index.html">ModuleName</a>
-                    </li>
-                    <li>SomeClass</li>
-                  </ul>
-                  <hgroup>
-                    <p>Class</p>
-                    <h1>SomeClass</h1>
-                  </hgroup>
-                  <p>Some in-source description of this class.</p>
-                  <pre>
-                    <code>class SomeClass</code>
-                  </pre>
-                </section>
-                <h2>Mentioned In</h2>
-                <ul>
-                  <li>
-                    <a href="../somearticle/index.html">Some article</a>
-                  </li>
-                </ul>
-                <h2>Topics</h2>
-                <h3>Instance Methods</h3>
-                <ul>
-                  <li>
-                    <a href="somemethod(with:and:)/index.html">
-                      <code>func someMethod(with first: Int, and second: String) -&gt; Bool</code>
-                    </a>
-                    <p>Some in-source description of this method.</p>
-                  </li>
-                </ul>
-                <h2>Relationships</h2>
-                <h3>Conforms To</h3>
-                <ul>
-                  <li>
-                    <a href="../someprotocol/index.html">
-                      <code>SomeProtocol</code>
-                    </a>
-                  </li>
-                </ul>
-              </article>
-            </noscript>
+            <noscript><article>
+          <section>
+            <ul>
+              <li>
+                <a href="../index.html">ModuleName</a>
+              </li>
+              <li>SomeClass</li>
+            </ul>
+            <hgroup>
+              <p>Class</p>
+              <h1>SomeClass</h1>
+            </hgroup>
+            <p>Some in-source description of this class.</p>
+            <pre><code>class SomeClass</code></pre>
+          </section>
+          <h2>Mentioned In</h2>
+          <ul>
+            <li>
+              <a href="../somearticle/index.html">Some article</a>
+            </li>
+          </ul>
+          <h2>Topics</h2>
+          <h3>Instance Methods</h3>
+          <ul>
+            <li>
+              <a href="somemethod(with:and:)/index.html">
+                <code>func someMethod(with first: Int, and second: String) -> Bool</code>
+              </a>
+              <p>Some in-source description of this method.</p>
+            </li>
+          </ul>
+          <h2>Relationships</h2>
+          <h3>Conforms To</h3>
+          <ul>
+            <li>
+              <a href="../someprotocol/index.html">
+                <code>SomeProtocol</code>
+              </a>
+            </li>
+          </ul>
+        </article></noscript>
             <div id="app"></div>
           </body>
         </html>
@@ -322,61 +319,67 @@ final class FileWritingHTMLContentConsumerTests: XCTestCase {
             <link rel="icon" href="/favicon.ico" />
             <title>someMethod(with:and:)</title>
             <script>var baseUrl = "/"</script>
-            <meta content="Some in-source description of this method." name="description"/>
-          </head>
+          <meta content="Some in-source description of this method." name="description"></head>
           <body>
-            <noscript>
-              <article>
-              <section>
-                <ul>
-                  <li>
-                    <a href="../../index.html">ModuleName</a>
-                  </li>
-                  <li>
-                    <a href="../index.html">SomeClass</a>
-                  </li>
-                  <li>someMethod(with:and:)</li>
-                </ul>
-                <hgroup>
-                  <p>Instance Method</p>
-                  <h1>someMethod(with:and:)</h1>
-                </hgroup>
-                <p>Some in-source description of this method.</p>
-                <pre>
-                  <code>func someMethod(with first: Int, and second: String) -&gt; Bool</code>
-                </pre>
-                <aside class="deprecated">
-                  <p class="label">Deprecated</p>
-                  <p>Some <b>formatted</b> description of why this method is deprecated.</p>
-                </aside>
-              </section>
-              <h2>Parameters</h2>
-              <dl>
-                <dt>first</dt>
-                <dd>
-                  <p>Description of the <code>first</code> parameter.</p>
-                </dd>
-                <dt>second</dt>
-                <dd>
-                  <p>Description of the <code>second</code> parameter.</p>
-                </dd>
-              </dl>
-              <h2>Return Value</h2>
-              <p>Description of the return value.</p>
-              <h2>Discussion</h2>
-              <p>Further description of this method and how to use it.</p>
-              <h2>See Also</h2>
-              <h3>Related Documentation</h3>
-              <ul>
-                <li>
-                  <a href="../../somearticle/index.html">
-                    <p>Some article</p>
-                  </a>
-                  <p>This is a <i>formatted</i> article.</p>
-                </li>
-              </ul>
-              </article>
-            </noscript>
+            <noscript><article>
+          <section>
+            <ul>
+              <li>
+                <a href="../../index.html">ModuleName</a>
+              </li>
+              <li>
+                <a href="../index.html">SomeClass</a>
+              </li>
+              <li>someMethod(with:and:)</li>
+            </ul>
+            <hgroup>
+              <p>Instance Method</p>
+              <h1>someMethod(with:and:)</h1>
+            </hgroup>
+            <p>Some in-source description of this method.</p>
+            <pre><code>func someMethod(with first: Int, and second: String) -> Bool</code></pre>
+            <aside class="deprecated">
+              <p class="label">
+                Deprecated
+              </p>
+              <p>
+                Some <b>formatted</b> description of why this method is deprecated.
+              </p>
+            </aside>
+          </section>
+          <h2>Parameters</h2>
+          <dl>
+            <dt>first</dt>
+            <dd>
+              <p>
+                Description of the <code>first</code> parameter.
+              </p>
+            </dd>
+            <dt>second</dt>
+            <dd>
+              <p>
+                Description of the <code>second</code> parameter.
+              </p>
+            </dd>
+          </dl>
+          <h2>Return Value</h2>
+          <p>Description of the return value.</p>
+          <h2>Discussion</h2>
+          <p>Further description of this method and how to use it.</p>
+          
+          <h2>See Also</h2>
+          <h3>Related Documentation</h3>
+          <ul>
+            <li>
+              <a href="../../somearticle/index.html">
+                <p>Some article</p>
+              </a>
+              <p>
+                This is a <i>formatted</i> article.
+              </p>
+            </li>
+          </ul>
+        </article></noscript>
             <div id="app"></div>
           </body>
         </html>
@@ -389,44 +392,53 @@ final class FileWritingHTMLContentConsumerTests: XCTestCase {
             <link rel="icon" href="/favicon.ico" />
             <title>Some article</title>
             <script>var baseUrl = "/"</script>
-            <meta content="This is a formatted article." name="description"/>
-          </head>
+          <meta content="This is a formatted article." name="description"></head>
           <body>
-            <noscript>
-              <article>
-                <section>
-                  <ul>
-                    <li>
-                      <a href="../index.html">ModuleName</a>
-                    </li>
-                    <li>Some article</li>
-                  </ul>
-                  <hgroup>
-                    <p>Article</p>
-                    <h1>Some article</h1>
-                  </hgroup>
-                  <p>This is a <i>formatted</i> article.</p>
-                  <aside class="deprecated">
-                    <p class="label">Deprecated</p>
-                    <p>Description of why this <i>article</i> is deprecated.</p>
-                  </aside>
-                </section>
-                <h2>Custom discussion</h2>
-                <p>It explains how a developer can perform some task using <a href="../someclass/index.html"><code>SomeClass</code></a> in this module.</p>
-                <h3>Details</h3>
-                <p>This subsection describes something more detailed.</p>
-                <h2>See Also</h2>
-                <h3>Related Documentation</h3>
-                <ul>
-                  <li>
-                    <a href="../someclass/index.html">
-                      <code>class SomeClass</code>
-                    </a>
-                    <p>Some in-source description of this class.</p>
-                  </li>
-                </ul>
-              </article>
-            </noscript>
+            <noscript><article>
+          <section>
+            <ul>
+              <li>
+                <a href="../index.html">ModuleName</a>
+              </li>
+              <li>Some article</li>
+            </ul>
+            <hgroup>
+              <p>Article</p>
+              <h1>Some article</h1>
+            </hgroup>
+            <p>
+              This is a <i>formatted</i> article.
+            </p>
+            <aside class="deprecated">
+              <p class="label">
+                Deprecated
+              </p>
+              <p>
+                Description of why this <i>article</i> is deprecated.
+              </p>
+            </aside>
+          </section>
+          <h2>Custom discussion</h2>
+          <p>
+            It explains how a developer can perform some task using 
+            <a href="../someclass/index.html">
+              <code>SomeClass</code>
+            </a>
+             in this module.
+          </p>
+          <h3>Details</h3>
+          <p>This subsection describes something more detailed.</p>
+          <h2>See Also</h2>
+          <h3>Related Documentation</h3>
+          <ul>
+            <li>
+              <a href="../someclass/index.html">
+                <code>class SomeClass</code>
+              </a>
+              <p>Some in-source description of this class.</p>
+            </li>
+          </ul>
+        </article></noscript>
             <div id="app"></div>
           </body>
         </html>
@@ -439,47 +451,41 @@ final class FileWritingHTMLContentConsumerTests: XCTestCase {
             <link rel="icon" href="/favicon.ico" />
             <title>SomeProtocol</title>
             <script>var baseUrl = "/"</script>
-            <meta content="Some in-source description of this protocol." name="description"/>
-          </head>
+          <meta content="Some in-source description of this protocol." name="description"></head>
           <body>
-            <noscript>
-              <article>
-                <section>
-                  <ul>
-                    <li>
-                      <a href="../index.html">
-                        ModuleName</a>
-                      </li>
-                    <li>
-                    SomeProtocol</li>
-                  </ul>
-                  <hgroup>
-                    <p>Protocol</p>
-                    <h1>SomeProtocol</h1>
-                  </hgroup>
-                  <p>Some in-source description of this protocol.</p>
-                  <pre>
-                    <code>protocol SomeProtocol</code>
-                  </pre>
-                </section>
-                <h2>Relationships</h2>
-                <h3>Conforming Types</h3>
-                <ul>
-                  <li>
-                    <a href="../someclass/index.html">
-                      <code>SomeClass</code>
-                    </a>
-                  </li>
-                </ul>
-              </article>
-            </noscript>
+            <noscript><article>
+          <section>
+            <ul>
+              <li>
+                <a href="../index.html">ModuleName</a>
+              </li>
+              <li>SomeProtocol</li>
+            </ul>
+            <hgroup>
+              <p>Protocol</p>
+              <h1>SomeProtocol</h1>
+            </hgroup>
+            <p>Some in-source description of this protocol.</p>
+            <pre><code>protocol SomeProtocol</code></pre>
+          </section>
+          <h2>Relationships</h2>
+          <h3>Conforming Types</h3>
+          <ul>
+            <li>
+              <a href="../someclass/index.html">
+                <code>SomeClass</code>
+              </a>
+            </li>
+          </ul>
+        </article></noscript>
             <div id="app"></div>
           </body>
         </html>
         """)
     }
 
-    func testAddsTagsToTemplateIfMissing() async throws {
+    @Test(arguments: [true, false], [true, false])
+    func addsTagsToTemplateIfMissing(templateHasTitleTag: Bool, templateHasNoScriptTag: Bool) async throws {
         let catalog = Folder(name: "Something.docc", content: [
             TextFile(name: "RootArticle.md", utf8Content: """
             # A single article
@@ -488,101 +494,107 @@ final class FileWritingHTMLContentConsumerTests: XCTestCase {
             """)
         ])
         
-        for withTitleTag in [true, false] {
-            for withNoScriptTag in [true, false] {
-                let maybeTitleTag = withTitleTag ? "<title>Documentation</title>" : ""
-                let maybeNoScriptTag = withNoScriptTag ? """
-                  <noscript>
-                    <p>Some existing information inside the no script tag</p>
-                  </noscript>
-                """ : ""
-                
-                let htmlTemplate = TextFile(name: "index.html", utf8Content: """
-                <html>
-                  <head>
-                    <meta charset="utf-8" />
-                    <link rel="icon" href="/favicon.ico" />
-                    \(maybeTitleTag)
-                  </head>
-                  <body>
-                  \(maybeNoScriptTag)
-                    <div id="app"></div>
-                  </body>
-                </html>
-                """)
-                
-                let fileSystem = try TestFileSystem(folders: [
-                    Folder(name: "path", content: [
-                        Folder(name: "to", content: [
-                            catalog
-                        ])
-                    ]),
-                    Folder(name: "template", content: [
-                        htmlTemplate
-                    ]),
-                    Folder(name: "output-dir", content: [])
-                ])
-                
-                let (inputs, dataProvider) = try DocumentationContext.InputsProvider(fileManager: fileSystem)
-                    .inputsAndDataProvider(startingPoint: URL(fileURLWithPath: "/path/to/\(catalog.name)"), options: .init())
-                
-                let context = try await DocumentationContext(bundle: inputs, dataProvider: dataProvider, configuration: .init())
-                
-                let htmlConsumer = try FileWritingHTMLContentConsumer(
-                    targetFolder: URL(fileURLWithPath: "/output-dir"),
-                    fileManager: fileSystem,
-                    htmlTemplate: URL(fileURLWithPath: "/template/index.html"),
-                    customHeader: nil,
-                    customFooter: nil,
-                    prettyPrintOutput: true
-                )
-                
-                try await ConvertActionConverter.convert(
-                    context: context,
-                    outputConsumer: TestOutputConsumer(),
-                    htmlContentConsumer: htmlConsumer,
-                    sourceRepository: nil,
-                    emitDigest: false,
-                    documentationCoverageOptions: .noCoverage
-                )
-                
-                // Because the TestOutputConsumer below doesn't create any files, we only expect the HTML files in the output directory
-                XCTAssertEqual(fileSystem.dump(subHierarchyFrom: "/output-dir"), """
-                output-dir/
-                ╰─ documentation/
-                   ╰─ rootarticle/
-                      ╰─ index.html
-                """)
-                
-                try assert(readHTML: fileSystem.contents(of: URL(fileURLWithPath: "/output-dir/documentation/rootarticle/index.html")), matches: """
-                <html>
-                  <head>
-                    <meta charset="utf-8" />
-                    <link rel="icon" href="/favicon.ico" />
-                    <title>A single article</title>
-                    <meta content="This is a formatted article that becomes the root page (because there is only one page)." name="description"/>
-                  </head>
-                  <body>
-                    <noscript>
-                      <article>
-                        <section>
-                          <ul>
-                            <li>RootArticle</li>
-                          </ul>
-                          <hgroup>
-                            <p>Article</p>
-                            <h1>RootArticle</h1>
-                          </hgroup>
-                          <p>This is a <i> formatted</i> article that becomes the root page (because there is only one page).</p>
-                        </section>
-                      </article>
-                    </noscript>
-                    <div id="app"></div>
-                  </body>
-                </html>
-                """)
+        let maybeTitleTag = templateHasTitleTag ? "\n  <title>Documentation</title>" : ""
+        let maybeNoScriptTag = templateHasNoScriptTag ? """
+        
+          <noscript>
+            <p>Some existing information inside the no script tag</p>
+          </noscript>
+        """ : ""
+        
+        let htmlTemplate = TextFile(name: "index.html", utf8Content: """
+        <html>
+          <head>
+            <meta charset="utf-8" />
+            <link rel="icon" href="/favicon.ico" />\(maybeTitleTag)
+          </head>
+          <body>\(maybeNoScriptTag)
+            <div id="app"></div>
+          </body>
+        </html>
+        """)
+        
+        let fileSystem = try TestFileSystem {
+            Folder(name: "path") {
+                Folder(name: "to") {
+                    catalog
+                }
             }
+            Folder(name: "template") {
+                htmlTemplate
+            }
+            Folder(name: "output-dir") {}
         }
+        
+        let (inputs, dataProvider) = try DocumentationContext.InputsProvider(fileManager: fileSystem)
+            .inputsAndDataProvider(startingPoint: URL(fileURLWithPath: "/path/to/\(catalog.name)"), options: .init())
+        
+        let context = try await DocumentationContext(bundle: inputs, dataProvider: dataProvider, configuration: .init())
+        
+        let htmlConsumer = try FileWritingHTMLContentConsumer(
+            targetFolder: URL(fileURLWithPath: "/output-dir"),
+            fileManager: fileSystem,
+            htmlTemplate: URL(fileURLWithPath: "/template/index.html"),
+            customHeader: nil,
+            customFooter: nil,
+            prettyPrintOutput: true
+        )
+        
+        try await ConvertActionConverter.convert(
+            context: context,
+            outputConsumer: TestOutputConsumer(),
+            htmlContentConsumer: htmlConsumer,
+            sourceRepository: nil,
+            emitDigest: false,
+            documentationCoverageOptions: .noCoverage
+        )
+        
+        // Because the TestOutputConsumer below doesn't create any files, we only expect the HTML files in the output directory
+        #expect(fileSystem.dump(subHierarchyFrom: "/output-dir") == """
+        output-dir/
+        ╰─ documentation/
+           ╰─ rootarticle/
+              ╰─ index.html
+        """)
+        
+        // In the current state, the whitespace around the metadata depends on how the text replacements were done
+        let expectedMetadata: String = if templateHasTitleTag {
+            """
+              <title>A single article</title>
+              <meta content="This is a formatted article that becomes the root page (because there is only one page)." name="description">
+            """
+        } else {
+            """
+              <title>A single article</title>
+            <meta content="This is a formatted article that becomes the root page (because there is only one page)." name="description">
+            """
+        }
+        
+        try assert(readHTML: fileSystem.contents(of: URL(fileURLWithPath: "/output-dir/documentation/rootarticle/index.html")), matches: """
+        <html>
+          <head>
+            <meta charset="utf-8" />
+            <link rel="icon" href="/favicon.ico" />
+        \(expectedMetadata)</head>
+          <body>
+        \(templateHasNoScriptTag ? "  " : "")<noscript><article>
+          <section>
+            <ul>
+              <li>RootArticle</li>
+            </ul>
+            <hgroup>
+              <p>Article</p>
+              <h1>RootArticle</h1>
+            </hgroup>
+            <p>
+              This is a <i>formatted</i> article that becomes the root page (because there is only one page).
+            </p>
+          </section>
+        </article></noscript>
+            <div id="app"></div>
+          </body>
+        </html>
+        """)
     }
 }
 
@@ -602,29 +614,6 @@ private class TestOutputConsumer: ConvertOutputConsumer, ExternalNodeConsumer {
     func consume(externalRenderNode: ExternalRenderNode) throws { }
 }
 
-func assert(readHTML: Data, matches expectedHTML: String, file: StaticString = #filePath, line: UInt = #line) {
-    // XMLNode on macOS and Linux pretty print with different indentation.
-    // To compare the XML structure without getting false positive failures because of indentation and other formatting differences,
-    // we explicitly process each string into an easy-to-compare format.
-    func formatForTestComparison(_ xmlString: String) -> String {
-        // This is overly simplified and won't result in "pretty" XML for general use but sufficient for test content comparisons
-        xmlString
-            // Put each tag on its own line
-            .replacingOccurrences(of: ">", with: ">\n")
-            // Remove leading indentation
-            .components(separatedBy: .newlines)
-            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-            .filter { !$0.isEmpty }
-            .joined(separator: "\n")
-            // Explicitly escape a few HTML characters that appear in the test content
-            .replacingOccurrences(of: "–", with: "&#x2013;") // en-dash
-            .replacingOccurrences(of: "—", with: "&#x2014;") // em-dash
-    }
-    
-    XCTAssertEqual(
-        formatForTestComparison(String(decoding: readHTML, as: UTF8.self)),
-        formatForTestComparison(expectedHTML),
-        file: file,
-        line: line
-    )
+func assert(readHTML: Data, matches expectedHTML: String, sourceLocation: SourceLocation = #_sourceLocation) {
+    #expect(String(decoding: readHTML, as: UTF8.self) == expectedHTML, sourceLocation: sourceLocation)
 }

--- a/Tests/DocCCommandLineTests/FileWritingHTMLContentConsumerTests.swift
+++ b/Tests/DocCCommandLineTests/FileWritingHTMLContentConsumerTests.swift
@@ -576,8 +576,7 @@ struct FileWritingHTMLContentConsumerTests {
             <meta charset="utf-8" />
             <link rel="icon" href="/favicon.ico" />
         \(expectedMetadata)</head>
-          <body>
-        \(templateHasNoScriptTag ? "  " : "")<noscript><article>
+          <body>\(templateHasNoScriptTag ? "\n  " : "")<noscript><article>
           <section>
             <ul>
               <li>RootArticle</li>
@@ -590,7 +589,7 @@ struct FileWritingHTMLContentConsumerTests {
               This is a <i>formatted</i> article that becomes the root page (because there is only one page).
             </p>
           </section>
-        </article></noscript>
+        </article></noscript>\(templateHasNoScriptTag ? "" : "\n")
             <div id="app"></div>
           </body>
         </html>

--- a/Tests/DocCCommandLineTests/StaticHostingWithContentTests.swift
+++ b/Tests/DocCCommandLineTests/StaticHostingWithContentTests.swift
@@ -1,36 +1,37 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2025 Apple Inc. and the Swift project authors
+ Copyright (c) 2025-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import XCTest
+import Testing
 import Foundation
 @testable import SwiftDocC
 @testable import DocCCommandLine
 import DocCTestUtilities
 
-class StaticHostingWithContentTests: XCTestCase {
+struct StaticHostingWithContentTests {
 
-    func testIncludesBasePathInPerPageIndexHTMLFile() async throws {
-        let catalog = Folder(name: "Something.docc", content: [
+    @Test(arguments: [true, false])
+    func includesBasePathInPerPageIndexHTMLFile(includeHTMLContent: Bool) async throws {
+        let catalog = Folder(name: "Something.docc") {
             TextFile(name: "RootArticle.md", utf8Content: """
             # A single article
             
             This is a _formatted_ article that becomes the root page (because there is only one page).
-            """),
+            """)
             
             TextFile(name: "header.html", utf8Content: """
             <p>Some header content</p>
-            """),
+            """)
             TextFile(name: "footer.html", utf8Content: """
             <p>Some footer content</p>
-            """),
-        ])
+            """)
+        }
         let htmlTemplateContent = """
         <html>
           <head>
@@ -47,105 +48,100 @@ class StaticHostingWithContentTests: XCTestCase {
         </html>
         """
         
-        let fileSystem = try TestFileSystem(folders: [
-            Folder(name: "path", content: [
-                Folder(name: "to", content: [
+        let fileSystem = try TestFileSystem {
+            Folder(name: "path") {
+                Folder(name: "to") {
                     catalog
-                ])
-            ]),
-            Folder(name: "template", content: [
-                TextFile(name: "index.html", utf8Content: htmlTemplateContent.replacingOccurrences(of: "{{BASE_PATH}}", with: "")),
-                TextFile(name: "index-template.html", utf8Content: htmlTemplateContent),
-            ]),
-            Folder(name: "output-dir", content: [])
-        ])
+                }
+            }
+            Folder(name: "template") {
+                TextFile(name: "index.html", utf8Content: htmlTemplateContent.replacingOccurrences(of: "{{BASE_PATH}}", with: ""))
+                TextFile(name: "index-template.html", utf8Content: htmlTemplateContent)
+            }
+            Folder(name: "output-dir") {}
+        }
         
         let basePath = "some/test/base-path"
         
-        for includeHTMLContent in [true, false] {
-            
-            var action = try ConvertAction(
-                documentationBundleURL: URL(fileURLWithPath: "/path/to/\(catalog.name)"),
-                outOfProcessResolver: nil,
-                analyze: false,
-                targetDirectory: URL(fileURLWithPath: "/output-dir"),
-                htmlTemplateDirectory: URL(fileURLWithPath: "/template"),
-                emitDigest: false,
-                currentPlatforms: nil,
-                buildIndex: false,
-                fileManager: fileSystem,
-                temporaryDirectory: URL(fileURLWithPath: "/tmp"),
-                experimentalEnableCustomTemplates: true,
-                transformForStaticHosting: true,
-                includeContentInEachHTMLFile: includeHTMLContent,
-                hostingBasePath: basePath
-            )
-            // The old `Indexer` type doesn't work with virtual file systems.
-            action._completelySkipBuildingIndex = true
-            
-            _ = try await action.perform(logHandle: .none)
-            
-            // Because the TestOutputConsumer below, doesn't create any files, we only expect the HTML files in the output directory
-            XCTAssertEqual(fileSystem.dump(subHierarchyFrom: "/output-dir"), """
-            output-dir/
-            ├─ data/
-            │  ╰─ documentation/
-            │     ╰─ rootarticle.json
-            ├─ documentation/
-            │  ╰─ rootarticle/
-            │     ╰─ index.html
-            ├─ downloads/
-            │  ╰─ Something/
-            ├─ images/
-            │  ╰─ Something/
-            ├─ index.html
-            ├─ metadata.json
-            ╰─ videos/
-               ╰─ Something/
-            """)
-            
-            let expectedTitleAndMetaContent = includeHTMLContent ? """
-            <title>A single article</title>
-            <meta content="This is a formatted article that becomes the root page (because there is only one page)." name="description"/>
-            """ : "<title>Documentation</title>"
-            
-            let expectedNoScriptContent = includeHTMLContent ? """
-            <article>
-              <section>
-                <ul>
-                  <li>RootArticle</li>
-                </ul>
-                <hgroup>
-                  <p>Article</p>
-                  <h1>RootArticle</h1>
-                </hgroup>
-                <p>This is a <i> formatted</i> article that becomes the root page (because there is only one page).</p>
-              </section>
-            </article>
-            """ : "<p>Some existing information inside the no script tag</p>"
-            
-            // The footer comes before the header to match the behavior of ConvertFileWritingConsumer.
-            try assert(readHTML: fileSystem.contents(of: URL(fileURLWithPath: "/output-dir/documentation/rootarticle/index.html")), matches: """
-            <html>
-              <head>
-                <meta charset="utf-8" />
-                <link rel="icon" href="/some/test/base-path/favicon.ico" />
-                \(expectedTitleAndMetaContent)
-              </head>
-              <body>
-                <template id="custom-footer">
-                  <p>Some footer content</p>
-                </template>
-                <template id="custom-header">
-                  <p>Some header content</p>
-                </template>
-                <noscript>
-                  \(expectedNoScriptContent)
-                </noscript>
-                <div id="app"></div>
-              </body>
-            </html>
-            """)
-        }
+        var action = try ConvertAction(
+            documentationBundleURL: URL(fileURLWithPath: "/path/to/\(catalog.name)"),
+            outOfProcessResolver: nil,
+            analyze: false,
+            targetDirectory: URL(fileURLWithPath: "/output-dir"),
+            htmlTemplateDirectory: URL(fileURLWithPath: "/template"),
+            emitDigest: false,
+            currentPlatforms: nil,
+            buildIndex: false,
+            fileManager: fileSystem,
+            temporaryDirectory: URL(fileURLWithPath: "/tmp"),
+            experimentalEnableCustomTemplates: true,
+            transformForStaticHosting: true,
+            includeContentInEachHTMLFile: includeHTMLContent,
+            hostingBasePath: basePath
+        )
+        // The old `Indexer` type doesn't work with virtual file systems.
+        action._completelySkipBuildingIndex = true
+        
+        _ = try await action.perform(logHandle: .none)
+        
+        // Because the TestOutputConsumer below, doesn't create any files, we only expect the HTML files in the output directory
+        #expect(fileSystem.dump(subHierarchyFrom: "/output-dir") == """
+        output-dir/
+        ├─ data/
+        │  ╰─ documentation/
+        │     ╰─ rootarticle.json
+        ├─ documentation/
+        │  ╰─ rootarticle/
+        │     ╰─ index.html
+        ├─ downloads/
+        │  ╰─ Something/
+        ├─ images/
+        │  ╰─ Something/
+        ├─ index.html
+        ├─ metadata.json
+        ╰─ videos/
+           ╰─ Something/
+        """)
+        
+        let expectedTitleAndMetaContent = includeHTMLContent ? """
+          <title>A single article</title>
+          <meta content="This is a formatted article that becomes the root page (because there is only one page)." name="description">
+        """ : "  <title>Documentation</title>\n  "
+        
+        let expectedNoScriptContent = includeHTMLContent ? """
+            <noscript>\
+        <article>\
+        <section>\
+        <ul>\
+        <li>RootArticle</li>\
+        </ul>\
+        <hgroup>\
+        <p>Article</p>\
+        <h1>RootArticle</h1>\
+        </hgroup>\
+        <p>This is a <i>formatted</i> article that becomes the root page (because there is only one page).</p>\
+        </section>\
+        </article>\
+        </noscript>
+        """ : """
+        
+            <noscript>
+              <p>Some existing information inside the no script tag</p>
+            </noscript>
+        """
+        
+        // The footer comes before the header to match the behavior of ConvertFileWritingConsumer.
+        try assert(readHTML: fileSystem.contents(of: URL(fileURLWithPath: "/output-dir/documentation/rootarticle/index.html")), matches: """
+        <html>
+          <head>
+            <meta charset="utf-8" />
+            <link rel="icon" href="/some/test/base-path/favicon.ico" />
+          \(expectedTitleAndMetaContent)</head>
+          <body>\(includeHTMLContent ? "\n" : "")\
+        <template id="custom-footer"><p>Some footer content</p></template><template id="custom-header"><p>Some header content</p></template>\(expectedNoScriptContent)
+            <div id="app"></div>
+          </body>
+        </html>
+        """)
     }
 }

--- a/Tests/DocCCommandLineTests/StaticHostingWithContentTests.swift
+++ b/Tests/DocCCommandLineTests/StaticHostingWithContentTests.swift
@@ -137,8 +137,7 @@ struct StaticHostingWithContentTests {
             <meta charset="utf-8" />
             <link rel="icon" href="/some/test/base-path/favicon.ico" />
           \(expectedTitleAndMetaContent)</head>
-          <body>\(includeHTMLContent ? "\n" : "")\
-        <template id="custom-footer"><p>Some footer content</p></template><template id="custom-header"><p>Some header content</p></template>\(expectedNoScriptContent)
+          <body><template id="custom-footer"><p>Some footer content</p></template><template id="custom-header"><p>Some header content</p></template>\(includeHTMLContent ? "\n" : "")\(expectedNoScriptContent)
             <div id="app"></div>
           </body>
         </html>

--- a/Tests/DocCHTMLTests/HTMLFormatterTests.swift
+++ b/Tests/DocCHTMLTests/HTMLFormatterTests.swift
@@ -158,9 +158,7 @@ struct HTMLFormatterTests {
         let html = span(attributes: [.title(#"' & " <>"#)], contents: [.text("Some text")])
         
         #expect(htmlString(for: html, options: .prettyPrint) == """
-        <span title="' &amp; &quot; <>">
-          Some text
-        </span>
+        <span title="' &amp; &quot; <>">Some text</span>
         """)
     }
     

--- a/Tests/DocCHTMLTests/HTMLFormatterTests.swift
+++ b/Tests/DocCHTMLTests/HTMLFormatterTests.swift
@@ -339,6 +339,21 @@ struct HTMLFormatterTests {
     }
     
     @Test
+    func prettyFormatsTextSemanticAfterOtherElementOnSeparateLines() {
+        let html = header(contents: [
+            h2(contents: [.text("Some header")]),
+            span(contents: [.text("Some other information")]),
+        ])
+        
+        #expect(htmlString(for: html, options: .prettyPrint) == """
+        <header>
+          <h2>Some header</h2>
+          <span>Some other information</span>
+        </header>
+        """)
+    }
+    
+    @Test
     func includesOptionalEndTagsByDefault() {
         let definitionList = dl(contents: [
             dt(contents: [.text("range")]),

--- a/Tests/DocCHTMLTests/MarkdownRenderer+PageElementsTests.swift
+++ b/Tests/DocCHTMLTests/MarkdownRenderer+PageElementsTests.swift
@@ -54,7 +54,7 @@ struct MarkdownRenderer_PageElementsTests {
         let breadcrumbs = makeRenderer(goal: goal, elementsToReturn: elements).breadcrumbs(references: elements.map { $0.path }, currentPageNames: .single(.conceptual("ThisPage")))
         switch goal {
         case .richness:
-            breadcrumbs.assertMatches(prettyFormatted: true, expectedXMLString: """
+            breadcrumbs.assertMatches(prettyFormatted: true, expected: """
             <nav id="breadcrumbs">
               <ul>
                 <li>
@@ -71,7 +71,7 @@ struct MarkdownRenderer_PageElementsTests {
             </nav>
             """)
         case .conciseness:
-            breadcrumbs.assertMatches(prettyFormatted: true, expectedXMLString: """
+            breadcrumbs.assertMatches(prettyFormatted: true, expected: """
             <ul>
               <li>
                 <a href="../../index.html">ModuleName</a>
@@ -94,15 +94,21 @@ struct MarkdownRenderer_PageElementsTests {
         ])
         switch goal {
         case .richness:
-            availability.assertMatches(prettyFormatted: true, expectedXMLString: """
+            availability.assertMatches(prettyFormatted: true, expected: """
             <ul id="availability">
-              <li aria-label="First 1.2–3.4, Introduced in First 1.2 and deprecated in First 3.4" class="deprecated" title="Introduced in First 1.2 and deprecated in First 3.4">First 1.2–3.4</li>
-              <li aria-label="Second 1.2.3+, Available on Second 1.2.3 and later" title="Available on Second 1.2.3 and later">Second 1.2.3+</li>
-              <li aria-label="Third 4.5+, Available on Third 4.5 and later" class="beta" title="Available on Third 4.5 and later">Third 4.5+</li>
+              <li aria-label="First 1.2–3.4, Introduced in First 1.2 and deprecated in First 3.4" class="deprecated" title="Introduced in First 1.2 and deprecated in First 3.4">
+                First 1.2–3.4
+              </li>
+              <li aria-label="Second 1.2.3+, Available on Second 1.2.3 and later" title="Available on Second 1.2.3 and later">
+                Second 1.2.3+
+              </li>
+              <li aria-label="Third 4.5+, Available on Third 4.5 and later" class="beta" title="Available on Third 4.5 and later">
+                Third 4.5+
+              </li>
             </ul>
             """)
         case .conciseness:
-            availability.assertMatches(prettyFormatted: true, expectedXMLString: """
+            availability.assertMatches(prettyFormatted: true, expected: """
             <ul id="availability">
               <li>First 1.2–3.4</li>
               <li>Second 1.2.3+</li>
@@ -127,7 +133,7 @@ struct MarkdownRenderer_PageElementsTests {
         
         switch goal {
         case .richness:
-            parameters.assertMatches(prettyFormatted: true, expectedXMLString: """
+            parameters.assertMatches(prettyFormatted: true, expected: """
             <section id="Parameters">
               <h2>
                 <a href="#Parameters">Parameters</a>
@@ -142,25 +148,28 @@ struct MarkdownRenderer_PageElementsTests {
                 <dt>Second</dt>
                 <dd>
                   <p>
-                    Some <b>other</b> <i>formatted</i> description</p>
+                    Some <b>other</b> <i>formatted</i> description
+                  </p>
                   <p>That spans two paragraphs</p>
                 </dd>
               </dl>
             </section>
             """)
         case .conciseness:
-            parameters.assertMatches(prettyFormatted: true, expectedXMLString: """
+            parameters.assertMatches(prettyFormatted: true, expected: """
             <h2>Parameters</h2>
             <dl>
               <dt>First</dt>
               <dd>
-                <p>Some <i>formatted</i>description with <code>code</code>
+                <p>
+                  Some <i>formatted</i> description with <code>code</code>
                 </p>
               </dd>
               <dt>Second</dt>
               <dd>
                 <p>
-                  Some <b>other</b> <i>formatted</i> description</p>
+                  Some <b>other</b> <i>formatted</i> description
+                </p>
                 <p>That spans two paragraphs</p>
               </dd>
             </dl>
@@ -182,7 +191,7 @@ struct MarkdownRenderer_PageElementsTests {
                 .init(name: "ObjectiveCOnly", content: parseMarkup(string: "Only available in Objective-C")),
             ],
         ])
-        parameters.assertMatches(prettyFormatted: true, expectedXMLString: """
+        parameters.assertMatches(prettyFormatted: true, expected: """
         <section id="Parameters">
           <h2>
             <a href="#Parameters">Parameters</a>
@@ -222,7 +231,7 @@ struct MarkdownRenderer_PageElementsTests {
                 .init(name: "Third", content: parseMarkup(string: "Some description")),
             ],
         ])
-        parameters.assertMatches(prettyFormatted: true, expectedXMLString: """
+        parameters.assertMatches(prettyFormatted: true, expected: """
         <section id="Parameters">
           <h2>
             <a href="#Parameters">Parameters</a>
@@ -262,16 +271,16 @@ struct MarkdownRenderer_PageElementsTests {
         
         switch goal {
         case .richness:
-            returns.assertMatches(prettyFormatted: true, expectedXMLString: """
+            returns.assertMatches(prettyFormatted: true, expected: """
             <section id="Return-Value">
-            <h2>
-              <a href="#Return-Value">Return Value</a>
-            </h2>
-            \(commonHTML)
+              <h2>
+                <a href="#Return-Value">Return Value</a>
+              </h2>
+            \(commonHTML.indenting(depth: 1))
             </section>
             """)
         case .conciseness:
-            returns.assertMatches(prettyFormatted: true, expectedXMLString: """
+            returns.assertMatches(prettyFormatted: true, expected: """
             <h2>Return Value</h2>
             \(commonHTML)
             """)
@@ -286,23 +295,29 @@ struct MarkdownRenderer_PageElementsTests {
         ])
         
         let commonHTML = """
-        <p class="swift-only">First paragraph</p>
-        <p class="swift-only">Second paragraph</p>
-        <p class="occ-only">Other language’s paragraph</p>
+        <p class="swift-only">
+          First paragraph
+        </p>
+        <p class="swift-only">
+          Second paragraph
+        </p>
+        <p class="occ-only">
+          Other language’s paragraph
+        </p>
         """
         
         switch goal {
         case .richness:
-            returns.assertMatches(prettyFormatted: true, expectedXMLString: """
+            returns.assertMatches(prettyFormatted: true, expected: """
             <section id="Return-Value">
-            <h2>
-              <a href="#Return-Value">Return Value</a>
-            </h2>
-            \(commonHTML)
+              <h2>
+                <a href="#Return-Value">Return Value</a>
+              </h2>
+            \(commonHTML.indenting(depth: 1))
             </section>
             """)
         case .conciseness:
-            returns.assertMatches(prettyFormatted: true, expectedXMLString: """
+            returns.assertMatches(prettyFormatted: true, expected: """
             <h2>Return Value</h2>
             \(commonHTML)
             """)
@@ -348,28 +363,15 @@ struct MarkdownRenderer_PageElementsTests {
                 and second: SecondParameterValue
             ) throws -> ReturnValue
             """)
-            // FIXME: Pretty printing pre-formatted content changes the output (rdar://165755530)
-            declaration.assertMatches(prettyFormatted: true, expectedXMLString: """
-            <pre id="declaration">
-            <code>
-              <span class="keyword">func</span>
-               doSomething(
-                  with <span class="internalParameter">first</span>
-              : <a class="typeIdentifier" href="../../firstparametervalue/index.html">FirstParameterValue</a>
-              ,
-                  and <span class="internalParameter">second</span>
-              : <a class="typeIdentifier" href="../../secondparametervalue/index.html">SecondParameterValue</a>
-              
-              ) <span class="keyword">throws</span>
-               -&gt; <a class="typeIdentifier" href="../../returnvalue/index.html">ReturnValue</a>
-            </code>
-            </pre>
+            declaration.assertMatches(prettyFormatted: true, expected: """
+            <pre id="declaration"><code><span class="keyword">func</span> doSomething(
+                with <span class="internalParameter">first</span>: <a class="typeIdentifier" href="../../firstparametervalue/index.html">FirstParameterValue</a>,
+                and <span class="internalParameter">second</span>: <a class="typeIdentifier" href="../../secondparametervalue/index.html">SecondParameterValue</a>
+            ) <span class="keyword">throws</span> -> <a class="typeIdentifier" href="../../returnvalue/index.html">ReturnValue</a></code></pre>
             """)
         case .conciseness:
-            declaration.assertMatches(prettyFormatted: true, expectedXMLString: """
-            <pre>
-              <code>func doSomething(with first: FirstParameterValue, and second: SecondParameterValue) throws -&gt; ReturnValue</code>
-            </pre>
+            declaration.assertMatches(prettyFormatted: true, expected: """
+            <pre><code>func doSomething(with first: FirstParameterValue, and second: SecondParameterValue) throws -> ReturnValue</code></pre>
             """)
         }
     }
@@ -445,34 +447,12 @@ struct MarkdownRenderer_PageElementsTests {
             _ body: (UnsafeMutableBufferPointer<T>) throws(E) -> R
         ) throws(E) -> R where E : Error, T : ~Copyable, R : ~Copyable
         """)
-        // FIXME: Pretty printing pre-formatted content changes the output (rdar://165755530)
-        functionDeclaration.assertMatches(prettyFormatted: true, expectedXMLString: """
-        <pre id="declaration">
-        <code>
-          <span class="keyword">func</span>
-           withUnsafeTemporaryAllocation&lt;T, R, E&gt;(
-              of <span class="internalParameter">type</span>
-          : <span class="typeIdentifier">T</span>
-          .Type,
-              capacity: <span class="typeIdentifier">Int</span>
-          ,
-              _ <span class="internalParameter">body</span>
-          : (<span class="typeIdentifier">UnsafeMutableBufferPointer</span>
-          &lt;<span class="typeIdentifier">T</span>
-          &gt;) <span class="keyword">throws</span>
-          (<span class="typeIdentifier">E</span>
-          ) -&gt; <span class="typeIdentifier">R</span>
-          
-          ) <span class="keyword">throws</span>
-          (<span class="typeIdentifier">E</span>
-          ) -&gt; <span class="typeIdentifier">R</span>
-           <span class="keyword">where</span>
-           <span class="typeIdentifier">E</span>
-           : <span class="typeIdentifier">Error</span>
-          , <span class="typeIdentifier">T</span>
-           : ~Copyable, <span class="typeIdentifier">R</span>
-           : ~Copyable</code>
-        </pre>
+        functionDeclaration.assertMatches(prettyFormatted: true, expected: """
+        <pre id="declaration"><code><span class="keyword">func</span> withUnsafeTemporaryAllocation&lt;T, R, E>(
+            of <span class="internalParameter">type</span>: <span class="typeIdentifier">T</span>.Type,
+            capacity: <span class="typeIdentifier">Int</span>,
+            _ <span class="internalParameter">body</span>: (<span class="typeIdentifier">UnsafeMutableBufferPointer</span>&lt;<span class="typeIdentifier">T</span>>) <span class="keyword">throws</span>(<span class="typeIdentifier">E</span>) -> <span class="typeIdentifier">R</span>
+        ) <span class="keyword">throws</span>(<span class="typeIdentifier">E</span>) -> <span class="typeIdentifier">R</span> <span class="keyword">where</span> <span class="typeIdentifier">E</span> : <span class="typeIdentifier">Error</span>, <span class="typeIdentifier">T</span> : ~Copyable, <span class="typeIdentifier">R</span> : ~Copyable</code></pre>
         """)
         
         // @attached(accessor) @attached(peer, names: prefixed(`$`)) macro TaskLocal()
@@ -493,16 +473,9 @@ struct MarkdownRenderer_PageElementsTests {
         @attached(accessor) @attached(peer, names: prefixed(`$`))
         macro TaskLocal()
         """)
-        // FIXME: Pretty printing pre-formatted content changes the output (rdar://165755530)
-        macroDeclaration.assertMatches(prettyFormatted: true, expectedXMLString: """
-        <pre id="declaration">
-        <code>
-          <span class="attribute">@attached</span>
-          (accessor) <span class="attribute">@attached</span>
-          (peer, names: prefixed(`$`))
-          <span class="keyword">macro</span>
-           TaskLocal()</code>
-        </pre>
+        macroDeclaration.assertMatches(prettyFormatted: true, expected: """
+        <pre id="declaration"><code><span class="attribute">@attached</span>(accessor) <span class="attribute">@attached</span>(peer, names: prefixed(`$`))
+        <span class="keyword">macro</span> TaskLocal()</code></pre>
         """)
 
         // @freestanding(declaration) macro warning(_ message: String)
@@ -527,17 +500,9 @@ struct MarkdownRenderer_PageElementsTests {
         @freestanding(declaration)
         macro warning(_ message: String)
         """)
-        // FIXME: Pretty printing pre-formatted content changes the output (rdar://165755530)
-        macroDeclaration2.assertMatches(prettyFormatted: true, expectedXMLString: """
-        <pre id="declaration">
-        <code>
-          <span class="attribute">@freestanding</span>
-          (declaration)
-          <span class="keyword">macro</span>
-           warning(_ <span class="internalParameter">message</span>
-          : <span class="typeIdentifier">String</span>
-          )</code>
-        </pre>
+        macroDeclaration2.assertMatches(prettyFormatted: true, expected: """
+        <pre id="declaration"><code><span class="attribute">@freestanding</span>(declaration)
+        <span class="keyword">macro</span> warning(_ <span class="internalParameter">message</span>: <span class="typeIdentifier">String</span>)</code></pre>
         """)
     }
     
@@ -611,39 +576,18 @@ struct MarkdownRenderer_PageElementsTests {
                                        andSecond: (SecondParameterValue) second
                                            error: (NSError **) error;
             """)
-            // FIXME: Pretty printing pre-formatted content changes the output (rdar://165755530)
-            declaration.assertMatches(prettyFormatted: true, expectedXMLString: """
-            <pre id="declaration">
-            <code class="swift-only">
-              <span class="keyword">func</span>
-               doSomething(
-                  with <span class="internalParameter">first</span>
-              : <a class="typeIdentifier" href="../../firstparametervalue/index.html">FirstParameterValue</a>
-              ,
-                  and <span class="internalParameter">second</span>
-              : <a class="typeIdentifier" href="../../secondparametervalue/index.html">SecondParameterValue</a>
-              
-              ) <span class="keyword">throws</span>
-               -&gt; <a class="typeIdentifier" href="../../returnvalue/index.html">ReturnValue</a>
-            </code>
-            <code class="occ-only">- (<a class="typeIdentifier" href="../../returnvalue/index.html">ReturnValue</a>
-              ) doSomethingWithFirst: (<a class="typeIdentifier" href="../../firstparametervalue/index.html">FirstParameterValue</a>
-              ) <span class="internalParameter">first</span>
-              
-                                     andSecond: (<a class="typeIdentifier" href="../../secondparametervalue/index.html">SecondParameterValue</a>
-              ) <span class="internalParameter">second</span>
-              
-                                         error: (<a class="typeIdentifier" href="../../../foundation/nserror/index.html">NSError</a>
-               **) <span class="internalParameter">error</span>
-              ;</code>
-            </pre>
+            declaration.assertMatches(prettyFormatted: true, expected: """
+            <pre id="declaration"><code class="swift-only"><span class="keyword">func</span> doSomething(
+                with <span class="internalParameter">first</span>: <a class="typeIdentifier" href="../../firstparametervalue/index.html">FirstParameterValue</a>,
+                and <span class="internalParameter">second</span>: <a class="typeIdentifier" href="../../secondparametervalue/index.html">SecondParameterValue</a>
+            ) <span class="keyword">throws</span> -> <a class="typeIdentifier" href="../../returnvalue/index.html">ReturnValue</a></code><code class="occ-only">- (<a class="typeIdentifier" href="../../returnvalue/index.html">ReturnValue</a>) doSomethingWithFirst: (<a class="typeIdentifier" href="../../firstparametervalue/index.html">FirstParameterValue</a>) <span class="internalParameter">first</span>
+                                       andSecond: (<a class="typeIdentifier" href="../../secondparametervalue/index.html">SecondParameterValue</a>) <span class="internalParameter">second</span>
+                                           error: (<a class="typeIdentifier" href="../../../foundation/nserror/index.html">NSError</a> **) <span class="internalParameter">error</span>;</code></pre>
             """)
             
         case .conciseness:
-            declaration.assertMatches(prettyFormatted: true, expectedXMLString: """
-            <pre>
-              <code>func doSomething(with first: FirstParameterValue, and second: SecondParameterValue) throws -&gt; ReturnValue</code>
-            </pre>
+            declaration.assertMatches(prettyFormatted: true, expected: """
+            <pre><code>func doSomething(with first: FirstParameterValue, and second: SecondParameterValue) throws -> ReturnValue</code></pre>
             """)
         }
     }
@@ -714,7 +658,7 @@ struct MarkdownRenderer_PageElementsTests {
         
         switch goal {
         case .richness:
-            groupedSection.assertMatches(prettyFormatted: true, expectedXMLString: """
+            groupedSection.assertMatches(prettyFormatted: true, expected: """
             <section id="\(expectedSectionID)">
               <h2>
                 <a href="#\(expectedSectionID)">\(expectedGroupTitle)</a>
@@ -728,74 +672,86 @@ struct MarkdownRenderer_PageElementsTests {
                   <a href="../../someclass/index.html">
                     <code class="swift-only">
                       <span class="decorator">class </span>
-                      <span class="identifier">Some<wbr/>
-                        Class</span>
+                      <span class="identifier">
+                        Some<wbr>Class
+                      </span>
                     </code>
                     <code class="occ-only">
                       <span class="decorator">@interface </span>
-                      <span class="identifier">TLASome<wbr/>
-                          Class</span>
+                      <span class="identifier">
+                        TLASome<wbr>Class
+                      </span>
                     </code>
                   </a>
-                  <p>Some <i>formatted</i> description of this class</p>
+                  <p>
+                    Some <i>formatted</i> description of this class
+                  </p>
                 </li>
                 <li>
                   <a href="../../somearticle/index.html">
-                    <p class="api-collection">Some Article</p>
+                    <p class="api-collection">
+                      Some Article
+                    </p>
                   </a>
-                  <p>Some <b>formatted</b>description of this <i>article</i>.</p>
+                  <p>
+                    Some <b>formatted</b> description of this <i>article</i>.
+                  </p>
                 </li>
                 <li>
                   <a href="../../someclass/somemethod(with:and:)/index.html">
                     <code class="swift-only">
                       <span class="decorator">func </span>
-                      <span class="identifier">some<wbr/>
-                        Method</span>
+                      <span class="identifier">
+                        some<wbr>Method
+                      </span>
                       <span class="decorator">(</span>
                       <span class="identifier">with</span>
-                      <span class="decorator">:<wbr/>
-                         Int, </span>
+                      <span class="decorator">
+                        :<wbr> Int, 
+                      </span>
                       <span class="identifier">and</span>
-                      <span class="decorator">:<wbr/>
-                         String)</span>
+                      <span class="decorator">
+                        :<wbr> String)
+                      </span>
                     </code>
                     <code class="occ-only">
                       <span class="decorator">- </span>
-                      <span class="identifier">some<wbr/>
-                        Method<wbr/>
-                        With<wbr/>
-                        First:<wbr/>
-                        and<wbr/>
-                        Second:</span>
+                      <span class="identifier">
+                        some<wbr>Method<wbr>With<wbr>First:<wbr>and<wbr>Second:
+                      </span>
                     </code>
                   </a>
                 </li>
-            </ul>
+              </ul>
             </section>
             """)
         case .conciseness:
-            groupedSection.assertMatches(prettyFormatted: true, expectedXMLString: """
+            groupedSection.assertMatches(prettyFormatted: true, expected: """
             <h2>\(expectedGroupTitle)</h2>
             <h3>Group title</h3>
             <p>Some description of this group</p>
             <ul>
-            <li>
-              <a href="../../someclass/index.html">
-                <code>class SomeClass</code>
-              </a>
-              <p>Some <i>formatted</i> description of this class</p>
-            </li>
-            <li>
-              <a href="../../somearticle/index.html">
-                <p>Some Article</p>
-              </a>
-              <p>Some <b>formatted</b> description of this <i>article</i>.</p>
-            </li>
-            <li>
-              <a href="../../someclass/somemethod(with:and:)/index.html">
-                <code>func someMethod(with: Int, and: String)</code>
-              </a>
-            </li>
+              <li>
+                <a href="../../someclass/index.html">
+                  <code>class SomeClass</code>
+                </a>
+                <p>
+                  Some <i>formatted</i> description of this class
+                </p>
+              </li>
+              <li>
+                <a href="../../somearticle/index.html">
+                  <p>Some Article</p>
+                </a>
+                <p>
+                  Some <b>formatted</b> description of this <i>article</i>.
+                </p>
+              </li>
+              <li>
+                <a href="../../someclass/somemethod(with:and:)/index.html">
+                  <code>func someMethod(with: Int, and: String)</code>
+                </a>
+              </li>
             </ul>
             """)
         }
@@ -824,16 +780,16 @@ struct MarkdownRenderer_PageElementsTests {
         
         switch goal {
         case .richness:
-            discussion.assertMatches(prettyFormatted: true, expectedXMLString: """
+            discussion.assertMatches(prettyFormatted: true, expected: """
             <section id="Fallback">
-            <h2>
-              <a href="#Fallback">Fallback</a>
-            </h2>
-            \(commonHTML)
+              <h2>
+                <a href="#Fallback">Fallback</a>
+              </h2>
+            \(commonHTML.indenting(depth: 1))
             </section>
             """)
         case .conciseness:
-            discussion.assertMatches(prettyFormatted: true, expectedXMLString: """
+            discussion.assertMatches(prettyFormatted: true, expected: """
             <h2>Fallback</h2>
             \(commonHTML)
             """)
@@ -858,16 +814,16 @@ struct MarkdownRenderer_PageElementsTests {
         
         switch goal {
         case .richness:
-            discussion.assertMatches(prettyFormatted: true, expectedXMLString: """
+            discussion.assertMatches(prettyFormatted: true, expected: """
             <section id="Some-Heading">
-            <h2>
-              <a href="#Some-Heading">Some Heading</a>
-            </h2>
-            \(commonHTML)
+              <h2>
+                <a href="#Some-Heading">Some Heading</a>
+              </h2>
+            \(commonHTML.indenting(depth: 1))
             </section>
             """)
         case .conciseness:
-            discussion.assertMatches(prettyFormatted: true, expectedXMLString: """
+            discussion.assertMatches(prettyFormatted: true, expected: """
             <h2>Some Heading</h2>
             \(commonHTML)
             """)
@@ -953,5 +909,12 @@ private extension XMLNode {
             }
         }
         return result
+    }
+}
+
+private extension String {
+    func indenting(depth: Int) -> String {
+        let indentation = String(repeating: "  ", count: depth)
+        return indentation + replacingOccurrences(of: "\n", with: "\n" + indentation)
     }
 }

--- a/Tests/DocCHTMLTests/MarkdownRendererTests.swift
+++ b/Tests/DocCHTMLTests/MarkdownRendererTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2025 Apple Inc. and the Swift project authors
+ Copyright (c) 2025-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -212,7 +212,7 @@ struct MarkdownRendererTests {
                   <td>Seven</td>
                   <td>Eight</td>
                 </tr>
-            </tbody>
+              </tbody>
             </table>
             """
         )
@@ -280,10 +280,14 @@ struct MarkdownRendererTests {
             prettyFormatted: true,
             matches: """
             <aside class="note">
-              <p class="label">Note</p>
+              <p class="label">
+                Note
+              </p>
               <p>Something noteworthy</p>
               <aside class="important">
-                <p class="label">Important</p>
+                <p class="label">
+                  Important
+                </p>
                 <p>Something important</p>
               </aside>
             </aside>
@@ -312,10 +316,8 @@ struct MarkdownRendererTests {
             """,
             prettyFormatted: true,
             matches: """
-            <pre>
-              <code>Some block of code
-              </code>
-            </pre>
+            <pre><code>Some block of code
+            </code></pre>
             """
         )
         
@@ -325,10 +327,8 @@ struct MarkdownRendererTests {
             """,
             prettyFormatted: true,
             matches: """
-            <pre>
-              <code>Some block of code
-              </code>
-            </pre>
+            <pre><code>Some block of code
+            </code></pre>
             """
         )
         
@@ -340,10 +340,8 @@ struct MarkdownRendererTests {
             """,
             prettyFormatted: true,
             matches: """
-            <pre class="lang">
-              <code>Some block of code
-              </code>
-            </pre>
+            <pre class="lang"><code>Some block of code
+            </code></pre>
             """
         )
     }
@@ -357,14 +355,14 @@ struct MarkdownRendererTests {
         
         assert(
             rendering: "First  \nSecond", // ... but with two trailing spaces they are treated as line breaks
-            matches: "<p>First<br/>Second</p>"
+            matches: "<p>First<br>Second</p>"
         )
         
         assert(
             rendering: """
             -------
             """,
-            matches: "<hr/>"
+            matches: "<hr>"
         )
     }
     
@@ -404,10 +402,9 @@ struct MarkdownRendererTests {
             matches: """
             <p>
               <a href="../someclass/somemethod(_:_:)/index.html">
-                <code>some<wbr/>
-                  Method(<wbr/>
-                  _:<wbr/>
-                  _:)</code>
+                <code>
+                  some<wbr>Method(<wbr>_:<wbr>_:)
+                </code>
               </a>
             </p>
             """
@@ -421,16 +418,12 @@ struct MarkdownRendererTests {
             matches: """
             <p>
               <a href="../someclass/somemethod(_:_:)/index.html">
-                <code class="swift-only">do<wbr/>
-                  Something(<wbr/>
-                  with:<wbr/>
-                  and:)</code>
-                <code class="occ-only">do<wbr/>
-                  Something<wbr/>
-                  With<wbr/>
-                  First:<wbr/>
-                  and<wbr/>
-                  Second:</code>
+                <code class="swift-only">
+                  do<wbr>Something(<wbr>with:<wbr>and:)
+                </code>
+                <code class="occ-only">
+                  do<wbr>Something<wbr>With<wbr>First:<wbr>and<wbr>Second:
+                </code>
               </a>
             </p>
             """
@@ -440,8 +433,13 @@ struct MarkdownRendererTests {
         assert(
             rendering: "[Custom _formatted_ title](doc://com.example.test/documentation/Something/SomeClass/someMethod(_:_:))", // Simulate a link that's been locally resolved already
             elementToReturn: makeExampleMethodWithDifferentLanguageRepresentations(),
+            prettyFormatted: true,
             matches: """
-            <p><a href="../someclass/somemethod(_:_:)/index.html">Custom <i>formatted</i> title</a></p>
+            <p>
+              <a href="../someclass/somemethod(_:_:)/index.html">
+                Custom <i>formatted</i> title
+              </a>
+            </p>
             """
         )
         
@@ -450,7 +448,7 @@ struct MarkdownRendererTests {
             rendering: "[Some `CustomSymbolName` title](doc://com.example.test/documentation/Something/SomeClass/someMethod(_:_:))", // Simulate a link that's been locally resolved already
             elementToReturn: makeExampleMethodWithDifferentLanguageRepresentations(),
             matches: """
-            <p><a href="../someclass/somemethod(_:_:)/index.html">Some <code>Custom<wbr/>Symbol<wbr/>Name</code> title</a></p>
+            <p><a href="../someclass/somemethod(_:_:)/index.html">Some <code>Custom<wbr>Symbol<wbr>Name</code> title</a></p>
             """
         )
         
@@ -472,7 +470,7 @@ struct MarkdownRendererTests {
             prettyFormatted: true,
             matches: """
             <p>
-            <code>Some fallback link text</code>
+              <code>Some fallback link text</code>
             </p>
             """
         )
@@ -490,7 +488,7 @@ struct MarkdownRendererTests {
             matches: """
             <p>
               <picture>
-                <img alt="Some alt text" decoding="async" loading="lazy" src="../../../../images/com.test.example/some-image.png"/>
+                <img alt="Some alt text" decoding="async" loading="lazy" src="../../../../images/com.test.example/some-image.png">
               </picture>
             </p>
             """
@@ -509,7 +507,7 @@ struct MarkdownRendererTests {
             matches: """
             <p>
               <picture>
-                <img alt="Some alt text" decoding="async" loading="lazy" srcset="../../../../images/com.test.example/some-image@2x.png 2x, ../../../../images/com.test.example/some-image.png 1x"/>
+                <img alt="Some alt text" decoding="async" loading="lazy" srcset="../../../../images/com.test.example/some-image@2x.png 2x, ../../../../images/com.test.example/some-image.png 1x">
               </picture>
             </p>
             """
@@ -526,9 +524,9 @@ struct MarkdownRendererTests {
             matches: """
             <p>
               <picture>
-                <source media="(prefers-color-scheme: light)" src="../../../../images/com.test.example/some-image.png"/>
-                <source media="(prefers-color-scheme: dark)" src="../../../../images/com.test.example/some-image~dark.png"/>
-                <img alt="Some alt text" decoding="async" loading="lazy"/>
+                <source media="(prefers-color-scheme: light)" src="../../../../images/com.test.example/some-image.png">
+                <source media="(prefers-color-scheme: dark)" src="../../../../images/com.test.example/some-image~dark.png">
+                <img alt="Some alt text" decoding="async" loading="lazy">
               </picture>
             </p>
             """
@@ -551,9 +549,9 @@ struct MarkdownRendererTests {
             matches: """
             <p>
               <picture>
-                <source media="(prefers-color-scheme: light)" srcset="../../../../images/com.test.example/some-image@2x.png 2x, ../../../../images/com.test.example/some-image.png 1x"/>
-                <source media="(prefers-color-scheme: dark)" srcset="../../../../images/com.test.example/some-image~dark@2x.png 2x, ../../../../images/com.test.example/some-image~dark.png 1x"/>
-                <img alt="Some alt text" decoding="async" loading="lazy"/>
+                <source media="(prefers-color-scheme: light)" srcset="../../../../images/com.test.example/some-image@2x.png 2x, ../../../../images/com.test.example/some-image.png 1x">
+                <source media="(prefers-color-scheme: dark)" srcset="../../../../images/com.test.example/some-image~dark@2x.png 2x, ../../../../images/com.test.example/some-image~dark.png 1x">
+                <img alt="Some alt text" decoding="async" loading="lazy">
               </picture>
             </p>
             """
@@ -568,8 +566,8 @@ struct MarkdownRendererTests {
         )
         
         assert(
-            rendering: "This<br/> is a <em><!-- multi\n line\n comment-->formatted</em>paragraph.",
-            matches: "<p>This<br/> is a <em>formatted</em> paragraph.</p>"
+            rendering: "This<br/> is a <em><!-- multi\n line\n comment-->formatted</em> paragraph.",
+            matches: "<p>This<br> is a <em>formatted</em> paragraph.</p>"
         )
         
         assert(
@@ -600,10 +598,7 @@ struct MarkdownRendererTests {
             <!-- comment after block element -->
             """,
             matches: """
-            <details>
-                <summary>Some summary</summary>
-                <p>Some longer description</p>
-            </details>
+            <details><summary>Some summary</summary><p>Some longer description</p></details>
             """
         )
     }
@@ -627,7 +622,7 @@ struct MarkdownRendererTests {
             )
         )
         let htmlNodes = Document(parsing: markdownContent, options: [.parseSymbolLinks, .parseBlockDirectives]).children.map { renderer.visit($0) }
-        htmlNodes.assertMatches(prettyFormatted: prettyFormatted, expectedXMLString: expectedHTML, sourceLocation: sourceLocation)
+        htmlNodes.assertMatches(prettyFormatted: prettyFormatted, expected: expectedHTML, sourceLocation: sourceLocation)
     }
     
     private func makeExampleMethodWithDifferentLanguageRepresentations() -> LinkedElement {
@@ -662,61 +657,29 @@ struct MarkdownRendererTests {
 // MARK: Helpers
 
 extension XMLNode {
-    func assertMatches(prettyFormatted: Bool, expectedXMLString: String, sourceLocation: Testing.SourceLocation = #_sourceLocation) {
-        _assertMatches(actualXMLString: rendered(prettyFormatted: prettyFormatted), expectedXMLString: expectedXMLString, sourceLocation: sourceLocation)
+    func assertMatches(prettyFormatted: Bool, expected: String, sourceLocation: Testing.SourceLocation = #_sourceLocation) {
+        #expect(rendered(prettyFormatted: prettyFormatted, sourceLocation: sourceLocation) == expected, sourceLocation: sourceLocation)
     }
     
-    fileprivate func rendered(prettyFormatted: Bool) -> String {
-        if prettyFormatted {
-            xmlString(options: [.nodePrettyPrint, .nodeCompactEmptyElement])
-        } else {
-            xmlString(options: .nodeCompactEmptyElement)
+    fileprivate func rendered(prettyFormatted: Bool, sourceLocation: Testing.SourceLocation = #_sourceLocation) -> String {
+        guard let htmlNode = HTMLNode(from: self) else {
+            Issue.record("Failed to convert node \(self.xmlString(options: .nodeCompactEmptyElement)) to HTML node", sourceLocation: sourceLocation)
+            return ""
         }
+        
+        return String(decoding: HTMLFormatter.format(htmlNode, options: prettyFormatted ? .prettyPrint : []), as: UTF8.self)
     }
 }
 
 extension Sequence<XMLNode> {
-    func assertMatches(prettyFormatted: Bool, expectedXMLString: String, sourceLocation: Testing.SourceLocation = #_sourceLocation) {
-        _assertMatches(actualXMLString: rendered(prettyFormatted: prettyFormatted), expectedXMLString: expectedXMLString, sourceLocation: sourceLocation)
+    func assertMatches(prettyFormatted: Bool, expected: String, sourceLocation: Testing.SourceLocation = #_sourceLocation) {
+        #expect(rendered(prettyFormatted: prettyFormatted, sourceLocation: sourceLocation) == expected, sourceLocation: sourceLocation)
     }
     
-    private func rendered(prettyFormatted: Bool) -> String {
-        map { $0.rendered(prettyFormatted: prettyFormatted) }
+    private func rendered(prettyFormatted: Bool, sourceLocation: Testing.SourceLocation = #_sourceLocation) -> String {
+        map { $0.rendered(prettyFormatted: prettyFormatted, sourceLocation: sourceLocation) }
             .joined(separator: prettyFormatted ? "\n" : "")
     }
-}
-
-extension Sequence<XMLElement> {
-    func assertMatches(prettyFormatted: Bool, expectedXMLString: String, sourceLocation: Testing.SourceLocation = #_sourceLocation) {
-        _assertMatches(actualXMLString: rendered(prettyFormatted: prettyFormatted), expectedXMLString: expectedXMLString, sourceLocation: sourceLocation)
-    }
-    
-    private func rendered(prettyFormatted: Bool) -> String {
-        map { $0.rendered(prettyFormatted: prettyFormatted) }
-            .joined(separator: prettyFormatted ? "\n" : "")
-    }
-}
-
-private func _assertMatches(actualXMLString: String, expectedXMLString: String, sourceLocation: Testing.SourceLocation = #_sourceLocation) {
-    // XMLNode on macOS and Linux pretty print with different indentation.
-    // To compare the XML structure without getting false positive failures because of indentation and other formatting differences,
-    // we explicitly process each string into an easy-to-compare format.
-    func formatForTestComparison(_ xmlString: String) -> String {
-        // This is overly simplified and won't result in "pretty" XML for general use but sufficient for test content comparisons
-        xmlString
-            // Put each tag on its own line
-            .replacingOccurrences(of: ">", with: ">\n")
-            // Remove leading indentation
-            .components(separatedBy: .newlines)
-            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-            .filter { !$0.isEmpty }
-            .joined(separator: "\n")
-            // Explicitly escape a few HTML characters that appear in the test content
-            .replacingOccurrences(of: "–", with: "&#x2013;") // en-dash
-            .replacingOccurrences(of: "—", with: "&#x2014;") // em-dash
-    }
-    
-    #expect(formatForTestComparison(actualXMLString) == formatForTestComparison(expectedXMLString), sourceLocation: sourceLocation)
 }
 
 struct SingleValueLinkProvider: LinkProvider {

--- a/Tests/SwiftDocCTests/Rendering/HTML/HTMLRenderer+FullPageTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/HTML/HTMLRenderer+FullPageTests.swift
@@ -149,18 +149,6 @@ struct HTMLRenderFullPageTests {
     }
 }
 
-private extension XMLNode {
-    func rendered(sourceLocation: Testing.SourceLocation = #_sourceLocation) -> String {
-        guard let htmlNode = HTMLNode(from: self) else {
-            Issue.record("Failed to convert node \(self.xmlString(options: .nodeCompactEmptyElement)) to HTML node", sourceLocation: sourceLocation)
-            return ""
-        }
-        
-        return String(decoding: HTMLFormatter.format(htmlNode, options: .prettyPrint), as: UTF8.self)
-    }
-}
-
-
-func assert(_ document: XMLDocument, matches expected: String, sourceLocation: SourceLocation = #_sourceLocation) {
-    #expect(document.rootElement()!.rendered(sourceLocation: sourceLocation) == expected, sourceLocation: sourceLocation)
+func assert(_ page: HTMLNode, matches expected: String, sourceLocation: SourceLocation = #_sourceLocation) {
+    #expect(String(decoding: HTMLFormatter.format(page, options: .prettyPrint), as: UTF8.self) == expected, sourceLocation: sourceLocation)
 }

--- a/Tests/SwiftDocCTests/Rendering/HTML/HTMLRenderer+FullPageTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/HTML/HTMLRenderer+FullPageTests.swift
@@ -62,13 +62,16 @@ struct HTMLRenderFullPageTests {
                 <legend>Select a color scheme preference</legend>
                 <label>
                   <input name="color-scheme" type="radio" value="light">
-                  Light</label>
-              <label>
-                <input name="color-scheme" type="radio" value="dark">
-                Dark</label>
-              <label>
-                <input checked name="color-scheme" type="radio" value="auto">
-                Auto</label>
+                  Light
+                </label>
+                <label>
+                  <input name="color-scheme" type="radio" value="dark">
+                  Dark
+                </label>
+                <label>
+                  <input checked name="color-scheme" type="radio" value="auto">
+                  Auto
+                </label>
               </fieldset>
             </footer>
           </body>
@@ -126,13 +129,16 @@ struct HTMLRenderFullPageTests {
                     <legend>Select a color scheme preference</legend>
                     <label>
                       <input name="color-scheme" type="radio" value="light">
-                      Light</label>
-                  <label>
-                    <input name="color-scheme" type="radio" value="dark">
-                    Dark</label>
-                  <label>
-                    <input checked name="color-scheme" type="radio" value="auto">
-                    Auto</label>
+                      Light
+                    </label>
+                    <label>
+                      <input name="color-scheme" type="radio" value="dark">
+                      Dark
+                    </label>
+                    <label>
+                      <input checked name="color-scheme" type="radio" value="auto">
+                      Auto
+                    </label>
                   </fieldset>
                 </footer>
                 <footer>A custom footer</footer>
@@ -143,33 +149,18 @@ struct HTMLRenderFullPageTests {
     }
 }
 
-// This workaround is modified from the similar code in FileWritingHTMLContentConsumerTests.swift
-func assert(_ html: XMLDocument, matches expectedHTML: String, sourceLocation: SourceLocation = #_sourceLocation) {
-    // XMLNode on macOS and Linux pretty print with different indentation.
-    // To compare the XML structure without getting false positive failures because of indentation and other formatting differences,
-    // we explicitly process each string into an easy-to-compare format.
-    func formatForTestComparison(_ xmlString: String) -> String {
-        // This is overly simplified and won't result in "pretty" XML for general use but sufficient for test content comparisons
-        xmlString
-            // Workaround document type differences
-            .replacingOccurrences(of: #"<?xml version="1.0" encoding="utf-8" standalone="no"?>"#, with: "")
-            .replacingOccurrences(of: #"<!DOCTYPE html PUBLIC "" "">"#, with: "<!DOCTYPE html>")
-            // Put each tag on its own line
-            .replacingOccurrences(of: ">", with: ">\n")
-            // Allow some meta tags to encode as void elements rather than self-closing elements
-            .replacingOccurrences(of: "\">", with: "\"/>")
-            // Remove leading indentation
-            .components(separatedBy: .newlines)
-            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-            .filter { !$0.isEmpty }
-            .joined(separator: "\n")
-            // Explicitly escape a few HTML characters that appear in the test content
-            .replacingOccurrences(of: "–", with: "&#x2013;") // en-dash
-            .replacingOccurrences(of: "—", with: "&#x2014;") // em-dash
-            // Shorten empty string attribute values
-            .replacingOccurrences(of: #"="""#, with: "")
+private extension XMLNode {
+    func rendered(sourceLocation: Testing.SourceLocation = #_sourceLocation) -> String {
+        guard let htmlNode = HTMLNode(from: self) else {
+            Issue.record("Failed to convert node \(self.xmlString(options: .nodeCompactEmptyElement)) to HTML node", sourceLocation: sourceLocation)
+            return ""
+        }
+        
+        return String(decoding: HTMLFormatter.format(htmlNode, options: .prettyPrint), as: UTF8.self)
     }
-    
-    let actualHTML: String = html.xmlString(options: .nodeCompactEmptyElement)
-    #expect(formatForTestComparison(actualHTML) == formatForTestComparison(expectedHTML), sourceLocation: sourceLocation)
+}
+
+
+func assert(_ document: XMLDocument, matches expected: String, sourceLocation: SourceLocation = #_sourceLocation) {
+    #expect(document.rootElement()!.rendered(sourceLocation: sourceLocation) == expected, sourceLocation: sourceLocation)
 }


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://165755530

## Summary

This is a follow up to https://github.com/swiftlang/swift-docc/pull/1571 ~(still open)~ and https://github.com/swiftlang/swift-docc/pull/1578 ~(still open)~ that minimally integrated the custom HTML formatter by traversing the XMLNode hierarchy and creating an HTMLNode hierarchy that it later formats.

This is clearly not the intended long-term solution but rather a step towards replacing the XMLNode hierarchy with a HTMLNode hierarchy. The reason for this short-term integration solution is to try and break up the work into smaller pieces that can be reviewed and iterated incrementally.

## Dependencies

This depends on and includes all the changes of:

- https://github.com/swiftlang/swift-docc/pull/1571
- https://github.com/swiftlang/swift-docc/pull/1578

## Testing

1. Build some documentation and pass `--output-format experimental-html-for-development` to DocC. 
2. Inspect the HTML files in DocC's output. It should be formatted using the custom formatter. 
  - An easy way to verify this is that the various `meta` elements end with `>` instead of `/>`
3. Build the same documentation with the same flags but with `DOCC_JSON_PRETTYPRINT="YES"` defined
4. Inspect the HTML files in DocC's output. It should be pretty printed (this wasn't the case before because the XMLNode formatter broke `pre` tags (where whitespace is significant).

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] ~Added~ Updated tests
- [x] Ran the `./bin/test` script and it succeeded
- ~[] Updated documentation if necessary~
