### PR TITLE
Handle unconditionally deprecated nodes as deprecated

### DIFF
--- a/Sources/DocCTestUtilities/SymbolGraphCreation.swift
+++ b/Sources/DocCTestUtilities/SymbolGraphCreation.swift
@@ -140,9 +140,11 @@ package func makeAvailabilityItem(
     introduced: SymbolGraph.SemanticVersion? = nil,
     deprecated: SymbolGraph.SemanticVersion? = nil,
     obsoleted: SymbolGraph.SemanticVersion? = nil,
+    renamed: String? = nil,
+    unconditionallyDeprecated: Bool = false,
     unconditionallyUnavailable: Bool = false
 ) -> SymbolGraph.Symbol.Availability.AvailabilityItem {
-    return SymbolGraph.Symbol.Availability.AvailabilityItem(domain: .init(rawValue: domainName), introducedVersion: introduced, deprecatedVersion: deprecated, obsoletedVersion: obsoleted, message: nil, renamed: nil, isUnconditionallyDeprecated: false, isUnconditionallyUnavailable: unconditionallyUnavailable, willEventuallyBeDeprecated: false)
+    return SymbolGraph.Symbol.Availability.AvailabilityItem(domain: .init(rawValue: domainName), introducedVersion: introduced, deprecatedVersion: deprecated, obsoletedVersion: obsoleted, message: nil, renamed: renamed, isUnconditionallyDeprecated: unconditionallyDeprecated, isUnconditionallyUnavailable: unconditionallyUnavailable, willEventuallyBeDeprecated: false)
 }
 
 package func makeSymbolNames(name: String) -> SymbolGraph.Symbol.Names {

--- a/Sources/SwiftDocC/Indexing/Navigator/RenderNode+NavigatorIndex.swift
+++ b/Sources/SwiftDocC/Indexing/Navigator/RenderNode+NavigatorIndex.swift
@@ -146,7 +146,13 @@ extension NavigatorIndexableRenderMetadataRepresentation {
 
 extension NavigatorIndexableRenderNodeRepresentation {
     var isPlatformDeprecated: Bool {
-        metadata.platforms?.contains { $0.deprecated != nil } == true
+        metadata.platforms?.contains {
+            // @available(*, deprecated: "1.2.3)
+            $0.deprecated != nil ||
+                // or without a specific version/string for "deprecated:", like so:
+                // @available(*, deprecated, renamed: "Sendable")
+                $0.unconditionallyDeprecated == true
+        } == true
     }
     var isDeprecated: Bool {
         isPlatformDeprecated

--- a/Tests/SwiftDocCTests/Indexing/RenderIndexTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/RenderIndexTests.swift
@@ -10,6 +10,7 @@
 
 import XCTest
 import DocCTestUtilities
+import SymbolKit
 
 @testable import SwiftDocC
 
@@ -716,6 +717,58 @@ final class RenderIndexTests: XCTestCase {
             symbolNode.isDeprecated,
             "A symbol with @DeprecationSummary but no platform deprecation should appear deprecated in the navigator index."
         )
+    }
+
+    func testRenderIndexGenerationWithPerPlatformUnconditionalDeprecation() async throws {
+        let catalog = Folder(name: "unit-test.docc", content: [
+            InfoPlist(displayName: "TestBundle", identifier: "com.test.example"),
+            JSONFile(name: "SomeModule.symbols.json", content: makeSymbolGraph(
+                moduleName: "SomeModule",
+                symbols: [
+                    makeSymbol(
+                        id: "some-symbol-id",
+                        kind: .typealias,
+                        pathComponents: ["SomeTypeAlias"],
+                        availability: [
+                            SymbolGraph.Symbol.Availability.AvailabilityItem(
+                                domain: .init(rawValue: "macOS"),
+                                introducedVersion: .init(major: 10, minor: 15, patch: 0),
+                                deprecatedVersion: nil,
+                                obsoletedVersion: nil,
+                                message: nil,
+                                renamed: "SomeOtherTypeAlias",
+                                isUnconditionallyDeprecated: true,
+                                isUnconditionallyUnavailable: false,
+                                willEventuallyBeDeprecated: false
+                            ),
+                            SymbolGraph.Symbol.Availability.AvailabilityItem(
+                                domain: .init(rawValue: "iOS"),
+                                introducedVersion: .init(major: 13, minor: 0, patch: 0),
+                                deprecatedVersion: nil,
+                                obsoletedVersion: nil,
+                                message: nil,
+                                renamed: "SomeOtherTypeAlias",
+                                isUnconditionallyDeprecated: true,
+                                isUnconditionallyUnavailable: false,
+                                willEventuallyBeDeprecated: false
+                            ),
+                        ]
+                    )
+                ]
+            )),
+        ])
+
+        let (_, context) = try await loadBundle(catalog: catalog)
+        let renderIndex = try generatedRenderIndex(
+            forIdentifier: "com.test.example",
+            inContext: context
+        )
+
+        let swiftNodes = try XCTUnwrap(renderIndex.interfaceLanguages["swift"])
+        let symbolNode = try XCTUnwrap(
+            findNode(titled: "SomeTypeAlias", in: swiftNodes)
+        )
+        XCTAssertTrue(symbolNode.isDeprecated, "Should be unconditionally deprecated")
     }
 
     private func findNode(titled title: String, in nodes: [RenderIndex.Node]) -> RenderIndex.Node? {

--- a/Tests/SwiftDocCTests/Indexing/RenderIndexTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/RenderIndexTests.swift
@@ -10,7 +10,6 @@
 
 import XCTest
 import DocCTestUtilities
-import SymbolKit
 
 @testable import SwiftDocC
 
@@ -730,27 +729,17 @@ final class RenderIndexTests: XCTestCase {
                         kind: .typealias,
                         pathComponents: ["SomeTypeAlias"],
                         availability: [
-                            SymbolGraph.Symbol.Availability.AvailabilityItem(
-                                domain: .init(rawValue: "macOS"),
-                                introducedVersion: .init(major: 10, minor: 15, patch: 0),
-                                deprecatedVersion: nil,
-                                obsoletedVersion: nil,
-                                message: nil,
+                            makeAvailabilityItem(
+                                domainName: "macOS",
+                                introduced: .init(major: 10, minor: 15, patch: 0),
                                 renamed: "SomeOtherTypeAlias",
-                                isUnconditionallyDeprecated: true,
-                                isUnconditionallyUnavailable: false,
-                                willEventuallyBeDeprecated: false
+                                unconditionallyDeprecated: true
                             ),
-                            SymbolGraph.Symbol.Availability.AvailabilityItem(
-                                domain: .init(rawValue: "iOS"),
-                                introducedVersion: .init(major: 13, minor: 0, patch: 0),
-                                deprecatedVersion: nil,
-                                obsoletedVersion: nil,
-                                message: nil,
+                            makeAvailabilityItem(
+                                domainName: "iOS",
+                                introduced: .init(major: 13, minor: 0, patch: 0),
                                 renamed: "SomeOtherTypeAlias",
-                                isUnconditionallyDeprecated: true,
-                                isUnconditionallyUnavailable: false,
-                                willEventuallyBeDeprecated: false
+                                unconditionallyDeprecated: true
                             ),
                         ]
                     )
@@ -768,7 +757,10 @@ final class RenderIndexTests: XCTestCase {
         let symbolNode = try XCTUnwrap(
             findNode(titled: "SomeTypeAlias", in: swiftNodes)
         )
-        XCTAssertTrue(symbolNode.isDeprecated, "Should be unconditionally deprecated")
+        XCTAssertTrue(
+            symbolNode.isDeprecated,
+            "Should be unconditionally deprecated"
+        )
     }
 
     private func findNode(titled title: String, in nodes: [RenderIndex.Node]) -> RenderIndex.Node? {


### PR DESCRIPTION
Resolves https://github.com/swiftlang/swift-docc/issues/1586

## Summary

This happens e.g. with

```swift
// Historical names
@available(*, deprecated, renamed: "Sendable")
@available(swift, obsoleted: 6.0, renamed: "Sendable")
public typealias ConcurrentValue = Sendable
```

Which were missing the deprecated marker without this fix.

Instead of just getting the deprecated string value, we also need to check if it was unconditionally deprecated.

## Testing

New unit test covering this situation

## Checklist

- [x] Added tests
- [ ] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary
