### PR TITLE
Deterministically register assets

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Bundle Assets/DataAssetManager.swift
+++ b/Sources/SwiftDocC/Infrastructure/Bundle Assets/DataAssetManager.swift
@@ -107,7 +107,7 @@ struct DataAssetManager {
     ///
     /// Data objects which have a file name ending with '~dark' are associated to their light variant.
     mutating func register(data datas: some Collection<URL>) throws {
-        for dataURL in datas {
+        for dataURL in datas.sorted(by: \.path) {
             let meta = try referenceMetaInformationForDataURL(dataURL)
 
             let referenceURL = URL(fileURLWithPath: meta.reference, isDirectory: false)
@@ -195,18 +195,32 @@ public struct DataAsset: Codable, Equatable {
     
     /// Returns the data that is registered to the data asset that best matches the given trait collection.
     ///
-    /// If no variant with the exact given trait collection is found, the variant that has the largest trait collection overlap with the
-    /// provided one is returned.
+    /// If no variant matches the given trait collection exactly, the closest variant is returned.
+    /// A matching user interface style is preferred over a matching display scale.
+    /// If there are multiple matches, the one with the lexicographically smallest URL path is used.
     public func data(bestMatching traitCollection: DataTraitCollection) -> BundleData {
-        guard let variant = variants[traitCollection] else {
-            // FIXME: If we can't find a variant that matches the given trait collection exactly,
-            // we should return the variant that has the largest trait collection overlap with the
-            // provided one. (rdar://68632024)
-            let first = variants.first!
-            return BundleData(url: first.value, traitCollection: first.key)
+        if let variant = variants[traitCollection] {
+            return BundleData(url: variant, traitCollection: traitCollection)
         }
-        
-        return BundleData(url: variant, traitCollection: traitCollection)
+
+        let style = traitCollection.userInterfaceStyle
+        let scale = traitCollection.displayScale
+        let best = variants.min { lhs, rhs in
+            if style != nil {
+                let lhsStyleMatches = style == lhs.key.userInterfaceStyle
+                let rhsStyleMatches = style == rhs.key.userInterfaceStyle
+                if lhsStyleMatches != rhsStyleMatches { return lhsStyleMatches }
+            }
+
+            if scale != nil {
+                let lhsScaleMatches = scale == lhs.key.displayScale
+                let rhsScaleMatches = scale == rhs.key.displayScale
+                if lhsScaleMatches != rhsScaleMatches { return lhsScaleMatches }
+            }
+
+            return lhs.value.path < rhs.value.path
+        }!
+        return BundleData(url: best.value, traitCollection: best.key)
     }
     
 }

--- a/Sources/SwiftDocC/Model/Rendering/References/ImageReference.swift
+++ b/Sources/SwiftDocC/Model/Rendering/References/ImageReference.swift
@@ -72,17 +72,18 @@ public struct ImageReference: MediaReference, URLReference, Equatable {
         
         // convert the data asset to a serializable object
         var result = [VariantProxy]()
-        // sort assets by URL path for deterministic sorting of images
-        for (key, value) in asset.variants.sorted(by: \.value.path) {
+        for (key, value) in asset.variants {
             let url = renderURL(for: value, prefixComponent: encoder.assetPrefixComponent)
             result.append(VariantProxy(url: url, traits: key, svgID: asset.metadata[value]?.svgID))
         }
+        result.sort(by: VariantProxy.isInOrder)
+
         try container.encode(result, forKey: .variants)
     }
     
     
     /// A codable proxy value that the image reference uses to serialize information about its asset variants.
-    public struct VariantProxy: Codable, Equatable {
+    public struct VariantProxy: MediaVariantProxy, Codable, Equatable {
         /// The URL to the file for this image variant.
         public var url: URL
         /// The traits of this image reference.

--- a/Sources/SwiftDocC/Model/Rendering/References/MediaReference.swift
+++ b/Sources/SwiftDocC/Model/Rendering/References/MediaReference.swift
@@ -19,3 +19,21 @@ public protocol MediaReference: RenderReference {
     /// This text helps screen readers describe the media.
     var altText: String? { get set }
 }
+
+/// A proxy value for information about an asset variant.
+protocol MediaVariantProxy {
+    /// The URL of the file for this variant.
+    var url: URL { get }
+    /// The traits of this variant.
+    var traits: [String] { get }
+}
+
+extension MediaVariantProxy {
+    /// Compares two variants by their rendered URL, and by traits for variants with identical URLs.
+    static func isInOrder(_ lhs: Self, _ rhs: Self) -> Bool {
+        if lhs.url.path != rhs.url.path {
+            return lhs.url.path < rhs.url.path
+        }
+        return lhs.traits.joined() < rhs.traits.joined()
+    }
+}

--- a/Sources/SwiftDocC/Model/Rendering/References/VideoReference.swift
+++ b/Sources/SwiftDocC/Model/Rendering/References/VideoReference.swift
@@ -80,17 +80,19 @@ public struct VideoReference: MediaReference, URLReference, Equatable {
         
         // convert the data asset to a serializable object
         var result = [VariantProxy]()
-        for (key, value) in asset.variants.sorted(by: \.value.path) {
+        for (key, value) in asset.variants {
             let url = renderURL(for: value, prefixComponent: encoder.assetPrefixComponent)
             result.append(VariantProxy(url: url, traits: key))
         }
+        result.sort(by: VariantProxy.isInOrder)
+
         try container.encode(result, forKey: .variants)
         
         try container.encode(poster, forKey: .poster)
     }
     
     /// A codable proxy value that the video reference uses to serialize information about its asset variants.
-    public struct VariantProxy: Codable, Equatable {
+    public struct VariantProxy: MediaVariantProxy, Codable, Equatable {
         /// The URL to the file for this video variant.
         public var url: URL
         /// The traits of this video reference.

--- a/Tests/SwiftDocCTests/Infrastructure/DataAssetManagerTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DataAssetManagerTests.swift
@@ -228,4 +228,48 @@ struct DataAssetManagerTests {
         try manager.register(data: imagesWithDuplicates)
         #expect(manager.fuzzyKeyIndex.keys.sorted().map({ "\($0)" }) == ["image", "woof"])
     }
+
+    @Test
+    func duplicateAssetsRegisterOnlyLastSortedAsset() throws {
+        let urls = [
+            URL(fileURLWithPath: "/catalog/assets/overview.png"),
+            URL(fileURLWithPath: "/catalog/content/assets/overview.png"),
+        ]
+        let trait = DataTraitCollection(userInterfaceStyle: .light, displayScale: .double)
+
+        var forward = DataAssetManager()
+        try forward.register(data: urls)
+
+        var reversed = DataAssetManager()
+        try reversed.register(data: urls.reversed())
+
+        #expect(
+            forward.data(named: "overview.png", bestMatching: trait)?.url
+                == URL(fileURLWithPath: "/catalog/content/assets/overview.png")
+        )
+        #expect(
+            forward.data(named: "overview.png", bestMatching: trait)?.url
+                == reversed.data(named: "overview.png", bestMatching: trait)?.url
+        )
+    }
+
+    @Test
+    func dataBestMatchingPrioritizesUserInterfaceStyleOverDisplayScale() {
+        var asset = DataAsset()
+        asset.register(URL(fileURLWithPath: "/catalog/a/overview.png"), with: .init(userInterfaceStyle: .dark, displayScale: .double))
+        asset.register(URL(fileURLWithPath: "/catalog/z/overview.png"), with: .init(userInterfaceStyle: .light, displayScale: .standard))
+
+        let match = asset.data(bestMatching: .init(userInterfaceStyle: .light, displayScale: .double))
+        #expect(match.url == URL(fileURLWithPath: "/catalog/z/overview.png"))
+    }
+
+    @Test
+    func dataBestMatchingWithSameStyleAndScaleMatchesBySmallestURLPath() {
+        var asset = DataAsset()
+        asset.register(URL(fileURLWithPath: "/catalog/z/overview.png"), with: .init(userInterfaceStyle: .light, displayScale: .standard))
+        asset.register(URL(fileURLWithPath: "/catalog/a/overview.png"), with: .init(userInterfaceStyle: .light, displayScale: .triple))
+
+        let match = asset.data(bestMatching: .init(userInterfaceStyle: .light, displayScale: .double))
+        #expect(match.url == URL(fileURLWithPath: "/catalog/a/overview.png"))
+    }
 }

--- a/Tests/SwiftDocCTests/Infrastructure/DataAssetManagerTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DataAssetManagerTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -9,38 +9,39 @@
 */
 
 import Foundation
-import XCTest
+import Testing
 @testable import SwiftDocC
 
-class DataAssetManagerTests: XCTestCase {
-    
-    func assertIsRegistered(named name: String, trait: DataTraitCollection, expectedURL: URL, manager: DataAssetManager, file: StaticString = #filePath, line: UInt = #line) {
-        let data = manager.data(named: name, bestMatching: trait)!
-        XCTAssertEqual(data.url, expectedURL)
-        XCTAssertEqual(data.traitCollection, trait)
+struct DataAssetManagerTests {
+
+    func assertIsRegistered(named name: String, trait: DataTraitCollection, expectedURL: URL, manager: DataAssetManager, sourceLocation: SourceLocation = #_sourceLocation) throws {
+        let data = try #require(manager.data(named: name, bestMatching: trait), sourceLocation: sourceLocation)
+        #expect(data.url == expectedURL, sourceLocation: sourceLocation)
+        #expect(data.traitCollection == trait, sourceLocation: sourceLocation)
     }
-    
-    func testWithoutDarkVariants() throws {
+
+    @Test
+    func registersImagesWithoutDarkVariants() throws {
         var manager = DataAssetManager()
         let images = ["Documentation/woof.png", "bark.jpg", "wuphf.jpeg", "woof.png"].compactMap(URL.init(string:))
         try manager.register(data: images)
-        
-        XCTAssertEqual(manager.storage.values.count, 3)
-        
+
+        #expect(manager.storage.values.count == 3)
+
         // The asset manager should contain all the images.
-        
-        assertIsRegistered(named: "bark.jpg", trait: .init(userInterfaceStyle: .light, displayScale: .standard), expectedURL: images[1], manager: manager)
-        assertIsRegistered(named: "wuphf.jpeg", trait: .init(userInterfaceStyle: .light, displayScale: .standard), expectedURL: images[2], manager: manager)
-        assertIsRegistered(named: "woof.png", trait: .init(userInterfaceStyle: .light, displayScale: .standard), expectedURL: images[3], manager: manager)
-        
+        try assertIsRegistered(named: "bark.jpg", trait: .init(userInterfaceStyle: .light, displayScale: .standard), expectedURL: images[1], manager: manager)
+        try assertIsRegistered(named: "wuphf.jpeg", trait: .init(userInterfaceStyle: .light, displayScale: .standard), expectedURL: images[2], manager: manager)
+        try assertIsRegistered(named: "woof.png", trait: .init(userInterfaceStyle: .light, displayScale: .standard), expectedURL: images[3], manager: manager)
+
         // The asset manager should contain not dark images.
-        
-        XCTAssertEqual(manager.data(named: "bark.jpg", bestMatching: .init(userInterfaceStyle: .dark))?.traitCollection, .init(userInterfaceStyle: .light, displayScale: .standard))
-        XCTAssertEqual(manager.data(named: "wuphf.jpeg", bestMatching: .init(userInterfaceStyle: .dark))?.traitCollection, .init(userInterfaceStyle: .light, displayScale: .standard))
-        XCTAssertEqual(manager.data(named: "woof.png", bestMatching: .init(userInterfaceStyle: .dark))?.traitCollection, .init(userInterfaceStyle: .light, displayScale: .standard))
+        let expectedFallback = DataTraitCollection(userInterfaceStyle: .light, displayScale: .standard)
+        for name in ["bark.jpg", "wuphf.jpeg", "woof.png"] {
+            #expect(manager.data(named: name, bestMatching: .init(userInterfaceStyle: .dark))?.traitCollection == expectedFallback)
+        }
     }
-    
-    func testWithDarkVariants() throws {
+
+    @Test
+    func registersLightAndDarkVariants() throws {
         var manager = DataAssetManager()
         let images = [
             "Documentation/woof.png",
@@ -51,22 +52,22 @@ class DataAssetManagerTests: XCTestCase {
             "wuphf~dark.jpeg",
         ].compactMap(URL.init(string:))
         try manager.register(data: images)
-        
-        XCTAssertEqual(manager.storage.values.count, 3)
-        
+
+        #expect(manager.storage.values.count == 3)
+
         // The asset manager should contain all the light and dark variants.
-        
-        assertIsRegistered(named: "woof.png", trait: .init(userInterfaceStyle: .light, displayScale: .standard), expectedURL: images[0], manager: manager)
-        assertIsRegistered(named: "woof.png", trait: .init(userInterfaceStyle: .dark, displayScale: .standard), expectedURL: images[1], manager: manager)
-        
-        assertIsRegistered(named: "bark.jpg", trait: .init(userInterfaceStyle: .light, displayScale: .standard), expectedURL: images[2], manager: manager)
-        assertIsRegistered(named: "bark.jpg", trait: .init(userInterfaceStyle: .dark, displayScale: .standard), expectedURL: images[3], manager: manager)
-        
-        assertIsRegistered(named: "wuphf.jpeg", trait: .init(userInterfaceStyle: .light, displayScale: .standard), expectedURL: images[4], manager: manager)
-        assertIsRegistered(named: "wuphf.jpeg", trait: .init(userInterfaceStyle: .dark, displayScale: .standard), expectedURL: images[5], manager: manager)
+        try assertIsRegistered(named: "woof.png", trait: .init(userInterfaceStyle: .light, displayScale: .standard), expectedURL: images[0], manager: manager)
+        try assertIsRegistered(named: "woof.png", trait: .init(userInterfaceStyle: .dark, displayScale: .standard), expectedURL: images[1], manager: manager)
+
+        try assertIsRegistered(named: "bark.jpg", trait: .init(userInterfaceStyle: .light, displayScale: .standard), expectedURL: images[2], manager: manager)
+        try assertIsRegistered(named: "bark.jpg", trait: .init(userInterfaceStyle: .dark, displayScale: .standard), expectedURL: images[3], manager: manager)
+
+        try assertIsRegistered(named: "wuphf.jpeg", trait: .init(userInterfaceStyle: .light, displayScale: .standard), expectedURL: images[4], manager: manager)
+        try assertIsRegistered(named: "wuphf.jpeg", trait: .init(userInterfaceStyle: .dark, displayScale: .standard), expectedURL: images[5], manager: manager)
     }
-    
-    func testImageDisplayScale() throws {
+
+    @Test
+    func registersDisplayScaleVariants() throws {
         var manager = DataAssetManager()
         let images = [
             "woof.png",
@@ -80,114 +81,115 @@ class DataAssetManagerTests: XCTestCase {
             "bark~dark@2x.jpg",
         ].compactMap(URL.init(string:))
         try manager.register(data: images)
-        
-        XCTAssertEqual(manager.storage.values.count, 2)
-        
+
+        #expect(manager.storage.values.count == 2)
+
         // The asset manager should contain all the light and dark variants, plus pixel density versions.
-        
-        assertIsRegistered(named: "woof.png", trait: .init(userInterfaceStyle: .light, displayScale: .standard), expectedURL: images[0], manager: manager)
-        assertIsRegistered(named: "woof.png", trait: .init(userInterfaceStyle: .dark, displayScale: .standard), expectedURL: images[1], manager: manager)
-        
-        assertIsRegistered(named: "woof.png", trait: .init(userInterfaceStyle: .dark, displayScale: .double), expectedURL: images[2], manager: manager)
-        assertIsRegistered(named: "woof.png", trait: .init(userInterfaceStyle: .dark, displayScale: .triple), expectedURL: images[3], manager: manager)
-        
-        assertIsRegistered(named: "woof.png", trait: .init(userInterfaceStyle: .light, displayScale: .double), expectedURL: images[4], manager: manager)
-        assertIsRegistered(named: "woof.png", trait: .init(userInterfaceStyle: .light, displayScale: .triple), expectedURL: images[5], manager: manager)
-        
-        assertIsRegistered(named: "bark.jpg", trait: .init(userInterfaceStyle: .light, displayScale: .standard), expectedURL: images[6], manager: manager)
-        assertIsRegistered(named: "bark.jpg", trait: .init(userInterfaceStyle: .dark, displayScale: .standard), expectedURL: images[7], manager: manager)
-        assertIsRegistered(named: "bark.jpg", trait: .init(userInterfaceStyle: .dark, displayScale: .double), expectedURL: images[8], manager: manager)
+        try assertIsRegistered(named: "woof.png", trait: .init(userInterfaceStyle: .light, displayScale: .standard), expectedURL: images[0], manager: manager)
+        try assertIsRegistered(named: "woof.png", trait: .init(userInterfaceStyle: .dark, displayScale: .standard), expectedURL: images[1], manager: manager)
+
+        try assertIsRegistered(named: "woof.png", trait: .init(userInterfaceStyle: .dark, displayScale: .double), expectedURL: images[2], manager: manager)
+        try assertIsRegistered(named: "woof.png", trait: .init(userInterfaceStyle: .dark, displayScale: .triple), expectedURL: images[3], manager: manager)
+
+        try assertIsRegistered(named: "woof.png", trait: .init(userInterfaceStyle: .light, displayScale: .double), expectedURL: images[4], manager: manager)
+        try assertIsRegistered(named: "woof.png", trait: .init(userInterfaceStyle: .light, displayScale: .triple), expectedURL: images[5], manager: manager)
+
+        try assertIsRegistered(named: "bark.jpg", trait: .init(userInterfaceStyle: .light, displayScale: .standard), expectedURL: images[6], manager: manager)
+        try assertIsRegistered(named: "bark.jpg", trait: .init(userInterfaceStyle: .dark, displayScale: .standard), expectedURL: images[7], manager: manager)
+        try assertIsRegistered(named: "bark.jpg", trait: .init(userInterfaceStyle: .dark, displayScale: .double), expectedURL: images[8], manager: manager)
     }
-    
-    func testTraitCollection() {
+
+    @Test
+    func mergesTraitCollections() {
         let lightTrait = DataTraitCollection(userInterfaceStyle: .light)
         let darkTrait = DataTraitCollection(userInterfaceStyle: .dark, displayScale: .double)
         let trait = DataTraitCollection(traitsFrom: [lightTrait, darkTrait])
-        
-        XCTAssertEqual(trait.userInterfaceStyle, .dark)
-        XCTAssertEqual(trait.displayScale, .double)
-        
+
+        #expect(trait.userInterfaceStyle == .dark)
+        #expect(trait.displayScale == .double)
+
         let trait2 = DataTraitCollection(traitsFrom: [lightTrait, darkTrait, lightTrait])
-        
-        XCTAssertEqual(trait2.userInterfaceStyle, .light)
-        XCTAssertEqual(trait2.displayScale, .double)
+
+        #expect(trait2.userInterfaceStyle == .light)
+        #expect(trait2.displayScale == .double)
     }
-    
+
     // Under the default settings this test will use `NSImage` under macOS
-    func testImageSize() throws {
-        let imageFileURL = Bundle.module.url(
-            forResource: "image", withExtension: "png", subdirectory: "Test Resources")!
-        XCTAssertTrue(FileManager.default.fileExists(atPath: imageFileURL.path))
+    @Test
+    func registersImageFromDisk() throws {
+        let imageFileURL = try #require(
+            Bundle.module.url(forResource: "image", withExtension: "png", subdirectory: "Test Resources")
+        )
+        #expect(FileManager.default.fileExists(atPath: imageFileURL.path))
 
         var manager = DataAssetManager()
-        
+
         // Register an image asset
         try manager.register(data: [imageFileURL])
 
         // Check the asset is registered
-        guard !manager.storage.values.isEmpty else {
-            XCTFail("Failed to register image asset")
-            return
-        }
-        assertIsRegistered(named: imageFileURL.lastPathComponent, trait: .init(userInterfaceStyle: .light, displayScale: .standard), expectedURL: imageFileURL, manager: manager)
+        try assertIsRegistered(named: imageFileURL.lastPathComponent, trait: .init(userInterfaceStyle: .light, displayScale: .standard), expectedURL: imageFileURL, manager: manager)
     }
-    
-    func testUpdateAsset() throws {
+
+    @Test
+    func updatesRegisteredAsset() throws {
         var manager = DataAssetManager()
         let images = [URL(string: "woof.png")!]
         try manager.register(data: images)
-        
-        XCTAssertEqual(manager.storage.count, 1)
-        
+
+        #expect(manager.storage.count == 1)
+
         // Fetch the asset.
-        guard var resolvedAsset = manager.allData(named: "woof.png") else {
-            XCTFail("Failed to resolve registered asset")
-            return
-        }
-        
+        var resolvedAsset = try #require(manager.allData(named: "woof.png"))
+
         // Modify the asset
         resolvedAsset.context = .download
-        
+
         // Update the manager storage
         manager.update(name: "woof.png", asset: resolvedAsset)
-        
+
         // Fetch the updated asset.
-        guard let updatedAsset = manager.allData(named: "woof.png") else {
-            XCTFail("Failed to resolve updated asset")
-            return
-        }
+        let updatedAsset = try #require(manager.allData(named: "woof.png"))
 
         // Verify it's the up to date asset.
-        XCTAssertEqual(updatedAsset.context, .download)
+        #expect(updatedAsset.context == .download)
     }
 
-    func testNonExistingAssets() throws {
+    @Test(arguments: [
+        (name: "blip", isRegistered: false),
+        (name: "image.jpg", isRegistered: false),
+        (name: "image.png", isRegistered: true),
+    ])
+    func resolvesOnlyRegisteredAssets(name: String, isRegistered: Bool) throws {
         var manager = DataAssetManager()
-        let images = ["image.png"].compactMap(URL.init(string:))
-        try manager.register(data: images)
-        
-        XCTAssertNil(manager.allData(named: "blip"))
-        XCTAssertNil(manager.allData(named: "image.jpg"))
-        XCTAssertNotNil(manager.allData(named: "image.png"))
+        try manager.register(data: ["image.png"].compactMap(URL.init(string:)))
+
+        if isRegistered {
+            #expect(manager.allData(named: name) != nil)
+        } else {
+            #expect(manager.allData(named: name) == nil)
+        }
     }
-    
-    func testLoadsImagesWithIdenticalNameSuffixes() throws {
+
+    @Test
+    func loadsImagesWithIdenticalNameSuffixes() throws {
         var manager = DataAssetManager()
         let images = [
             "image.png",
             "assets/different_image.png",
         ].compactMap(URL.init(string:))
         try manager.register(data: images)
-        
-        XCTAssertEqual(manager.allData(named: "image")?.variants.first?.value.path, "image.png")
-        XCTAssertEqual(manager.allData(named: "image.png")?.variants.first?.value.path, "image.png")
-        
-        XCTAssertEqual(manager.allData(named: "different_image")?.variants.first?.value.path, "assets/different_image.png")
-        XCTAssertEqual(manager.allData(named: "different_image.png")?.variants.first?.value.path, "assets/different_image.png")
-        XCTAssertNil(manager.allData(named: "assets/different_image.png"))
+
+        #expect(manager.allData(named: "image")?.variants.first?.value.path == "image.png")
+        #expect(manager.allData(named: "image.png")?.variants.first?.value.path == "image.png")
+
+        #expect(manager.allData(named: "different_image")?.variants.first?.value.path == "assets/different_image.png")
+        #expect(manager.allData(named: "different_image.png")?.variants.first?.value.path == "assets/different_image.png")
+        #expect(manager.allData(named: "assets/different_image.png") == nil)
     }
-    
-    func testFuzzyLookup() throws {
+
+    @Test
+    func fuzzyLookupMatchesNameWithoutExtension() throws {
         var manager = DataAssetManager()
         let images = [
             "image.png",
@@ -196,25 +198,26 @@ class DataAssetManagerTests: XCTestCase {
         try manager.register(data: images)
 
         // The fuzzy lookup will match "name" to "name.png"
-        XCTAssertEqual(manager.allData(named: "image")?.variants.first?.value.path, "image.png")
+        #expect(manager.allData(named: "image")?.variants.first?.value.path == "image.png")
         // But not "name.ext1" to "name.ext2"
-        XCTAssertNil(manager.allData(named: "image.JPG"))
-        
-        XCTAssertNil(manager.allData(named: "woof.jpg"))
-        XCTAssertEqual(manager.allData(named: "woof.JPG")?.variants.first?.value.path, "woof~dark.JPG")
-        XCTAssertEqual(manager.allData(named: "woof")?.variants.first?.value.path, "woof~dark.JPG")
+        #expect(manager.allData(named: "image.JPG") == nil)
+
+        #expect(manager.allData(named: "woof.jpg") == nil)
+        #expect(manager.allData(named: "woof.JPG")?.variants.first?.value.path == "woof~dark.JPG")
+        #expect(manager.allData(named: "woof")?.variants.first?.value.path == "woof~dark.JPG")
     }
-    
-    func testFuzzyLookupIndex() throws {
+
+    @Test
+    func buildsFuzzyKeyIndexWithUniqueKeys() throws {
         var manager = DataAssetManager()
-        
+
         // Test that we build the fuzzy index
         let images = [
             "image@2x.png",
             "assets/woof.JPG",
         ].compactMap(URL.init(string:))
         try manager.register(data: images)
-        XCTAssertEqual(manager.fuzzyKeyIndex.keys.sorted().map({"\($0)"}), ["image", "woof"])
+        #expect(manager.fuzzyKeyIndex.keys.sorted().map({ "\($0)" }) == ["image", "woof"])
 
         // Test we include only unique keys in the fuzzy index
         let imagesWithDuplicates = [
@@ -223,6 +226,6 @@ class DataAssetManagerTests: XCTestCase {
             "woof.png",
         ].compactMap(URL.init(string:))
         try manager.register(data: imagesWithDuplicates)
-        XCTAssertEqual(manager.fuzzyKeyIndex.keys.sorted().map({"\($0)"}), ["image", "woof"])
+        #expect(manager.fuzzyKeyIndex.keys.sorted().map({ "\($0)" }) == ["image", "woof"])
     }
 }

--- a/Tests/SwiftDocCTests/Rendering/URLReferenceTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/URLReferenceTests.swift
@@ -83,4 +83,100 @@ struct URLReferenceTests {
         decodedReference = try RenderJSONDecoder.makeDecoder().decode(VideoReference.self, from: jsonData)
         #expect(Array(decodedReference.asset.metadata.keys) == [URL(string: "/videos/com.example.bundle1/video.mov")!])
     }
+
+    @Test
+    func imageReferenceVariantsAreSorted() throws {
+        let encoder = RenderJSONEncoder.makeEncoder(assetPrefixComponent: "com.example.bundle")
+        var asset = DataAsset()
+        asset.register(
+            URL(fileURLWithPath: "/catalog/content/assets/overview.png"),
+            with: .init(userInterfaceStyle: .light, displayScale: .double)
+        )
+        asset.register(
+            URL(fileURLWithPath: "/catalog/assets/overview~dark.png"),
+            with: .init(userInterfaceStyle: .dark, displayScale: .double)
+        )
+        let reference = ImageReference(identifier: .init("image"), imageAsset: asset)
+
+        let jsonData = try encoder.encode(reference)
+        let object = try #require(try JSONSerialization.jsonObject(with: jsonData) as? [String: Any])
+        let variants = try #require(object["variants"] as? [[String: Any]])
+        let urls = variants.compactMap { $0["url"] as? String }
+        #expect(urls == [
+            "/images/com.example.bundle/overview.png",
+            "/images/com.example.bundle/overview~dark.png",
+        ])
+    }
+
+    @Test
+    func videoReferenceVariantsAreSorted() throws {
+        let encoder = RenderJSONEncoder.makeEncoder(assetPrefixComponent: "com.example.bundle")
+        var asset = DataAsset()
+        asset.register(
+            URL(fileURLWithPath: "/catalog/content/assets/overview.mov"),
+            with: .init(userInterfaceStyle: .light, displayScale: .double)
+        )
+        asset.register(
+            URL(fileURLWithPath: "/catalog/assets/overview~dark.mov"),
+            with: .init(userInterfaceStyle: .dark, displayScale: .double)
+        )
+        let reference = VideoReference(identifier: .init("video"), videoAsset: asset, poster: nil)
+
+        let jsonData = try encoder.encode(reference)
+        let object = try #require(try JSONSerialization.jsonObject(with: jsonData) as? [String: Any])
+        let variants = try #require(object["variants"] as? [[String: Any]])
+        let urls = variants.compactMap { $0["url"] as? String }
+        #expect(urls == [
+            "/videos/com.example.bundle/overview.mov",
+            "/videos/com.example.bundle/overview~dark.mov",
+        ])
+    }
+
+    @Test
+    func imageReferenceVariantsWithIdenticalURLsAreSortedByTraits() throws {
+        let encoder = RenderJSONEncoder.makeEncoder(assetPrefixComponent: "com.example.bundle")
+        var asset = DataAsset()
+        asset.register(
+            URL(fileURLWithPath: "/catalog/light/overview.png"),
+            with: .init(userInterfaceStyle: .light, displayScale: .double)
+        )
+        asset.register(
+            URL(fileURLWithPath: "/catalog/dark/overview.png"),
+            with: .init(userInterfaceStyle: .dark, displayScale: .double)
+        )
+        let reference = ImageReference(identifier: .init("image"), imageAsset: asset)
+
+        let jsonData = try encoder.encode(reference)
+        let object = try #require(try JSONSerialization.jsonObject(with: jsonData) as? [String: Any])
+        let variants = try #require(object["variants"] as? [[String: Any]])
+        #expect(variants.compactMap { $0["url"] as? String } == [
+            "/images/com.example.bundle/overview.png",
+            "/images/com.example.bundle/overview.png",
+        ])
+        #expect(variants.compactMap { $0["traits"] as? [String] } == [["2x", "dark"], ["2x", "light"]])
+    }
+
+    @Test
+    func videoReferenceVariantsWithIdenticalURLsAreSortedByTraits() throws {
+        let encoder = RenderJSONEncoder.makeEncoder(assetPrefixComponent: "com.example.bundle")
+        var asset = DataAsset()
+        asset.register(
+            URL(fileURLWithPath: "/catalog/light/overview.mov"),
+            with: .init(userInterfaceStyle: .light, displayScale: .double)
+        )
+        asset.register(
+            URL(fileURLWithPath: "/catalog/dark/overview.mov"),
+            with: .init(userInterfaceStyle: .dark, displayScale: .double)
+        )
+        let reference = VideoReference(identifier: .init("video"), videoAsset: asset, poster: nil)
+
+        let jsonData = try encoder.encode(reference)
+        let object = try #require(try JSONSerialization.jsonObject(with: jsonData) as? [String: Any])
+        let variants = try #require(object["variants"] as? [[String: Any]])
+        #expect(variants.compactMap { $0["url"] as? String } == [
+            "/videos/com.example.bundle/overview.mov",
+            "/videos/com.example.bundle/overview.mov",
+        ])
+        #expect(variants.compactMap { $0["traits"] as? [String] } == [["2x", "dark"], ["2x", "light"]])
+    }
 }

--- a/Tests/SwiftDocCTests/Rendering/URLReferenceTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/URLReferenceTests.swift
@@ -1,91 +1,86 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2025 Apple Inc. and the Swift project authors
+ Copyright (c) 2025-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import XCTest
+import Foundation
+import Testing
 @testable import SwiftDocC
 
-class URLReferenceTests: XCTestCase {
+struct URLReferenceTests {
     struct MockReference: URLReference {
         static var baseURL: URL = URL(string: "/mocks/")!
     }
-    func testRenderURLIgnoresAbsoluteWebURLs() throws {
-        let testUrl = try XCTUnwrap(URL(string: "https://example.com/"))
-        let urlReference = MockReference()
-        XCTAssertEqual(urlReference.renderURL(for: testUrl, prefixComponent: nil), testUrl)
+
+    @Test(arguments: [
+        (URL(string: "https://example.com/")!, URL(string: "https://example.com/")!),
+        (URL(string: "/mocks/example.com/mock-name")!, URL(string: "/mocks/example.com/mock-name")!),
+        (URL(string: "file://full/path/to/mock-name")!, URL(string: "/mocks/mock-name")!),
+    ])
+    func rendersURLRelativeToBaseURL(input: URL, expected: URL) {
+        #expect(MockReference().renderURL(for: input, prefixComponent: nil) == expected)
     }
-    
-    func testRenderURLIgnoresPrefacedURLs() throws {
-        let testUrl = try XCTUnwrap(URL(string: "/mocks/example.com/mock-name"))
-        let urlReference = MockReference()
-        XCTAssertEqual(urlReference.renderURL(for: testUrl, prefixComponent: nil), testUrl)
-    }
-    
-    func testRenderURLPreparesUnprefacedURLs() throws {
-        let testUrl = try XCTUnwrap(URL(string: "file://full/path/to/mock-name"))
-        let expectedUrl = try XCTUnwrap(URL(string: "/mocks/mock-name"))
-        let urlReference = MockReference()
-        XCTAssertEqual(urlReference.renderURL(for: testUrl, prefixComponent: nil), expectedUrl)
-    }
-    
-    func testImageReferenceRoundtripsAcrossBundles() throws {
+
+    @Test
+    func imageReferenceRoundtripsAcrossBundles() throws {
         // Encode the reference in bundle 1
         var encoder = RenderJSONEncoder.makeEncoder(assetPrefixComponent: "com.example.bundle1")
         var asset = DataAsset()
         asset.register(URL(string: "image.png")!, with: .init())
         let reference = ImageReference(identifier: .init("image"), imageAsset: asset)
-        
+
         // Verify it was encoded correctly
-        var jsonData = try XCTUnwrap(try encoder.encode(reference))
+        var jsonData = try encoder.encode(reference)
         var decodedReference = try RenderJSONDecoder.makeDecoder().decode(ImageReference.self, from: jsonData)
-        XCTAssertEqual(Array(decodedReference.asset.metadata.keys), [URL(string: "/images/com.example.bundle1/image.png")!])
-        
+        #expect(Array(decodedReference.asset.metadata.keys) == [URL(string: "/images/com.example.bundle1/image.png")!])
+
         // Re-encode the reference from bundle 1 in bundle 2 and ensure that the URL has not changed
         encoder = RenderJSONEncoder.makeEncoder(assetPrefixComponent: "com.example.bundle2")
-        jsonData = try XCTUnwrap(try encoder.encode(decodedReference))
+        jsonData = try encoder.encode(decodedReference)
         decodedReference = try RenderJSONDecoder.makeDecoder().decode(ImageReference.self, from: jsonData)
-        XCTAssertEqual(Array(decodedReference.asset.metadata.keys), [URL(string: "/images/com.example.bundle1/image.png")!])
+        #expect(Array(decodedReference.asset.metadata.keys) == [URL(string: "/images/com.example.bundle1/image.png")!])
     }
-    
-    func testDownloadReferenceRoundtripsAcrossBundles() throws {
+
+    @Test
+    func downloadReferenceRoundtripsAcrossBundles() throws {
         // Encode the reference in bundle 1
         var encoder = RenderJSONEncoder.makeEncoder(assetPrefixComponent: "com.example.bundle1")
         let reference = DownloadReference(identifier: .init("download"), renderURL: URL(string: "download.zip")!, checksum: nil)
-        
+
         // Verify it was encoded correctly
-        var jsonData = try XCTUnwrap(try encoder.encode(reference))
+        var jsonData = try encoder.encode(reference)
         var decodedReference = try RenderJSONDecoder.makeDecoder().decode(DownloadReference.self, from: jsonData)
-        XCTAssertEqual(decodedReference.url, URL(string: "/downloads/com.example.bundle1/download.zip")!)
-        
+        #expect(decodedReference.url == URL(string: "/downloads/com.example.bundle1/download.zip")!)
+
         // Re-encode the reference from bundle 1 in bundle 2 and ensure that the URL has not changed
         encoder = RenderJSONEncoder.makeEncoder(assetPrefixComponent: "com.example.bundle2")
-        jsonData = try XCTUnwrap(try encoder.encode(decodedReference))
+        jsonData = try encoder.encode(decodedReference)
         decodedReference = try RenderJSONDecoder.makeDecoder().decode(DownloadReference.self, from: jsonData)
-        XCTAssertEqual(decodedReference.url, URL(string: "/downloads/com.example.bundle1/download.zip")!)
+        #expect(decodedReference.url == URL(string: "/downloads/com.example.bundle1/download.zip")!)
     }
-    
-    func testVideoReferenceRoundtripsAcrossBundles() throws {
+
+    @Test
+    func videoReferenceRoundtripsAcrossBundles() throws {
         // Encode the reference in bundle 1
         var encoder = RenderJSONEncoder.makeEncoder(assetPrefixComponent: "com.example.bundle1")
         var asset = DataAsset()
         asset.register(URL(string: "video.mov")!, with: .init())
         let reference = VideoReference(identifier: .init("video"), videoAsset: asset, poster: nil)
-        
+
         // Verify it was encoded correctly
-        var jsonData = try XCTUnwrap(try encoder.encode(reference))
+        var jsonData = try encoder.encode(reference)
         var decodedReference = try RenderJSONDecoder.makeDecoder().decode(VideoReference.self, from: jsonData)
-        XCTAssertEqual(Array(decodedReference.asset.metadata.keys), [URL(string: "/videos/com.example.bundle1/video.mov")!])
+        #expect(Array(decodedReference.asset.metadata.keys) == [URL(string: "/videos/com.example.bundle1/video.mov")!])
 
         // Re-encode the reference from bundle 1 in bundle 2 and ensure that the URL has not changed
         encoder = RenderJSONEncoder.makeEncoder(assetPrefixComponent: "com.example.bundle2")
-        jsonData = try XCTUnwrap(try encoder.encode(decodedReference))
+        jsonData = try encoder.encode(decodedReference)
         decodedReference = try RenderJSONDecoder.makeDecoder().decode(VideoReference.self, from: jsonData)
-        XCTAssertEqual(Array(decodedReference.asset.metadata.keys), [URL(string: "/videos/com.example.bundle1/video.mov")!])
+        #expect(Array(decodedReference.asset.metadata.keys) == [URL(string: "/videos/com.example.bundle1/video.mov")!])
     }
 }


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://182512073

## Summary

DocC keys assets by filename, so if two files with the same name in different directories collide, the winner is chosen by iterating an unordered set. Variants are also serialised by the winning source path instead of the rendered URL. This changes the process to sort assets prior to registration, and sort encoded variants by the rendered URL using traits as a tie-breaker.

This PR also modernises tests associated with this code path.

## Dependencies

N/A

## Testing

1. Create a catalog with two image assets sharing a filename in different subdirs, and referenced in an article.
2. Run `docc convert` several times in separate processes, each to its own output dir.
3. Previously, the output would differ across runs. With this patch, it should be identical.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
