### PR TITLE
Deterministically render conditional conformances

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/DocumentationContentRenderer.swift
+++ b/Sources/SwiftDocC/Model/Rendering/DocumentationContentRenderer.swift
@@ -194,7 +194,9 @@ public class DocumentationContentRenderer {
         }
         
         let isLeaf = SymbolReference.isLeaf(symbol)
-        let parentName = context.parents(of: reference).first
+        // A symbol can be reached in the topic graph through one or more parent nodes.
+        // To ensure stable ordering, use the parent with the shortest path to the symbol.
+        let parentName = context.shortestFinitePath(to: reference)?.last
             .flatMap { try? context.entity(with: $0).symbol?.names.title }
         
         let options = ConformanceSection.ConstraintRenderOptions(

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -468,6 +468,11 @@ public struct RenderNodeTranslator: SemanticVisitor {
             
             
             for dependencyReference in dependencies.topicReferences {
+                // If this reference is also a direct reference of the page,
+                // do not redundantly process it as a dependency reference.
+                guard renderReferences[dependencyReference.absoluteString] == nil else {
+                    continue
+                }
                 var dependencyRenderReference: TopicRenderReference
                 if let renderContext, let prerendered = renderContext.store.content(for: dependencyReference)?.renderReference as? TopicRenderReference {
                     dependencyRenderReference = prerendered
@@ -478,7 +483,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
                 renderReferences[dependencyReference.absoluteString] = dependencyRenderReference
             }
             
-            // Add any conformance constraints to the reference, if any are present.
+            // Add conformance constraints to the reference, if any are present.
             if let conformanceSection = renderer.conformanceSectionFor(reference, collectedConstraints: collectedConstraints) {
                 renderReference.conformance = conformanceSection
             }

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -447,17 +447,9 @@ public struct RenderNodeTranslator: SemanticVisitor {
         
         for reference in collectedTopicReferences {
             var renderReference: TopicRenderReference
-            var dependencies: RenderReferenceDependencies
-            
-            if let renderContext, let prerendered = renderContext.store.content(for: reference)?.renderReference as? TopicRenderReference,
-                let renderReferenceDependencies = renderContext.store.content(for: reference)?.renderReferenceDependencies {
-                renderReference = prerendered
-                dependencies = renderReferenceDependencies
-            } else {
-                dependencies = RenderReferenceDependencies()
-                renderReference = renderer.renderReference(for: reference, dependencies: &dependencies)
-            }
-            
+            let dependencies: RenderReferenceDependencies
+            (renderReference, dependencies) = makeRenderReference(for: reference, with: renderer)
+
             for link in dependencies.linkReferences {
                 linkReferences[link.identifier.identifier] = link
             }
@@ -466,20 +458,13 @@ public struct RenderNodeTranslator: SemanticVisitor {
                 imageReferences[imageReference.identifier.identifier] = imageReference
             }
             
-            
             for dependencyReference in dependencies.topicReferences {
                 // If this reference is also a direct reference of the page,
                 // do not redundantly process it as a dependency reference.
                 guard renderReferences[dependencyReference.absoluteString] == nil else {
                     continue
                 }
-                var dependencyRenderReference: TopicRenderReference
-                if let renderContext, let prerendered = renderContext.store.content(for: dependencyReference)?.renderReference as? TopicRenderReference {
-                    dependencyRenderReference = prerendered
-                } else {
-                    var dependencies = RenderReferenceDependencies()
-                    dependencyRenderReference = renderer.renderReference(for: dependencyReference, dependencies: &dependencies)
-                }
+                let (dependencyRenderReference, _) = makeRenderReference(for: dependencyReference, with: renderer)
                 renderReferences[dependencyReference.absoluteString] = dependencyRenderReference
             }
             
@@ -500,6 +485,22 @@ public struct RenderNodeTranslator: SemanticVisitor {
         }
         
         return renderReferences
+    }
+
+    /// Creates the render reference for the given topic reference and gathers its dependencies,
+    // reusing a pre-rendered reference from the render context store if available.
+    private func makeRenderReference(
+        for reference: ResolvedTopicReference,
+        with renderer: DocumentationContentRenderer
+    ) -> (TopicRenderReference, RenderReferenceDependencies) {
+        if let renderContext,
+           let content = renderContext.store.content(for: reference),
+           let prerendered = content.renderReference as? TopicRenderReference {
+            return (prerendered, content.renderReferenceDependencies)
+        }
+        var dependencies = RenderReferenceDependencies()
+        let renderReference = renderer.renderReference(for: reference, dependencies: &dependencies)
+        return (renderReference, dependencies)
     }
     
     private func addReferences(_ references: [String: some RenderReference], to node: inout RenderNode) {

--- a/Tests/SwiftDocCTests/Rendering/DocumentationContentRendererTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/DocumentationContentRendererTests.swift
@@ -12,6 +12,7 @@ import Testing
 import SymbolKit
 import Markdown
 @testable import SwiftDocC
+import DocCTestUtilities
 import DocCCommon
 
 struct DocumentationContentRendererTests {
@@ -123,6 +124,49 @@ struct DocumentationContentRendererTests {
                 kind: .typeIdentifier, identifier: nil, preciseIdentifier: nil
             ),
         ])
+    }
+
+    @Test
+    func trivialConformanceFilterUsesShortestPathParent() async throws {
+        let selfIsBar = SymbolGraph.Symbol.Swift.Extension(
+            extendedModule: "SomeModule",
+            typeKind: .struct,
+            constraints: [.init(kind: .sameType, leftTypeName: "Self", rightTypeName: "Bar")]
+        )
+
+        let catalog = Folder(name: "unit-test.docc", content: [
+            JSONFile(name: "SomeModule.symbols.json", content: makeSymbolGraph(
+                moduleName: "SomeModule",
+                symbols: [
+                    makeSymbol(id: "s:Foo", kind: .struct, pathComponents: ["Foo"]),
+                    makeSymbol(id: "s:Outer", kind: .struct, pathComponents: ["Outer"]),
+                    makeSymbol(id: "s:Bar", kind: .struct, pathComponents: ["Outer", "Bar"]),
+                    makeSymbol(id: "s:member", kind: .method, pathComponents: ["Outer", "Bar", "member"], otherMixins: [selfIsBar]),
+                ],
+                relationships: [
+                    .init(source: "s:Bar", target: "s:Outer", kind: .memberOf, targetFallback: nil),
+                    .init(source: "s:member", target: "s:Bar", kind: .memberOf, targetFallback: nil),
+                ]
+            )),
+        ])
+
+        let context = try await load(catalog: catalog)
+        let bundleID = context.inputs.id
+        let memberReference = ResolvedTopicReference(bundleID: bundleID, path: "/documentation/SomeModule/Outer/Bar/member", sourceLanguage: .swift)
+        let shorterParentReference = ResolvedTopicReference(bundleID: bundleID, path: "/documentation/SomeModule/Foo", sourceLanguage: .swift)
+
+        // Add `Foo` as a second parent of `member` with a shorter path than the original parent `Bar`.
+        let memberNode = try #require(context.topicGraph.nodeWithReference(memberReference))
+        let shorterParentNode = try #require(context.topicGraph.nodeWithReference(shorterParentReference))
+        context.topicGraph.addEdge(from: shorterParentNode, to: memberNode)
+
+        #expect(context.parents(of: memberReference).count == 2)
+        #expect(context.shortestFinitePath(to: memberReference)?.last?.path == "/documentation/SomeModule/Foo")
+
+        // The shortest path parent is `Foo`, so the `Self is Bar` constraint is non-trivial and must be retained.
+        let section = DocumentationContentRenderer(context: context)
+            .conformanceSectionFor(memberReference, collectedConstraints: [:])
+        #expect(section?.constraints.plainText == "Self is Bar.")
     }
 
     private func makeDocumentationContentRenderer() async throws -> DocumentationContentRenderer {

--- a/Tests/SwiftDocCTests/Rendering/DocumentationContentRendererTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/DocumentationContentRendererTests.swift
@@ -1,150 +1,136 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import XCTest
+import Testing
 import SymbolKit
 import Markdown
 @testable import SwiftDocC
 import DocCCommon
 
-class DocumentationContentRendererTests: XCTestCase {
-    func testReplacesTypeIdentifierSubHeadingFragmentWithIdentifierForSwift() async throws {
+struct DocumentationContentRendererTests {
+    @Test
+    func replacesTypeIdentifierSubHeadingFragmentWithIdentifierForSwift() async throws {
         let subHeadingFragments = try await makeDocumentationContentRenderer()
             .subHeadingFragments(for: nodeWithSubheadingAndNavigatorVariants)
-        
-        XCTAssertEqual(
-            subHeadingFragments.defaultValue,
-            [
-                DeclarationRenderSection.Token(
-                    text: "class",
-                    kind: .keyword,
-                    identifier: nil,
-                    preciseIdentifier: nil
-                ),
-                DeclarationRenderSection.Token(
-                    text: " ",
-                    kind: .text,
-                    identifier: nil,
-                    preciseIdentifier: nil
-                ),
-                DeclarationRenderSection.Token(
-                    text: "ClassInSwift",
-                    
-                    // The 'typeIdentifier' value of the symbol's declaration is replaced with an 'identifier'.
-                    kind: .identifier,
-                    identifier: nil,
-                    preciseIdentifier: nil
-                )
-            ]
-        )
+
+        #expect(subHeadingFragments.defaultValue == [
+            DeclarationRenderSection.Token(
+                text: "class",
+                kind: .keyword,
+                identifier: nil,
+                preciseIdentifier: nil
+            ),
+            DeclarationRenderSection.Token(
+                text: " ",
+                kind: .text,
+                identifier: nil,
+                preciseIdentifier: nil
+            ),
+            DeclarationRenderSection.Token(
+                text: "ClassInSwift",
+
+                // The 'typeIdentifier' value of the symbol's declaration is replaced with an 'identifier'.
+                kind: .identifier,
+                identifier: nil,
+                preciseIdentifier: nil
+            ),
+        ])
     }
-    
-    func testDoesNotReplaceSubHeadingFragmentsForOtherLanguagesThanSwift() async throws {
+
+    @Test
+    func doesNotReplaceSubHeadingFragmentsForNonSwiftLanguages() async throws {
         let subHeadingFragments = try await makeDocumentationContentRenderer()
             .subHeadingFragments(for: nodeWithSubheadingAndNavigatorVariants)
-        
+
         guard case .replace(let fragments) = subHeadingFragments.variants.first?.patch.first else {
-            XCTFail("Unexpected patch")
+            Issue.record("Unexpected patch")
             return
         }
-        
-        XCTAssertEqual(
-            fragments,
-            [
-                DeclarationRenderSection.Token(
-                    text: "class",
-                    kind: .keyword, identifier: nil, preciseIdentifier: nil
-                ),
-                DeclarationRenderSection.Token(
-                    text: " ",
-                    kind: .text, identifier: nil, preciseIdentifier: nil
-                ),
-                DeclarationRenderSection.Token(
-                    text: "ClassInAnotherLanguage",
-                    kind: .typeIdentifier, identifier: nil, preciseIdentifier: nil
-                )
-            ]
-        )
+
+        #expect(fragments == [
+            DeclarationRenderSection.Token(
+                text: "class",
+                kind: .keyword, identifier: nil, preciseIdentifier: nil
+            ),
+            DeclarationRenderSection.Token(
+                text: " ",
+                kind: .text, identifier: nil, preciseIdentifier: nil
+            ),
+            DeclarationRenderSection.Token(
+                text: "ClassInAnotherLanguage",
+                kind: .typeIdentifier, identifier: nil, preciseIdentifier: nil
+            ),
+        ])
     }
-    
-    func testReplacesTypeIdentifierNavigatorFragmentWithIdentifierForSwift() async throws {
+
+    @Test
+    func replacesTypeIdentifierNavigatorFragmentWithIdentifierForSwift() async throws {
         let navigatorFragments = try await makeDocumentationContentRenderer()
             .navigatorFragments(for: nodeWithSubheadingAndNavigatorVariants)
-        
-        XCTAssertEqual(
-            navigatorFragments.defaultValue,
-            [
-                DeclarationRenderSection.Token(
-                    text: "class",
-                    kind: .keyword,
-                    identifier: nil,
-                    preciseIdentifier: nil
-                ),
-                DeclarationRenderSection.Token(
-                    text: " ",
-                    kind: .text,
-                    identifier: nil,
-                    preciseIdentifier: nil
-                ),
-                DeclarationRenderSection.Token(
-                    text: "ClassInSwift",
-                    
-                    // The 'typeIdentifier' value of the symbol's declaration is replaced with an 'identifier'.
-                    kind: .identifier,
-                    identifier: nil,
-                    preciseIdentifier: nil
-                )
-            ]
-        )
+
+        #expect(navigatorFragments.defaultValue == [
+            DeclarationRenderSection.Token(
+                text: "class",
+                kind: .keyword,
+                identifier: nil,
+                preciseIdentifier: nil
+            ),
+            DeclarationRenderSection.Token(
+                text: " ",
+                kind: .text,
+                identifier: nil,
+                preciseIdentifier: nil
+            ),
+            DeclarationRenderSection.Token(
+                text: "ClassInSwift",
+
+                // The 'typeIdentifier' value of the symbol's declaration is replaced with an 'identifier'.
+                kind: .identifier,
+                identifier: nil,
+                preciseIdentifier: nil
+            ),
+        ])
     }
-    
-    func testDoesNotReplacesNavigatorFragmentsForOtherLanguagesThanSwift() async throws {
+
+    @Test
+    func doesNotReplaceNavigatorFragmentsForNonSwiftLanguages() async throws {
         let navigatorFragments = try await makeDocumentationContentRenderer()
             .navigatorFragments(for: nodeWithSubheadingAndNavigatorVariants)
-        
+
         guard case .replace(let fragments) = navigatorFragments.variants.first?.patch.first else {
-            XCTFail("Unexpected patch")
+            Issue.record("Unexpected patch")
             return
         }
-        
-        XCTAssertEqual(
-            fragments,
-            [
-                DeclarationRenderSection.Token(
-                    text: "class",
-                    kind: .keyword, identifier: nil, preciseIdentifier: nil
-                ),
-                DeclarationRenderSection.Token(
-                    text: " ",
-                    kind: .text, identifier: nil, preciseIdentifier: nil
-                ),
-                DeclarationRenderSection.Token(
-                    text: "ClassInAnotherLanguage",
-                    kind: .typeIdentifier, identifier: nil, preciseIdentifier: nil
-                )
-            ]
-        )
+
+        #expect(fragments == [
+            DeclarationRenderSection.Token(
+                text: "class",
+                kind: .keyword, identifier: nil, preciseIdentifier: nil
+            ),
+            DeclarationRenderSection.Token(
+                text: " ",
+                kind: .text, identifier: nil, preciseIdentifier: nil
+            ),
+            DeclarationRenderSection.Token(
+                text: "ClassInAnotherLanguage",
+                kind: .typeIdentifier, identifier: nil, preciseIdentifier: nil
+            ),
+        ])
     }
-}
 
-private extension DocumentationDataVariantsTrait {
-    static var otherLanguage: DocumentationDataVariantsTrait { .init(interfaceLanguage: "otherLanguage") }
-}
-
-private extension DocumentationContentRendererTests {
-    func makeDocumentationContentRenderer() async throws -> DocumentationContentRenderer {
-        let (_, context) = try await testBundleAndContext()
+    private func makeDocumentationContentRenderer() async throws -> DocumentationContentRenderer {
+        let context = try await makeEmptyContext()
         return DocumentationContentRenderer(context: context)
     }
-    
-    var nodeWithSubheadingAndNavigatorVariants: DocumentationNode {
+
+    private var nodeWithSubheadingAndNavigatorVariants: DocumentationNode {
         var node = DocumentationNode(
             reference: ResolvedTopicReference(
                 bundleID: "org.swift.example",
@@ -163,7 +149,7 @@ private extension DocumentationContentRendererTests {
             semantic: nil,
             platformNames: nil
         )
-        
+
         node.semantic = Symbol(
             kindVariants: .init(values: [
                 .swift: SymbolGraph.Symbol.Kind(parsedIdentifier: .class, displayName: "Class"),
@@ -219,7 +205,11 @@ private extension DocumentationContentRendererTests {
             httpResponsesSection: nil,
             redirects: nil
         )
-        
+
         return node
     }
+}
+
+private extension DocumentationDataVariantsTrait {
+    static var otherLanguage: DocumentationDataVariantsTrait { .init(interfaceLanguage: "otherLanguage") }
 }

--- a/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorTests.swift
@@ -10,6 +10,7 @@
 
 import Foundation
 import XCTest
+import Testing
 @testable import SwiftDocC
 import DocCTestUtilities
 import Markdown
@@ -1585,5 +1586,44 @@ class RenderNodeTranslatorTests: XCTestCase {
         let article = try XCTUnwrap(context.entity(with: reference).semantic as? Article)
         var translator = RenderNodeTranslator(context: context, identifier: reference)
         return try XCTUnwrap(translator.visitArticle(article) as? RenderNode)
+    }
+}
+
+struct RenderNodeTranslatorTests_new {
+    @Test
+    func curatedReferenceKeepsConformanceWhenAlsoReachedAsADependency() async throws {
+        let selfIsBar = SymbolGraph.Symbol.Swift.Extension(
+            extendedModule: "SomeModule",
+            typeKind: .struct,
+            constraints: [.init(kind: .sameType, leftTypeName: "Self", rightTypeName: "Bar")]
+        )
+
+        let catalog = Folder(name: "unit-test.docc", content: [
+            JSONFile(name: "SomeModule.symbols.json", content: makeSymbolGraph(
+                moduleName: "SomeModule",
+                symbols: [
+                    makeSymbol(id: "s:Foo", kind: .struct, pathComponents: ["Foo"]),
+                    makeSymbol(id: "s:Bar", kind: .struct, pathComponents: ["Bar"]),
+                    makeSymbol(id: "s:x", kind: .method, pathComponents: ["Foo", "x"], otherMixins: [selfIsBar]),
+                    makeSymbol(id: "s:y", kind: .method, pathComponents: ["Foo", "y"], docComment: "See ``Foo/x`` for details."),
+                ],
+                relationships: [
+                    .init(source: "s:x", target: "s:Foo", kind: .memberOf, targetFallback: nil),
+                    .init(source: "s:y", target: "s:Foo", kind: .memberOf, targetFallback: nil),
+                ]
+            )),
+        ])
+
+        let context = try await load(catalog: catalog)
+        let bundleID = context.inputs.id
+
+        // `x` and `y` are both curated under `Foo`, and `y`'s abstract links to `x`.
+        // So on `Foo`'s page, `x` is both a direct reference and a dependency via `y`.
+        let fooReference = ResolvedTopicReference(bundleID: bundleID, path: "/documentation/SomeModule/Foo", sourceLanguage: .swift)
+        let renderNode = DocumentationNodeConverter(context: context).convert(try context.entity(with: fooReference))
+
+        let memberReference = ResolvedTopicReference(bundleID: bundleID, path: "/documentation/SomeModule/Foo/x", sourceLanguage: .swift)
+        let renderedReference = try #require(renderNode.references[memberReference.absoluteString] as? TopicRenderReference)
+        #expect(renderedReference.conformance?.constraints.plainText == "Self is Bar.")
     }
 }


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://182511900

## Summary

Conditional conformance constraints (e.g. "Available when Self is X") are not consistently present across multiple builds. This is due to two independent sources of non-determinism:

- When checking whether a `Self is <Parent>` constraint is trivially true and can be hidden, the renderer picks the symbol's parent from an unordered collection. However, symbols can sometimes be reached through multiple parent nodes in the topic graph, causing the constraint to be filtered out in some builds and retained in others.
- A reference can be present in a page both directly and as a dependency of another reference (e.g. via a symbol link in an abstract). Only the direct path attaches conformance constraints, so whichever write happened last decides whether the reference includes conformances.

To resolve these issues:

- When checking a `Self is <Parent>` constraint, the renderer now picks the parent with the shortest finite path in the topic graph, which is guaranteed to remain consistent for a given set of inputs.
- The code path that adds dependency references now also includes conformance constraints, and the information is present in the final list of references irrespective of the write order.

This PR also modernises tests for the documentation content renderer.

## Dependencies

N/A

## Testing

1. Build a catalog with both offending cases:
    - a member reachable from more than one parent that carries a conditional conformance (e.g. a protocol default implementation surfaced under both the protocol and a conforming type)
    - a symbol that is only reached through another reference's abstract (a symbol link), rather than being directly curated.
2. Run `docc convert` several times in separate processes, each to its own output dir.
3. Previously, the conformance list would change across runs. With these fixes, the output is identical across runs.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
