### PR TITLE
Fix non-deterministic symbol declaration selection

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "eeed44b5b6e983a51b5d5a022a8c2b97a40041bb6c47f5b37c72fe7a3c051a91",
+  "originHash" : "2fff306cb5f2eafe5611ebea6e6ad4ae8fc7053e599ab8d227d0a103774977dd",
   "pins" : [
     {
       "identity" : "swift-argument-parser",
@@ -70,7 +70,7 @@
       "location" : "https://github.com/swiftlang/swift-docc-symbolkit.git",
       "state" : {
         "branch" : "main",
-        "revision" : "3ecb7056ce6895621c5378caa254e2d6959e8ee5"
+        "revision" : "cf6249d437ae23fb46a1c735d0240edb23cc35a8"
       }
     },
     {

--- a/Sources/SwiftDocC/LinkTargets/LinkDestinationSummary.swift
+++ b/Sources/SwiftDocC/LinkTargets/LinkDestinationSummary.swift
@@ -494,25 +494,6 @@ extension LinkDestinationSummary {
     }
 }
 
-private extension [[PlatformName?]: SymbolGraph.Symbol.DeclarationFragments] {
-    func mainRenderFragments() -> SymbolGraph.Symbol.DeclarationFragments? {
-        self.min(by: { lhs, rhs in
-            // Join all the platform IDs and use that to get a stable value
-            lhs.key.compactMap(\.?.rawValue).joined() < lhs.key.compactMap(\.?.rawValue).joined()
-        })?.value
-    }
-    
-    func renderDeclarationTokens() -> [DeclarationRenderSection.Token]? {
-        mainRenderFragments()?.declarationFragments.renderDeclarationTokens()
-    }
-}
-
-private extension [SymbolGraph.Symbol.DeclarationFragments.Fragment] {
-    func renderDeclarationTokens() -> [DeclarationRenderSection.Token] {
-        map { .init(fragment: $0, identifier: nil) }
-    }
-}
-
 extension LinkDestinationSummary {
     
     /// Creates a link destination summary for a landmark on a page.

--- a/Sources/SwiftDocC/Model/Rendering/HTML/HTMLRenderer.swift
+++ b/Sources/SwiftDocC/Model/Rendering/HTML/HTMLRenderer.swift
@@ -303,7 +303,7 @@ package struct HTMLRenderer {
             var fragmentsByLanguage = [SourceLanguage: [SymbolGraph.Symbol.DeclarationFragments.Fragment]]()
             for (trait, variant) in symbol.declarationVariants.allValues {
                 guard let language = trait.sourceLanguage else { continue }
-                fragmentsByLanguage[language] = variant.values.first?.declarationFragments
+                fragmentsByLanguage[language] = variant.mainRenderFragments()?.declarationFragments
             }
             
             if fragmentsByLanguage.values.contains(where: { !$0.isEmpty }) {

--- a/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/DeclarationsSectionTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/DeclarationsSectionTranslator.swift
@@ -170,8 +170,8 @@ struct DeclarationsSectionTranslator: RenderSectionTranslator {
 
                     let conformance = renderNodeTranslator.contentRenderer.conformanceSectionFor(overloadReference, collectedConstraints: [:])
 
-                    let declarationFragments = overload.declarationVariants[trait]?.values
-                        .first?
+                    let declarationFragments = overload.declarationVariants[trait]?
+                        .mainRenderFragments()?
                         .declarationFragments
                     precondition(
                         declarationFragments != nil,

--- a/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/DeclarationsSectionTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/DeclarationsSectionTranslator.swift
@@ -223,6 +223,11 @@ struct DeclarationsSectionTranslator: RenderSectionTranslator {
             let renderLanguageIDs = [
                 trait.interfaceLanguage ?? renderNodeTranslator.identifier.sourceLanguage.id
             ]
+
+            // Use the highest-priority platform declaration to compute the LCS for the common fragments.
+            // `declarations` is checked to be non-nil above, so it is safe to force unwrap here.
+            let highestPriorityDeclaration = declaration.mainRenderFragments()!
+                .declarationFragments.flatMap(preProcessFragment(_:))
             for pair in declaration {
                 let (platforms, declaration) = pair
                 let expandedPlatforms = expandPlatformsWithFallbacks(platforms)
@@ -241,10 +246,9 @@ struct DeclarationsSectionTranslator: RenderSectionTranslator {
                         OverloadDeclaration($0.declaration.flatMap(preProcessFragment(_:)), $0.reference, $0.conformance)
                     })
 
-                    // Collect the "common fragments" so we can highlight the ones that are different
-                    // in each declaration
+                    // Collect the "common fragments" so we can highlight the ones that differ
                     let commonFragments = commonFragments(
-                        for: (mainDeclaration, renderNode.identifier, nil),
+                        for: (highestPriorityDeclaration, renderNode.identifier, nil),
                         overloadDeclarations: processedOverloadDeclarations,
                         mainDeclarationIndex: overloads.displayIndex
                     )

--- a/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/DeclarationsSectionTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/DeclarationsSectionTranslator.swift
@@ -208,17 +208,6 @@ struct DeclarationsSectionTranslator: RenderSectionTranslator {
                 return platforms + fallbacks
             }
 
-            func comparePlatformNames(_ lhs: PlatformName?, _ rhs: PlatformName?) -> Bool {
-                guard let lhsValue = lhs, let rhsValue = rhs else {
-                    return lhs == nil
-                }
-                return lhsValue.rawValue < rhsValue.rawValue
-            }
-
-            func sortPlatformNames(_ platforms: [PlatformName?]) -> [PlatformName?] {
-                platforms.sorted(by: comparePlatformNames(_:_:))
-            }
-
             var declarations: [DeclarationRenderSection] = []
             let renderLanguageIDs = [
                 trait.interfaceLanguage ?? renderNodeTranslator.identifier.sourceLanguage.id
@@ -231,7 +220,7 @@ struct DeclarationsSectionTranslator: RenderSectionTranslator {
             for pair in declaration {
                 let (platforms, declaration) = pair
                 let expandedPlatforms = expandPlatformsWithFallbacks(platforms)
-                let platformNames = sortPlatformNames(expandedPlatforms)
+                let platformNames = expandedPlatforms.sorted { PlatformName.isInOrder($0?.rawValue, $1?.rawValue) }
 
                 let renderedTokens: [DeclarationRenderSection.Token]
                 let otherDeclarations: DeclarationRenderSection.OtherDeclarations?
@@ -280,7 +269,7 @@ struct DeclarationsSectionTranslator: RenderSectionTranslator {
                 for pair in alternateDeclarations {
                     let (platforms, decls) = pair
                     let expandedPlatforms = expandPlatformsWithFallbacks(platforms)
-                    let platformNames = sortPlatformNames(expandedPlatforms)
+                    let platformNames = expandedPlatforms.sorted { PlatformName.isInOrder($0?.rawValue, $1?.rawValue) }
                     for alternateDeclaration in decls {
                         let renderedTokens = alternateDeclaration.declarationFragments.map(translateFragment)
 
@@ -301,7 +290,7 @@ struct DeclarationsSectionTranslator: RenderSectionTranslator {
                 guard let lhsPlatform = lhs.platforms.first, let rhsPlatform = rhs.platforms.first else {
                     return lhs.platforms.isEmpty
                 }
-                return comparePlatformNames(lhsPlatform, rhsPlatform)
+                return PlatformName.isInOrder(lhsPlatform?.rawValue, rhsPlatform?.rawValue)
             }
 
             return DeclarationsRenderSection(declarations: declarations)

--- a/Sources/SwiftDocC/Semantics/Symbol/PlatformDeclarations.swift
+++ b/Sources/SwiftDocC/Semantics/Symbol/PlatformDeclarations.swift
@@ -1,0 +1,30 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2026 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import SymbolKit
+
+extension [[PlatformName?]: SymbolGraph.Symbol.DeclarationFragments] {
+    func mainRenderFragments() -> SymbolGraph.Symbol.DeclarationFragments? {
+        self.min(by: { lhs, rhs in
+            // Join all the platform IDs and use that to get a stable value
+            lhs.key.compactMap(\.?.rawValue).joined() < lhs.key.compactMap(\.?.rawValue).joined()
+        })?.value
+    }
+
+    func renderDeclarationTokens() -> [DeclarationRenderSection.Token]? {
+        mainRenderFragments()?.declarationFragments.renderDeclarationTokens()
+    }
+}
+
+extension [SymbolGraph.Symbol.DeclarationFragments.Fragment] {
+    func renderDeclarationTokens() -> [DeclarationRenderSection.Token] {
+        map { .init(fragment: $0, identifier: nil) }
+    }
+}

--- a/Sources/SwiftDocC/Semantics/Symbol/PlatformDeclarations.swift
+++ b/Sources/SwiftDocC/Semantics/Symbol/PlatformDeclarations.swift
@@ -11,10 +11,13 @@
 import SymbolKit
 
 extension [[PlatformName?]: SymbolGraph.Symbol.DeclarationFragments] {
+    /// The declaration fragments for the group with the highest priority platform.
     func mainRenderFragments() -> SymbolGraph.Symbol.DeclarationFragments? {
         self.min(by: { lhs, rhs in
-            // Join all the platform IDs and use that to get a stable value
-            lhs.key.compactMap(\.?.rawValue).joined() < lhs.key.compactMap(\.?.rawValue).joined()
+            PlatformName.isInOrder(
+                lhs.key.compactMap { $0 }.min()?.rawValue,
+                rhs.key.compactMap { $0 }.min()?.rawValue
+            )
         })?.value
     }
 

--- a/Sources/SwiftDocC/Semantics/Symbol/PlatformName.swift
+++ b/Sources/SwiftDocC/Semantics/Symbol/PlatformName.swift
@@ -11,12 +11,23 @@
 import Foundation
 
 /// A supported platform's name representation.
-public struct PlatformName: Codable, Hashable, Equatable {
+public struct PlatformName: Codable, Hashable, Comparable {
     public var rawValue: String
-    
+
     /// Compares platform names independently of any known aliases differences or possible incomplete display names.
     public static func == (lhs: PlatformName, rhs: PlatformName) -> Bool {
         return lhs.rawValue == rhs.rawValue
+    }
+
+    /// Hashes the entity using the raw value, consistent with the implementation of ``==``.
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(rawValue)
+    }
+
+    /// Compares two platform names using the order defined in ``sortedPlatforms``.
+    /// Unknown platforms are lexicographically sorted after known platforms.
+    public static func < (lhs: PlatformName, rhs: PlatformName) -> Bool {
+        isInOrder(lhs.rawValue, rhs.rawValue)
     }
     
     /// Creates a new platform name value.

--- a/Tests/SwiftDocCTests/LinkTargets/LinkDestinationSummaryTests.swift
+++ b/Tests/SwiftDocCTests/LinkTargets/LinkDestinationSummaryTests.swift
@@ -907,6 +907,77 @@ struct LinkDestinationSummaryTests {
         
         try assertRoundTripCoding(summaries)
     }
+
+    @Test
+    func chooseHighestPriorityPlatformDeclarationForMultiPlatformSymbol() async throws {
+        func symbolGraph(platformName: String, declarationSuffix: String) -> JSONFile<SymbolGraph> {
+            JSONFile(name: "\(platformName).symbols.json", content: makeSymbolGraph(
+                moduleName: "ModuleName",
+                platform: .init(operatingSystem: .init(name: platformName)),
+                symbols: [
+                    makeSymbol(id: "some-symbol-id", kind: .func, pathComponents: ["someFunction()"], declaration: [
+                        .init(kind: .keyword,    spelling: "func",                              preciseIdentifier: nil),
+                        .init(kind: .text,       spelling: " ",                                 preciseIdentifier: nil),
+                        .init(kind: .identifier, spelling: "someFunction_\(declarationSuffix)", preciseIdentifier: nil),
+                    ])
+                ]
+            ))
+        }
+
+        let catalog = Folder(name: "unit-test.docc", content: [
+            InfoPlist(displayName: "ModuleName", identifier: "com.test.example"),
+            symbolGraph(platformName: "iOS",   declarationSuffix: "iOS"),
+            symbolGraph(platformName: "macOS", declarationSuffix: "macOS"),
+        ])
+
+        let context = try await load(catalog: catalog)
+        #expect(context.diagnostics.isEmpty, "Unexpected problems: \(context.diagnostics.map(\.summary))")
+        let moduleReference = try #require(context.soleRootModuleReference)
+
+        let reference = try #require(context.knownPages.first(where: { $0.path == "\(moduleReference.path)/someFunction()" }))
+        let node = try context.entity(with: reference)
+        let renderNode = DocumentationNodeConverter(context: context).convert(node)
+        let summary = try #require(node.externallyLinkableElementSummaries(context: context, renderNode: renderNode).first)
+
+        // iOS is higher priority than macOS
+        #expect(summary.plainTextDeclaration == "func someFunction_iOS")
+    }
+
+    @Test
+    func chooseHighestPriorityPlatformDeclarationWhenPlatformsShareDeclaration() async throws {
+        func symbolGraph(platformName: String, declarationSuffix: String) -> JSONFile<SymbolGraph> {
+            JSONFile(name: "\(platformName).symbols.json", content: makeSymbolGraph(
+                moduleName: "ModuleName",
+                platform: .init(operatingSystem: .init(name: platformName)),
+                symbols: [
+                    makeSymbol(id: "some-symbol-id", kind: .func, pathComponents: ["someFunction()"], declaration: [
+                        .init(kind: .keyword,    spelling: "func",                              preciseIdentifier: nil),
+                        .init(kind: .text,       spelling: " ",                                 preciseIdentifier: nil),
+                        .init(kind: .identifier, spelling: "someFunction_\(declarationSuffix)", preciseIdentifier: nil),
+                    ])
+                ]
+            ))
+        }
+
+        let catalog = Folder(name: "unit-test.docc", content: [
+            InfoPlist(displayName: "ModuleName", identifier: "com.test.example"),
+            symbolGraph(platformName: "iOS",   declarationSuffix: "shared"),
+            symbolGraph(platformName: "tvOS",  declarationSuffix: "shared"),
+            symbolGraph(platformName: "macOS", declarationSuffix: "macOS"),
+        ])
+
+        let context = try await load(catalog: catalog)
+        #expect(context.diagnostics.isEmpty, "Unexpected problems: \(context.diagnostics.map(\.summary))")
+        let moduleReference = try #require(context.soleRootModuleReference)
+
+        let reference = try #require(context.knownPages.first(where: { $0.path == "\(moduleReference.path)/someFunction()" }))
+        let node = try context.entity(with: reference)
+        let renderNode = DocumentationNodeConverter(context: context).convert(node)
+        let summary = try #require(node.externallyLinkableElementSummaries(context: context, renderNode: renderNode).first)
+
+        // iOS in the merged [iOS, tvOS] group is higher priority than macOS
+        #expect(summary.plainTextDeclaration == "func someFunction_shared")
+    }
 }
 
 private extension SymbolGraph.Symbol.Availability.AvailabilityItem {

--- a/Tests/SwiftDocCTests/Model/PlatformDeclarationsTests.swift
+++ b/Tests/SwiftDocCTests/Model/PlatformDeclarationsTests.swift
@@ -1,0 +1,42 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2026 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Testing
+import SymbolKit
+@testable import SwiftDocC
+
+struct PlatformDeclarationsTests {
+    private func declaration(_ spelling: String) -> SymbolGraph.Symbol.DeclarationFragments {
+        .init(declarationFragments: [.init(kind: .identifier, spelling: spelling, preciseIdentifier: nil)])
+    }
+
+    @Test
+    func picksHighestPriorityPlatformDeclaration() {
+        let variants: [[PlatformName?]: SymbolGraph.Symbol.DeclarationFragments] = [
+            [.macOS]: declaration("macOS"),
+            [.iOS]:   declaration("iOS"),
+            [.tvOS]:  declaration("tvOS"),
+        ]
+        // iOS is higher priority than macOS and tvOS
+        #expect(variants.mainRenderFragments()?.declarationFragments == declaration("iOS").declarationFragments)
+    }
+
+    @Test
+    func picksHighestPriorityPlatformWithinMergedGroup() {
+        for mergedKey: [PlatformName?] in [[.iOS, .tvOS], [.tvOS, .iOS]] {
+            let variants: [[PlatformName?]: SymbolGraph.Symbol.DeclarationFragments] = [
+                mergedKey: declaration("shared"),
+                [.macOS]:  declaration("macOS"),
+            ]
+            // iOS in the merged key for the shared declaration is higher priority than macOS
+            #expect(variants.mainRenderFragments()?.declarationFragments == declaration("shared").declarationFragments)
+        }
+    }
+}

--- a/Tests/SwiftDocCTests/Rendering/DeclarationsRenderSectionTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/DeclarationsRenderSectionTests.swift
@@ -10,6 +10,7 @@
 
 import Foundation
 import XCTest
+import Testing
 @testable import SwiftDocC
 import DocCTestUtilities
 import SymbolKit
@@ -576,4 +577,60 @@ private func declarationsAndHighlights(for section: DeclarationRenderSection) ->
     var declarations = otherDeclarations.declarations.map(\.tokens)
     declarations.insert(section.tokens, at: otherDeclarations.displayIndex)
     return declarations.flatMap(declarationAndHighlights(for:))
+}
+
+@Suite
+struct DeclarationsRenderSectionTests_new {
+    // This verifies determinism in previously non-deterministic behavior that cannot be reproduced reliably in a test.
+    // If you suspect that your changes might affect this test, you need to run it repeatedly (and relaunch for each repetition)
+    // to verify that the behavior remains deterministic.
+    @Test
+    func highlightsOverloadsAgainstHighestPriorityPlatformDeclaration() async throws {
+        func declaration(type: String, default defaultValue: String) -> SymbolGraph.Symbol.DeclarationFragments {
+            .init(declarationFragments: [
+                .init(kind: .keyword, spelling: "func", preciseIdentifier: nil),
+                .init(kind: .text, spelling: " ", preciseIdentifier: nil),
+                .init(kind: .identifier, spelling: "make", preciseIdentifier: nil),
+                .init(kind: .text, spelling: "(_ value: \(type) = \(defaultValue))", preciseIdentifier: nil),
+            ])
+        }
+
+        func graph(platform: String, default defaultValue: String) -> SymbolGraph {
+            makeSymbolGraph(
+                moduleName: "Overloads",
+                platform: .init(operatingSystem: .init(name: platform)),
+                symbols: [
+                    // A method whose default value changes per platform.
+                    makeSymbol(id: "main", kind: .func, pathComponents: ["make(_:)"], otherMixins: [declaration(type: "Value", default: defaultValue)]),
+                    // An overload with a different parameter type that always has the macOS default value.
+                    makeSymbol(id: "sibling", kind: .func, pathComponents: ["make(_:)"], otherMixins: [declaration(type: "Other", default: ".standard")]),
+                ])
+        }
+
+        var configuration = DocumentationContext.Configuration()
+        configuration.featureFlags.isExperimentalOverloadedSymbolPresentationEnabled = true
+
+        let catalog = Folder(name: "unit-test.docc", content: [
+            JSONFile(name: "macos.symbols.json", content: graph(platform: "macos", default: ".standard")),
+            JSONFile(name: "tvos.symbols.json", content: graph(platform: "tvos", default: ".compact")),
+            JSONFile(name: "watchos.symbols.json", content: graph(platform: "watchos", default: ".mini")),
+            JSONFile(name: "visionos.symbols.json", content: graph(platform: "visionos", default: ".immersive")),
+        ])
+        let context = try await load(catalog: catalog, configuration: configuration)
+
+        let reference = try #require(context.documentationCache.reference(symbolID: "main"))
+        let symbol = try #require(context.entity(with: reference).semantic as? Symbol)
+        var translator = RenderNodeTranslator(context: context, identifier: reference)
+        let renderNode = try #require(translator.visitSymbol(symbol) as? RenderNode)
+        let section = try #require(renderNode.primaryContentSections.compactMap({ $0 as? DeclarationsRenderSection }).first)
+
+        // The macOS declaration must be used to compute the LCS, where only the parameter type differs.
+        // If a different platform is used, the sibling overload gets highlighted differently here.
+        #expect(declarationsAndHighlights(for: try #require(section.declarations.first)) == [
+            "func make(_ value: Other = .standard)",
+            "                   ~~~~~             ",
+            "func make(_ value: Value = .standard)",
+            "                   ~~~~~             ",
+        ])
+    }
 }


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://182555854&181916399

## Summary

The `min(by:)` comparator in `mainRenderFragments()` compared the LHS to the LHS, making it trivially false and causing the declaration fragments to be non-deterministically chosen. This patch updates this to use the platform ordering in `PlatformName` to pick the declaration of the highest priority platform. It also updates other code paths that choose declaration fragments to use this logic. Additionally, it updates the related overloads highlighting logic to deterministically use the declaration from `mainRenderFragments()` to compute the common fragments.

The only case where this comparator deviates from a strict weak ordering is in the case of macos vs macosX86, where both architectures are stored as the "macOS" platform and have the same priority in the platform hierarchy. However, this is now an unreachable state thanks to the fix in https://github.com/swiftlang/swift-docc-symbolkit/pull/112 which picks arm64 symbols in favour of x86 symbols when declarations from both architectures are present. The swift-docc-symbolkit dependency has been updated here to include the above fix.

## Dependencies

N/A

## Testing

1. Create symbol graphs with a symbol whose declaration varies across multiple platforms.
2. Run `docc convert` multiple times into different output dirs
3. Compare the symbol declaration on the rendered page. Prior to this patch, it might change across runs. With this patch, it remains consistent.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
