### PR TITLE
Fix benchmark build with swift-argument-parser

### DIFF
--- a/bin/benchmark/Sources/benchmark/Commands.swift
+++ b/bin/benchmark/Sources/benchmark/Commands.swift
@@ -12,8 +12,7 @@ import ArgumentParser
 import Foundation
 
 @main
-struct BenchmarkCommand: @MainActor ParsableCommand {
-    @MainActor
+struct BenchmarkCommand: ParsableCommand {
     static let configuration = CommandConfiguration(
             abstract: "A utility for performing benchmarks for Swift-DocC.",
             subcommands: [Measure.self, Diff.self, CompareTo.self, MeasureCommits.self, RenderTrend.self],

--- a/bin/benchmark/Sources/benchmark/Subcommands/CommitCommands.swift
+++ b/bin/benchmark/Sources/benchmark/Subcommands/CommitCommands.swift
@@ -12,7 +12,7 @@ import Foundation
 import ArgumentParser
 import SwiftDocC
 
-struct CompareTo: @MainActor ParsableCommand {
+struct CompareTo: ParsableCommand {
     @Argument(
         help: "The baseline 'commit-ish' to compare the current checkout against."
     )
@@ -31,29 +31,30 @@ struct CompareTo: @MainActor ParsableCommand {
         return outputDirectory ?? URL(fileURLWithPath: ".") // fallback to the current directory
     }
     
-    @MainActor
     mutating func run() throws {
-        let currentDocCExecutable = try MeasureAction.buildDocC(at: doccProjectRootURL)
-        let currentBenchmarkResult = try MeasureAction.gatherMeasurements(
-            doccExecutable: currentDocCExecutable,
-            repeatCount: measureOptions.repeatCount,
-            doccConvertCommand: measureOptions.doccConvertCommand,
-            computeMissingOutputSizeMetrics: measureOptions.computeMissingOutputSizeMetrics
-        )
-        
-        let currentOutputFile = outputDirectoryOrFallback.appendingPathComponent("benchmark-current.json")
-        try MeasureAction.writeResults(currentBenchmarkResult, to: currentOutputFile)
-        
-        let commitBenchmarkResult = try gatherMeasurementsForDocCCommit(
-            commitHash,
-            repeatCount: measureOptions.repeatCount,
-            doccConvertCommand: measureOptions.doccConvertCommand,
-            computeMissingOutputSizeMetrics: measureOptions.computeMissingOutputSizeMetrics
-        )
-        let commitOutputFile = outputDirectoryOrFallback.appendingPathComponent("benchmark-\(commitHash).json")
-        try MeasureAction.writeResults(commitBenchmarkResult, to: commitOutputFile)
-        
-        try DiffAction(beforeFile: commitOutputFile, afterFile: currentOutputFile).run()
+        try MainActor.assumeIsolated {
+            let currentDocCExecutable = try MeasureAction.buildDocC(at: doccProjectRootURL)
+            let currentBenchmarkResult = try MeasureAction.gatherMeasurements(
+                doccExecutable: currentDocCExecutable,
+                repeatCount: measureOptions.repeatCount,
+                doccConvertCommand: measureOptions.doccConvertCommand,
+                computeMissingOutputSizeMetrics: measureOptions.computeMissingOutputSizeMetrics
+            )
+
+            let currentOutputFile = outputDirectoryOrFallback.appendingPathComponent("benchmark-current.json")
+            try MeasureAction.writeResults(currentBenchmarkResult, to: currentOutputFile)
+
+            let commitBenchmarkResult = try gatherMeasurementsForDocCCommit(
+                commitHash,
+                repeatCount: measureOptions.repeatCount,
+                doccConvertCommand: measureOptions.doccConvertCommand,
+                computeMissingOutputSizeMetrics: measureOptions.computeMissingOutputSizeMetrics
+            )
+            let commitOutputFile = outputDirectoryOrFallback.appendingPathComponent("benchmark-\(commitHash).json")
+            try MeasureAction.writeResults(commitBenchmarkResult, to: commitOutputFile)
+
+            try DiffAction(beforeFile: commitOutputFile, afterFile: currentOutputFile).run()
+        }
     }
 }
 

--- a/bin/benchmark/Sources/benchmark/Subcommands/Diff.swift
+++ b/bin/benchmark/Sources/benchmark/Subcommands/Diff.swift
@@ -14,7 +14,7 @@ import SwiftDocC
 
 // For argument parsing and validation
 
-struct Diff: @MainActor ParsableCommand {
+struct Diff: ParsableCommand {
     @Argument(
         help: "The benchmark.json file to treat as the 'before' values in the diff.",
         transform: { URL(fileURLWithPath: $0) }
@@ -34,13 +34,14 @@ struct Diff: @MainActor ParsableCommand {
     )
     var jsonOutputFile: URL?
     
-    @MainActor
     mutating func run() throws {
-        try DiffAction(
-            beforeFile: beforeFile,
-            afterFile: afterFile,
-            jsonOutputFile: jsonOutputFile
-        ).run()
+        try MainActor.assumeIsolated {
+            try DiffAction(
+                beforeFile: beforeFile,
+                afterFile: afterFile,
+                jsonOutputFile: jsonOutputFile
+            ).run()
+        }
     }
 }
 

--- a/bin/benchmark/Sources/benchmark/Subcommands/Measure.swift
+++ b/bin/benchmark/Sources/benchmark/Subcommands/Measure.swift
@@ -56,7 +56,7 @@ struct MeasureOptions: ParsableCommand {
     }
 }
 
-struct Measure: @MainActor ParsableCommand {
+struct Measure: ParsableCommand {
     @Option(
         name: .customLong("output"),
         help: "The path to write the output benchmark measurements file.",
@@ -93,15 +93,16 @@ struct Measure: @MainActor ParsableCommand {
         }
     }
     
-    @MainActor
     mutating func run() throws {
-        try MeasureAction(
-            repeatCount: measureOptions.repeatCount,
-            outputLocation: outputLocation,
-            baseBenchmark: baseBenchmark,
-            doccConvertCommand: measureOptions.doccConvertCommand,
-            computeMissingOutputSizeMetrics: measureOptions.computeMissingOutputSizeMetrics
-        ).run()
+        try MainActor.assumeIsolated {
+            try MeasureAction(
+                repeatCount: measureOptions.repeatCount,
+                outputLocation: outputLocation,
+                baseBenchmark: baseBenchmark,
+                doccConvertCommand: measureOptions.doccConvertCommand,
+                computeMissingOutputSizeMetrics: measureOptions.computeMissingOutputSizeMetrics
+            ).run()
+        }
     }
 }
 

--- a/bin/benchmark/Sources/benchmark/Subcommands/RenderTrend.swift
+++ b/bin/benchmark/Sources/benchmark/Subcommands/RenderTrend.swift
@@ -14,7 +14,7 @@ import SwiftDocC
 
 // For argument parsing and validation
 
-struct RenderTrend: @MainActor ParsableCommand {
+struct RenderTrend: ParsableCommand {
     @Option(
         name: .customLong("filter"),
         help: "A list metric IDs to render trends for. If no filters are specified, trends are rendered for all numeric metrics."
@@ -27,12 +27,13 @@ struct RenderTrend: @MainActor ParsableCommand {
     )
     var benchmarkResults: [URL]
     
-    @MainActor
     mutating func run() throws {
-        try RenderTrendAction(
-            metricFilters: metricFilters,
-            benchmarkResults: benchmarkResults
-        ).run()
+        try MainActor.assumeIsolated {
+            try RenderTrendAction(
+                metricFilters: metricFilters,
+                benchmarkResults: benchmarkResults
+            ).run()
+        }
     }
 }
 


### PR DESCRIPTION
ParsableCommand in swift-argument-parser requires a Sendable conformance, which a `@MainActor` does not satisfy. The CLI entry point runs synchronously on the main thread, so this can be replaced with `MainActor.assumeIsolated` inside the run blocks.