### PR TITLE
Test `bin/benchmark` and `bin/make-test-bundle` in CI

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -28,6 +28,7 @@ jobs:
       # - CMake: https://github.com/swiftlang/swift-docc/pull/1115
       enable_windows_checks: false
       enable_macos_checks: true
+
   soundness:
     name: Soundness
     uses: swiftlang/github-workflows/.github/workflows/soundness.yml@0.0.13
@@ -44,3 +45,58 @@ jobs:
       format_check_enabled: false
       # The docs check is disabled as it requires a large number of changes.
       docs_check_enabled: false
+
+  # Detect which auxiliary packages are affected by the PR,
+  # so that the build jobs only run when relevant.
+  changes:
+    name: Detect changed packages
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      make_test_bundle: ${{ steps.filter.outputs.make_test_bundle }}
+      benchmark: ${{ steps.filter.outputs.benchmark }}
+    steps:
+      - id: filter
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          changed="$(gh api --paginate \
+            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+            --jq '.[].filename')"
+          echo "Changed files:"
+          echo "$changed"
+
+          make_test_bundle=false
+          benchmark=false
+          # `bin/make-test-bundle` has no dependencies, only check its source.
+          if echo "$changed" | grep -qE '^bin/make-test-bundle/'; then make_test_bundle=true; fi
+          # `bin/benchmark` depends on the benchmark schema in `Sources/SwiftDocC/Benchmark/`.
+          # Build and test it if its source or this dependency changes.
+          if echo "$changed" | grep -qE '^(bin/benchmark/|Sources/SwiftDocC/Benchmark/|Package\.(swift|resolved)$)'; then benchmark=true; fi
+
+          echo "make_test_bundle=$make_test_bundle" >> "$GITHUB_OUTPUT"
+          echo "benchmark=$benchmark" >> "$GITHUB_OUTPUT"
+
+  make-test-bundle:
+    name: Build bin/make-test-bundle
+    needs: changes
+    if: ${{ needs.changes.outputs.make_test_bundle == 'true' }}
+    runs-on: ubuntu-latest
+    container:
+      image: swiftlang/swift:nightly-main-jammy
+    steps:
+      - uses: actions/checkout@v4
+      - run: swift build --package-path bin/make-test-bundle
+
+  benchmark:
+    name: Build and test bin/benchmark
+    needs: changes
+    if: ${{ needs.changes.outputs.benchmark == 'true' }}
+    runs-on: ubuntu-latest
+    container:
+      image: swiftlang/swift:nightly-main-jammy
+    steps:
+      - uses: actions/checkout@v4
+      - run: swift test --parallel --package-path bin/benchmark

--- a/bin/test
+++ b/bin/test
@@ -22,6 +22,32 @@ DOCC_ROOT="$(dirname $(dirname $(filepath $0)))"
 # Build SwiftDocC.
 swift test --parallel --package-path "$DOCC_ROOT"
 
+base_ref=""
+if git -C "$DOCC_ROOT" rev-parse --verify --quiet origin/main >/dev/null 2>&1; then
+    base_ref="origin/main"
+fi
+# Build and test auxiliary Swift packages under `bin/`.
+# These are separate packages that aren't covered by `swift test` above.
+# To avoid rebuilding them on every run, only build an auxiliary package if
+# the package source changes or a package it depends on changes.
+should_build() {
+    [ -z "$base_ref" ] && return 0
+    git -C "$DOCC_ROOT" diff --name-only "$base_ref"...HEAD | grep -qE "$1"
+}
+
+# `bin/make-test-bundle` has no dependencies, only check its source.
+if should_build '^bin/make-test-bundle/'; then
+    printf "=> Building make-test-bundle…\n"
+    swift build --package-path "$DOCC_ROOT/bin/make-test-bundle"
+fi
+
+# `bin/benchmark` depends on the benchmark schema in `Sources/SwiftDocC/Benchmark/`.
+# Build and test it if its source or this dependency changes.
+if should_build '^(bin/benchmark/|Sources/SwiftDocC/Benchmark/|Package\.(swift|resolved)$)'; then
+    printf "=> Building and testing benchmark…\n"
+    swift test --parallel --package-path "$DOCC_ROOT/bin/benchmark"
+fi
+
 # Run source code checks for the codebase.
 LC_ALL=C "$DOCC_ROOT"/bin/check-source
 


### PR DESCRIPTION
We have auxiliary packages in this repository that, in some cases, depend on SwiftDocC. Changes to the main package may impact them, but they are currently not being built or tested in CI. Update `bin/test` to optionally build and test these packages if their source or dependents change. Also update the GitHub Actions workflow to include two optional jobs to build and test auxiliary packages. A prerequisite job checks for changes that impact these packages and sets boolean flags that are used to determine if the individual jobs need to run.

rdar://182804873
