### PR TITLE
Allow cross language curation in See Also sections

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -1035,7 +1035,8 @@ public struct RenderNodeTranslator: SemanticVisitor {
     private func isReferenceAvailable(
         _ reference: ResolvedTopicReference,
         allowedTraits: Set<DocumentationDataVariantsTrait>,
-        availableTraits: Set<DocumentationDataVariantsTrait>
+        availableTraits: Set<DocumentationDataVariantsTrait>,
+        inSeeAlsoSection: Bool = false
     ) -> Bool {
         // If this is a reference to a non-symbol kind (article, tutorial, sample code, etc.),
         // and is external to the bundle, then curate the topic irrespective of the source
@@ -1053,9 +1054,14 @@ public struct RenderNodeTranslator: SemanticVisitor {
         if availableSourceLanguageTraits.isDisjoint(with: referenceSourceLanguages) {
             // An external symbol may have no language overlap with the module being built,
             // so filtering it out would mean it is not curated anywhere (rdar://94406023).
-            // For local references, this curation is forbidden. ``DocumentationCurator`` emits a warning,
-            // and the reference is filtered out here so it doesn't appear in the rendered topic section.
-            return context.isExternal(reference: reference)
+            //
+            // Local references with no language overlap are disallowed in Topics sections
+            // as the reference would be unreachable in the navigator hierarchy.
+            // ``DocumentationCurator`` emits a warning, and the reference is dropped here.
+            //
+            // Local references with no language overlap are allowed in See Also sections
+            // since they do not contribute to the navigator hierarchy.
+            return inSeeAlsoSection || context.isExternal(reference: reference)
         }
 
         return allowedTraits.contains { trait in
@@ -1155,6 +1161,8 @@ public struct RenderNodeTranslator: SemanticVisitor {
         availableTraits: Set<DocumentationDataVariantsTrait>,
         contentCompiler: inout RenderContentCompiler
     ) -> [TaskGroupRenderSection] {
+        let isSeeAlsoSection = topics is SeeAlsoSection
+
         return topics.taskGroups.compactMap { group in
             let supportedLanguages = group.directives[SupportedLanguage.directiveName]?.compactMap {
                 SupportedLanguage(from: $0, source: nil, for: context.inputs, featureFlags: context.configuration.featureFlags)?.language
@@ -1182,7 +1190,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
                     return true
                 }
 
-                return isReferenceAvailable(reference, allowedTraits: allowedTraits, availableTraits: availableTraits)
+                return isReferenceAvailable(reference, allowedTraits: allowedTraits, availableTraits: availableTraits, inSeeAlsoSection: isSeeAlsoSection)
             }
             
             let taskGroupRenderSection = TaskGroupRenderSection(

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationCuratorTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationCuratorTests.swift
@@ -769,4 +769,33 @@ struct DocumentationCuratorTests_new {
         #expect(!swiftOnlyRenderNode.topicSections.flatMap(\.identifiers).contains { $0.hasSuffix("/ObjcOnlyClass") },
                 "The cross-language reference should not be present in the parent page")
     }
+
+    @Test
+    func retainsCrossLanguageLinkInSeeAlsoSection() async throws {
+        let context = try await load(catalog:
+            Folder(name: "unit-test.docc", content: [
+                JSONFile(name: "ModuleName-swift.symbols.json", content: makeSymbolGraph(moduleName: "ModuleName", symbols: [
+                    makeSymbol(id: "swift-only-class", language: .swift, kind: .class, pathComponents: ["SwiftOnlyClass"]),
+                ])),
+                JSONFile(name: "ModuleName-objc.symbols.json", content: makeSymbolGraph(moduleName: "ModuleName", symbols: [
+                    makeSymbol(id: "objc-only-class", language: .objectiveC, kind: .class, pathComponents: ["ObjcOnlyClass"]),
+                ])),
+                TextFile(name: "SwiftOnlyClass.md", utf8Content: """
+                # ``ModuleName/SwiftOnlyClass``
+
+                ## See Also
+
+                - ``ObjcOnlyClass``
+                """),
+            ])
+        )
+
+        #expect(context.diagnostics.map(\.identifier) == [], "Encountered unexpected problems: \(context.diagnostics.map(\.summary))")
+
+        let converter = DocumentationNodeConverter(context: context)
+        let swiftOnlyReference = try #require(context.knownPages.first(where: { $0.lastPathComponent == "SwiftOnlyClass" }))
+        let swiftOnlyRenderNode = converter.convert(try context.entity(with: swiftOnlyReference))
+        #expect(swiftOnlyRenderNode.seeAlsoSections.flatMap(\.identifiers).contains { $0.hasSuffix("/ObjcOnlyClass") },
+                "Cross-language reference should be present in the parent page's See Also section")
+    }
 }


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://182898058

## Summary

1588c4d2dd8b61f85bde4b9305ca48f87a8a9d0d removed support for curating internal links with no language overlap, and added a warning for cases that are encountered. This is due to the reference being unreachable in the navigator hierarchy. However, See Also sections do not contribute to the navigator hierarchy, and are not bound by this restriction. Update the filter to allow cross-language curation with no overlap in See Also sections.

## Dependencies

N/A

## Testing

1. Create a multi-language framework, with Swift-only and ObjC-only symbols.
2. Curate the ObjC-only symbol in the See Also section of a Swift-only symbol.
3. Previously, this link would be dropped. Now, it is retained.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
