### PR TITLE
Bump timeout for `ConvertServiceTests.processAndAssert`

### DIFF
--- a/Tests/SwiftDocCTests/DocumentationService/ConvertService/ConvertServiceTests.swift
+++ b/Tests/SwiftDocCTests/DocumentationService/ConvertService/ConvertServiceTests.swift
@@ -2416,7 +2416,7 @@ class ConvertServiceTests: XCTestCase {
             expectation.fulfill()
         }
         
-        wait(for: [expectation], timeout: 1.0)
+        wait(for: [expectation], timeout: 1.5)
     }
     
     /// Asserts that the given render reference store contains the given topic.


### PR DESCRIPTION
The convert service tests has a `processAndAssert` helper, which checks for expectations with a 1.0s timeout. This is too eager on Linux when running with the address sanitizer on CI, where the instrumented code is slowed down enough to cause tests using this helper to fail. Bump the timeout by 0.5s to provide some breathing room.
