### PR TITLE
Document CDDefaultCodeListingLanguage and CDDefaultModuleKind in context

### DIFF
--- a/Sources/docc/DocCDocumentation.docc/adding-structure-to-your-documentation-pages.md
+++ b/Sources/docc/DocCDocumentation.docc/adding-structure-to-your-documentation-pages.md
@@ -75,6 +75,15 @@ symbols and other content. For more information, see
 In addition to presenting rich content, a custom landing page organizes the top-level 
 symbols and other content in your documentation hierarchy.
 
+By default, DocC labels the module at the top of its landing page as "Framework".
+To use a different label, such as "SDK" or "Package", set the `CDDefaultModuleKind` key in your documentation catalog's `Info.plist` file.
+You can also customize this label on a per-page basis using the ``TitleHeading`` directive.
+
+```xml
+<key>CDDefaultModuleKind</key>
+<string>SDK</string>
+```
+
 ### Arrange Top-Level Symbols Using Topic Groups
 
 By default, DocC arranges the symbols in your framework according to their 

--- a/Sources/docc/DocCDocumentation.docc/adding-structure-to-your-documentation-pages.md
+++ b/Sources/docc/DocCDocumentation.docc/adding-structure-to-your-documentation-pages.md
@@ -75,9 +75,11 @@ symbols and other content. For more information, see
 In addition to presenting rich content, a custom landing page organizes the top-level 
 symbols and other content in your documentation hierarchy.
 
-By default, DocC labels the module at the top of its landing page as "Framework".
-To use a different label, such as "SDK" or "Package", set the `CDDefaultModuleKind` key in your documentation catalog's `Info.plist` file.
+If your module represents something other than a framework, you can customize the title heading of its landing page.
+Set the `CDDefaultModuleKind` key in your documentation catalog's `Info.plist` file, or pass the `--fallback-default-module-kind` command-line option, to use a different label, such as "SDK" or "Package".
 You can also customize this label on a per-page basis using the ``TitleHeading`` directive.
+
+By default, DocC displays "Framework" as the title heading for your module's landing page.
 
 ```xml
 <key>CDDefaultModuleKind</key>

--- a/Sources/docc/DocCDocumentation.docc/formatting-your-documentation-content.md
+++ b/Sources/docc/DocCDocumentation.docc/formatting-your-documentation-content.md
@@ -184,6 +184,14 @@ have one or more aliases.
 | xml         | html, xhtml, rss, atom, xjb, xsd, xsl, plist, wsf, svg |
 | yaml        | yml                                                    |
 
+If most of your code listings use the same language, set a catalog-wide default in your documentation catalog's `Info.plist` file using the `CDDefaultCodeListingLanguage` key.
+DocC applies that language to any code listing that doesn't specify one, including indented code blocks, which have no Markdown syntax for specifying a language identifier.
+
+```xml
+<key>CDDefaultCodeListingLanguage</key>
+<string>swift</string>
+```
+
 ### Add Bulleted, Numbered, and Term Lists
 
 DocC supports the following list types:

--- a/Sources/docc/DocCDocumentation.docc/formatting-your-documentation-content.md
+++ b/Sources/docc/DocCDocumentation.docc/formatting-your-documentation-content.md
@@ -184,7 +184,7 @@ have one or more aliases.
 | xml         | html, xhtml, rss, atom, xjb, xsd, xsl, plist, wsf, svg |
 | yaml        | yml                                                    |
 
-If most of your code listings use the same language, set a catalog-wide default in your documentation catalog's `Info.plist` file using the `CDDefaultCodeListingLanguage` key.
+If most of your code listings use the same language, you can specify a catalog-wide default code listing language in your documentation catalog's (optional) `Info.plist` file using the `CDDefaultCodeListingLanguage` key, or pass the `--default-code-listing-language` command-line option.
 DocC applies that language to any code listing that doesn't specify one, including indented code blocks, which have no Markdown syntax for specifying a language identifier.
 
 ```xml


### PR DESCRIPTION
Bug/issue #, if applicable: N/A

[Forums thread](https://forums.swift.org/t/proposal-document-supported-info-plist-keys-for-documentation-catalogs/87799)

## Summary

Two `Info.plist` keys supported by DocC catalogs — `CDDefaultCodeListingLanguage` and
`CDDefaultModuleKind` — had no user-facing documentation. Users had to read library source code to discover them.

Rather than adding a standalone reference page, this PR surfaces each key inline in the existing page where it's most contextually relevant, following the approach suggested in the Swift Forums discussion with maintainers.

The other keys identified in `DocumentationBundle+Info.swift` (`CDAppleDefaultAvailability`, `CDExperimentalFeatureFlags`, `CFBundleDisplayName`, `CFBundleIdentifier`) are intentionally not documented here, per maintainer guidance that they are either discouraged, exist for historical reasons, or are not ready for user-facing documentation.

## Dependencies

None.

## Testing

Documentation only change.

## Checklist

- [ ] Added tests
- [ ] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary