### PR TITLE
Preserve contentful HTML when transforming archives

### DIFF
--- a/Sources/DocCCommandLine/Transformers/StaticHostableTransformer.swift
+++ b/Sources/DocCCommandLine/Transformers/StaticHostableTransformer.swift
@@ -74,8 +74,133 @@ struct StaticHostableTransformer {
                 try fileManager.createDirectory(at: outputDirectoryURL, withIntermediateDirectories: true, attributes: [:])
             }
             
-            try fileManager.createFile(at: outputDirectoryURL.appendingPathComponent("index.html"), contents: indexHTMLData)
+            let outputIndexHTMLURL = outputDirectoryURL.appendingPathComponent("index.html")
+            let outputIndexHTMLData = indexHTMLDataPreservingPageContent(
+                at: outputIndexHTMLURL
+            )
+
+            try fileManager.createFile(
+                at: outputIndexHTMLURL,
+                contents: outputIndexHTMLData
+            )
         }
+    }
+
+    private func indexHTMLDataPreservingPageContent(at outputURL: URL) -> Data {
+        guard fileManager.fileExists(atPath: outputURL.path),
+              let existingData = try? fileManager.contents(of: outputURL),
+              let existingHTML = String(data: existingData, encoding: .utf8),
+              let pageContent = PageSpecificHTMLContent(html: existingHTML),
+              let templateHTML = String(data: indexHTMLData, encoding: .utf8),
+              let updatedHTML = pageContent.inserting(into: templateHTML)
+        else {
+            return indexHTMLData
+        }
+
+        return Data(updatedHTML.utf8)
+    }
+}
+
+private struct PageSpecificHTMLContent {
+    let title: String
+    let description: String?
+    let noScriptContent: String
+
+    init?(html: String) {
+        guard
+            let titleRange = Self.contentRange(of: "title", in: html),
+            let noScriptRange = Self.contentRange(of: "noscript", in: html)
+        else {
+            return nil
+        }
+
+        let noScriptContent = String(html[noScriptRange])
+
+        // Contentful route HTML uses an article as its semantic fallback.
+        guard noScriptContent.range(
+            of: #"<article(?:\s|>)"#,
+            options: [.regularExpression, .caseInsensitive]
+        ) != nil else {
+            return nil
+        }
+
+        self.title = String(html[titleRange])
+        self.description = Self.descriptionRange(in: html).map {
+            String(html[$0])
+        }
+        self.noScriptContent = noScriptContent
+    }
+
+    func inserting(into template: String) -> String? {
+        var result = template
+
+        guard let noScriptRange = Self.contentRange(
+            of: "noscript",
+            in: result
+        ) else {
+            return nil
+        }
+        result.replaceSubrange(noScriptRange, with: noScriptContent)
+
+        if let existingDescriptionRange = Self.descriptionRange(in: result) {
+            result.replaceSubrange(
+                existingDescriptionRange,
+                with: description ?? ""
+            )
+        } else if let description {
+            guard let headRange = Self.contentRange(
+                of: "head",
+                in: result
+            ) else {
+                return nil
+            }
+            result.insert(contentsOf: description, at: headRange.upperBound)
+        }
+
+        guard let titleRange = Self.contentRange(
+            of: "title",
+            in: result
+        ) else {
+            return nil
+        }
+        result.replaceSubrange(titleRange, with: title)
+
+        return result
+    }
+
+    private static func contentRange(
+        of elementName: String,
+        in html: String
+    ) -> Range<String.Index>? {
+        guard
+            let openingTag = html.range(
+                of: "<\(elementName)\\b[^>]*>",
+                options: [.regularExpression, .caseInsensitive]
+            ),
+            let closingTag = html.range(
+                of: "</\(elementName)\\s*>",
+                options: [.regularExpression, .caseInsensitive],
+                range: openingTag.upperBound..<html.endIndex
+            )
+        else {
+            return nil
+        }
+
+        return openingTag.upperBound..<closingTag.lowerBound
+    }
+
+    private static func descriptionRange(
+        in html: String
+    ) -> Range<String.Index>? {
+        guard let headRange = contentRange(of: "head", in: html) else {
+            return nil
+        }
+
+        return html.range(
+            of: #"<meta\b[^>]*\bname\s*=\s*["']description["'][^>]*\/?>"#,
+            options: [.regularExpression, .caseInsensitive],
+            range: headRange
+        )
     }
 }
 

--- a/Tests/DocCCommandLineTests/StaticHostingWithContentTests.swift
+++ b/Tests/DocCCommandLineTests/StaticHostingWithContentTests.swift
@@ -13,6 +13,7 @@ import Foundation
 @testable import SwiftDocC
 @testable import DocCCommandLine
 import DocCTestUtilities
+import Testing
 
 class StaticHostingWithContentTests: XCTestCase {
 
@@ -147,5 +148,124 @@ class StaticHostingWithContentTests: XCTestCase {
             </html>
             """)
         }
+    }
+}
+
+@Suite
+struct StaticHostingWithContentProcessArchiveTests {
+
+    @Test
+    func preservesContentfulRouteHTMLWhenChangingBasePath() async throws {
+        let sentinel = "This sentence must survive archive processing: DOCC_1588_SENTINEL."
+
+        let catalog = Folder(name: "Example.docc", content: [
+            TextFile(name: "Example.md", utf8Content: """
+            # Example Documentation
+
+            \(sentinel)
+            """),
+        ])
+
+        let htmlTemplate = """
+        <html>
+          <head>
+            <link rel="icon" href="{{BASE_PATH}}/favicon.ico" />
+            <title>Documentation</title>
+          </head>
+          <body>
+            <noscript>
+              <p>This page requires JavaScript.</p>
+            </noscript>
+            <div id="app"></div>
+          </body>
+        </html>
+        """
+
+        let fileSystem = try TestFileSystem(folders: [
+            Folder(name: "path", content: [
+                Folder(name: "to", content: [catalog]),
+            ]),
+            Folder(name: "template", content: [
+                TextFile(
+                    name: "index.html",
+                    utf8Content: htmlTemplate.replacingOccurrences(
+                        of: "{{BASE_PATH}}",
+                        with: ""
+                    )
+                ),
+                TextFile(name: "index-template.html", utf8Content: htmlTemplate),
+            ]),
+            Folder(name: "output-dir", content: []),
+        ])
+
+        var convertAction = try ConvertAction(
+            documentationBundleURL: URL(fileURLWithPath: "/path/to/Example.docc"),
+            outOfProcessResolver: nil,
+            analyze: false,
+            targetDirectory: URL(fileURLWithPath: "/output-dir"),
+            htmlTemplateDirectory: URL(fileURLWithPath: "/template"),
+            emitDigest: false,
+            currentPlatforms: nil,
+            buildIndex: false,
+            fileManager: fileSystem,
+            temporaryDirectory: URL(fileURLWithPath: "/tmp"),
+            experimentalEnableCustomTemplates: true,
+            transformForStaticHosting: true,
+            includeContentInEachHTMLFile: true,
+            hostingBasePath: nil
+        )
+        convertAction._completelySkipBuildingIndex = true
+
+        _ = try await convertAction.perform(logHandle: .none)
+
+        let routeURL = URL(
+            fileURLWithPath: "/output-dir/documentation/example/index.html"
+        )
+
+        let originalHTML = try #require(
+            String(
+                data: fileSystem.contents(of: routeURL),
+                encoding: .utf8
+            )
+        )
+
+        #expect(originalHTML.contains(sentinel))
+        #expect(originalHTML.contains("<title>Example Documentation</title>"))
+
+        let indexHTMLData = try StaticHostableTransformer.indexHTMLData(
+            in: URL(fileURLWithPath: "/template"),
+            with: "internship-test",
+            fileManager: fileSystem
+        )
+
+        let transformer = StaticHostableTransformer(
+            dataDirectory: URL(fileURLWithPath: "/output-dir/data"),
+            fileManager: fileSystem,
+            outputURL: URL(fileURLWithPath: "/output-dir"),
+            indexHTMLData: indexHTMLData
+        )
+        try transformer.transform()
+
+        let processedHTML = try #require(
+            String(
+                data: fileSystem.contents(of: routeURL),
+                encoding: .utf8
+            )
+        )
+
+        #expect(
+            processedHTML.contains(#"<meta content="\#(sentinel)" name="description"/>"#),
+            "Processing should preserve the page-specific description."
+        )
+        #expect(
+            processedHTML.contains("<p>\(sentinel)</p>"),
+            "Processing should preserve the semantic fallback content."
+        )
+        #expect(
+            processedHTML.contains("<title>Example Documentation</title>"),
+            "Processing should preserve the page-specific title."
+        )
+        #expect(processedHTML.contains("/internship-test/favicon.ico"))
+        #expect(!processedHTML.contains("{{BASE_PATH}}"))
     }
 }


### PR DESCRIPTION
## Summary

- Preserve page-specific titles, descriptions, and semantic fallback content when processing a contentful archive.
- Continue applying the new hosting base path and renderer template.
- Add focused virtual-file-system regression coverage.

Fixes #1588

## Testing

- Focused contentful static-hosting regression test
- StaticHostableTransformerTests
- TransformForStaticHostingActionTests
- StaticHostingWithContentTests
- Manual process-archive reproduction
- Source and license checks

The full local test run passed except for two existing tests whose shell commands do not support checkout paths containing spaces.