### PR TITLE
Only crawl each page once during curation

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/DocumentationCurator.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationCurator.swift
@@ -148,8 +148,11 @@ struct DocumentationCurator {
     ///   - prepareForCuration: An optional closure to call just before walking the node's task group links.
     ///   - relateNodes: A closure to call when a parent <-> child relationship is found.
     mutating func crawlChildren(of nodeReference: ResolvedTopicReference, prepareForCuration: (ResolvedTopicReference) -> Void = {_ in}, relateNodes: (ResolvedTopicReference, ResolvedTopicReference) -> Void) throws {
-        // Keeping track if all articles have been curated.
-        curatedNodes.insert(nodeReference)
+        // Track if all articles have been curated.
+        // If a node has already been crawled, skip it.
+        guard curatedNodes.insert(nodeReference).inserted else {
+            return
+        }
 
         guard let documentationNode = context.documentationCache[nodeReference] else {
             return
@@ -336,11 +339,6 @@ struct DocumentationCurator {
 
                 // Link reference successfully resolved to a topic node
                 relateNodes(nodeReference, childReference)
-                
-                guard !curatedNodes.contains(childReference) else {
-                    // Don't crawl the same symbol more than once. 
-                    continue
-                }
                 
                 // Descend further into curated topics
                 try crawlChildren(of: childReference, prepareForCuration: prepareForCuration, relateNodes: relateNodes)

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationCuratorTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationCuratorTests.swift
@@ -798,4 +798,71 @@ struct DocumentationCuratorTests_new {
         #expect(swiftOnlyRenderNode.seeAlsoSections.flatMap(\.identifiers).contains { $0.hasSuffix("/ObjcOnlyClass") },
                 "Cross-language reference should be present in the parent page's See Also section")
     }
+
+    // This verifies determinism in previously non-deterministic behavior that cannot be reproduced reliably in a test.
+    // If you suspect that your changes might affect this test,
+    // you need to run it repeatedly (and relaunch for each repetition) to verify that the behavior remains deterministic.
+    @Test
+    func validatesEachSymbolTaskGroupLinksOnlyOnce() async throws {
+        let context = try await load(catalog:
+            Folder(name: "unit-test.docc", content: [
+                JSONFile(name: "ModuleName-swift.symbols.json", content: makeSymbolGraph(moduleName: "ModuleName", symbols: [
+                    makeSymbol(id: "some-container", language: .swift, kind: .class, pathComponents: ["SomeContainer"]),
+                    makeSymbol(id: "swift-only-class", language: .swift, kind: .class, pathComponents: ["SwiftOnlyClass"]),
+                ])),
+                JSONFile(name: "ModuleName-objc.symbols.json", content: makeSymbolGraph(moduleName: "ModuleName", symbols: [
+                    makeSymbol(id: "objc-only-class", language: .objectiveC, kind: .class, pathComponents: ["ObjcOnlyClass"]),
+                ])),
+                TextFile(name: "SomeContainer.md", utf8Content: """
+                # ``ModuleName/SomeContainer``
+
+                ## Topics
+
+                ### Curating another top-level symbol
+
+                - ``SwiftOnlyClass``
+                """),
+                TextFile(name: "SwiftOnlyClass.md", utf8Content: """
+                # ``ModuleName/SwiftOnlyClass``
+
+                ## Topics
+
+                ### Cross-language curation
+
+                - ``ObjcOnlyClass``
+                """),
+            ])
+        )
+
+        #expect(context.diagnostics.map(\.identifier) == ["UnreachableCrossLanguageCuration"],
+                "Encountered unexpected problems: \(context.diagnostics.map(\.summary))")
+    }
+
+    @Test
+    func validatesEachArticleTaskGroupLinksOnlyOnce() async throws {
+        let context = try await load(catalog:
+            Folder(name: "unit-test.docc", content: [
+                TextFile(name: "First.md", utf8Content: """
+                # First article
+
+                ## Topics
+
+                - <doc:Second>
+                """),
+                TextFile(name: "Second.md", utf8Content: """
+                # Second article
+
+                ## Topics
+
+                - <https://example.com/something>
+                """),
+            ])
+        )
+
+        #expect(context.diagnostics.map(\.identifier) == ["org.swift.docc.InvalidDocumentationLink"],
+                "Encountered unexpected problems: \(context.diagnostics.map(\.summary))")
+        #expect(context.diagnostics.map(\.summary) == [
+            "The link 'https://example.com/something' isn't valid"
+        ])
+    }
 }


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://183418909

## Summary

The documentation curator starts crawling at every top-level page. Since a top-level page can be curated under another top-level page, a page can be both a starting point for the crawl and a descendant of another starting point.

We currently only check at the recursive call site if a page has been crawled. Due to this, a top-level page can be processed twice in a non-recursive manner (once as a descendant, and once as a top-level starting point), leading to identical diagnostics being emitted twice. This occurs deterministically with articles as the input is ordered, but non-deterministically with symbols as the input is a set, whose ordering is not guaranteed.

Move the guard to an earlier point where it ensures that each page is only crawled once, either as a top-level page or a descendant.

## Dependencies

N/A

## Testing

1. Create a catalog with two articles, where one curates the other.
2. Add an invalid link to the child article.
3. `xcrun docc convert` on the catalog.
4. Previously, the "invalid link" diagnostic would be emitted twice. Now, it is emitted only once.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
