### PR TITLE
Serialize DocCHTMLTests on Linux to avoid libxml2 crash

### DIFF
--- a/Tests/DocCHTMLTests/DocCHTMLTestSuites.swift
+++ b/Tests/DocCHTMLTests/DocCHTMLTestSuites.swift
@@ -1,0 +1,34 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2026 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Testing
+
+/// A parent suite that groups together all of the DocCHTMLTests suites.
+///
+/// On Linux, FoundationXML is backed by libxml2, which isn't thread-safe by default.
+/// The library uses global state that backs the XMLNode type,
+/// and it's the caller's responsibility to synchronize access to it [1].
+/// It also documents that "xmlCleanupParser is not thread-safe",
+/// and memory corruption may occur if other threads make libxml2 calls afterwards [2].
+///
+/// Swift Testing runs in parallel by default, with multiple XMLNode trees being built and torn down at the same time.
+/// On Linux, this causes the tests to intermittently crash with SIGSEGV (signal 11) inside `XMLNode.deinit`.
+///
+/// To avoid these crashes, the tests that use libxml2 are run serially on Linux.
+///
+/// [1]: https://gnome.pages.gitlab.gnome.org/libxml2/html/parser_8h.html#a642085a16c74b8352e92a89c348cc9c4
+/// [2]: https://gnome.pages.gitlab.gnome.org/libxml2/html/parser_8h.html#a7eb4447bac68a016b428f51cc402369f
+#if canImport(FoundationXML)
+@Suite(.serialized)
+enum DocCHTMLTestSuites {}
+#else
+@Suite
+enum DocCHTMLTestSuites {}
+#endif

--- a/Tests/DocCHTMLTests/HTMLFormatterTests.swift
+++ b/Tests/DocCHTMLTests/HTMLFormatterTests.swift
@@ -13,6 +13,7 @@ import Testing
 @testable import DocCHTML
 import DocCCommon
 
+extension DocCHTMLTestSuites {
 struct HTMLFormatterTests {
     
     @Test
@@ -441,7 +442,8 @@ struct HTMLFormatterTests {
         """)
     }
 }
-    
+}
+
 private func htmlString(for element: HTMLNode, options: HTMLFormatter.Options = []) -> String {
     String(decoding: HTMLFormatter.format(element, options: options), as: UTF8.self)
 }

--- a/Tests/DocCHTMLTests/MarkdownRenderer+PageElementsTests.swift
+++ b/Tests/DocCHTMLTests/MarkdownRenderer+PageElementsTests.swift
@@ -22,6 +22,7 @@ import Markdown
 import DocCCommon
 import SymbolKit
 
+extension DocCHTMLTestSuites {
 struct MarkdownRenderer_PageElementsTests {
     @Test(arguments: RenderGoal.allCases)
     func renderingBreadcrumbs(goal: RenderGoal) {
@@ -868,6 +869,7 @@ struct MarkdownRenderer_PageElementsTests {
         let document = Document(parsing: string, options: [.parseBlockDirectives, .parseSymbolLinks])
         return Array(document.children)
     }
+}
 }
 
 struct MultiValueLinkProvider: LinkProvider {

--- a/Tests/DocCHTMLTests/MarkdownRendererTests.swift
+++ b/Tests/DocCHTMLTests/MarkdownRendererTests.swift
@@ -21,6 +21,7 @@ import DocCHTML
 import Markdown
 import DocCCommon
 
+extension DocCHTMLTestSuites {
 struct MarkdownRendererTests {
     @Test
     func renderingParagraphsWithFormattedText() {
@@ -652,6 +653,7 @@ struct MarkdownRendererTests {
             abstract: nil // Not relevant for inline links
         )
     }
+}
 }
 
 // MARK: Helpers

--- a/Tests/DocCHTMLTests/WordBreakTests.swift
+++ b/Tests/DocCHTMLTests/WordBreakTests.swift
@@ -19,6 +19,7 @@ import Foundation
 import Testing
 @testable import DocCHTML
 
+extension DocCHTMLTestSuites {
 struct WordBreakTests {
     @Test
     func insertsWordBreaks() {
@@ -83,4 +84,5 @@ struct WordBreakTests {
         
         #expect(withWordBreaks == expectedHTML, sourceLocation: sourceLocation)
     }
+}
 }


### PR DESCRIPTION
On Linux, FoundationXML is backed by libxml2, which isn't thread-safe by default. The library uses global state that backs the XMLNode type, and it's the caller's responsibility to synchronize access to it [1]. It also documents that "xmlCleanupParser is not thread-safe", and memory corruption is likely if other threads make libxml2 calls afterwards [2].

Swift Testing runs in parallel by default, with multiple XMLNode trees being built and torn down at the same time. On Linux, this causes the tests to intermittently crash with SIGSEGV (signal 11) inside `XMLNode.deinit`.

Group all DocCHTMLTests suites under a parent suite, and run it serially on Linux to avoid crashes. macOS can continue to run them in parallel as it uses a thread-safe XML implementation.

[1]: https://gnome.pages.gitlab.gnome.org/libxml2/html/parser_8h.html#a642085a16c74b8352e92a89c348cc9c4
[2]: https://gnome.pages.gitlab.gnome.org/libxml2/html/parser_8h.html#a7eb4447bac68a016b428f51cc402369f

A recent occurrence of this: https://github.com/swiftlang/swift-docc/actions/runs/30365670915/job/90296159959?pr=1605