### PR TITLE
Enable Python formatting check on GitHub Actions

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Fix Python formatting (#1572)
+6dc63de6c0b5c93e6afd6d127018ef2ca246fe90

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -43,9 +43,3 @@ jobs:
       format_check_enabled: false
       # The docs check is disabled as it requires a large number of changes.
       docs_check_enabled: false
-      # The Python lint check is buggy due to flake8's default ignore list
-      # being overridden by the config in the workflow definition. The check
-      # needs to remain disabled until the fix is merged and released:
-      #
-      # https://github.com/swiftlang/github-workflows/pull/279
-      python_lint_check_enabled: false


### PR DESCRIPTION
GitHub CI runs a Python formatting check with flake8 as part of the soundness check suite. The check was buggy due to flake8's default ignore list being overridden by the config in the workflow definition. This has been fixed in v0.0.12 [1], and the check can now be enabled. This patch removes the configuration value that disabled the check. It also adds the commit that reformatted the Python file to `.git-blame-ignore-revs`, to allow git blame to correctly show meaningful changes to the file from prior to the reformat. Most tools recognise this file by default, and exclude the commits listed in it when using git blame. However, git itself does not use this file by default. To use this with raw git commands, it can be configured with:

```
git config --global blame.ignoreRevsFile .git-blame-ignore-revs
```

[1]: https://github.com/swiftlang/github-workflows/pull/279

This is a follow-up to #1572.
