### PR TITLE
Don't use framework default availability if an availability exists at symbol level

### DIFF
--- a/Sources/SwiftDocC/Model/MarkdownOutput/Translation/MarkdownOutputSemanticVisitor.swift
+++ b/Sources/SwiftDocC/Model/MarkdownOutput/Translation/MarkdownOutputSemanticVisitor.swift
@@ -132,14 +132,17 @@ extension MarkdownOutputSemanticVisitor {
         // Availability - defaults, overridden with symbol, overridden with metadata
         
         var availabilities: [String: MarkdownOutputNode.Metadata.Availability] = [:]
-        if let primaryModule = metadata.symbol?.modules.first {
+        
+        let symbolAvailability = symbol.availability?.availability ?? []
+        // Framework defaults only apply if there are no specific availabilities at symbol level.
+        if !symbolAvailability.contains(where: { $0.domain != nil }), let primaryModule = metadata.symbol?.modules.first {
             for availability in bundle.info.defaultAvailability?.modules[primaryModule] ?? [] {
                 let meta = MarkdownOutputNode.Metadata.Availability(availability)
                 availabilities[meta.platform] = meta
             }
         }
-         
-        for availability in symbol.availability?.availability ?? [] {
+        
+        for availability in symbolAvailability {
             let meta = MarkdownOutputNode.Metadata.Availability(availability)
             availabilities[meta.platform] = meta
         }

--- a/Tests/SwiftDocCTests/Rendering/Markdown/MarkdownOutputTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/Markdown/MarkdownOutputTests.swift
@@ -884,10 +884,13 @@ struct MarkdownOutputTests {
         #expect(node.metadata.symbol?.modules == ["MarkdownOutput", "Swift"])
     }
     
+    private let iOSPlatform = SymbolGraph.Platform(operatingSystem: .init(name: "ios"))
+    private let macOSPlatform = SymbolGraph.Platform(operatingSystem: .init(name: "macosx"))
+    
     @Test
     func symbolMetadataGetsDefaultAvailability() async throws {
         let catalog = catalog(files: [
-            JSONFile(name: "MarkdownOutput.symbols.json", content: makeSymbolGraph(moduleName: "MarkdownOutput", symbols: [
+            JSONFile(name: "MarkdownOutput.symbols.json", content: makeSymbolGraph(moduleName: "MarkdownOutput", platform: iOSPlatform, symbols: [
                 makeSymbol(id: "MarkdownSymbol", kind: .struct, pathComponents: ["MarkdownSymbol"], docComment: "A basic symbol to test markdown output")
             ])),
             InfoPlist(defaultAvailability: [
@@ -900,9 +903,24 @@ struct MarkdownOutputTests {
     }
     
     @Test
+    func symbolMetadataGetsSymbolLevelAvailability() async throws {
+        let catalog = catalog(files: [
+            JSONFile(name: "MarkdownOutput.symbols.json", content: makeSymbolGraph(moduleName: "MarkdownOutput", platform: iOSPlatform, symbols: [
+                makeSymbol(id: "MarkdownSymbol", kind: .struct, pathComponents: ["MarkdownSymbol"], docComment: "A basic symbol to test markdown output", availability: [.init(domainName: "iOS", introduced: .init(string: "2.0.0"), deprecated: nil)])
+            ])),
+            InfoPlist(defaultAvailability: [
+                "MarkdownOutput" : [.init(platformName: .iOS, platformVersion: "1.0.0")]
+            ])
+        ])
+        let (node, _) = try await markdownOutput(catalog: catalog, path: "MarkdownSymbol")
+        let availability = try #require(node.metadata.availability)
+        #expect(availability.contains(.init(platform: "iOS", introduced: "2.0.0", deprecated: nil, unavailable: false)))
+    }
+    
+    @Test
     func symbolAvailabilityIsCapturedFromMetadataBlock() async throws {
         let catalog = catalog(files: [
-            JSONFile(name: "MarkdownOutput.symbols.json", content: makeSymbolGraph(moduleName: "MarkdownOutput", symbols: [
+            JSONFile(name: "MarkdownOutput.symbols.json", content: makeSymbolGraph(moduleName: "MarkdownOutput", platform: iOSPlatform, symbols: [
                 makeSymbol(id: "MarkdownSymbol", kind: .struct, pathComponents: ["MarkdownSymbol"], docComment: "A basic symbol to test markdown output")
             ])),
             InfoPlist(defaultAvailability: [
@@ -912,7 +930,7 @@ struct MarkdownOutputTests {
                 # ``MarkdownSymbol``
                 
                 @Metadata {
-                    @Available(iPadOS, introduced: "13.1")
+                    @Available(iOS, introduced: "13.1")
                 }
                 
                 A basic symbol to test markdown output
@@ -924,8 +942,47 @@ struct MarkdownOutputTests {
         ])
         let (node, _) = try await markdownOutput(catalog: catalog, path: "MarkdownSymbol")
         let availability = try #require(node.metadata.availability)
-        let expected = MarkdownOutputNode.Metadata.Availability(platform: "iPadOS", introduced: "13.1.0", deprecated: nil, unavailable: false)
+        let expected = MarkdownOutputNode.Metadata.Availability(platform: "iOS", introduced: "13.1.0", deprecated: nil, unavailable: false)
         #expect(availability.contains(expected))
+    }
+    
+    @Test
+    func symbolAvailabilityOnePlatformDoesntUseDefaults() async throws {
+        // A symbol that only exists in the macOS graph should not show as available on iOS.
+        let catalog = catalog(files: [
+            JSONFile(
+                name: "MarkdownOutput-macOS.symbols.json",
+                content: makeSymbolGraph(
+                    moduleName: "MarkdownOutput",
+                    platform: macOSPlatform,
+                    symbols: [
+                        makeSymbol(
+                            id: "MarkdownSymbol",
+                            kind: .struct,
+                            pathComponents: ["MarkdownSymbol"],
+                            docComment: "A basic symbol to test markdown output"
+                        )
+                    ]
+                )),
+            JSONFile(
+                name: "MarkdownOutput-iOS.symbols.json",
+                content: makeSymbolGraph(
+                    moduleName: "MarkdownOutput",
+                    platform: iOSPlatform,
+                    symbols: []
+                )),
+            InfoPlist(defaultAvailability: [
+                "MarkdownOutput" : [
+                    .init(platformName: .iOS, platformVersion: "1.0.0"),
+                    .init(platformName: .macOS, platformVersion: "1.0.0"),
+                ]
+            ]),
+        ])
+        
+        let (node, _) = try await markdownOutput(catalog: catalog, path: "MarkdownSymbol")
+        let availability = try #require(node.metadata.availability)
+        #expect(availability.count == 1)
+        #expect(availability.first?.platform == "macOS")
     }
     
     @Test(arguments: [


### PR DESCRIPTION
Bug/issue #, if applicable: 183307404

## Summary

Markdown export was incorrectly using framework default availability in all cases, and only overwriting per-platform when symbol-level markings were there. This didn't make a difference if the symbol graphs contained availability for all platforms, but for symbol graphs generated with `-active-platform-availability-only`, incorrect information was exported.

If symbol-level availability markings are present, then the defaults should not be used at all. 

## Dependencies

N/A

## Testing

1. Create a symbol with platform-specific availability in a multi-platform target, with framework-level default availability for iOS and macOS.

```
/// A class to demonstrate availability
@available(macOS 26.0, *)
@available(iOS, unavailable)
public class MySymbol {
}

2. Export iOS and macOS symbol graphs with the `-active-platform-availability-only` option set: 

```
xcodebuild -scheme YOUR_SCHEME -destination 'generic/platform=macOS' OTHER_SWIFT_FLAGS="-emit-symbol-graph -emit-symbol-graph-dir $(pwd)/output/macos -active-platform-availability-only" build

xcodebuild -scheme YOUR_SCHEME -destination 'generic/platform=iOS' OTHER_SWIFT_FLAGS="-emit-symbol-graph -emit-symbol-graph-dir $(pwd)/output/ios -active-platform-availability-only" build
```

3. Build the documentation for your project with the experimental markdown flag enabled, passing in the symbol graphs linked above for the additional symbol graphs parameter. 

4. Before this change, the MacOS-only symbol would be marked as available for iOS in the markdown export. After this change, it is not. 

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary - N/A
