### PR TITLE
Include symbol relationships in markdown export

### DIFF
--- a/Sources/SwiftDocC/Model/MarkdownOutput/Translation/MarkdownOutputSemanticVisitor.swift
+++ b/Sources/SwiftDocC/Model/MarkdownOutput/Translation/MarkdownOutputSemanticVisitor.swift
@@ -57,23 +57,8 @@ extension MarkdownOutputSemanticVisitor {
         add(targetIdentifier: target.path, type: type, subtype: subtype)
     }
     
-    func pathAndName(from fallbackTarget: String) -> (path: String, name: String) {
-        let path: String
-        let name: String
-        let components = fallbackTarget.components(separatedBy: ".")
-        if components.count > 1 {
-            path = "/documentation/\(components.joined(separator: "/"))"
-            name = components.last ?? fallbackTarget
-        } else {
-            path = fallbackTarget
-            name = fallbackTarget
-        }
-        return (path, name)
-    }
-    
     mutating func add(fallbackTarget: String, type: MarkdownOutputManifest.RelationshipType, subtype: RelationshipsGroup.Kind?) {
-        let (targetIdentifier, _) = pathAndName(from: fallbackTarget)
-        add(targetIdentifier: targetIdentifier, type: type, subtype: subtype)
+        add(targetIdentifier: fallbackTarget, type: type, subtype: subtype)
     }
     
     mutating func add(targetIdentifier: String, type: MarkdownOutputManifest.RelationshipType, subtype: RelationshipsGroup.Kind?) {
@@ -215,9 +200,7 @@ extension MarkdownOutputSemanticVisitor {
                     if let fallback = symbol.relationships.targetFallbacks[destination] {
                         add(fallbackTarget: fallback, type: .relatedSymbol, subtype: relationshipGroup.kind)
                         markdownWalker.startNewParagraphIfRequired()
-                        let (path, name) = pathAndName(from: fallback)
-                        let link = Link(destination: path, title: name, [InlineCode(name)])
-                        markdownWalker.defaultVisit(link)
+                        markdownWalker.defaultVisit(InlineCode(fallback))
                     }
                 }
             }

--- a/Sources/SwiftDocC/Model/MarkdownOutput/Translation/MarkdownOutputSemanticVisitor.swift
+++ b/Sources/SwiftDocC/Model/MarkdownOutput/Translation/MarkdownOutputSemanticVisitor.swift
@@ -57,14 +57,22 @@ extension MarkdownOutputSemanticVisitor {
         add(targetIdentifier: target.path, type: type, subtype: subtype)
     }
     
-    mutating func add(fallbackTarget: String, type: MarkdownOutputManifest.RelationshipType, subtype: RelationshipsGroup.Kind?) {
-        let targetIdentifier: String
+    func pathAndName(from fallbackTarget: String) -> (path: String, name: String) {
+        let path: String
+        let name: String
         let components = fallbackTarget.components(separatedBy: ".")
         if components.count > 1 {
-            targetIdentifier = "/documentation/\(components.joined(separator: "/"))"
+            path = "/documentation/\(components.joined(separator: "/"))"
+            name = components.last ?? fallbackTarget
         } else {
-            targetIdentifier = fallbackTarget
+            path = fallbackTarget
+            name = fallbackTarget
         }
+        return (path, name)
+    }
+    
+    mutating func add(fallbackTarget: String, type: MarkdownOutputManifest.RelationshipType, subtype: RelationshipsGroup.Kind?) {
+        let (targetIdentifier, _) = pathAndName(from: fallbackTarget)
         add(targetIdentifier: targetIdentifier, type: type, subtype: subtype)
     }
     
@@ -187,14 +195,29 @@ extension MarkdownOutputSemanticVisitor {
         
         manifest?.relationships.formUnion(markdownWalker.outgoingReferences)
         
+        if symbol.relationships.groups.isEmpty == false {
+            markdownWalker.visit(Heading(level: 2, Text(RelationshipsSection.title)))
+        }
         for relationshipGroup in symbol.relationships.groups {
+            markdownWalker.visit(Heading(level: 3, Text(relationshipGroup.sectionTitle)))
             for destination in relationshipGroup.destinations {
                 switch context.resolve(destination, in: identifier) {
                 case .success(let resolved):
+                    // Add the relationship to the manifest
                     add(target: resolved, type: .relatedSymbol, subtype: relationshipGroup.kind)
+                    
+                    // Add the relationship to the markdown
+                    markdownWalker.startNewParagraphIfRequired()
+                    let link = Link(destination: resolved.path, title: resolved.lastPathComponent, [InlineCode(resolved.lastPathComponent)])
+                    markdownWalker.defaultVisit(link)
+                    
                 case .failure:
                     if let fallback = symbol.relationships.targetFallbacks[destination] {
                         add(fallbackTarget: fallback, type: .relatedSymbol, subtype: relationshipGroup.kind)
+                        markdownWalker.startNewParagraphIfRequired()
+                        let (path, name) = pathAndName(from: fallback)
+                        let link = Link(destination: path, title: name, [InlineCode(name)])
+                        markdownWalker.defaultVisit(link)
                     }
                 }
             }

--- a/Tests/SwiftDocCTests/Rendering/Markdown/MarkdownOutputTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/Markdown/MarkdownOutputTests.swift
@@ -766,6 +766,106 @@ struct MarkdownOutputTests {
         #expect(node.markdown.contains(expectedList))
     }
     
+    @Test
+    func conformsToIncludedInExport() async throws {
+        let symbols = [
+            makeSymbol(id: "MO_Conformer", kind: .struct, pathComponents: ["LocalConformer"]),
+            makeSymbol(id: "MO_Protocol", kind: .protocol, pathComponents: ["LocalProtocol"]),
+        ]
+        
+        let relationships = [
+            SymbolGraph.Relationship(source: "MO_Conformer", target: "MO_Protocol", kind: .conformsTo, targetFallback: nil),
+            SymbolGraph.Relationship(source: "MO_Conformer", target: "s:SH", kind: .conformsTo, targetFallback: "Swift.Hashable")
+        ]
+        
+        let catalog = catalog(files: [
+            JSONFile(name: "MarkdownOutput.symbols.json", content:
+                    makeSymbolGraph(moduleName: "MarkdownOutput", symbols: symbols, relationships: relationships))
+        ])
+        
+        let (node, _) = try await markdownOutput(catalog: catalog, path: "LocalConformer")
+        let title = RelationshipsGroup(kind: .conformsTo, destinations: []).sectionTitle
+        let markdown = node.markdown
+        #expect(markdown.contains(title))
+        let link = "\n[`LocalProtocol`](/documentation/MarkdownOutput/LocalProtocol)"
+        #expect(markdown.contains(link))
+        let externalLink = "\n[`Hashable`](/documentation/Swift/Hashable)"
+        #expect(markdown.contains(externalLink))
+    }
+    
+    @Test
+    func conformingTypesIncludedInExport() async throws {
+        let symbols = [
+            makeSymbol(id: "MO_Conformer", kind: .struct, pathComponents: ["LocalConformer"]),
+            makeSymbol(id: "MO_Protocol", kind: .protocol, pathComponents: ["LocalProtocol"]),
+        ]
+        
+        let relationships = [
+            SymbolGraph.Relationship(source: "MO_Conformer", target: "MO_Protocol", kind: .conformsTo, targetFallback: nil),
+        ]
+        
+        let catalog = catalog(files: [
+            JSONFile(name: "MarkdownOutput.symbols.json", content:
+                    makeSymbolGraph(moduleName: "MarkdownOutput", symbols: symbols, relationships: relationships))
+        ])
+        
+        let (node, _) = try await markdownOutput(catalog: catalog, path: "LocalProtocol")
+        let title = RelationshipsGroup(kind: .conformingTypes, destinations: []).sectionTitle
+        let markdown = node.markdown
+        #expect(markdown.contains(title))
+        let link = "\n[`LocalConformer`](/documentation/MarkdownOutput/LocalConformer)"
+        #expect(markdown.contains(link))
+    }
+    
+    @Test
+    func inheritsFromIncludedInExport() async throws {
+        let symbols = [
+            makeSymbol(id: "MO_Super", kind: .class, pathComponents: ["LocalSuper"]),
+            makeSymbol(id: "MO_Sub", kind: .class, pathComponents: ["LocalSub"]),
+        ]
+        
+        let relationships = [
+            SymbolGraph.Relationship(source: "MO_Sub", target: "MO_Super", kind: .inheritsFrom, targetFallback: nil),
+        ]
+        
+        let catalog = catalog(files: [
+            JSONFile(name: "MarkdownOutput.symbols.json", content:
+                    makeSymbolGraph(moduleName: "MarkdownOutput", symbols: symbols, relationships: relationships))
+        ])
+        
+        let (node, _) = try await markdownOutput(catalog: catalog, path: "LocalSub")
+        let title = RelationshipsGroup(kind: .inheritsFrom, destinations: []).sectionTitle
+        let markdown = node.markdown
+        #expect(markdown.contains(title))
+        let link = "\n[`LocalSuper`](/documentation/MarkdownOutput/LocalSuper)"
+        #expect(markdown.contains(link))
+    }
+    
+    @Test
+    func inheritedByIncludedInExport() async throws {
+        let symbols = [
+            makeSymbol(id: "MO_Super", kind: .class, pathComponents: ["LocalSuper"]),
+            makeSymbol(id: "MO_Sub", kind: .class, pathComponents: ["LocalSub"]),
+        ]
+        
+        let relationships = [
+            SymbolGraph.Relationship(source: "MO_Sub", target: "MO_Super", kind: .inheritsFrom, targetFallback: nil),
+        ]
+        
+        let catalog = catalog(files: [
+            JSONFile(name: "MarkdownOutput.symbols.json", content:
+                    makeSymbolGraph(moduleName: "MarkdownOutput", symbols: symbols, relationships: relationships))
+        ])
+        
+        let (node, _) = try await markdownOutput(catalog: catalog, path: "LocalSuper")
+        let title = RelationshipsGroup(kind: .inheritedBy, destinations: []).sectionTitle
+        let markdown = node.markdown
+        #expect(markdown.contains(title))
+        let link = "\n[`LocalSub`](/documentation/MarkdownOutput/LocalSub)"
+        #expect(markdown.contains(link))
+    }
+    
+    
     // MARK: - Metadata
     
     @Test 

--- a/Tests/SwiftDocCTests/Rendering/Markdown/MarkdownOutputTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/Markdown/MarkdownOutputTests.swift
@@ -789,7 +789,8 @@ struct MarkdownOutputTests {
         let localProtocolLink = "\n[`LocalProtocol`](/documentation/MarkdownOutput/LocalProtocol)"
         #expect(conformerMarkdown.contains(localProtocolLink))
         let externalProtocolLink = "\n[`Hashable`](/documentation/Swift/Hashable)"
-        #expect(conformerMarkdown.contains(externalProtocolLink))
+        #expect(conformerMarkdown.contains(externalProtocolLink) == false)
+        #expect(conformerMarkdown.contains("\n`Swift.Hashable`"))
         
         let (protocolNode, _) = try await markdownOutput(catalog: catalog, path: "LocalProtocol")
         let protocolMarkdown = protocolNode.markdown
@@ -1299,11 +1300,11 @@ struct MarkdownOutputTests {
                         symbols: [
                             makeSymbol(id: "local-conformer-id", kind: .struct, pathComponents: ["LocalConformer"]),
                             makeSymbol(id: "local-protocol-id", kind: .protocol, pathComponents: ["LocalProtocol"]),
-                            makeSymbol(id: "external-protocol-id", kind: .struct, pathComponents: ["ExternalConformer"])
+                            makeSymbol(id: "external-conformer-id", kind: .struct, pathComponents: ["ExternalConformer"])
                         ],
                         relationships: [
                             SymbolGraph.Relationship(source: "local-conformer-id", target: "local-protocol-id", kind: .conformsTo, targetFallback: nil),
-                            SymbolGraph.Relationship(source: "external-protocol-id", target: "s:SH", kind: .conformsTo, targetFallback: "Swift.Hashable")
+                            SymbolGraph.Relationship(source: "external-conformer-id", target: "s:SH", kind: .conformsTo, targetFallback: "Swift.Hashable")
                         ]
                     ))
         ])
@@ -1322,8 +1323,9 @@ struct MarkdownOutputTests {
         
         let (_, externalManifest) = try await markdownOutput(catalog: catalog, path: "ExternalConformer")
         let externalRelated = externalManifest.relationships.filter { $0.relationshipType == .relatedSymbol }
+        // Unresolved symbol should use the fallback identifier
         #expect(externalRelated.contains(where: {
-            $0.targetIdentifier == "/documentation/Swift/Hashable" && $0.subtype == .conformsTo
+            $0.targetIdentifier == "Swift.Hashable" && $0.subtype == .conformsTo
         }))
     }
 }

--- a/Tests/SwiftDocCTests/Rendering/Markdown/MarkdownOutputTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/Markdown/MarkdownOutputTests.swift
@@ -235,7 +235,7 @@ struct MarkdownOutputTests {
                 
                 """),
             JSONFile(name: "MarkdownOutput.symbols.json", content: makeSymbolGraph(moduleName: "MarkdownOutput", symbols: [
-                makeSymbol(id: "MarkdownSymbol", kind: .struct, pathComponents: ["MarkdownSymbol"], docComment: "A basic symbol to test markdown output")
+                makeSymbol(id: "markdown-symbol-id", kind: .struct, pathComponents: ["MarkdownSymbol"], docComment: "A basic symbol to test markdown output")
             ]))
         ])
         
@@ -276,8 +276,8 @@ struct MarkdownOutputTests {
                 - ``OtherMarkdownSymbol``
                 """),
             JSONFile(name: "MarkdownOutput.symbols.json", content: makeSymbolGraph(moduleName: "MarkdownOutput", symbols: [
-                makeSymbol(id: "MarkdownSymbol", kind: .struct, pathComponents: ["MarkdownSymbol"], docComment: "A basic symbol to test markdown output. Different to ``OtherMarkdownSymbol``"),
-                makeSymbol(id: "OtherMarkdownSymbol", kind: .struct, pathComponents: ["OtherMarkdownSymbol"], docComment: "A basic symbol to test markdown output. Different to ``MarkdownSymbol``")
+                makeSymbol(id: "markdown-symbol-id", kind: .struct, pathComponents: ["MarkdownSymbol"], docComment: "A basic symbol to test markdown output. Different to ``OtherMarkdownSymbol``"),
+                makeSymbol(id: "other-markdown-symbol-id", kind: .struct, pathComponents: ["OtherMarkdownSymbol"], docComment: "A basic symbol to test markdown output. Different to ``MarkdownSymbol``")
             ]))
         ])
         
@@ -767,105 +767,66 @@ struct MarkdownOutputTests {
     }
     
     @Test
-    func conformsToIncludedInExport() async throws {
-        let symbols = [
-            makeSymbol(id: "MO_Conformer", kind: .struct, pathComponents: ["LocalConformer"]),
-            makeSymbol(id: "MO_Protocol", kind: .protocol, pathComponents: ["LocalProtocol"]),
-        ]
-        
-        let relationships = [
-            SymbolGraph.Relationship(source: "MO_Conformer", target: "MO_Protocol", kind: .conformsTo, targetFallback: nil),
-            SymbolGraph.Relationship(source: "MO_Conformer", target: "s:SH", kind: .conformsTo, targetFallback: "Swift.Hashable")
-        ]
-        
+    func protocolRelationshipsIncludedInExport() async throws {
         let catalog = catalog(files: [
             JSONFile(name: "MarkdownOutput.symbols.json", content:
-                    makeSymbolGraph(moduleName: "MarkdownOutput", symbols: symbols, relationships: relationships))
+                    makeSymbolGraph(
+                        moduleName: "MarkdownOutput",
+                        symbols: [
+                            makeSymbol(id: "local-conformer-id", kind: .struct, pathComponents: ["LocalConformer"]),
+                            makeSymbol(id: "local-protocol-id", kind: .protocol, pathComponents: ["LocalProtocol"]),
+                        ],
+                        relationships: [
+                            SymbolGraph.Relationship(source: "local-conformer-id", target: "local-protocol-id", kind: .conformsTo, targetFallback: nil),
+                            SymbolGraph.Relationship(source: "local-conformer-id", target: "s:SH", kind: .conformsTo, targetFallback: "Swift.Hashable")
+                        ]
+                    ))
         ])
         
-        let (node, _) = try await markdownOutput(catalog: catalog, path: "LocalConformer")
-        let title = RelationshipsGroup(kind: .conformsTo, destinations: []).sectionTitle
-        let markdown = node.markdown
-        #expect(markdown.contains(title))
-        let link = "\n[`LocalProtocol`](/documentation/MarkdownOutput/LocalProtocol)"
-        #expect(markdown.contains(link))
-        let externalLink = "\n[`Hashable`](/documentation/Swift/Hashable)"
-        #expect(markdown.contains(externalLink))
+        let (conformerNode, _) = try await markdownOutput(catalog: catalog, path: "LocalConformer")
+        let conformerMarkdown = conformerNode.markdown
+        #expect(conformerMarkdown.contains(RelationshipsGroup(kind: .conformsTo, destinations: []).sectionTitle))
+        let localProtocolLink = "\n[`LocalProtocol`](/documentation/MarkdownOutput/LocalProtocol)"
+        #expect(conformerMarkdown.contains(localProtocolLink))
+        let externalProtocolLink = "\n[`Hashable`](/documentation/Swift/Hashable)"
+        #expect(conformerMarkdown.contains(externalProtocolLink))
+        
+        let (protocolNode, _) = try await markdownOutput(catalog: catalog, path: "LocalProtocol")
+        let protocolMarkdown = protocolNode.markdown
+        #expect(protocolMarkdown.contains(RelationshipsGroup(kind: .conformingTypes, destinations: []).sectionTitle))
+        let conformerLink = "\n[`LocalConformer`](/documentation/MarkdownOutput/LocalConformer)"
+        #expect(protocolMarkdown.contains(conformerLink))
     }
-    
+        
     @Test
-    func conformingTypesIncludedInExport() async throws {
-        let symbols = [
-            makeSymbol(id: "MO_Conformer", kind: .struct, pathComponents: ["LocalConformer"]),
-            makeSymbol(id: "MO_Protocol", kind: .protocol, pathComponents: ["LocalProtocol"]),
-        ]
-        
-        let relationships = [
-            SymbolGraph.Relationship(source: "MO_Conformer", target: "MO_Protocol", kind: .conformsTo, targetFallback: nil),
-        ]
-        
+    func inheritanceRelationshipsIncludedInExport() async throws {
         let catalog = catalog(files: [
             JSONFile(name: "MarkdownOutput.symbols.json", content:
-                    makeSymbolGraph(moduleName: "MarkdownOutput", symbols: symbols, relationships: relationships))
+                    makeSymbolGraph(
+                        moduleName: "MarkdownOutput",
+                        symbols: [
+                            makeSymbol(id: "local-superclass-id", kind: .class, pathComponents: ["LocalSuper"]),
+                            makeSymbol(id: "local-subclass-id", kind: .class, pathComponents: ["LocalSub"]),
+                        ],
+                        relationships: [
+                            SymbolGraph.Relationship(source: "local-subclass-id", target: "local-superclass-id", kind: .inheritsFrom, targetFallback: nil),
+                        ]
+                    ))
         ])
         
-        let (node, _) = try await markdownOutput(catalog: catalog, path: "LocalProtocol")
-        let title = RelationshipsGroup(kind: .conformingTypes, destinations: []).sectionTitle
-        let markdown = node.markdown
-        #expect(markdown.contains(title))
-        let link = "\n[`LocalConformer`](/documentation/MarkdownOutput/LocalConformer)"
-        #expect(markdown.contains(link))
+        let (inheritorNode, _) = try await markdownOutput(catalog: catalog, path: "LocalSub")
+        let inheritorMarkdown = inheritorNode.markdown
+        #expect(inheritorMarkdown.contains(RelationshipsGroup(kind: .inheritsFrom, destinations: []).sectionTitle))
+        let superclassLink = "\n[`LocalSuper`](/documentation/MarkdownOutput/LocalSuper)"
+        #expect(inheritorMarkdown.contains(superclassLink))
+        
+        let (superclassNode, _) = try await markdownOutput(catalog: catalog, path: "LocalSuper")
+        let superclassMarkdown = superclassNode.markdown
+        #expect(superclassMarkdown.contains(RelationshipsGroup(kind: .inheritedBy, destinations: []).sectionTitle))
+        let subclassLink = "\n[`LocalSub`](/documentation/MarkdownOutput/LocalSub)"
+        #expect(superclassMarkdown.contains(subclassLink))
     }
-    
-    @Test
-    func inheritsFromIncludedInExport() async throws {
-        let symbols = [
-            makeSymbol(id: "MO_Super", kind: .class, pathComponents: ["LocalSuper"]),
-            makeSymbol(id: "MO_Sub", kind: .class, pathComponents: ["LocalSub"]),
-        ]
-        
-        let relationships = [
-            SymbolGraph.Relationship(source: "MO_Sub", target: "MO_Super", kind: .inheritsFrom, targetFallback: nil),
-        ]
-        
-        let catalog = catalog(files: [
-            JSONFile(name: "MarkdownOutput.symbols.json", content:
-                    makeSymbolGraph(moduleName: "MarkdownOutput", symbols: symbols, relationships: relationships))
-        ])
-        
-        let (node, _) = try await markdownOutput(catalog: catalog, path: "LocalSub")
-        let title = RelationshipsGroup(kind: .inheritsFrom, destinations: []).sectionTitle
-        let markdown = node.markdown
-        #expect(markdown.contains(title))
-        let link = "\n[`LocalSuper`](/documentation/MarkdownOutput/LocalSuper)"
-        #expect(markdown.contains(link))
-    }
-    
-    @Test
-    func inheritedByIncludedInExport() async throws {
-        let symbols = [
-            makeSymbol(id: "MO_Super", kind: .class, pathComponents: ["LocalSuper"]),
-            makeSymbol(id: "MO_Sub", kind: .class, pathComponents: ["LocalSub"]),
-        ]
-        
-        let relationships = [
-            SymbolGraph.Relationship(source: "MO_Sub", target: "MO_Super", kind: .inheritsFrom, targetFallback: nil),
-        ]
-        
-        let catalog = catalog(files: [
-            JSONFile(name: "MarkdownOutput.symbols.json", content:
-                    makeSymbolGraph(moduleName: "MarkdownOutput", symbols: symbols, relationships: relationships))
-        ])
-        
-        let (node, _) = try await markdownOutput(catalog: catalog, path: "LocalSuper")
-        let title = RelationshipsGroup(kind: .inheritedBy, destinations: []).sectionTitle
-        let markdown = node.markdown
-        #expect(markdown.contains(title))
-        let link = "\n[`LocalSub`](/documentation/MarkdownOutput/LocalSub)"
-        #expect(markdown.contains(link))
-    }
-    
-    
+     
     // MARK: - Metadata
     
     @Test 
@@ -950,7 +911,7 @@ struct MarkdownOutputTests {
     func symbolDocumentHasSymbolType() async throws {
         let catalog = catalog(files: [
             JSONFile(name: "MarkdownOutput.symbols.json", content: makeSymbolGraph(moduleName: "MarkdownOutput", symbols: [
-                makeSymbol(id: "MarkdownSymbol", kind: .struct, pathComponents: ["MarkdownSymbol"], docComment: "A basic symbol to test markdown output")
+                makeSymbol(id: "markdown-symbol-id", kind: .struct, pathComponents: ["MarkdownSymbol"], docComment: "A basic symbol to test markdown output")
             ]))
         ])
         let (node, _) = try await markdownOutput(catalog: catalog, path: "MarkdownSymbol")
@@ -961,8 +922,8 @@ struct MarkdownOutputTests {
     func symbolDocumentPopulatesMetadata() async throws {
         let catalog = catalog(files: [
             JSONFile(name: "MarkdownOutput.symbols.json", content: makeSymbolGraph(moduleName: "MarkdownOutput", symbols: [
-                makeSymbol(id: "MarkdownSymbol", kind: .struct, pathComponents: ["MarkdownSymbol"], docComment: "A basic symbol to test markdown output"),
-                makeSymbol(id: "MarkdownSymbol_init_name", kind: .`init`, pathComponents: ["MarkdownSymbol", "init(name:)"])
+                makeSymbol(id: "markdown-symbol-id", kind: .struct, pathComponents: ["MarkdownSymbol"], docComment: "A basic symbol to test markdown output"),
+                makeSymbol(id: "markdown-symbol-init-name-id", kind: .`init`, pathComponents: ["MarkdownSymbol", "init(name:)"])
             ]))
         ])
         let (node, _) = try await markdownOutput(catalog: catalog, path: "MarkdownSymbol/init(name:)")
@@ -976,7 +937,7 @@ struct MarkdownOutputTests {
     func symbolExtendedModulePopulatesMetadata() async throws {
         let catalog = catalog(files: [
             JSONFile(name: "MarkdownOutput.symbols.json", content: makeSymbolGraph(moduleName: "MarkdownOutput", symbols: [
-                makeSymbol(id: "Array_asdf", kind: .property, pathComponents: ["Swift", "Array", "asdf"], otherMixins: [SymbolGraph.Symbol.Swift.Extension(extendedModule: "Swift", constraints: [])])
+                makeSymbol(id: "array-asdf-id", kind: .property, pathComponents: ["Swift", "Array", "asdf"], otherMixins: [SymbolGraph.Symbol.Swift.Extension(extendedModule: "Swift", constraints: [])])
                 ])
              )
         ])
@@ -991,7 +952,7 @@ struct MarkdownOutputTests {
     func symbolMetadataGetsDefaultAvailability() async throws {
         let catalog = catalog(files: [
             JSONFile(name: "MarkdownOutput.symbols.json", content: makeSymbolGraph(moduleName: "MarkdownOutput", platform: iOSPlatform, symbols: [
-                makeSymbol(id: "MarkdownSymbol", kind: .struct, pathComponents: ["MarkdownSymbol"], docComment: "A basic symbol to test markdown output")
+                makeSymbol(id: "markdown-symbol-id", kind: .struct, pathComponents: ["MarkdownSymbol"], docComment: "A basic symbol to test markdown output")
             ])),
             InfoPlist(defaultAvailability: [
                 "MarkdownOutput" : [.init(platformName: .iOS, platformVersion: "1.0.0")]
@@ -1006,7 +967,7 @@ struct MarkdownOutputTests {
     func symbolMetadataGetsSymbolLevelAvailability() async throws {
         let catalog = catalog(files: [
             JSONFile(name: "MarkdownOutput.symbols.json", content: makeSymbolGraph(moduleName: "MarkdownOutput", platform: iOSPlatform, symbols: [
-                makeSymbol(id: "MarkdownSymbol", kind: .struct, pathComponents: ["MarkdownSymbol"], docComment: "A basic symbol to test markdown output", availability: [.init(domainName: "iOS", introduced: .init(string: "2.0.0"), deprecated: nil)])
+                makeSymbol(id: "markdown-symbol-id", kind: .struct, pathComponents: ["MarkdownSymbol"], docComment: "A basic symbol to test markdown output", availability: [.init(domainName: "iOS", introduced: .init(string: "2.0.0"), deprecated: nil)])
             ])),
             InfoPlist(defaultAvailability: [
                 "MarkdownOutput" : [.init(platformName: .iOS, platformVersion: "1.0.0")]
@@ -1021,7 +982,7 @@ struct MarkdownOutputTests {
     func symbolAvailabilityIsCapturedFromMetadataBlock() async throws {
         let catalog = catalog(files: [
             JSONFile(name: "MarkdownOutput.symbols.json", content: makeSymbolGraph(moduleName: "MarkdownOutput", platform: iOSPlatform, symbols: [
-                makeSymbol(id: "MarkdownSymbol", kind: .struct, pathComponents: ["MarkdownSymbol"], docComment: "A basic symbol to test markdown output")
+                makeSymbol(id: "markdown-symbol-id", kind: .struct, pathComponents: ["MarkdownSymbol"], docComment: "A basic symbol to test markdown output")
             ])),
             InfoPlist(defaultAvailability: [
                 "MarkdownOutput" : [.init(platformName: .iOS, platformVersion: "1.0.0")]
@@ -1057,7 +1018,7 @@ struct MarkdownOutputTests {
                     platform: macOSPlatform,
                     symbols: [
                         makeSymbol(
-                            id: "MarkdownSymbol",
+                            id: "markdown-symbol-id",
                             kind: .struct,
                             pathComponents: ["MarkdownSymbol"],
                             docComment: "A basic symbol to test markdown output"
@@ -1110,9 +1071,9 @@ struct MarkdownOutputTests {
     func symbolDeprecationRepresentedInMetadata() async throws {
         let catalog = catalog(files: [
             JSONFile(name: "MarkdownOutput.symbols.json", content: makeSymbolGraph(moduleName: "MarkdownOutput", symbols: [
-                makeSymbol(id: "MarkdownSymbol", kind: .struct, pathComponents: ["MarkdownSymbol"], docComment: "A basic symbol to test markdown output"),
+                makeSymbol(id: "markdown-symbol-id", kind: .struct, pathComponents: ["MarkdownSymbol"], docComment: "A basic symbol to test markdown output"),
                 makeSymbol(
-                    id: "MarkdownSymbol_fullName",
+                    id: "markdown-symbol_full-name-id",
                     kind: .property,
                     pathComponents: ["MarkdownSymbol", "fullName"],
                     docComment: "A basic property to test markdown output",
@@ -1171,12 +1132,12 @@ struct MarkdownOutputTests {
     func symbolIdentifierMatchesSymbolGraph() async throws {
         let catalog = catalog(files: [
             JSONFile(name: "MarkdownOutput.symbols.json", content: makeSymbolGraph(moduleName: "MarkdownOutput", symbols: [
-                makeSymbol(id: "MarkdownSymbol_Identifier", kind: .struct, pathComponents: ["MarkdownSymbol"], docComment: "A basic symbol to test markdown output"),
+                makeSymbol(id: "markdown-symbol-id", kind: .struct, pathComponents: ["MarkdownSymbol"], docComment: "A basic symbol to test markdown output"),
             ]))
         ])
         
         let (node, _) = try await markdownOutput(catalog: catalog, path: "MarkdownSymbol")
-        #expect(node.metadata.symbol?.preciseIdentifier == "MarkdownSymbol_Identifier")
+        #expect(node.metadata.symbol?.preciseIdentifier == "markdown-symbol-id")
     }
     
     @Test
@@ -1227,7 +1188,7 @@ struct MarkdownOutputTests {
                 - ``MarkdownSymbol``
                 """),
             JSONFile(name: "MarkdownOutput.symbols.json", content: makeSymbolGraph(moduleName: "MarkdownOutput", symbols: [
-                makeSymbol(id: "MarkdownSymbol", kind: .struct, pathComponents: ["MarkdownSymbol"], docComment: "A basic symbol to test markdown output")
+                makeSymbol(id: "markdown-symbol-id", kind: .struct, pathComponents: ["MarkdownSymbol"], docComment: "A basic symbol to test markdown output")
             ]))
         ])
         
@@ -1244,7 +1205,7 @@ struct MarkdownOutputTests {
         
         let catalog = catalog(files: [
             JSONFile(name: "MarkdownOutput.symbols.json", content: makeSymbolGraph(moduleName: "MarkdownOutput", symbols: [
-                makeSymbol(id: "MarkdownSymbol_Identifier", kind: .struct, pathComponents: ["MarkdownSymbol"], docComment: "A basic symbol to test markdown output"),
+                makeSymbol(id: "markdown-symbol-id", kind: .struct, pathComponents: ["MarkdownSymbol"], docComment: "A basic symbol to test markdown output"),
             ])),
             TextFile(name: "RowsAndColumns.md", utf8Content: """
                 # Rows and Columns
@@ -1300,18 +1261,18 @@ struct MarkdownOutputTests {
     @Test
     func symbolInheritancePopulatesManifest() async throws {
         
-        let symbols = [
-            makeSymbol(id: "MO_Subclass", kind: .class, pathComponents: ["LocalSubclass"]),
-            makeSymbol(id: "MO_Superclass", kind: .class, pathComponents: ["LocalSuperclass"])
-        ]
-        
-        let relationships = [
-            SymbolGraph.Relationship(source: "MO_Subclass", target: "MO_Superclass", kind: .inheritsFrom, targetFallback: nil)
-        ]
-        
         let catalog = catalog(files: [
             JSONFile(name: "MarkdownOutput.symbols.json", content:
-                    makeSymbolGraph(moduleName: "MarkdownOutput", symbols: symbols, relationships: relationships))
+                    makeSymbolGraph(
+                        moduleName: "MarkdownOutput",
+                        symbols: [
+                            makeSymbol(id: "local-subclass-id", kind: .class, pathComponents: ["LocalSubclass"]),
+                            makeSymbol(id: "local-superclass-id", kind: .class, pathComponents: ["LocalSuperclass"])
+                        ],
+                        relationships: [
+                            SymbolGraph.Relationship(source: "local-subclass-id", target: "local-superclass-id", kind: .inheritsFrom, targetFallback: nil)
+                        ]
+                    ))
         ])
         
         
@@ -1330,21 +1291,21 @@ struct MarkdownOutputTests {
         
     @Test
     func symbolConformancePopulatesManifest() async throws {
-        
-        let symbols = [
-            makeSymbol(id: "MO_Conformer", kind: .struct, pathComponents: ["LocalConformer"]),
-            makeSymbol(id: "MO_Protocol", kind: .protocol, pathComponents: ["LocalProtocol"]),
-            makeSymbol(id: "MO_ExternalConformer", kind: .struct, pathComponents: ["ExternalConformer"])
-        ]
-        
-        let relationships = [
-            SymbolGraph.Relationship(source: "MO_Conformer", target: "MO_Protocol", kind: .conformsTo, targetFallback: nil),
-            SymbolGraph.Relationship(source: "MO_ExternalConformer", target: "s:SH", kind: .conformsTo, targetFallback: "Swift.Hashable")
-        ]
-        
+                
         let catalog = catalog(files: [
             JSONFile(name: "MarkdownOutput.symbols.json", content:
-                    makeSymbolGraph(moduleName: "MarkdownOutput", symbols: symbols, relationships: relationships))
+                    makeSymbolGraph(
+                        moduleName: "MarkdownOutput",
+                        symbols: [
+                            makeSymbol(id: "local-conformer-id", kind: .struct, pathComponents: ["LocalConformer"]),
+                            makeSymbol(id: "local-protocol-id", kind: .protocol, pathComponents: ["LocalProtocol"]),
+                            makeSymbol(id: "external-protocol-id", kind: .struct, pathComponents: ["ExternalConformer"])
+                        ],
+                        relationships: [
+                            SymbolGraph.Relationship(source: "local-conformer-id", target: "local-protocol-id", kind: .conformsTo, targetFallback: nil),
+                            SymbolGraph.Relationship(source: "external-protocol-id", target: "s:SH", kind: .conformsTo, targetFallback: "Swift.Hashable")
+                        ]
+                    ))
         ])
         
         let (_, manifest) = try await markdownOutput(catalog: catalog, path: "LocalConformer")


### PR DESCRIPTION
<!--
If you are opening a pull request against a release branch, see
https://www.swift.org/contributing#release-branch-pull-requests
-->

Bug/issue #, if applicable: 183133511

## Summary

Symbol relationships (conforms to, conforming types, inherited by, inherits from) are not currently included in the exported markdown document. While those relationships are available in the manifest, it is still useful content which should be included in the markdown file.

## Dependencies

N/A

## Testing

1. Generate markdown export from any documented project containing protocol or class relationships by running the `convert` command with the `--enable-experimental-markdown-output` flag. 
2. Open the markdown file for a symbol with protocol or class relationships
3. Observe that there is no **Relationships** section (before this change), or that there is now a **Relationships** section containing sub-sections for the relevant relationships categories (conforms to, conforming types, inherits from, inherited by, as appropriate)

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary: N/A
