### PR TITLE
Don't add section headers for markdown sections that turn out to have no content

### DIFF
--- a/Sources/SwiftDocC/Model/MarkdownOutput/Translation/MarkdownOutputMarkdownWalker.swift
+++ b/Sources/SwiftDocC/Model/MarkdownOutput/Translation/MarkdownOutputMarkdownWalker.swift
@@ -72,6 +72,9 @@ extension MarkdownOutputMarkupWalker {
             return
         }
         
+        // Some content is filtered from the markdown export. If this entire section consists of filtered content, the heading should not be added. 
+        let markdownBeforeSection = markdown
+        
         if let heading = addingHeading ?? type(of: section).title, heading.isEmpty == false {
             // Don't add if there is already a heading in the content
             if let first = section.content.first as? Heading, first.level == 2 {
@@ -80,9 +83,15 @@ extension MarkdownOutputMarkupWalker {
                 visit(Heading(level: 2, Text(heading)))
             }
         }
+        let markdownWithSectionHeading = markdown
         
         for content in section.content {
             self.visit(content)
+        }
+        
+        if markdown == markdownWithSectionHeading {
+            // No content was added for this section, revert to where we were before
+            markdown = markdownBeforeSection
         }
     }
         

--- a/Tests/SwiftDocCTests/Rendering/Markdown/MarkdownOutputTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/Markdown/MarkdownOutputTests.swift
@@ -769,8 +769,13 @@ struct MarkdownOutputTests {
     @Test
     func sectionsThatAreEmptyAfterFilteringDoNotHaveHeadingsAdded() async throws {
         let catalog = catalog(files: [
-            JSONFile(name: "MarkdownOutput.symbols.json", content: makeSymbolGraph(moduleName: "MarkdownOutput", symbols: [
-                makeSymbol(id: "MarkdownSymbol.myFunction", kind: .method, pathComponents: ["MarkdownSymbol", "myFunction(_:)"], docComment: """
+            JSONFile(
+                name: "MarkdownOutput.symbols.json",
+                content: makeSymbolGraph(
+                    moduleName: "MarkdownOutput",
+                    symbols: [
+                        makeSymbol(id: "markdown-symbol-id", kind: .struct, pathComponents: ["MarkdownSymbol"]),
+                        makeSymbol(id: "markdown-symbol-my-function-id", kind: .method, pathComponents: ["MarkdownSymbol", "myFunction(_:)"], docComment: """
                     Everything is described in the abstract.
                     
                     - Parameters:
@@ -780,7 +785,10 @@ struct MarkdownOutputTests {
                         This should be removed, but should not lead to a discussion heading.
                     }
                     """)
-            ]
+                    ],
+                    relationships: [
+                        .init(source: "markdown-symbol-my-function-id", target: "markdown-symbol-id", kind: .memberOf, targetFallback: nil)
+                    ]
             ))
         ])
         let (node, _) = try await markdownOutput(catalog: catalog, path: "MarkdownSymbol/myFunction(_:)")

--- a/Tests/SwiftDocCTests/Rendering/Markdown/MarkdownOutputTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/Markdown/MarkdownOutputTests.swift
@@ -766,6 +766,28 @@ struct MarkdownOutputTests {
         #expect(node.markdown.contains(expectedList))
     }
     
+    @Test
+    func sectionsThatAreEmptyAfterFilteringDoNotHaveHeadingsAdded() async throws {
+        let catalog = catalog(files: [
+            JSONFile(name: "MarkdownOutput.symbols.json", content: makeSymbolGraph(moduleName: "MarkdownOutput", symbols: [
+                makeSymbol(id: "MarkdownSymbol.myFunction", kind: .method, pathComponents: ["MarkdownSymbol", "myFunction(_:)"], docComment: """
+                    Everything is described in the abstract.
+                    
+                    - Parameters:
+                      - arg: The first argument. 
+                    
+                    @Comment {
+                        This should be removed, but should not lead to a discussion heading.
+                    }
+                    """)
+            ]
+            ))
+        ])
+        let (node, _) = try await markdownOutput(catalog: catalog, path: "MarkdownSymbol/myFunction(_:)")
+        #expect(node.markdown.contains("## Parameters"))
+        #expect(node.markdown.contains("## Discussion") == false)
+    }
+    
     // MARK: - Metadata
     
     @Test 

--- a/Tests/SwiftDocCTests/Rendering/Markdown/MarkdownOutputTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/Markdown/MarkdownOutputTests.swift
@@ -774,7 +774,21 @@ struct MarkdownOutputTests {
                 content: makeSymbolGraph(
                     moduleName: "MarkdownOutput",
                     symbols: [
-                        makeSymbol(id: "markdown-symbol-id", kind: .struct, pathComponents: ["MarkdownSymbol"]),
+                        makeSymbol(id: "markdown-symbol-id", kind: .struct, pathComponents: ["MarkdownSymbol"], docComment: """
+                            Abstract.
+                                                        
+                            The next heading will appear in the output as it does not imply a `Section` in the document so is just markdown content. The last two headings should not appear, because they are `Section`s, but have no section content.
+                            
+                            ## Random heading
+                            
+                            ## Topics
+                            
+                            ## See Also
+                            
+                            @Comment {
+                                This should be removed, but should not lead to a See Also heading.
+                            }
+                            """),
                         makeSymbol(id: "markdown-symbol-my-function-id", kind: .method, pathComponents: ["MarkdownSymbol", "myFunction(_:)"], docComment: """
                     Everything is described in the abstract.
                     
@@ -791,9 +805,15 @@ struct MarkdownOutputTests {
                     ]
             ))
         ])
-        let (node, _) = try await markdownOutput(catalog: catalog, path: "MarkdownSymbol/myFunction(_:)")
-        #expect(node.markdown.contains("## Parameters"))
-        #expect(node.markdown.contains("## Discussion") == false)
+        let (functionNode, _) = try await markdownOutput(catalog: catalog, path: "MarkdownSymbol/myFunction(_:)")
+        #expect(functionNode.markdown.contains("## Parameters"))
+        #expect(functionNode.markdown.contains("## Discussion") == false)
+        
+        let (structNode, _) = try await markdownOutput(catalog: catalog, path: "MarkdownSymbol")
+        #expect(structNode.markdown.contains("## Overview"))
+        #expect(structNode.markdown.contains("## Random heading"))
+        #expect(structNode.markdown.contains("## Topics") == false)
+        #expect(structNode.markdown.contains("## See Also") == false)
     }
     
     // MARK: - Metadata


### PR DESCRIPTION
Bug/issue #, if applicable: 183308686

## Summary

When generating markdown exports, some documents have section headings with no content. This is because some kinds of content (e.g. HTML, comments) are excluded from output. This PR amends the markdown export to not include these empty section headers by checking that content was actually added during processing of a section.

## Dependencies

N/A

## Testing

Define a function with markdown-exlcluded content forming the entire discussion: 

```
/// Does things that can be described very briefly.
    ///
    /// - Parameters:
    ///   - code: The code you pass in.
    ///
    ///   @Comment { this is a comment }
    public static func myFunction(with code: String) {
    }
```

Generate markdown export for this symbol using `docc convert` with `--enable-experimental-markdown-export`

Before this change, the export will have an empty `## Discussion` heading at the end. After this change, it will not. 

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary:  N/A
