### PR TITLE
Preserve link titles for markdown output instead of replacing them with target document title

### DIFF
--- a/Sources/SwiftDocC/Model/MarkdownOutput/Translation/MarkdownOutputMarkdownWalker.swift
+++ b/Sources/SwiftDocC/Model/MarkdownOutput/Translation/MarkdownOutputMarkdownWalker.swift
@@ -308,15 +308,19 @@ extension MarkdownOutputMarkupWalker {
             linkListAbstract = nil
         }
         
-        let linkMarkup: any RecurringInlineMarkup
-        if doc.semantic is Symbol {
-            linkMarkup = InlineCode(linkTitle)
+        var convertedLink = Link(destination: outputDestination, title: linkTitle, [])
+        // Preserve any inline title markup for the link. If the plain text value is the same as the destination, then this was an auto-link or double-backtick symbol link and will require an appropriate title.
+        if link.plainText == link.destination {
+            if doc.semantic is Symbol {
+                convertedLink.setInlineChildren([InlineCode(linkTitle)])
+            } else {
+                convertedLink.setInlineChildren([Text(linkTitle)])
+            }
         } else {
-            linkMarkup = Text(linkTitle)
+            convertedLink.setInlineChildren(link.inlineChildren)
         }
         
-        let link = Link(destination: outputDestination, title: linkTitle, [linkMarkup])
-        return (link, linkListAbstract)
+        return (convertedLink, linkListAbstract)
     }
     
     mutating func visitLink(_ link: Link) {

--- a/Sources/SwiftDocC/Model/MarkdownOutput/Translation/MarkdownOutputMarkdownWalker.swift
+++ b/Sources/SwiftDocC/Model/MarkdownOutput/Translation/MarkdownOutputMarkdownWalker.swift
@@ -215,7 +215,8 @@ extension MarkdownOutputMarkupWalker {
         
         guard
             let resolved = context.referenceIndex[destination],
-            let node = context.topicGraph.nodeWithReference(resolved)
+            let doc = try? context.entity(with: resolved),
+            let symbol = doc.semantic as? Symbol
         else {
             // Unresolved symbol - use code voice, unless we're in a list, in which case, ignore it
             if isRenderingLinkList {
@@ -225,25 +226,19 @@ extension MarkdownOutputMarkupWalker {
             return (code, nil)
         }
         
-        let linkTitle: String
+        var linkTitle = symbol.proseVariants[.swift] ?? symbol.title
         var linkListAbstract: (any Markup)?
                 
-        if isRenderingLinkList,
-           let doc = try? context.entity(with: resolved),
-           let symbol = doc.semantic as? Symbol
-        {
+        if isRenderingLinkList {
             linkListAbstract = (doc.semantic as? Symbol)?.abstract
             if let fragments = symbol.navigator {
                 linkTitle = fragments
                     .map { $0.spelling }
                     .joined(separator: " ")
-            } else {
-                linkTitle = symbol.proseVariants.firstValue ?? symbol.title
             }
             relationships.insert(relationship(source: resolved, type: .belongsToTopic, subtype: nil))
-        } else {
-            linkTitle = node.title
         }
+        
         let (link, _) = convertLink(Link(destination: destination, title: linkTitle, [InlineCode(linkTitle)]), relationships: &relationships)
         return (link, linkListAbstract)
     }
@@ -298,7 +293,7 @@ extension MarkdownOutputMarkupWalker {
             }
             linkTitle = anchorSection?.title ?? article.title?.plainText ?? resolved.lastPathComponent
         } else if let symbol = doc.semantic as? Symbol {
-            linkTitle = anchorSection?.title ?? symbol.proseVariants.firstValue ?? symbol.title
+            linkTitle = anchorSection?.title ?? symbol.proseVariants[.swift] ?? symbol.title
         } else {
             linkTitle = anchorSection?.title ?? resolved.lastPathComponent
         }

--- a/Sources/SwiftDocC/Model/MarkdownOutput/Translation/MarkdownOutputMarkdownWalker.swift
+++ b/Sources/SwiftDocC/Model/MarkdownOutput/Translation/MarkdownOutputMarkdownWalker.swift
@@ -309,8 +309,8 @@ extension MarkdownOutputMarkupWalker {
         }
         
         var convertedLink = Link(destination: outputDestination, title: linkTitle, [])
-        // Preserve any inline title markup for the link. If the plain text value is the same as the destination, then this was an auto-link or double-backtick symbol link and will require an appropriate title.
-        if link.plainText == link.destination {
+        // Preserve any inline title markup for the link. If the plain text value is the same as the destination, or was empty, then this was an auto-link or double-backtick symbol link and will require an appropriate title.
+        if link.plainText == link.destination || link.plainText.isEmpty {
             if doc.semantic is Symbol {
                 convertedLink.setInlineChildren([InlineCode(linkTitle)])
             } else {

--- a/Tests/SwiftDocCTests/Rendering/Markdown/MarkdownOutputTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/Markdown/MarkdownOutputTests.swift
@@ -304,6 +304,13 @@ struct MarkdownOutputTests {
                 
                 This is a [named symbol link](doc:MarkdownSymbol)
                 This is not <doc:MarkdownSymbol>
+                
+                This has an empty title [](doc:LinkDestination)
+                
+                This is a reference link with an empty title [][link-id]
+                This is a reference link with a title [title][link-id]
+                
+                [link-id]: doc:LinkDestination
                 """),
             TextFile(name: "LinkDestination.md", utf8Content: """
                 # Link Destination
@@ -316,10 +323,20 @@ struct MarkdownOutputTests {
         ])
         
         let (node, _) = try await markdownOutput(catalog: catalog, path: "RootDocument")
-        #expect(node.markdown.contains("This is a [named *link*](/documentation/MarkdownOutput/LinkDestination"))
-        #expect(node.markdown.contains("This is not [Link Destination](/documentation/MarkdownOutput/LinkDestination"))
-        #expect(node.markdown.contains("This is a [named symbol link](/documentation/MarkdownOutput/MarkdownSymbol"))
-        #expect(node.markdown.contains("This is not [`MarkdownSymbol`](/documentation/MarkdownOutput/MarkdownSymbol)"))
+        
+        let expectedLinks = [
+            "This is a [named *link*](/documentation/MarkdownOutput/LinkDestination",
+            "This is not [Link Destination](/documentation/MarkdownOutput/LinkDestination",
+            "This is a [named symbol link](/documentation/MarkdownOutput/MarkdownSymbol",
+            "This is not [`MarkdownSymbol`](/documentation/MarkdownOutput/MarkdownSymbol)",
+            "This has an empty title [Link Destination](/documentation/MarkdownOutput/LinkDestination",
+            "This is a reference link with an empty title [Link Destination](/documentation/MarkdownOutput/LinkDestination)",
+            "This is a reference link with a title [title](/documentation/MarkdownOutput/LinkDestination)",
+        ]
+        
+        for expectedLink in expectedLinks {
+            #expect(node.markdown.contains(expectedLink))
+        }
     }
         
     @Test

--- a/Tests/SwiftDocCTests/Rendering/Markdown/MarkdownOutputTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/Markdown/MarkdownOutputTests.swift
@@ -288,6 +288,39 @@ struct MarkdownOutputTests {
         let expectedLinkList = "[`MarkdownSymbol`](/documentation/MarkdownOutput/MarkdownSymbol)\n\nA basic symbol to test markdown output. Different to [`OtherMarkdownSymbol`](/documentation/MarkdownOutput/OtherMarkdownSymbol)"
         #expect(node.markdown.contains(expectedLinkList))
     }
+    
+    @Test
+    func linkTitlesAreRetained() async throws {
+        let catalog = catalog(files: [
+            TextFile(name: "RootDocument.md", utf8Content: """
+                # Links
+                
+                Tests the processing of named links
+                
+                ## Overview
+                
+                This is a [named *link*](doc:LinkDestination)
+                This is not <doc:LinkDestination>
+                
+                This is a [named symbol link](doc:MarkdownSymbol)
+                This is not <doc:MarkdownSymbol>
+                """),
+            TextFile(name: "LinkDestination.md", utf8Content: """
+                # Link Destination
+                
+                This document title should not replace the specific title in the link
+                """),
+            JSONFile(name: "MarkdownOutput.symbols.json", content: makeSymbolGraph(moduleName: "MarkdownOutput", symbols: [
+                makeSymbol(id: "MarkdownSymbol", kind: .struct, pathComponents: ["MarkdownSymbol"], docComment: "A basic symbol to test markdown output."),
+            ]))
+        ])
+        
+        let (node, _) = try await markdownOutput(catalog: catalog, path: "RootDocument")
+        #expect(node.markdown.contains("This is a [named *link*](/documentation/MarkdownOutput/LinkDestination"))
+        #expect(node.markdown.contains("This is not [Link Destination](/documentation/MarkdownOutput/LinkDestination"))
+        #expect(node.markdown.contains("This is a [named symbol link](/documentation/MarkdownOutput/MarkdownSymbol"))
+        #expect(node.markdown.contains("This is not [`MarkdownSymbol`](/documentation/MarkdownOutput/MarkdownSymbol)"))
+    }
         
     @Test
     func languageTabOnlyIncludesPrimaryLanguage() async throws {

--- a/Tests/SwiftDocCTests/Rendering/ProseSymbolNameTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/ProseSymbolNameTests.swift
@@ -40,9 +40,6 @@ struct ProseSymbolNameTests {
 
         var expectedSwiftText: String { swiftProse ?? swiftTitle }
         var expectedObjCText: String { objcProse ?? objcTitle }
-        /// The markdown renderer accesses `firstValue` of a multi-language symbol, so an
-        /// Objective-C-only prose name bleeds into the Swift rendering path.
-        var markdownHasKnownIssue: Bool { swiftProse == nil && objcProse != nil }
 
         var testDescription: String { name }
     }
@@ -86,8 +83,7 @@ struct ProseSymbolNameTests {
         try assertAllFormats(
             context: context, reference: reference,
             expectedSwift: (setup.expectedSwiftText, setup.expectedSwiftHTML),
-            expectedObjC: (setup.expectedObjCText, setup.expectedObjCHTML),
-            markdownHasKnownIssue: setup.markdownHasKnownIssue
+            expectedObjC: (setup.expectedObjCText, setup.expectedObjCHTML)
         )
     }
 
@@ -104,8 +100,7 @@ struct ProseSymbolNameTests {
         try assertAllFormats(
             context: context, reference: reference,
             expectedSwift: (setup.expectedText, setup.expectedHTML),
-            expectedObjC: nil,
-            markdownHasKnownIssue: false
+            expectedObjC: nil
         )
     }
 
@@ -122,14 +117,11 @@ struct ProseSymbolNameTests {
     ///     Swift representation (or the single language representation).
     ///   - expectedObjC: The same for the Objective-C representation, or `nil` for a symbol that
     ///     only has a single-language representation.
-    ///   - markdownHasKnownIssue: Whether the markdown output is expected to be incorrect because
-    ///     the markdown renderer doesn't support multi-language symbols.
     private func assertAllFormats(
         context: DocumentationContext,
         reference: ResolvedTopicReference,
         expectedSwift: (text: String, html: String),
-        expectedObjC: (text: String, html: String)?,
-        markdownHasKnownIssue: Bool
+        expectedObjC: (text: String, html: String)?
     ) throws {
         let node = try context.entity(with: reference)
         let renderNode = DocumentationNodeConverter(context: context).convert(node)
@@ -165,21 +157,13 @@ struct ProseSymbolNameTests {
         var visitor = MarkdownOutputSemanticVisitor(context: context, node: node)
         let output = visitor.createOutput()
         let markdown = try #require(output).markdown
-        func assertMarkdown() {
-            #expect(markdown.contains("`\(expectedSwift.text)`"),
-                    "Markdown missing expected inline code `\(expectedSwift.text)`; got: \(markdown)")
-            // When a prose name replaces the title, the full title should not appear.
-            if expectedSwift.text != Self.swiftTitle {
-                #expect(!markdown.contains("`\(Self.swiftTitle)`"),
-                        "Markdown unexpectedly contains the full title `\(Self.swiftTitle)`; got: \(markdown)")
-            }
-        }
-        if markdownHasKnownIssue {
-            withKnownIssue("Markdown renderer does not support multi-language symbols") {
-                assertMarkdown()
-            }
-        } else {
-            assertMarkdown()
+        
+        #expect(markdown.contains("`\(expectedSwift.text)`"),
+                "Markdown missing expected inline code `\(expectedSwift.text)`; got: \(markdown)")
+        // When a prose name replaces the title, the full title should not appear.
+        if expectedSwift.text != Self.swiftTitle {
+            #expect(!markdown.contains("`\(Self.swiftTitle)`"),
+                    "Markdown unexpectedly contains the full title `\(Self.swiftTitle)`; got: \(markdown)")
         }
     }
 


### PR DESCRIPTION
Bug/issue #, if applicable: 181279947

## Summary

Document or symbol links within the same module that had a specified name (e.g. `[named link](doc:Destination)` were losing the `named link` title and having the title of the linked document used instead. This PR preserves link titles in markdown export.

## Dependencies

N/A

## Testing

Create a document containing a named link in the `[name](doc:Destination)` format, to a symbol or other document. Create markdown by running `docc convert` with the `--enable-experimental-markdown-output` flag enabled. 

Prior to this change, the link will be formatted in the output as `[Document Title](/path/to/document)`. 

After this change, the link will be formatted as `[name](/path/to/document)`. 


## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary -> N/A
