### PR TITLE
Update swift-docc-symbolkit dependency

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -70,7 +70,7 @@
       "location" : "https://github.com/swiftlang/swift-docc-symbolkit.git",
       "state" : {
         "branch" : "main",
-        "revision" : "cf6249d437ae23fb46a1c735d0240edb23cc35a8"
+        "revision" : "c1f9484553d29afb981b95458b37c1c3d3e1bcd7"
       }
     },
     {


### PR DESCRIPTION
This pulls in swiftlang/swift-docc-symbolkit#113.