### PR TITLE
Enable Windows builds on GitHub Actions

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -16,18 +16,18 @@ jobs:
     name: Test
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.13
     with:
+      enable_macos_checks: true
       linux_host_archs: '["x86_64", "aarch64"]'
       linux_swift_versions: '["nightly-main", "nightly-6.3"]'
       windows_swift_versions: '["nightly-main", "nightly-6.3"]'
-      # The Windows CI runs are disabled due to issues with file names on Windows.
-      # The CMake build tests for Windows are also not present at the moment.
-      # They can be enabled in the future once Windows CI is fixed.
+      # The package and tests build on Windows, but the tests don't pass yet,
+      # due to issues with filenames on Windows. For now, the Windows CI runs
+      # build the package, and only build the tests without running them.
       # Related PRs:
       #
-      # - File names: https://github.com/swiftlang/swift-docc/pull/668
+      # - Filenames: https://github.com/swiftlang/swift-docc/pull/668
       # - CMake: https://github.com/swiftlang/swift-docc/pull/1115
-      enable_windows_checks: false
-      enable_macos_checks: true
+      windows_build_command: "Invoke-Program swift build --build-tests"
 
   soundness:
     name: Soundness


### PR DESCRIPTION
Windows CI on GitHub Actions were previously disabled due to tests not being able to run successfully. However, the package and tests are able to build on Windows. The test failures are potentially fixed by #668. Until then, enable just building on Windows CI.