### PR TITLE
Revert "Replace duplicate logic with equivalent SymbolKit API (#1286)"

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
@@ -96,8 +96,8 @@ struct PathHierarchy {
             let moduleNode: Node
             
             if !loader.hasPrimaryURL(moduleName: moduleName) {
-                let (moduleName, _) = GraphCollector.moduleNameFor(graph, at: url)
-                guard let existingModuleNode = roots[moduleName]
+                guard let moduleName = SymbolGraphLoader.moduleNameFor(url),
+                      let existingModuleNode = roots[moduleName]
                 else { continue }
                 moduleNode = existingModuleNode
             } else if let existingModuleNode = roots[moduleName] {

--- a/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphLoader.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphLoader.swift
@@ -90,7 +90,7 @@ struct SymbolGraphLoader {
 
                 symbolGraphTransformer?(&symbolGraph)
 
-                let (moduleName, isMainSymbolGraph) = GraphCollector.moduleNameFor(symbolGraph, at: symbolGraphURL)
+                let (moduleName, isMainSymbolGraph) = Self.moduleNameFor(symbolGraph, at: symbolGraphURL)
                 // If the bundle provides availability defaults add symbol availability data.
                 self.addDefaultAvailability(to: &symbolGraph, moduleName: moduleName)
 
@@ -301,6 +301,49 @@ struct SymbolGraphLoader {
             }
             symbolGraph.symbols = symbolsWithFilledIntroducedVersions
         }
+    }
+    
+    /// Returns the module name, if any, in the file name of a given symbol-graph URL.
+    ///
+    /// Returns "Combine", if it's a main symbol-graph file, such as "Combine.symbols.json".
+    /// Returns "Swift", if it's an extension file such as, "Combine@Swift.symbols.json".
+    /// - parameter url: A URL to a symbol graph file.
+    /// - returns: A module name, or `nil` if the file name cannot be parsed.
+    static func moduleNameFor(_ url: URL) -> String? {
+        let fileName = url.lastPathComponent.components(separatedBy: ".symbols.json")[0]
+
+        let fileNameComponents = fileName.components(separatedBy: "@")
+        if fileNameComponents.count > 2 {
+            // Two "@"s found in the name - it's a cross import symbol graph:
+            // "Framework1@Framework2@_Framework1_Framework2.symbols.json"
+            return fileNameComponents[0]
+        }
+        
+        return fileName.split(separator: "@", maxSplits: 1).last.map({ String($0) })
+    }
+    
+    /// Returns the module name of a symbol graph based on the JSON data and file name.
+    ///
+    /// Useful during decoding the symbol graphs to implement the correct name logic starting with the module name in the JSON.
+    private static func moduleNameFor(_ symbolGraph: SymbolGraph, at url: URL) -> (String, Bool) {
+        let isMainSymbolGraph = !url.lastPathComponent.contains("@")
+        
+        let moduleName: String
+        if isMainSymbolGraph || symbolGraph.module.bystanders != nil {
+            // For main symbol graphs, get the module name from the symbol graph's data
+
+            // When bystander modules are present, the symbol graph is a cross-import overlay, and
+            // we need to preserve the original module name to properly render it. It is still
+            // kept with the extension symbols, due to the merging behavior of UnifiedSymbolGraph.
+            moduleName = symbolGraph.module.name
+        } else {
+            // For extension symbol graphs, derive the extended module's name from the file name.
+            //
+            // The per-symbol `extendedModule` value is the same as the main module for most symbols, so it's not a good way to find the name
+            // of the module that was extended (rdar://63200368).
+            moduleName = SymbolGraphLoader.moduleNameFor(url)!
+        }
+        return (moduleName, isMainSymbolGraph)
     }
 }
 


### PR DESCRIPTION
<!--
If you are opening a pull request against a release branch, see
https://www.swift.org/contributing#release-branch-pull-requests
-->

Bug/issue #, if applicable: 183708988

## Summary

This reverts commit `b577c7220a6c7f10b2b7c7fcb98457ebf92a3921`.

The SymbolKit API [1] is not interchangeable with the DocC API [2], as cross-module overlays wont get the expected result for rendering [3].

SymbolKit logic includes `if isMainSymbolGraph && graph.module.bystanders == nil {` while DocC implementation changes this piece of logic to `if isMainSymbolGraph || symbolGraph.module.bystanders != nil {`

This change causes non expected data to be surfaced in the rendered documentation.

## Dependencies

_Describe any dependencies this PR might have, such as an associated branch in another repository._

## Testing

_Describe how a reviewer can test the functionality of your PR. Provide test content to test with if
applicable._

Steps:
1. _Provide setup instructions._
2. _Explain in detail how the functionality can be tested._

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [ ] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary
