### PR TITLE
Consider all availability variants before raising warning about DeprecationSummary

### DIFF
--- a/Sources/SwiftDocC/Model/DocumentationNode.swift
+++ b/Sources/SwiftDocC/Model/DocumentationNode.swift
@@ -903,7 +903,7 @@ public struct DocumentationNode {
                 directive.name == DeprecationSummary.directiveName ? directive : nil
             }
         }
-        guard let deprecationSummaryDirective, let symbol = unifiedSymbol?.documentedSymbol else {
+        guard let deprecationSummaryDirective, let symbol, let unifiedSymbol else {
             // Nothing to warn about unless there is a DeprecationSummary directive in the markup
             return
         }
@@ -912,7 +912,15 @@ public struct DocumentationNode {
         
         // Check the information from both the source attributes and the Available directive before raising a warning.
         let availabilityFromSource = {
-            var availability = symbol.availability ?? []
+            var combinedInSourceAvailability: [String: SymbolGraph.Symbol.Availability.AvailabilityItem] = [:]
+            for availabilities in unifiedSymbol.availability.values {
+                for item in availabilities where item.obsoletedVersion == nil && !item.isUnconditionallyUnavailable {
+                    let name = item.domain.map({ PlatformName(operatingSystemName: $0.rawValue).displayName }) ?? "*"
+                    combinedInSourceAvailability[name] = item
+                }
+            }
+            
+            var availability = Array(combinedInSourceAvailability.values)
             let isDeprecatedPartitionIndex = availability.partition(by: { $0.isUnconditionallyDeprecated || $0.deprecatedVersion != nil })
             return (
                 available:  availability[..<isDeprecatedPartitionIndex],

--- a/Tests/SwiftDocCTests/Model/DeprecationSummaryTests.swift
+++ b/Tests/SwiftDocCTests/Model/DeprecationSummaryTests.swift
@@ -424,6 +424,49 @@ struct DeprecationSummaryTests {
         let topicRef = try #require(deprecatedRef, "Expected to find a topic render reference for SomeTypeAlias")
         #expect(topicRef.isDeprecated == true, "Symbol should be marked as deprecated with a message")
     }
+    
+    @Test(arguments: Self.allMainPlatforms)
+    func doesNotWarnAboutDeprecationSummaryIfSymbolIsDeprecatedForOnePlatform(_ deprecatedPlatform: SymbolGraph.Platform) async throws {
+        let name = "requestImageDataForAsset:options:resultHandler:"
+        
+        let catalog = Folder(name: "unit-test.docc") {
+            for (number, platform) in zip(1..., Self.allMainPlatforms) {
+                JSONFile(name: "SomeModule-\(number).symbols.json", content: makeSymbolGraph(moduleName: "SomeModule", platform: platform, symbols: [
+                    makeSymbol(id: "some-symbol-id", kind: .protocol, pathComponents: ["SomeClass", name], docComment: "Nothing", availability: [
+                        .init(domainName: platform.name, introduced: .init(major: 1, minor: 2, patch: 3), deprecated: platform == deprecatedPlatform ? .init(major: 2, minor: 3, patch: 4) : nil)
+                    ])
+                ]))
+            }
+            
+            TextFile(name: "SomeTypeAlias.md", utf8Content: """
+            # ``SomeClass/\(name)``
+            
+            A documentation extension file that provides a custom deprecation summary for this symbol.
+            
+            \(Self.deprecationSummaryDirective)
+            """)
+        }
+        
+        let context = try await load(catalog: catalog)
+        #expect(context.diagnostics.map(\.identifier) == [],
+                "Unexpected problems: \(context.diagnostics.map(\.summary))")
+        
+        // Verify that DocC displays the deprecation text.
+        let node = try #require(context.documentationCache["some-symbol-id"])
+        let converter = DocumentationNodeConverter(context: context)
+        let renderNode = converter.convert(node)
+        
+        #expect(renderNode.deprecationSummary?.firstParagraph == [.text("Some description, from the directive, of why this protocol is deprecated.")])
+    }
+    
+    private static let allMainPlatforms: [SymbolGraph.Platform] = [
+        .init(operatingSystem: .init(name: "ios")),
+        .init(operatingSystem: .init(name: "ios"), environment: "macabi"), // Mac Catalyst
+        .init(operatingSystem: .init(name: "macos")),
+        .init(operatingSystem: .init(name: "watchos")),
+        .init(operatingSystem: .init(name: "tvos")),
+        .init(operatingSystem: .init(name: "visionos")),
+    ]
 
     private static func makeInSourceAvailabilityInfo(
         domain: String?,


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://184145251

## Summary

This fixes a false positive where the warning about using `@DeprecationSummary` for an available symbol didn't consider all availability variants if DocC was passed a collection of platform-specific symbol graph files (for the same module) in the same build where each symbol graph file only contains the in-source availability annotations for that platform.

Before this change, the node would only look at one variant of the availability which could lead to a false positive warning about the symbol being available if it was available for _that_ platform. This warning was non-deterministic because it wasn't deterministic which of the availability variants the node looked at.

## Dependencies

None

## Testing

I'm not aware of any quick and easy way to create this setup but this is a tedious and fairly complicated way:

- Create a project with one symbol that's available for one platform.
    - Add a `@DeprecationSummary` for 
- Generate a symbol graph file for that platform (for example by building documentation and discarding the documentation and setting aside the intermediate symbol graph file for that platform).
- For a number of other platforms:  
  - Update the in-source availability annotation to be for _that_ platform
  - For _only some_ of the platforms, 
  - Generate, and set aside, a new symbol graph for that platform.
- Call `docc convert` and pass it all the gathered symbol graph files for all those platforms (each with only availability information for that platform)
  - There shouldn't be a warning about the `@DeprecationSummary` because the symbol is deprecated for one (or some of those platforms)
- Repeat the `docc convert` a few times (you don't need to regather the symbol graph files). 
  - There shouldn't be a `@DeprecationSummary` warning when rebuilding with the same inputs.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
