### PR TITLE
Transform "bundle" identifiers with colon characters into valid identifiers

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/DocumentationBundle+Identifier.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationBundle+Identifier.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2024-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -24,7 +24,7 @@ extension DocumentationBundle {
                 .joined(separator: "-")
         }
         
-        private static let charactersToReplace = CharacterSet.urlHostAllowed.inverted
+        private static let charactersToReplace = CharacterSet.urlHostAllowed.inverted.union([":"])
     }
 }
 

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationBundleIdentifierTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationBundleIdentifierTests.swift
@@ -18,6 +18,7 @@ struct DocumentationBundleIdentifierTests {
     @Test(arguments: [
         "com.example.test": "com.example.test",
         "Package  Name": "Package-Name", // The initializer transforms the value to a valid identifier
+        "Before: After": "Before-After", // The initializer transforms the value to a valid identifier
     ])
     func replacedDisallowedCharactersWhenInitialized(_ input: String, expectedParsedValue: String) {
         #expect(Identifier(rawValue: input).rawValue == expectedParsedValue)
@@ -30,6 +31,9 @@ struct DocumentationBundleIdentifierTests {
         
         let idWithSpace: Identifier = "Package  Name"
         #expect(idWithSpace.rawValue == "Package-Name", "The initializer transforms the value to a valid identifier")
+        
+        let idWithColon: Identifier = "Before: After"
+        #expect(idWithColon.rawValue == "Before-After", "The initializer transforms the value to a valid identifier")
     }
     
     @Test

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationBundleIdentifierTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationBundleIdentifierTests.swift
@@ -1,59 +1,65 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2024-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import XCTest
+import Testing
+import Foundation
 @testable import SwiftDocC
 
-class DocumentationBundleIdentifierTests: XCTestCase {
+struct DocumentationBundleIdentifierTests {
     private typealias Identifier = DocumentationBundle.Identifier
     
-    func testInitialization() {
-        let id = Identifier(rawValue: "com.example.test")
-        XCTAssertEqual(id.rawValue, "com.example.test")
-        
-        let idWithSpace = Identifier(rawValue: "Package  Name")
-        XCTAssertEqual(idWithSpace.rawValue, "Package-Name", "The initializer transforms the value to a valid identifier")
+    @Test(arguments: [
+        "com.example.test": "com.example.test",
+        "Package  Name": "Package-Name", // The initializer transforms the value to a valid identifier
+    ])
+    func replacedDisallowedCharactersWhenInitialized(_ input: String, expectedParsedValue: String) {
+        #expect(Identifier(rawValue: input).rawValue == expectedParsedValue)
     }
     
-    func testExpressibleByStringLiteral() {
+    @Test
+    func replacedDisallowedCharactersWhenExpressibleByStringLiteral() {
         let id: Identifier = "com.example.test"
-        XCTAssertEqual(id.rawValue, "com.example.test")
+        #expect(id.rawValue == "com.example.test")
         
         let idWithSpace: Identifier = "Package  Name"
-        XCTAssertEqual(idWithSpace.rawValue, "Package-Name", "The initializer transforms the value to a valid identifier")
+        #expect(idWithSpace.rawValue == "Package-Name", "The initializer transforms the value to a valid identifier")
     }
     
-    func testEquatable() {
-        XCTAssertEqual(Identifier(rawValue: "A"), "A")
-        XCTAssertNotEqual(Identifier(rawValue: "A"), "B")
+    @Test
+    func isEquatableWithStringLiteral() {
+        #expect(Identifier(rawValue: "A") == "A")
+        #expect(Identifier(rawValue: "A") != "B")
     }
     
-    func testComparable() {
-        XCTAssertLessThan(Identifier(rawValue: "B"), "C")
-        XCTAssertGreaterThan(Identifier(rawValue: "B"), "A")
+    @Test
+    func isComparableToStringLiteral() {
+        #expect(Identifier(rawValue: "B") < "C")
+        #expect(Identifier(rawValue: "B") > "A")
     }
     
-    func testCustomStringConvertible() {
-        XCTAssertEqual(Identifier(rawValue: "com.example.test").description, "com.example.test")
-        XCTAssertEqual(Identifier(rawValue: "Package  Name").description, "Package-Name")
-        
+    @Test
+    func describesItsRawValue() {
+        #expect(Identifier(rawValue: "com.example.test").description == "com.example.test")
+        #expect(Identifier(rawValue: "Package  Name").description == "Package-Name")
     }
     
-    func testEncodesAsPlainString() throws {
+    @Test
+    func encodesAsSinglePlainStringValue() throws {
         let id = Identifier(rawValue: "com.example.test")
         let encoded = try String(data: JSONEncoder().encode(id), encoding: .utf8)
-        XCTAssertEqual(encoded, "\"com.example.test\"")
+        #expect(encoded == "\"com.example.test\"")
     }
     
-    func testDecodingFromPlainString() throws {
+    @Test
+    func canDecodeFromFromPlainString() throws {
         let decoded = try JSONDecoder().decode(Identifier.self, from: Data("\"com.example.test\"".utf8))
-        XCTAssertEqual(decoded, "com.example.test")
+        #expect(decoded == "com.example.test")
     }
 }


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

This updates `DocumentationBundle/Identifier` to handle colon (`:`) by transforming it into a hyphen (`-`), like other disallowed characters. 

## Dependencies

None.

## Testing

- Build documentation and specify a "bundle" identifier that contains a colon, for example `Before: After`, either in the Info.plist or via the `--fallback-bundle-identifier` command line option.
- Inspect the output JSON for one of the pages of documentation
  - The "host" component of the reference URLs should have replaced the colon (`:`) with a hyphen (`-`) so that it could be parsed as a valid URL.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
