### PR TITLE
Sort the RenderMetadata modules by name for articles

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -643,13 +643,12 @@ public struct RenderNodeTranslator: SemanticVisitor {
         }
         
         let moduleNames = modules.compactMap { reference -> String? in
-            guard let node = try? context.entity(with: reference) else { return nil }
-            return node.name.plainText
+            try? context.entity(with: reference).name.plainText
         }
         if !moduleNames.isEmpty {
-            node.metadata.modules = moduleNames.map({
-                return RenderMetadata.Module(name: $0, relatedModules: nil)
-            })
+            node.metadata.modules = moduleNames.sorted().map {
+                RenderMetadata.Module(name: $0, relatedModules: nil)
+            }
         }
         
         let documentationNode = try! context.entity(with: identifier)


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://184325594

## Summary

This sorts the `RenderMetadata` modules by name for articles. 

## Dependencies

None.

## Testing

There isn't a supported setup where you can reproduce this issue.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- ~[ ] Added tests~. This issue can only happen in unsupported setups. 
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
