### PR TITLE
Fix the low hanging fruit of strict-concurrency warnings

### DIFF
--- a/Sources/DocCCommandLine/Action/Actions/Convert/ConvertFileWritingConsumer.swift
+++ b/Sources/DocCCommandLine/Action/Actions/Convert/ConvertFileWritingConsumer.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -247,16 +247,16 @@ struct ConvertFileWritingConsumer: ConvertOutputConsumer, ExternalNodeConsumer, 
     }
     
     /// File name for the documentation coverage file emitted during conversion.
-    static var docCoverageFileName = "documentation-coverage.json"
+    static let docCoverageFileName = "documentation-coverage.json"
     
     /// File name for the build metadata file emitted during conversion.
-    static var buildMetadataFileName = "metadata.json"
+    static let buildMetadataFileName = "metadata.json"
     
     /// File name for the linkable entity file emitted during conversion.
-    static var linkableEntitiesFileName = "linkable-entities.json"
+    static let linkableEntitiesFileName = "linkable-entities.json"
     
     /// File name for the link hierarchy file emitted during conversion.
-    static var linkHierarchyFileName = "link-hierarchy.json"
+    static let linkHierarchyFileName = "link-hierarchy.json"
 }
 
 enum Digest {

--- a/Sources/SwiftDocC/Coverage/DocumentationCoverageOptions.swift
+++ b/Sources/SwiftDocC/Coverage/DocumentationCoverageOptions.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -11,7 +11,7 @@
 /// Resolves and validates the arguments needed to enable the documentation coverage feature.
 ///
 /// These options are used by the `Convert` subcommand.
-public struct DocumentationCoverageOptions {
+public struct DocumentationCoverageOptions: Sendable {
     public init(
         level: DocumentationCoverageLevel,
         kindFilterOptions: KindFilterOptions = []) {
@@ -54,7 +54,7 @@ extension DocumentationCoverageOptions {
 }
 
 /// Specifies whether the documentation coverage feature is enabled and, if it is, what amount of specificity is selected.
-public enum DocumentationCoverageLevel: String, Codable, CaseIterable {
+public enum DocumentationCoverageLevel: String, Codable, CaseIterable, Sendable {
     /// No documentation coverage data should be emitted and no documentation coverage information should be displayed in console
     case none
     /// Documentation coverage data should be emitted and a high-level summary should be displayed in console
@@ -67,7 +67,7 @@ extension DocumentationCoverageOptions {
 
     /// Represents kinds to select and display documentation coverage statistics for.
     /// Note: This enum is not meant to be persisted between runs
-    public struct KindFilterOptions: OptionSet, Hashable, CustomDebugStringConvertible {
+    public struct KindFilterOptions: OptionSet, Hashable, CustomDebugStringConvertible, Sendable {
 
         public typealias RawValue = Int
         public let rawValue: Int

--- a/Sources/SwiftDocC/Coverage/DocumentationCoverageOptions.swift
+++ b/Sources/SwiftDocC/Coverage/DocumentationCoverageOptions.swift
@@ -25,9 +25,11 @@ public struct DocumentationCoverageOptions: Sendable {
     }
 
     /// An instance configured to represent the choice not to produce any documentation coverage artifacts or output.
-    public static var noCoverage: DocumentationCoverageOptions = DocumentationCoverageOptions(
-        level: .none,
-        kindFilterOptions: [])
+    public static var noCoverage: DocumentationCoverageOptions {
+        get { DocumentationCoverageOptions(level: .none, kindFilterOptions: []) }
+        @available(*, deprecated, message: "Create a new value instead of modifying this one. This deprecated setter will be removed after 6.5 is released.")
+        set { /* Do nothing */ }
+    }
 
     // The desired level of documentation coverage as specified during invocation.
     public var level: DocumentationCoverageLevel

--- a/Sources/SwiftDocC/Coverage/DocumentationCoverageOptions.swift
+++ b/Sources/SwiftDocC/Coverage/DocumentationCoverageOptions.swift
@@ -27,7 +27,7 @@ public struct DocumentationCoverageOptions: Sendable {
     /// An instance configured to represent the choice not to produce any documentation coverage artifacts or output.
     public static var noCoverage: DocumentationCoverageOptions {
         get { DocumentationCoverageOptions(level: .none, kindFilterOptions: []) }
-        @available(*, deprecated, message: "Create a new value instead of modifying this one. This deprecated setter will be removed after 6.5 is released.")
+        @available(*, deprecated, message: "Setting this value has no effect; create a new value instead. This value will become read-only after 6.5 is released.")
         set { /* Do nothing */ }
     }
 

--- a/Sources/SwiftDocC/DocumentationService/Models/DocumentationServer+MessageType.swift
+++ b/Sources/SwiftDocC/DocumentationService/Models/DocumentationServer+MessageType.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -13,7 +13,7 @@ public extension DocumentationServer {
     ///
     /// The type of a service message is used to determine which service a server should invoke to process the message.
     struct MessageType: Codable, RawRepresentable, Hashable, CustomDebugStringConvertible,
-                               ExpressibleByStringLiteral, Equatable {
+                               ExpressibleByStringLiteral, Equatable, Sendable {
         /// The string representation of the message.
         public var rawValue: String
         

--- a/Sources/SwiftDocC/Indexing/IndexingRecord.swift
+++ b/Sources/SwiftDocC/Indexing/IndexingRecord.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -36,7 +36,7 @@ public struct IndexingRecord: Equatable {
     /**
      The kind of documentation for a search result.
      */
-    public struct Kind: RawRepresentable, Equatable {
+    public struct Kind: RawRepresentable, Equatable, Sendable {
         public var rawValue: String
         public init(rawValue: String) {
             self.rawValue = rawValue

--- a/Sources/SwiftDocC/Indexing/Navigator/AvailabilityIndex+Ext.swift
+++ b/Sources/SwiftDocC/Indexing/Navigator/AvailabilityIndex+Ext.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -68,7 +68,7 @@ extension AvailabilityIndex {
  - Note: The name reflects what a render node JSON provides to identify a programming language.
  The name has been decided to avoid confusion with locale languages.
  */
-public struct InterfaceLanguage: Hashable, CustomStringConvertible, Codable, Equatable {
+public struct InterfaceLanguage: Hashable, CustomStringConvertible, Codable, Equatable, Sendable {
     
     public typealias ID = UInt8
     
@@ -214,7 +214,7 @@ public struct Platform: Hashable, CustomStringConvertible, Codable, Equatable {
     
     // MARK: - PlatformName
     
-    public struct Name: Hashable, CustomStringConvertible, Codable, Equatable {
+    public struct Name: Hashable, CustomStringConvertible, Codable, Equatable, Sendable {
         
         public typealias ID = UInt64
         

--- a/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
+++ b/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
@@ -242,7 +242,7 @@ public class NavigatorIndex {
     
     /// Indicates the page type of a given item inside the tree.
     /// - Note: This information is stored as `UInt8` to decrease the required size to store it and make the comparison faster between types.
-    public enum PageType: UInt8 {
+    public enum PageType: UInt8, Sendable {
         case root = 0
         case article = 1
         case tutorial = 2

--- a/Sources/SwiftDocC/Infrastructure/Bundle Assets/DataAssetManager.swift
+++ b/Sources/SwiftDocC/Infrastructure/Bundle Assets/DataAssetManager.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -297,10 +297,12 @@ public struct DataTraitCollection: Hashable, Codable {
     }
     
     /// Returns all the asset's registered variants.
-    public static var allCases: [DataTraitCollection] = {
-        return UserInterfaceStyle.allCases.flatMap { style in DisplayScale.allCases.map { .init(userInterfaceStyle: style, displayScale: $0)}}
-    }()
-    
+    public static var allCases: [DataTraitCollection] {
+        get { _allCases }
+        @available(*, deprecated, message: "Create a new value instead of modifying this one. This deprecated setter will be removed after 6.5 is released.")
+        set { _allCases = newValue }
+    }
+    private static var _allCases: [DataTraitCollection] = UserInterfaceStyle.allCases.flatMap { style in DisplayScale.allCases.map { .init(userInterfaceStyle: style, displayScale: $0)}}
 }
 
 /// The interface style for a rendering context.

--- a/Sources/SwiftDocC/Infrastructure/Communication/Code colors/CodeColorsPreferenceKey.swift
+++ b/Sources/SwiftDocC/Infrastructure/Communication/Code colors/CodeColorsPreferenceKey.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -14,7 +14,7 @@
 /// A key defines a code-listing component that renderers use for syntax highlighting.
 ///
 /// - Note: Preference keys are backed by strings, so you can add new keys without breaking the public API.
-public struct CodeColorsPreferenceKey: Hashable, Codable {
+public struct CodeColorsPreferenceKey: Hashable, Codable, Sendable {
     private var rawValue: String
     
     /// Initializes a code color-preference key from a raw value.

--- a/Sources/SwiftDocC/Infrastructure/Communication/MessageType.swift
+++ b/Sources/SwiftDocC/Infrastructure/Communication/MessageType.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -13,7 +13,7 @@
 /// Clients can use the type of the message to determine which handler to invoke.
 ///
 /// - Note: Message types are backed by strings, so you can add new types without breaking the public API.
-public struct MessageType: Codable, RawRepresentable, Hashable, CustomDebugStringConvertible {
+public struct MessageType: Codable, RawRepresentable, Hashable, CustomDebugStringConvertible, Sendable {
     public var rawValue: String
     
     /// Creates a type from a raw value.

--- a/Sources/SwiftDocC/Infrastructure/Diagnostics/DiagnosticFile.swift
+++ b/Sources/SwiftDocC/Infrastructure/Diagnostics/DiagnosticFile.swift
@@ -24,7 +24,7 @@ struct DiagnosticFile: Codable {
     // Breaking changes should increment the major version component.
     // Non breaking additions should increment the minor version.
     // Bug fixes should increment the patch version.
-    static var currentVersion = SemanticVersion(major: 1, minor: 1, patch: 0, prerelease: nil, buildMetadata: nil)
+    static let currentVersion = SemanticVersion(major: 1, minor: 1, patch: 0, prerelease: nil, buildMetadata: nil)
     
     enum Error: Swift.Error {
         case unknownMajorVersion(found: SemanticVersion, latestKnown: SemanticVersion)

--- a/Sources/SwiftDocC/Infrastructure/Diagnostics/DiagnosticFormattingOptions.swift
+++ b/Sources/SwiftDocC/Infrastructure/Diagnostics/DiagnosticFormattingOptions.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -9,7 +9,7 @@
 */
 
 /// A type that encapsulate the possible formatting options for diagnostics.
-public struct DiagnosticFormattingOptions: OptionSet {
+public struct DiagnosticFormattingOptions: OptionSet, Sendable {
     public let rawValue: UInt
 
     public init(rawValue: UInt) {

--- a/Sources/SwiftDocC/Infrastructure/Diagnostics/DiagnosticSeverity.swift
+++ b/Sources/SwiftDocC/Infrastructure/Diagnostics/DiagnosticSeverity.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -13,7 +13,7 @@
 
  Diagnostics have a severity in order to give the user an indication of what a message means to them and whether it's immediately actionable or blocking.
  */
-public enum DiagnosticSeverity: Int, Codable, CustomStringConvertible {
+public enum DiagnosticSeverity: Int, Codable, CustomStringConvertible, Sendable {
     /**
      An error.
 

--- a/Sources/SwiftDocC/Infrastructure/Extensions/KindIdentifier+Curation.swift
+++ b/Sources/SwiftDocC/Infrastructure/Extensions/KindIdentifier+Curation.swift
@@ -1,14 +1,14 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2022-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import SymbolKit
+@preconcurrency import SymbolKit
 
 extension SymbolGraph.Symbol.KindIdentifier {
     /// The kinds of symbols that should not generate pages in the documentation hierarchy.

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+TypeSignature.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+TypeSignature.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2023-2025 Apple Inc. and the Swift project authors
+ Copyright (c) 2023-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -9,7 +9,7 @@
 */
 
 private import Foundation
-import SymbolKit
+@preconcurrency import SymbolKit
 
 // MARK: From symbols
 

--- a/Sources/SwiftDocC/Infrastructure/Symbol Graph/ExtendedTypeFormatExtension.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Graph/ExtendedTypeFormatExtension.swift
@@ -1,14 +1,14 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import SymbolKit
+@preconcurrency import SymbolKit
 
 // MARK: Custom Relationship Kind Identifiers
 

--- a/Sources/SwiftDocC/Infrastructure/Topic Graph/AutomaticCuration.swift
+++ b/Sources/SwiftDocC/Infrastructure/Topic Graph/AutomaticCuration.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -10,7 +10,7 @@
 
 private import Foundation
 private import Markdown
-import SymbolKit
+@preconcurrency import SymbolKit
 private import DocCCommon
 
 private let automaticSeeAlsoLimit: Int = {

--- a/Sources/SwiftDocC/Infrastructure/Workspace/DocumentationWorkspaceDataProvider.swift
+++ b/Sources/SwiftDocC/Infrastructure/Workspace/DocumentationWorkspaceDataProvider.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information

--- a/Sources/SwiftDocC/Infrastructure/Workspace/DocumentationWorkspaceDataProvider.swift
+++ b/Sources/SwiftDocC/Infrastructure/Workspace/DocumentationWorkspaceDataProvider.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information

--- a/Sources/SwiftDocC/Model/Identifier.swift
+++ b/Sources/SwiftDocC/Model/Identifier.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -149,7 +149,7 @@ public struct ResolvedTopicReference: Hashable, Codable, Equatable, CustomString
     }
     
     /// A synchronized reference cache to store resolved references.
-    private static var sharedPool = Synchronized([ReferenceBundleIdentifier: [ReferenceKey: ResolvedTopicReference]]())
+    private static let sharedPool = Synchronized([ReferenceBundleIdentifier: [ReferenceKey: ResolvedTopicReference]]())
     
     /// Clears cached references belonging to the bundle with the given identifier.
     /// - Parameter id: The identifier of the bundle to which the method should clear belonging references.

--- a/Sources/SwiftDocC/Model/Kind.swift
+++ b/Sources/SwiftDocC/Model/Kind.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -10,7 +10,7 @@
 
 extension DocumentationNode {
     /// The kind of a documentation node.
-    public struct Kind: Hashable, Codable {
+    public struct Kind: Hashable, Codable, Sendable {
         /// The name of the kind, suitable for display.
         public var name: String
         /// A globally unique identifier for the kind, typically a reverse-dns name.

--- a/Sources/SwiftDocC/Model/ParametersAndReturnValidator.swift
+++ b/Sources/SwiftDocC/Model/ParametersAndReturnValidator.swift
@@ -9,8 +9,8 @@
 */
 
 import Foundation
-import SymbolKit
-import Markdown
+@preconcurrency import SymbolKit
+@preconcurrency import Markdown
 import DocCCommon
 
 /// A type that validates and filters a symbol's parameter and return value documentation based on the symbol's function signature.

--- a/Sources/SwiftDocC/Model/Rendering/DocumentationContentRenderer.swift
+++ b/Sources/SwiftDocC/Model/Rendering/DocumentationContentRenderer.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -9,7 +9,7 @@
 */
 
 import Foundation
-import SymbolKit
+@preconcurrency import SymbolKit
 private import Markdown
 
 public struct RenderReferenceDependencies {

--- a/Sources/SwiftDocC/Model/Rendering/RenderNode.Tag.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNode.Tag.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -12,7 +12,7 @@ import Foundation
 
 public extension RenderNode {
     /// A tag that can be assigned to a render node.
-    struct Tag: Codable, Equatable {
+    struct Tag: Codable, Equatable, Sendable {
         /// The tag type.
         let type: String
         /// The text to display.

--- a/Sources/SwiftDocC/Model/Rendering/Symbol/DeclarationsRenderSection.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Symbol/DeclarationsRenderSection.swift
@@ -75,14 +75,14 @@ public struct DeclarationRenderSection: Codable, Equatable {
     ///
     /// A lexical token is a string with an associated meaning in source code.
     /// For example, `123` is represented as a single token of kind "number".
-    public struct Token: Codable, Hashable, Equatable {
+    public struct Token: Codable, Hashable, Equatable, Sendable {
         /// The token text content.
         public var text: String
         /// The token programming kind.
         public let kind: Kind
         
         /// The list of all expected tokens in a declaration.
-        public enum Kind: String, Codable, RawRepresentable {
+        public enum Kind: String, Codable, RawRepresentable, Sendable {
             /// A known keyword, like "class" or "var".
             case keyword
             /// An attribute, for example, "@main".
@@ -119,7 +119,7 @@ public struct DeclarationRenderSection: Codable, Equatable {
         public var highlight: Highlight?
 
         /// The kinds of highlights that can be applied to a token.
-        public enum Highlight: String, Codable, RawRepresentable {
+        public enum Highlight: String, Codable, RawRepresentable, Sendable {
             /// A highlight representing generalized change, not specifically added or removed.
             case changed
         }

--- a/Sources/SwiftDocC/Model/Rendering/Symbol/DeclarationsRenderSection.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Symbol/DeclarationsRenderSection.swift
@@ -15,7 +15,7 @@ public struct DeclarationsRenderSection: RenderSection, Codable, Equatable {
     /// The section title, by default `nil`.
     public static var title: String? {
         get { nil }
-        @available(*, deprecated, message: "Create a new value instead of modifying this one. This deprecated setter will be removed after 6.5 is released.")
+        @available(*, deprecated, message: "Setting this value has no effect; create a new value instead. This value will become read-only after 6.5 is released.")
         set { /* Do nothing */ }
     }
     

--- a/Sources/SwiftDocC/Model/Rendering/Symbol/DeclarationsRenderSection.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Symbol/DeclarationsRenderSection.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -13,7 +13,11 @@ import Foundation
 /// A compound section that contains a list of declaration sections.
 public struct DeclarationsRenderSection: RenderSection, Codable, Equatable {
     /// The section title, by default `nil`.
-    public static var title: String? = nil
+    public static var title: String? {
+        get { nil }
+        @available(*, deprecated, message: "Create a new value instead of modifying this one. This deprecated setter will be removed after 6.5 is released.")
+        set { /* Do nothing */ }
+    }
     
     public var kind: RenderSectionKind = .declarations
     /// The list of declaration sections.

--- a/Sources/SwiftDocC/Model/Rendering/Tutorial/References/DownloadReference.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Tutorial/References/DownloadReference.swift
@@ -20,7 +20,7 @@ public struct DownloadReference: RenderReference, URLReference, Equatable {
 
     public static var baseURL: URL {
         get { URL(string: "/\(locationName)/")! }
-        @available(*, deprecated, message: "Create a new value instead of modifying this one. This deprecated setter will be removed after 6.5 is released.")
+        @available(*, deprecated, message: "Setting this value has no effect; create a new value instead. This value will become read-only after 6.5 is released.")
         set { /* Do nothing */ }
     }
     

--- a/Sources/SwiftDocC/Model/Rendering/Tutorial/References/DownloadReference.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Tutorial/References/DownloadReference.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -18,7 +18,11 @@ public struct DownloadReference: RenderReference, URLReference, Equatable {
     /// that contains downloads.
     public static let locationName = "downloads"
 
-    public static var baseURL = URL(string: "/\(locationName)/")!
+    public static var baseURL: URL {
+        get { URL(string: "/\(locationName)/")! }
+        @available(*, deprecated, message: "Create a new value instead of modifying this one. This deprecated setter will be removed after 6.5 is released.")
+        set { /* Do nothing */ }
+    }
     
     public var type: RenderReferenceType = .download
     

--- a/Sources/SwiftDocC/Model/Rendering/Variants/JSONPointer.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Variants/JSONPointer.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -13,7 +13,7 @@ import Foundation
 /// A pointer to a specific value in a JSON document.
 ///
 /// For more information, see [RFC6901](https://datatracker.ietf.org/doc/html/rfc6901).
-public struct JSONPointer: Codable, CustomStringConvertible, Equatable {
+public struct JSONPointer: Codable, CustomStringConvertible, Equatable, Sendable {
     /// The path components of the pointer.
     ///
     /// The path components of the pointer are not escaped.

--- a/Sources/SwiftDocC/Model/Section/Sections/Abstract.swift
+++ b/Sources/SwiftDocC/Model/Section/Sections/Abstract.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -12,9 +12,7 @@ public import Markdown
 
 /// A one-paragraph section that represents a symbol's abstract description.
 public struct AbstractSection: Section {
-    public static var title: String? {
-        return nil
-    }
+    public static let title: String? = nil
     public var content: [any Markup] {
         return paragraph.children.compactMap { $0.detachedFromParent }
     }

--- a/Sources/SwiftDocC/Model/Section/Sections/DeprecatedSection.swift
+++ b/Sources/SwiftDocC/Model/Section/Sections/DeprecatedSection.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -13,9 +13,7 @@ public import Markdown
 
 /// A section that contains deprecation information.
 public struct DeprecatedSection: Section {
-    public static var title: String? {
-        return "Deprecated"
-    }
+    public static let title: String? = "Deprecated"
     public var content: [any Markup]
     
     /// Creates a new deprecation section with the given markup content.

--- a/Sources/SwiftDocC/Model/Section/Sections/DictionaryKeysSection.swift
+++ b/Sources/SwiftDocC/Model/Section/Sections/DictionaryKeysSection.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2023 Apple Inc. and the Swift project authors
+ Copyright (c) 2023-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -10,9 +10,7 @@
 
 /// A section that contains a dictionary's keys.
 public struct DictionaryKeysSection {
-    public static var title: String {
-        return "Properties"
-    }
+    public static let title: String = "Properties"
     
     /// The list of dictionary keys.
     public var dictionaryKeys = [DictionaryKey]()

--- a/Sources/SwiftDocC/Model/Section/Sections/Discussion.swift
+++ b/Sources/SwiftDocC/Model/Section/Sections/Discussion.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -11,9 +11,7 @@
 public import Markdown
 
 public struct DiscussionSection: Section {
-    public static var title: String? {
-        return "Discussion"
-    }
+    public static let title: String? = "Discussion"
     public var content: [any Markup]
     
     /// Creates a new discussion section with the given markup content.

--- a/Sources/SwiftDocC/Model/Section/Sections/HTTPBodySection.swift
+++ b/Sources/SwiftDocC/Model/Section/Sections/HTTPBodySection.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2023 Apple Inc. and the Swift project authors
+ Copyright (c) 2023-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -10,9 +10,7 @@
 
 /// A section that contains a request's upload body.
 public struct HTTPBodySection {
-    public static var title: String {
-        return "Request Body"
-    }
+    public static let title = "Request Body"
     
     /// The request body.
     public var body: HTTPBody

--- a/Sources/SwiftDocC/Model/Section/Sections/HTTPResponsesSection.swift
+++ b/Sources/SwiftDocC/Model/Section/Sections/HTTPResponsesSection.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2023 Apple Inc. and the Swift project authors
+ Copyright (c) 2023-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -10,9 +10,7 @@
 
 /// A section that contains an HTTP request's responses.
 public struct HTTPResponsesSection {
-    public static var title: String {
-        return "Response Codes"
-    }
+    public static let title = "Response Codes"
     
     /// The list of responses.
     public var responses = [HTTPResponse]()

--- a/Sources/SwiftDocC/Model/Section/Sections/ParametersSection.swift
+++ b/Sources/SwiftDocC/Model/Section/Sections/ParametersSection.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -10,9 +10,7 @@
 
 /// A section that contains a function's parameters.
 public struct ParametersSection {
-    public static var title: String? {
-        return "Parameters"
-    }
+    public static let title: String? = "Parameters"
     
     /// The list of function parameters.
     public let parameters: [Parameter]

--- a/Sources/SwiftDocC/Model/Section/Sections/PropertyListPossibleValuesSection.swift
+++ b/Sources/SwiftDocC/Model/Section/Sections/PropertyListPossibleValuesSection.swift
@@ -36,9 +36,7 @@ public struct PropertyListPossibleValuesSection {
         }
     }
     
-    public static var title: String {
-        return "Possible Values"
-    }
+    public static let title = "Possible Values"
     
     /// The list of possible values.
     public let possibleValues: [PossibleValue]

--- a/Sources/SwiftDocC/Model/Section/Sections/ReturnsSection.swift
+++ b/Sources/SwiftDocC/Model/Section/Sections/ReturnsSection.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -12,8 +12,6 @@ public import Markdown
 
 /// A section that contains return value information for a function.
 public struct ReturnsSection: Section {
-    public static var title: String? {
-        return "Return Value"
-    }
+    public static let title: String? = "Return Value"
     public var content: [any Markup]
 }

--- a/Sources/SwiftDocC/Model/Section/Sections/SeeAlso.swift
+++ b/Sources/SwiftDocC/Model/Section/Sections/SeeAlso.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -12,7 +12,7 @@ public import Markdown
 
 /// A section that contains groups of related symbols or external links.
 public struct SeeAlsoSection: GroupedSection {
-    public private(set) static var title: String? = "See Also"
+    public static let title: String? = "See Also"
     
     public var content: [any Markup]
 

--- a/Sources/SwiftDocC/Model/Section/Sections/Topics.swift
+++ b/Sources/SwiftDocC/Model/Section/Sections/Topics.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -15,9 +15,7 @@ typealias GroupedLinkRanges = [[SourceRange?]]
 
 /// A section that contains groups of symbols.
 public struct TopicsSection: GroupedSection {
-    public static var title: String? {
-        return "Topics"
-    }
+    public static let title: String? = "Topics"
     public var content: [any Markup]
     
     /// Creates a new topics section with the given content.

--- a/Sources/SwiftDocC/Semantics/Metadata/Availability.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/Availability.swift
@@ -48,7 +48,7 @@ extension Metadata {
         public static let directiveName: String = "Available"
         public static let introducedVersion = "5.8"
 
-        public enum Platform: RawRepresentable, Hashable, DirectiveArgumentValueConvertible {
+        public enum Platform: RawRepresentable, Hashable, DirectiveArgumentValueConvertible, Sendable {
             case macOS, iOS, watchOS, tvOS
 
             case other(String)

--- a/Sources/SwiftDocC/Semantics/Symbol/DocumentationDataVariants.swift
+++ b/Sources/SwiftDocC/Semantics/Symbol/DocumentationDataVariants.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -132,7 +132,7 @@ extension DocumentationDataVariants {
 extension DocumentationDataVariants: Equatable where Variant: Equatable {}
 
 /// The trait associated with a variant of some piece of information about a documentation node.
-public struct DocumentationDataVariantsTrait: Hashable {
+public struct DocumentationDataVariantsTrait: Hashable, Sendable {
     /// The Swift programming language.
     public static var swift = DocumentationDataVariantsTrait(sourceLanguage: .swift)
     

--- a/Sources/SwiftDocC/Semantics/Symbol/DocumentationDataVariants.swift
+++ b/Sources/SwiftDocC/Semantics/Symbol/DocumentationDataVariants.swift
@@ -134,10 +134,18 @@ extension DocumentationDataVariants: Equatable where Variant: Equatable {}
 /// The trait associated with a variant of some piece of information about a documentation node.
 public struct DocumentationDataVariantsTrait: Hashable, Sendable {
     /// The Swift programming language.
-    public static var swift = DocumentationDataVariantsTrait(sourceLanguage: .swift)
+    public static var swift: DocumentationDataVariantsTrait {
+        get { DocumentationDataVariantsTrait(sourceLanguage: .swift) }
+        @available(*, deprecated, message: "Create a new value instead of modifying this one. This deprecated setter will be removed after 6.5 is released.")
+        set { /* Do nothing */ }
+    }
     
     /// The Objective-C programming language.
-    public static var objectiveC = DocumentationDataVariantsTrait(sourceLanguage: .objectiveC)
+    public static var objectiveC: DocumentationDataVariantsTrait {
+        get { DocumentationDataVariantsTrait(sourceLanguage: .objectiveC) }
+        @available(*, deprecated, message: "Create a new value instead of modifying this one. This deprecated setter will be removed after 6.5 is released.")
+        set { /* Do nothing */ }
+    }
     
     /// The language in which the documentation node is relevant.
     public var interfaceLanguage: String? {
@@ -147,7 +155,7 @@ public struct DocumentationDataVariantsTrait: Hashable, Sendable {
     private(set) var sourceLanguage: SourceLanguage?
     
     /// A special trait that represents the fallback trait, which internal clients can use to access the default value of a collection of variants.
-    static var fallback = DocumentationDataVariantsTrait()
+    static let fallback = DocumentationDataVariantsTrait()
     
     /// Creates a new trait given an interface language.
     ///

--- a/Sources/SwiftDocC/Semantics/Symbol/DocumentationDataVariants.swift
+++ b/Sources/SwiftDocC/Semantics/Symbol/DocumentationDataVariants.swift
@@ -136,14 +136,14 @@ public struct DocumentationDataVariantsTrait: Hashable, Sendable {
     /// The Swift programming language.
     public static var swift: DocumentationDataVariantsTrait {
         get { DocumentationDataVariantsTrait(sourceLanguage: .swift) }
-        @available(*, deprecated, message: "Create a new value instead of modifying this one. This deprecated setter will be removed after 6.5 is released.")
+        @available(*, deprecated, message: "Setting this value has no effect; create a new value instead. This value will become read-only after 6.5 is released.")
         set { /* Do nothing */ }
     }
     
     /// The Objective-C programming language.
     public static var objectiveC: DocumentationDataVariantsTrait {
         get { DocumentationDataVariantsTrait(sourceLanguage: .objectiveC) }
-        @available(*, deprecated, message: "Create a new value instead of modifying this one. This deprecated setter will be removed after 6.5 is released.")
+        @available(*, deprecated, message: "Setting this value has no effect; create a new value instead. This value will become read-only after 6.5 is released.")
         set { /* Do nothing */ }
     }
     

--- a/Sources/SwiftDocC/Semantics/Symbol/PlatformName.swift
+++ b/Sources/SwiftDocC/Semantics/Symbol/PlatformName.swift
@@ -11,7 +11,7 @@
 import Foundation
 
 /// A supported platform's name representation.
-public struct PlatformName: Codable, Hashable, Comparable {
+public struct PlatformName: Codable, Hashable, Comparable, Sendable {
     public var rawValue: String
 
     /// Compares platform names independently of any known aliases differences or possible incomplete display names.

--- a/Sources/SwiftDocC/Servers/DocumentationSchemeHandler.swift
+++ b/Sources/SwiftDocC/Servers/DocumentationSchemeHandler.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -18,9 +18,7 @@ public class DocumentationSchemeHandler: NSObject {
     
     // The schema to support the documentation.
     public static let scheme = "doc"
-    public static var fullScheme: String {
-        return "\(scheme)://"
-    }
+    public static let fullScheme = "\(scheme)://"
     
     /// Fallback handler is called if the response data is nil.
     public var fallbackHandler: FallbackResponseHandler?

--- a/Sources/SwiftDocC/Utility/FoundationExtensions/NoOpSignposterShim.swift
+++ b/Sources/SwiftDocC/Utility/FoundationExtensions/NoOpSignposterShim.swift
@@ -40,7 +40,7 @@ package struct NoOpSignposterShim : @unchecked Sendable {
     
     package var isEnabled: Bool { false }
     
-    package struct ID {
+    package struct ID: Sendable {
         static var exclusive = ID()
     }
     package func makeSignpostID() -> ID { ID() }


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

This fixes the very easiest strict-concurrency warnings that are raised when `.enableExperimentalFeature("StrictConcurrency")` is added to the Swift settings for `SwiftDocC` and `DocCCommandLine`. 

Note: I'm sure that there are more types that can safely be marked `Sendable` but I didn't see any warnings about those types so I didn't go through any additional types to audit them for sendability.

## Dependencies

None

## Testing

- Include `.enableExperimentalFeature("StrictConcurrency")` in the Swift settings for the 
- Build docc and count the number of compiler warnings
- Checkout the "main" branch and repeat the same two steps from above
- Compare the number of warnings between this branch and main. 
  - The number of warnings should have gone down by a lot (over a hundred)

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- ~[ ] Added tests~ There's nothing 
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary`
