### PR TITLE
Respect `@SupportedLanguage` when resolving article links

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/DocumentationCurator.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationCurator.swift
@@ -102,13 +102,20 @@ struct DocumentationCurator {
                 return path.prependingLeadingSlash
             }
         }()
-        let reference = ResolvedTopicReference(
+        let lookupReference = ResolvedTopicReference(
             bundleID: resolved.bundleID,
             path: sourceArticlePath,
             sourceLanguages: resolved._sourceLanguages)
-        
-        guard let currentArticle = self.context.uncuratedArticles[reference],
-            let documentationNode = try? DocumentationNode(reference: reference, article: currentArticle.value) else { return nil }
+
+        guard let currentArticle = self.context.uncuratedArticles[lookupReference] else { return nil }
+
+        guard let (documentationNode, _) = DocumentationContext.documentationNodeAndTitle(
+            for: currentArticle,
+            availableSourceLanguages: resolved.sourceLanguages,
+            kind: .article,
+            in: context.inputs
+        ) else { return nil }
+        let reference = documentationNode.reference
         
         // An article has been found which needs to be extracted from the article cache
         // and curated under the current symbol. To do this we need to re-create the reference


### PR DESCRIPTION
## Summary

When an article is registered in the documentation context, the documentation node uses the supported languages indicated in the article with `@SupportedLanguage`, and falls back to the root module's supported languages for articles that don't use the directive. In cases where there is more than one module, articles are not registered. If they are manually curated, the documentation node is created when resolving the article link. The logic used to create this node is inconsistent with the registration process. Reconcile the two to use the same method to ensure that an article correctly stores its supported languages.

## Dependencies

N/A

## Testing

This can only occur in an unsupported configuration where multiple modules are present in a single catalog. All articles are correctly registered when a single root module is present.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

~- [ ] Added tests~ (occurs only in unsupported configuration)
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
